### PR TITLE
CMake: update skip list for test folders

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,7 +100,7 @@ macro(onedpl_add_test test_source_file)
     add_dependencies(build-all ${_test_name})
 endmacro()
 
-set(_skip_regex_for_not_dpcpp "(xpu_api)")
+set(_skip_regex_for_not_dpcpp "(xpu_api/algorithms|xpu_api/functional|xpu_api/numerics)")
 file(GLOB_RECURSE UNIT_TESTS "*.pass.cpp")
 foreach (_file IN LISTS UNIT_TESTS)
     if (_file MATCHES "${_skip_regex_for_not_dpcpp}" AND NOT ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")


### PR DESCRIPTION
Signed-off-by: Veprev, Alexey <alexey.veprev@intel.com>

Update skip list in order to return previous behavior after https://github.com/oneapi-src/oneDPL/pull/358. There is no direct functional impact, but it is needed for some infrastructure/testing parts.

Despite the fact that random tests require DPC++ compiler they can detect availability internally, so there is no need to skip them on higher level (in CMake).