### PR TITLE
[pstl] LLVM sync In: Use logical operator for loop condition in the tests find_end and search_n

### DIFF
--- a/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
@@ -101,7 +101,7 @@ test(const ::std::size_t bits)
             for (auto r : res)
             {
                 ::std::size_t i = r, isub = 0;
-                for (; i < n1 & isub < n2; ++i, ++isub)
+                for (; i < n1 && isub < n2; ++i, ++isub)
                     in[i] = sub[isub];
 #ifdef _PSTL_TEST_FIND_END
                 invoke_on_all_policies<0>()(test_find_end<T>(), in.begin(), in.begin() + n1, sub.begin(),

--- a/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
@@ -67,7 +67,7 @@ test()
             {
                 Sequence<T> in(n1, [](::std::size_t) { return T(0); });
                 ::std::size_t i = r, isub = 0;
-                for (; i < n1 & isub < n2; ++i, ++isub)
+                for (; i < n1 && isub < n2; ++i, ++isub)
                     in[i] = value;
 
                 invoke_on_all_policies<0>()(test_search_n<T>(), in.begin(), in.begin() + n1, n2, value,


### PR DESCRIPTION
Fix a probable typo in two PSTL tests that causes warnings with GCC.

Patch by Jonathan Wakely (jwakely).

Reviewed By: zoecarver

Differential Revision: https://reviews.llvm.org/D102327