### PR TITLE
Filter kernel bundles to only include images that contain the needed kernel

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -200,8 +200,8 @@ class __kernel_compiler
     {
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
         auto __kernel_id = sycl::get_kernel_id<_DerivedKernelName>();
-        auto __kernel_bundle =
-            sycl::get_kernel_bundle<sycl::bundle_state::executable>(__exec.queue().get_context(), {__kernel_id});
+        auto __kernel_bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            __exec.queue().get_context(), {__exec.queue().get_device()}, {__kernel_id});
         return __kernel_bundle.get_kernel(__kernel_id);
 #else
         sycl::program __program(__exec.queue().get_context());


### PR DESCRIPTION
Before the patch, the obtained kernel bundle contains all application kernels compatible with any device in the context; this may cause huge JIT overheads, for example if an application also uses oneAPI libraries such as oneMKL which may contain hundreds of kernels. 
