### PR TITLE
Fix documentation build

### DIFF
--- a/documentation/library_guide/requirements.txt
+++ b/documentation/library_guide/requirements.txt
@@ -1,5 +1,6 @@
 breathe==4.9.1
 sphinx==3.4.0
+jinja2<3.1
 docutils>=0.15
 sphinx_book_theme
 sphinx-intl==2.0.0


### PR DESCRIPTION
Added condition for jinja2 version to avoid the error blocking documentation build. The error is caused by jinja2 imports deprecation (https://github.com/sphinx-doc/sphinx/issues/10291, https://github.com/pallets/jinja/releases). 
Singed-off-by: Valentina Kats valentina.kats@intel.com