### PR TITLE
Bugfix for CMake openMP setup

### DIFF
--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -64,7 +64,7 @@ if (EXISTS "${_onedpl_headers}")
 
             # Some compilers may fail if _openmp_flag is not in CMAKE_REQUIRED_LIBRARIES.
             set(_onedpl_saved_required_libs ${CMAKE_REQUIRED_LIBRARIES})
-            set(CMAKE_REQUIRED_LIBRARIES ${_openmp_option})
+            set(CMAKE_REQUIRED_LIBRARIES ${_openmp_flag})
             check_cxx_compiler_flag(${_openmp_flag} _openmp_option)
             set(CMAKE_REQUIRED_LIBRARIES ${_onedpl_saved_required_libs})
             unset(_onedpl_saved_required_libs)


### PR DESCRIPTION
Bugfix in CMake setup for `cmake/templates/oneDPLConfig.cmake.in`:
This PR uses the variable `_openmp_flag` to set up `CMAKE_REQUIRED_LIBRARIES`.  Previously, it was using an uninitialized variable `_openmp_option`.  It seems that this was just a typo.
Following similar structure in `CMakeLists.txt`, and following the intention as stated in the comment two lines above.