### PR TITLE
Specialize work-group sizes for scan-based algorithms

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -802,12 +802,12 @@ __pattern_mismatch(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __
 // copy_if
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Iterator1, typename _IteratorOrTuple, typename _AlgoType, typename _CreateMaskOp,
-          typename _CopyByMaskOp>
+template <typename _ExecutionPolicy, typename _Iterator1, typename _IteratorOrTuple, typename _AlgoType,
+          typename _CreateMaskOp, typename _CopyByMaskOp>
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<
     _ExecutionPolicy, ::std::pair<_IteratorOrTuple, typename ::std::iterator_traits<_Iterator1>::difference_type>>
-__pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last, _IteratorOrTuple __output_first, _AlgoType,
-                    _CreateMaskOp __create_mask_op, _CopyByMaskOp __copy_by_mask_op)
+__pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last, _IteratorOrTuple __output_first,
+                    _AlgoType, _CreateMaskOp __create_mask_op, _CopyByMaskOp __copy_by_mask_op)
 {
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
 
@@ -822,9 +822,9 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _IteratorOrTuple>();
     auto __buf2 = __keep2(__output_first, __output_first + __n);
 
-    auto __res =
-        __par_backend_hetero::__parallel_scan_copy(::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
-                                                   __buf2.all_view(), __n, _AlgoType{}, __create_mask_op, __copy_by_mask_op);
+    auto __res = __par_backend_hetero::__parallel_scan_copy(::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
+                                                            __buf2.all_view(), __n, _AlgoType{}, __create_mask_op,
+                                                            __copy_by_mask_op);
 
     ::std::size_t __num_copied = __res.get();
     return ::std::make_pair(__output_first + __n, __num_copied);
@@ -870,13 +870,14 @@ __pattern_partition_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterato
 
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
     using _ReduceOp = ::std::plus<_It1DifferenceType>;
-    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type, ::oneapi::dpl::__internal::__algorithm_type::partition>;
+    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type,
+                                               ::oneapi::dpl::__internal::__algorithm_type::partition>;
 
     unseq_backend::__create_mask<_UnaryPredicate, _It1DifferenceType> __create_mask_op{__pred};
     unseq_backend::__partition_by_mask<_ReduceOp, /*inclusive*/ ::std::true_type> __copy_by_mask_op{_ReduceOp{}};
 
     auto __result = __pattern_scan_copy(
-        ::std::forward<_ExecutionPolicy>(__exec), __first, __last, 
+        ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
         __par_backend_hetero::zip(
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result1),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result2)),
@@ -894,7 +895,8 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_unique_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last, _Iterator2 __result_first,
                       _BinaryPredicate __pred, /*vector*/ ::std::true_type, /*parallel*/ ::std::true_type)
 {
-    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type, ::oneapi::dpl::__internal::__algorithm_type::unique>;
+    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type,
+                                               ::oneapi::dpl::__internal::__algorithm_type::unique>;
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
     unseq_backend::__copy_by_mask<::std::plus<_It1DifferenceType>, oneapi::dpl::__internal::__pstl_assign,
                                   /*inclusive*/ ::std::true_type, 1>
@@ -902,8 +904,8 @@ __pattern_unique_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 
     __create_mask_unique_copy<__not_pred<_BinaryPredicate>, _It1DifferenceType> __create_mask_op{
         __not_pred<_BinaryPredicate>{__pred}};
 
-    auto __result = __pattern_scan_copy(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result_first, _AlgoType{},
-                                        __create_mask_op, __copy_by_mask_op);
+    auto __result = __pattern_scan_copy(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result_first,
+                                        _AlgoType{}, __create_mask_op, __copy_by_mask_op);
 
     return __result_first + __result.second;
 }
@@ -1623,7 +1625,8 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
     using _MaskAssigner = unseq_backend::__mask_assigner<2>;
     using _InitType = unseq_backend::__no_init_value<_Size1>;
     using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
-    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type, ::oneapi::dpl::__internal::__algorithm_type::set_operation>;
+    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type,
+                                               ::oneapi::dpl::__internal::__algorithm_type::set_operation>;
 
     _ReduceOp __reduce_op;
     _Assigner __assign_op;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1621,6 +1621,7 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
     using _MaskAssigner = unseq_backend::__mask_assigner<2>;
     using _InitType = unseq_backend::__no_init_value<_Size1>;
     using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type, ::oneapi::dpl::__internal::__algorithm_type::set_operation>;
 
     _ReduceOp __reduce_op;
     _Assigner __assign_op;
@@ -1650,7 +1651,7 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
                 __buf1.all_view(), __buf2.all_view(),
                 oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
                     __mask_buf.get_buffer())),
-            __buf3.all_view(), __reduce_op, _InitType{},
+            __buf3.all_view(), __reduce_op, _InitType{}, _AlgoType{},
             // local scan
             unseq_backend::__scan</*inclusive*/ ::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _Assigner,
                                   _MaskAssigner, decltype(__create_mask_op), _InitType>{

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -293,41 +293,43 @@ struct __parallel_scan_submitter;
 template <typename _CustomName, typename... _PropagateScanName>
 struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name<_PropagateScanName...>>
 {
-    static constexpr int __iters_per_item(::oneapi::dpl::__internal::__algorithm_type __algo_type)
+    static constexpr int
+    __iters_per_item(::oneapi::dpl::__internal::__algorithm_type __algo_type)
     {
         using namespace ::oneapi::dpl::__internal;
         switch (__algo_type)
         {
-            case __algorithm_type::partition:
-                return 1;
-            case __algorithm_type::unique:
-                return 2;
-            case __algorithm_type::set_operation:
-                return 4;
-            case __algorithm_type::scan_copy:
-                return 16;
-            case __algorithm_type::transform_scan:
-                return 32;
-            default:
-                return 16;
+        case __algorithm_type::partition:
+            return 1;
+        case __algorithm_type::unique:
+            return 2;
+        case __algorithm_type::set_operation:
+            return 4;
+        case __algorithm_type::scan_copy:
+            return 16;
+        case __algorithm_type::transform_scan:
+            return 32;
+        default:
+            return 16;
         }
     }
 
-    static constexpr ::std::size_t __preferred_wgroup_size(::oneapi::dpl::__internal::__algorithm_type __algo_type)
+    static constexpr ::std::size_t
+    __preferred_wgroup_size(::oneapi::dpl::__internal::__algorithm_type __algo_type)
     {
         using namespace ::oneapi::dpl::__internal;
         switch (__algo_type)
         {
-            case __algorithm_type::transform_scan:
-                return 128;
-            case __algorithm_type::scan_copy:
-                return 256;
-            case __algorithm_type::unique:
-            case __algorithm_type::set_operation:
-                return 512;
-            case __algorithm_type::partition:
-            default:
-                return ::std::numeric_limits<::std::size_t>::max();
+        case __algorithm_type::transform_scan:
+            return 128;
+        case __algorithm_type::scan_copy:
+            return 256;
+        case __algorithm_type::unique:
+        case __algorithm_type::set_operation:
+            return 512;
+        case __algorithm_type::partition:
+        default:
+            return ::std::numeric_limits<::std::size_t>::max();
         }
     }
 
@@ -335,7 +337,8 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
               typename _InitType, typename _AlgoType, typename _LocalScan, typename _GroupScan, typename _GlobalScan>
     auto
     operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _BinaryOperation __binary_op,
-               _InitType __init, _AlgoType, _LocalScan __local_scan, _GroupScan __group_scan, _GlobalScan __global_scan) const
+               _InitType __init, _AlgoType, _LocalScan __local_scan, _GroupScan __group_scan,
+               _GlobalScan __global_scan) const
     {
         using _Type = typename _InitType::__value_type;
         using _LocalScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
@@ -348,7 +351,8 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
         // get the work group size adjusted to the local memory limit
         // TODO: find a way to generalize getting of reliable work-group sizes
-        ::std::size_t __wgroup_size_max = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_Type));
+        ::std::size_t __wgroup_size_max =
+            oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_Type));
 
         ::std::size_t __wgroup_size = ::std::min(__wgroup_size_max, __preferred_wgroup_size(_AlgoType::value));
 
@@ -375,7 +379,6 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
             __wgroup_size = ::std::atoi(__wgroup_size_override);
         }
 #endif
-
 
         auto __size_per_wg = __iters_per_witem * __wgroup_size;
         auto __n_groups = (__n - 1) / __size_per_wg + 1;
@@ -791,8 +794,8 @@ __parallel_transform_scan_single_group(_ExecutionPolicy&& __exec, _InRng&& __in_
     }
 }
 
-template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinaryOperation, typename _InitType, typename _AlgoType,
-          typename _LocalScan, typename _GroupScan, typename _GlobalScan,
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinaryOperation, typename _InitType,
+          typename _AlgoType, typename _LocalScan, typename _GroupScan, typename _GlobalScan,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0>
 auto
 __parallel_transform_scan_base(_ExecutionPolicy&& __exec, _Range1&& __in_rng, _Range2&& __out_rng,
@@ -810,12 +813,13 @@ __parallel_transform_scan_base(_ExecutionPolicy&& __exec, _Range1&& __in_rng, _R
         __binary_op, __init, _AlgoType{}, __local_scan, __group_scan, __global_scan);
 }
 
-template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation, typename _InitType, typename _AlgoType,
-          typename _BinaryOperation, typename _Inclusive,
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation, typename _InitType,
+          typename _AlgoType, typename _BinaryOperation, typename _Inclusive,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0>
 auto
 __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __in_rng, _Range2&& __out_rng, ::std::size_t __n,
-                          _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op, _Inclusive, _AlgoType)
+                          _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op, _Inclusive,
+                          _AlgoType)
 {
     using _Type = typename _InitType::__value_type;
 
@@ -889,28 +893,26 @@ struct __invoke_single_group_copy_if
         if (__is_full_group)
             return __par_backend_hetero::__parallel_copy_if_static_single_group_submitter<
                 _SizeType, __num_elems_per_item, __wg_size, true,
-                   oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+                oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
                     __scan_copy_single_wg_kernel<::std::integral_constant<::std::uint16_t, __wg_size>,
-                                                ::std::integral_constant<::std::uint16_t, __num_elems_per_item>,
-                                                /* _IsFullGroup= */ std::true_type, _CustomName>>
-                >()(
+                                                 ::std::integral_constant<::std::uint16_t, __num_elems_per_item>,
+                                                 /* _IsFullGroup= */ std::true_type, _CustomName>>>()(
                 __exec, ::std::forward<_InRng>(__in_rng), ::std::forward<_OutRng>(__out_rng), __n, _InitType{},
                 _ReduceOp{}, ::std::forward<_Pred>(__pred));
         else
             return __par_backend_hetero::__parallel_copy_if_static_single_group_submitter<
                 _SizeType, __num_elems_per_item, __wg_size, false,
-                   oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+                oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
                     __scan_copy_single_wg_kernel<::std::integral_constant<::std::uint16_t, __wg_size>,
-                                                ::std::integral_constant<::std::uint16_t, __num_elems_per_item>,
-                                                /* _IsFullGroup= */ std::false_type, _CustomName>>
-                >()(
+                                                 ::std::integral_constant<::std::uint16_t, __num_elems_per_item>,
+                                                 /* _IsFullGroup= */ std::false_type, _CustomName>>>()(
                 __exec, ::std::forward<_InRng>(__in_rng), ::std::forward<_OutRng>(__out_rng), __n, _InitType{},
                 _ReduceOp{}, ::std::forward<_Pred>(__pred));
     }
 };
 
-template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _AlgoType, typename _CreateMaskOp,
-          typename _CopyByMaskOp,
+template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _AlgoType,
+          typename _CreateMaskOp, typename _CopyByMaskOp,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0>
 auto
 __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _AlgoType,
@@ -987,7 +989,8 @@ __parallel_copy_if(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out
         using CreateOp = unseq_backend::__create_mask<_Pred, _Size>;
         using CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, oneapi::dpl::__internal::__pstl_assign,
                                                      /*inclusive*/ ::std::true_type, 1>;
-        using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type, ::oneapi::dpl::__internal::__algorithm_type::scan_copy>;
+        using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type,
+                                                   ::oneapi::dpl::__internal::__algorithm_type::scan_copy>;
 
         return __parallel_scan_copy(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_InRng>(__in_rng),
                                     ::std::forward<_OutRng>(__out_rng), __n, _AlgoType{}, CreateOp{__pred}, CopyOp{});

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -309,9 +309,8 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
             return 16;
         case __algorithm_type::transform_scan:
             return 32;
-        default:
-            return 16;
         }
+        return 16;
     }
 
     static constexpr ::std::size_t
@@ -328,9 +327,9 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         case __algorithm_type::set_operation:
             return 512;
         case __algorithm_type::partition:
-        default:
             return ::std::numeric_limits<::std::size_t>::max();
         }
+        return ::std::numeric_limits<::std::size_t>::max();
     }
 
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinaryOperation,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -365,19 +365,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         __wgroup_size = ::std::min({__wgroup_size, __wgroup_size_kernel_1, __wgroup_size_kernel_2});
 #endif
 
-#ifdef _ONEDPL_SCAN_ITER_SIZE
-        constexpr decltype(__wgroup_size) __iters_per_witem = _ONEDPL_SCAN_ITER_SIZE;
-#else
         constexpr decltype(__wgroup_size) __iters_per_witem = __iters_per_item(_AlgoType::value);
-#endif
-
-#ifdef _ONEDPL_SCAN_TUNING_MODE
-        // Override wgsize if performing a tuning sweep
-        if (const char* __wgroup_size_override = ::std::getenv("_ONEDPL_SCAN_WG_SIZE"))
-        {
-            __wgroup_size = ::std::atoi(__wgroup_size_override);
-        }
-#endif
 
         auto __size_per_wg = __iters_per_witem * __wgroup_size;
         auto __n_groups = (__n - 1) / __size_per_wg + 1;

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -18,6 +18,7 @@
 
 #include <iterator>
 #include "../parallel_backend.h"
+#include "../utils.h"
 #if _ONEDPL_BACKEND_SYCL
 #    include "dpcpp/execution_sycl_defs.h"
 #    include "algorithm_impl_hetero.h" // to use __pattern_walk2_brick
@@ -161,6 +162,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     if (__first == __last)
         return __result;
 
+    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type, ::oneapi::dpl::__internal::__algorithm_type::transform_scan>;
     const auto __n = __last - __first;
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -175,7 +177,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
 
         oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(::std::forward<_ExecutionPolicy>(__exec),
                                                                      __buf1.all_view(), __buf2.all_view(), __n,
-                                                                     __unary_op, __init, __binary_op, _Inclusive{})
+                                                                     __unary_op, __init, __binary_op, _Inclusive{}, _AlgoType{})
             .wait();
     }
     else
@@ -199,7 +201,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
 
         // Run main algorithm and save data into temporary buffer
         oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(__policy, __buf1.all_view(), __buf2.all_view(),
-                                                                     __n, __unary_op, __init, __binary_op, _Inclusive{})
+                                                                     __n, __unary_op, __init, __binary_op, _Inclusive{}, _AlgoType{})
             .wait();
 
         // Move data from temporary buffer into results

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -162,7 +162,8 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     if (__first == __last)
         return __result;
 
-    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type, ::oneapi::dpl::__internal::__algorithm_type::transform_scan>;
+    using _AlgoType = ::std::integral_constant<::oneapi::dpl::__internal::__algorithm_type,
+                                               ::oneapi::dpl::__internal::__algorithm_type::transform_scan>;
     const auto __n = __last - __first;
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -175,9 +176,9 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
         auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
         auto __buf2 = __keep2(__result, __result + __n);
 
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(::std::forward<_ExecutionPolicy>(__exec),
-                                                                     __buf1.all_view(), __buf2.all_view(), __n,
-                                                                     __unary_op, __init, __binary_op, _Inclusive{}, _AlgoType{})
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
+            ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n, __unary_op, __init,
+            __binary_op, _Inclusive{}, _AlgoType{})
             .wait();
     }
     else
@@ -201,7 +202,8 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
 
         // Run main algorithm and save data into temporary buffer
         oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(__policy, __buf1.all_view(), __buf2.all_view(),
-                                                                     __n, __unary_op, __init, __binary_op, _Inclusive{}, _AlgoType{})
+                                                                     __n, __unary_op, __init, __binary_op, _Inclusive{},
+                                                                     _AlgoType{})
             .wait();
 
         // Move data from temporary buffer into results

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -48,7 +48,6 @@ namespace dpl
 namespace __internal
 {
 
-
 // TODO: find a better spot for this
 enum class __algorithm_type
 {
@@ -59,7 +58,6 @@ enum class __algorithm_type
     unique,
     other
 };
-
 
 template <typename Iterator>
 using is_const_iterator =

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -48,7 +48,6 @@ namespace dpl
 namespace __internal
 {
 
-// TODO: find a better spot for this
 enum class __algorithm_type
 {
     transform_scan,

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -48,6 +48,17 @@ namespace dpl
 namespace __internal
 {
 
+
+// TODO: find a better spot for this
+enum class __algorithm_type
+{
+    transform_scan,
+    set_operation,
+    scan_copy,
+    other
+};
+
+
 template <typename Iterator>
 using is_const_iterator =
     typename ::std::is_const<typename ::std::remove_pointer<typename ::std::iterator_traits<Iterator>::pointer>::type>;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -55,6 +55,8 @@ enum class __algorithm_type
     transform_scan,
     set_operation,
     scan_copy,
+    partition,
+    unique,
     other
 };
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -50,12 +50,11 @@ namespace __internal
 
 enum class __algorithm_type
 {
-    transform_scan,
-    set_operation,
-    scan_copy,
-    partition,
-    unique,
-    other
+    transform_scan = 0,
+    set_operation = 1,
+    scan_copy = 2,
+    partition = 3,
+    unique = 4
 };
 
 template <typename Iterator>


### PR DESCRIPTION
This PR allows us to change the work-group size and iterations per work-item for the scan family of algorithms. We choose values for these parameters that optimize performance for devices of interest.