### PR TITLE
Multiple backends prototype

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -42,9 +42,9 @@ __pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-    auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n, __buf.all_view());
+    auto __future_obj = oneapi::dpl::__par_backend<_BackendTag>::__parallel_for(
+        ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
+        __buf.all_view());
     return __future_obj;
 }
 
@@ -66,9 +66,9 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
-    auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n, __buf1.all_view(), __buf2.all_view());
+    auto __future = oneapi::dpl::__par_backend<_BackendTag>::__parallel_for(
+        ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
+        __buf1.all_view(), __buf2.all_view());
 
     if constexpr (_IsSync::value)
         __future.wait();
@@ -95,10 +95,9 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator3>();
     auto __buf3 = __keep3(__first3, __first3 + __n);
 
-    auto __future =
-        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
-                                                          __buf1.all_view(), __buf2.all_view(), __buf3.all_view());
+    auto __future = oneapi::dpl::__par_backend<_BackendTag>::__parallel_for(
+        ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
+        __buf1.all_view(), __buf2.all_view(), __buf3.all_view());
 
     return __future.__make_future(__first3 + __n);
 }
@@ -140,9 +139,9 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& _
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_reduce<_RepackedTp,
+                                                                                ::std::true_type /*is_commutative*/>(
+        ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf1.all_view(), __buf2.all_view());
 }
@@ -167,9 +166,9 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& _
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_reduce<_RepackedTp,
+                                                                                ::std::true_type /*is_commutative*/>(
+        ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf.all_view());
 }
@@ -205,9 +204,9 @@ __pattern_transform_scan_base_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
     auto __buf2 = __keep2(__result, __result + __n);
 
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n, __unary_op,
-        __init, __binary_op, _Inclusive{});
+    auto __res = oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_scan(
+        ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n, __unary_op, __init,
+        __binary_op, _Inclusive{});
     return __res.__make_future(__result + __n);
 }
 

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -147,8 +147,8 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
-    __bknd::__parallel_for(
-        _BackendTag{}, ::std::forward<decltype(policy)>(policy),
+    oneapi::dpl::__par_backend<_BackendTag>::__parallel_for(
+        ::std::forward<decltype(policy)>(policy),
         custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::lower_bound>{comp, size, use_32bit_indexing},
         value_size, zip_vw)
         .wait();
@@ -179,8 +179,8 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
-    __bknd::__parallel_for(
-        _BackendTag{}, std::forward<decltype(policy)>(policy),
+    oneapi::dpl::__par_backend<_BackendTag>::::__parallel_for(
+        std::forward<decltype(policy)>(policy),
         custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::upper_bound>{comp, size, use_32bit_indexing},
         value_size, zip_vw)
         .wait();
@@ -211,7 +211,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
-    __bknd::__parallel_for(_BackendTag{}, std::forward<decltype(policy)>(policy),
+    oneapi::dpl::__par_backend<_BackendTag>::__parallel_for(std::forward<decltype(policy)>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::binary_search>{
                                comp, size, use_32bit_indexing},
                            value_size, zip_vw)

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -63,8 +63,10 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 
     InputIterator2 last2 = first2 + n;
 
+    using __buffer_backend_tag = typename oneapi::dpl::internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
+
     // compute head flags
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _flags(policy, n);
+    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _flags(policy, n);
     auto flags = _flags.get();
     flags[0] = 1;
 
@@ -72,7 +74,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
-    oneapi::dpl::__par_backend::__buffer<Policy, OutputType> _temp(policy, n);
+    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, OutputType> _temp(policy, n);
     auto temp = _temp.get();
 
     temp[0] = init;

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -66,7 +66,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     using __buffer_backend_tag = typename oneapi::dpl::__internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
 
     // compute head flags
-    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _flags(policy, n);
+    __par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _flags(policy, n);
     auto flags = _flags.get();
     flags[0] = 1;
 
@@ -74,7 +74,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
-    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, OutputType> _temp(policy, n);
+    __par_backend_buffer<__buffer_backend_tag, Policy, OutputType> _temp(policy, n);
     auto temp = _temp.get();
 
     temp[0] = init;

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -125,7 +125,7 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
     InputIterator2 last2 = first2 + n;
 
     // compute head flags
-    oneapi::dpl::__par_backend_hetero::__buffer<Policy, FlagType> _flags(policy, n);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, Policy, FlagType> _flags(policy, n);
     {
         auto flag_buf = _flags.get_buffer();
         auto flags = flag_buf.get_host_access(sycl::read_write);
@@ -136,7 +136,7 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
-    oneapi::dpl::__par_backend_hetero::__buffer<Policy, OutputType> _temp(policy, n);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, Policy, OutputType> _temp(policy, n);
     {
         auto temp_buf = _temp.get_buffer();
         auto temp = temp_buf.get_host_access(sycl::read_write);

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -63,7 +63,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 
     InputIterator2 last2 = first2 + n;
 
-    using __buffer_backend_tag = typename oneapi::dpl::internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
+    using __buffer_backend_tag = typename oneapi::dpl::__internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
 
     // compute head flags
     oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _flags(policy, n);

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -66,7 +66,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     using __buffer_backend_tag = typename oneapi::dpl::__internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
 
     // compute head flags
-    __par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _flags(policy, n);
+    oneapi::dpl::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _flags(policy, n);
     auto flags = _flags.get();
     flags[0] = 1;
 
@@ -74,7 +74,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
-    __par_backend_buffer<__buffer_backend_tag, Policy, OutputType> _temp(policy, n);
+    oneapi::dpl::__par_backend_buffer<__buffer_backend_tag, Policy, OutputType> _temp(policy, n);
     auto temp = _temp.get();
 
     temp[0] = init;

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -59,7 +59,9 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     typedef unsigned int FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
 
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _mask(policy, n);
+    using __buffer_backend_tag = typename oneapi::dpl::internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
+
+    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n);
     auto mask = _mask.get();
 
     mask[0] = 1;

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -61,7 +61,7 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 
     using __buffer_backend_tag = typename oneapi::dpl::__internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
 
-    __par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n);
+    oneapi::dpl::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n);
     auto mask = _mask.get();
 
     mask[0] = 1;
@@ -111,7 +111,7 @@ inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
 
     FlagType initial_mask = 1;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<Policy, FlagType> _mask(policy, n);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, Policy, FlagType> _mask(policy, n);
     {
         auto mask_buf = _mask.get_buffer();
         auto mask = mask_buf.get_host_access(sycl::read_write);

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -59,7 +59,7 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     typedef unsigned int FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
 
-    using __buffer_backend_tag = typename oneapi::dpl::internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
+    using __buffer_backend_tag = typename oneapi::dpl::__internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
 
     oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n);
     auto mask = _mask.get();

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -61,7 +61,7 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 
     using __buffer_backend_tag = typename oneapi::dpl::__internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
 
-    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n);
+    __par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n);
     auto mask = _mask.get();
 
     mask[0] = 1;

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -137,7 +137,8 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
 
     // Buffer is used to store results of the scan of the mask. Values indicate which position
     // in result2 needs to be written with the scanned_values element.
-    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _scanned_tail_flags(policy, n);
+    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _scanned_tail_flags(policy,
+                                                                                                              n);
 
     // Compute the sum of the segments. scanned_tail_flags values are not used.
     inclusive_scan(policy, make_zip_iterator(first2, _mask.get()), make_zip_iterator(first2, _mask.get()) + n,

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -113,9 +113,11 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef uint64_t CountType;
 
+    using __buffer_backend_tag = typename oneapi::dpl::internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
+
     // buffer that is used to store a flag indicating if the associated key is not equal to
     // the next key, and thus its associated sum should be part of the final result
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _mask(policy, n + 1);
+    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n + 1);
     auto mask = _mask.get();
     mask[0] = 1;
 
@@ -131,11 +133,11 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     // buffer stores the sums of values associated with a given key. Sums are copied with
     // a shift into result2, and the shift is computed at the same time as the sums, so the
     // sums can't be written to result2 directly.
-    oneapi::dpl::__par_backend::__buffer<Policy, ValueType> _scanned_values(policy, n);
+    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, ValueType> _scanned_values(policy, n);
 
     // Buffer is used to store results of the scan of the mask. Values indicate which position
     // in result2 needs to be written with the scanned_values element.
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _scanned_tail_flags(policy, n);
+    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _scanned_tail_flags(policy, n);
 
     // Compute the sum of the segments. scanned_tail_flags values are not used.
     inclusive_scan(policy, make_zip_iterator(first2, _mask.get()), make_zip_iterator(first2, _mask.get()) + n,

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -117,7 +117,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
 
     // buffer that is used to store a flag indicating if the associated key is not equal to
     // the next key, and thus its associated sum should be part of the final result
-    __par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n + 1);
+    oneapi::dpl::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n + 1);
     auto mask = _mask.get();
     mask[0] = 1;
 
@@ -133,11 +133,11 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     // buffer stores the sums of values associated with a given key. Sums are copied with
     // a shift into result2, and the shift is computed at the same time as the sums, so the
     // sums can't be written to result2 directly.
-    __par_backend_buffer<__buffer_backend_tag, Policy, ValueType> _scanned_values(policy, n);
+    oneapi::dpl::__par_backend_buffer<__buffer_backend_tag, Policy, ValueType> _scanned_values(policy, n);
 
     // Buffer is used to store results of the scan of the mask. Values indicate which position
     // in result2 needs to be written with the scanned_values element.
-    __par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _scanned_tail_flags(policy,
+    oneapi::dpl::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _scanned_tail_flags(policy,
                                                                                                               n);
 
     // Compute the sum of the segments. scanned_tail_flags values are not used.

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -117,7 +117,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
 
     // buffer that is used to store a flag indicating if the associated key is not equal to
     // the next key, and thus its associated sum should be part of the final result
-    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n + 1);
+    __par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n + 1);
     auto mask = _mask.get();
     mask[0] = 1;
 
@@ -133,11 +133,11 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     // buffer stores the sums of values associated with a given key. Sums are copied with
     // a shift into result2, and the shift is computed at the same time as the sums, so the
     // sums can't be written to result2 directly.
-    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, ValueType> _scanned_values(policy, n);
+    __par_backend_buffer<__buffer_backend_tag, Policy, ValueType> _scanned_values(policy, n);
 
     // Buffer is used to store results of the scan of the mask. Values indicate which position
     // in result2 needs to be written with the scanned_values element.
-    oneapi::dpl::__internal::__par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _scanned_tail_flags(policy,
+    __par_backend_buffer<__buffer_backend_tag, Policy, FlagType> _scanned_tail_flags(policy,
                                                                                                               n);
 
     // Compute the sum of the segments. scanned_tail_flags values are not used.

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -113,7 +113,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef uint64_t CountType;
 
-    using __buffer_backend_tag = typename oneapi::dpl::internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
+    using __buffer_backend_tag = typename oneapi::dpl::__internal::__par_buffer_backend_selector<_Tag>::__backend_tag;
 
     // buffer that is used to store a flag indicating if the associated key is not equal to
     // the next key, and thus its associated sum should be part of the final result

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -267,17 +267,18 @@ __sycl_reduce_by_segment(__internal::__hetero_tag<_BackendTag>, _ExecutionPolicy
 
     // intermediate reductions within a workgroup
     auto __partials =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __val_type>(__exec, __n_groups).get_buffer();
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, __val_type>(__exec, __n_groups).get_buffer();
 
-    auto __end_idx = oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, 1).get_buffer();
+    auto __end_idx =
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, __diff_type>(__exec, 1).get_buffer();
 
     // the number of segment ends found in each work group
     auto __seg_ends =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n_groups).get_buffer();
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, __diff_type>(__exec, __n_groups).get_buffer();
 
     // buffer that stores an exclusive scan of the results
     auto __seg_ends_scanned =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n_groups).get_buffer();
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, __diff_type>(__exec, __n_groups).get_buffer();
 
     // 1. Count the segment ends in each workgroup
     auto __seg_end_identification = __exec.queue().submit([&](sycl::handler& __cgh) {

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -30,9 +30,9 @@
 #ifndef _ONEDPL_SCAN_BY_SEGMENT_IMPL_H
 #define _ONEDPL_SCAN_BY_SEGMENT_IMPL_H
 
-#if _ONEDPL_BACKEND_SYCL
-
 #include <type_traits>
+
+#if _ONEDPL_BACKEND_SYCL
 #include <cstddef>
 #include <cstdint>
 #include <utility>
@@ -401,5 +401,51 @@ __scan_by_segment_impl_common(__internal::__hetero_tag<_BackendTag>, Policy&& po
 } // namespace internal
 } // namespace dpl
 } // namespace oneapi
-#endif
-#endif
+
+#endif // _ONEDPL_BACKEND_SYCL
+
+namespace oneapi
+{
+namespace dpl
+{
+namespace internal
+{
+
+//------------------------------------------------------------------------------
+// __par_buffer_backend_selector staff - for resolve __backend_tag in the places
+// of code where we have backend tags / dispatch tags in the same type
+//------------------------------------------------------------------------------
+
+template <typename, typename = void>
+struct has_member_backend_tag_type : ::std::false_type
+{
+};
+
+template <typename T>
+struct has_member_backend_tag_type<T, ::std::void_t<typename T::__backend_tag>> : ::std::true_type
+{
+};
+
+template <typename T>
+constexpr bool has_member_backend_tag_type_v = has_member_backend_tag_type<T>::value;
+
+template <class _Tag, typename = void>
+struct __par_buffer_backend_selector;
+
+template <class _Tag>
+struct __par_buffer_backend_selector<_Tag, std::enable_if_t<has_member_backend_tag_type_v<_Tag>>>
+{
+    using __backend_tag = typename _Tag::__backend_tag;
+};
+
+template <class _Tag>
+struct __par_buffer_backend_selector<_Tag, std::enable_if_t<!has_member_backend_tag_type_v<_Tag>>>
+{
+    using __backend_tag = oneapi::dpl::__internal::__serial_backend_tag;
+};
+
+} // namespace internal
+} // namespace dpl
+} // namespace oneapi
+
+#endif // _ONEDPL_SCAN_BY_SEGMENT_IMPL_H

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -33,20 +33,20 @@
 #include <type_traits>
 
 #if _ONEDPL_BACKEND_SYCL
-#include <cstddef>
-#include <cstdint>
-#include <utility>
-#include <algorithm>
+#    include <cstddef>
+#    include <cstdint>
+#    include <utility>
+#    include <algorithm>
 
-#include "../pstl/algorithm_fwd.h"
-#include "../pstl/parallel_backend.h"
-#include "../pstl/hetero/utils_hetero.h"
+#    include "../pstl/algorithm_fwd.h"
+#    include "../pstl/parallel_backend.h"
+#    include "../pstl/hetero/utils_hetero.h"
 
-#include "../pstl/hetero/dpcpp/utils_ranges_sycl.h"
-#include "../pstl/hetero/dpcpp/unseq_backend_sycl.h"
-#include "../pstl/hetero/dpcpp/parallel_backend_sycl_utils.h"
+#    include "../pstl/hetero/dpcpp/utils_ranges_sycl.h"
+#    include "../pstl/hetero/dpcpp/unseq_backend_sycl.h"
+#    include "../pstl/hetero/dpcpp/parallel_backend_sycl_utils.h"
 
-#include "../pstl/hetero/dpcpp/sycl_traits.h" //SYCL traits specialization for some oneDPL types.
+#    include "../pstl/hetero/dpcpp/sycl_traits.h" //SYCL traits specialization for some oneDPL types.
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -408,7 +408,7 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace internal
+namespace __internal
 {
 
 //------------------------------------------------------------------------------
@@ -444,7 +444,7 @@ struct __par_buffer_backend_selector<_Tag, std::enable_if_t<!has_member_backend_
     using __backend_tag = oneapi::dpl::__internal::__serial_backend_tag;
 };
 
-} // namespace internal
+} // namespace __internal
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -147,11 +147,12 @@ struct __sycl_scan_by_segment_impl
         ::std::size_t __n_groups = __internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
 
         auto __partials =
-            oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __val_type>(__exec, __n_groups).get_buffer();
+            oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, __val_type>(__exec, __n_groups)
+                .get_buffer();
 
         // the number of segment ends found in each work group
         auto __seg_ends =
-            oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, bool>(__exec, __n_groups).get_buffer();
+            oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, bool>(__exec, __n_groups).get_buffer();
 
         // 1. Work group reduction
         auto __wg_scan = __exec.queue().submit([&](sycl::handler& __cgh) {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1324,7 +1324,7 @@ __pattern_copy_if(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(1) < __n)
     {
-        __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
         return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _DifferenceType __m{};
@@ -1443,7 +1443,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     _DifferenceType __n = __last - __first;
-    __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+    __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool>  __mask_buf(__exec, __n);
     // 1. find a first iterator that should be removed
     return __internal::__except_handler([&]() {
         bool* __mask = __mask_buf.get();
@@ -1480,7 +1480,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         __n -= __min;
         __first += __min;
 
-        __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n);
+        __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n);
         _Tp* __result = __buf.get();
         __mask += __min;
         _DifferenceType __m{};
@@ -1604,7 +1604,7 @@ __pattern_unique_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(2) < __n)
     {
-        __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
         if (_DifferenceType(2) < __n)
         {
             return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
@@ -1857,7 +1857,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
     auto __m = __middle - __first;
     if (__m <= __n / 2)
     {
-        __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n - __m);
+        __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n - __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
             __par_backend<__backend_tag>::__parallel_for(
@@ -1885,7 +1885,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
     }
     else
     {
-        __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __m);
+        __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
             __par_backend<__backend_tag>::__parallel_for(
@@ -2367,7 +2367,7 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(1) < __n)
     {
-        __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
         return __internal::__except_handler([&__exec, __n, __first, __out_true, __out_false, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _ReturnType __m{};
@@ -2591,7 +2591,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
         {
             typedef typename ::std::iterator_traits<_RandomAccessIterator1>::value_type _T1;
             typedef typename ::std::iterator_traits<_RandomAccessIterator2>::value_type _T2;
-            __par_backend::__buffer<_ExecutionPolicy, _T1> __buf(__exec, __n1);
+            __par_backend_buffer<__backend_tag, _ExecutionPolicy, _T1 > __buf(__exec, __n1);
             _T1* __r = __buf.get();
 
             __par_backend<__backend_tag>::__parallel_stable_sort(
@@ -3087,7 +3087,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     auto __n = __last - __first;
-    __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n);
+    __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp > __buf(__exec, __n);
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
@@ -3218,7 +3218,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     const _DifferenceType __n1 = __last1 - __first1;
     const _DifferenceType __n2 = __last2 - __first2;
 
-    __par_backend::__buffer<_ExecutionPolicy, _T> __buf(__exec, __size_func(__n1, __n2));
+    __par_backend_buffer<__backend_tag, _ExecutionPolicy, _T > __buf(__exec, __size_func(__n1, __n2));
 
     return __internal::__except_handler(
         [&__exec, __n1, __first1, __last1, __first2, __last2, __result, __comp, __size_func, __set_op, &__buf]() {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -154,8 +154,8 @@ __pattern_walk1(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardItera
     typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
     auto __func = [&__f](_ReferenceType arg) { __f(arg); };
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_for_each(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                           __func);
+        __par_backend<__backend_tag>::__parallel_for_each(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                                          __func);
     });
 }
 
@@ -167,10 +167,10 @@ __pattern_walk1(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                      [__f](_RandomAccessIterator __i, _RandomAccessIterator __j) {
-                                          __internal::__brick_walk1(__i, __j, __f, _IsVector{});
-                                      });
+        __par_backend<__backend_tag>::__parallel_for(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                                     [__f](_RandomAccessIterator __i, _RandomAccessIterator __j) {
+                                                         __internal::__brick_walk1(__i, __j, __f, _IsVector{});
+                                                     });
     });
 }
 
@@ -192,8 +192,8 @@ __pattern_walk_brick(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             [__brick](_RandomAccessIterator __i, _RandomAccessIterator __j) { __brick(__i, __j, _IsVector{}); });
     });
 }
@@ -253,8 +253,8 @@ __pattern_walk_brick_n(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ra
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + __n,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __first + __n,
             [__brick](_RandomAccessIterator __i, _RandomAccessIterator __j) { __brick(__i, __j - __i, _IsVector{}); });
         return __first + __n;
     });
@@ -321,8 +321,8 @@ __pattern_walk2(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
             [__f, __first1, __first2](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 __internal::__brick_walk2(__i, __j, __first2 + (__i - __first1), __f, _IsVector{});
             });
@@ -345,10 +345,10 @@ __pattern_walk2(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardItera
         typedef typename ::std::iterator_traits<_ForwardIterator1>::reference _ReferenceType1;
         typedef typename ::std::iterator_traits<_ForwardIterator2>::reference _ReferenceType2;
 
-        __par_backend::__parallel_for_each(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __begin, __end,
-                                           [&__f](::std::tuple<_ReferenceType1, _ReferenceType2> __val) {
-                                               __f(::std::get<0>(__val), ::std::get<1>(__val));
-                                           });
+        __par_backend<__backend_tag>::__parallel_for_each(::std::forward<_ExecutionPolicy>(__exec), __begin, __end,
+                                                          [&__f](::std::tuple<_ReferenceType1, _ReferenceType2> __val) {
+                                                              __f(::std::get<0>(__val), ::std::get<1>(__val));
+                                                          });
 
         //TODO: parallel_for_each does not allow to return correct iterator value according to the ::std::transform
         // implementation. Therefore, iterator value is calculated separately.
@@ -398,8 +398,8 @@ __pattern_walk2_brick(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
             [__first1, __first2, __brick](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 __brick(__i, __j, __first2 + (__i - __first1), _IsVector{});
             });
@@ -423,11 +423,11 @@ __pattern_walk2_brick(__parallel_forward_tag, _ExecutionPolicy&& __exec, _Forwar
     typedef typename ::std::iterator_traits<_ForwardIterator2>::reference _ReferenceType2;
 
     return __except_handler([&]() {
-        __par_backend::__parallel_for_each(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __begin, __end,
-                                           [__brick](::std::tuple<_ReferenceType1, _ReferenceType2> __val) {
-                                               __brick(::std::get<0>(__val),
-                                                       ::std::forward<_ReferenceType2>(::std::get<1>(__val)));
-                                           });
+        __par_backend<__backend_tag>::__parallel_for_each(
+            ::std::forward<_ExecutionPolicy>(__exec), __begin, __end,
+            [__brick](::std::tuple<_ReferenceType1, _ReferenceType2> __val) {
+                __brick(::std::get<0>(__val), ::std::forward<_ReferenceType2>(::std::get<1>(__val)));
+            });
 
         //TODO: parallel_for_each does not allow to return correct iterator value according to the ::std::transform
         // implementation. Therefore, iterator value is calculated separately.
@@ -446,8 +446,8 @@ __pattern_walk2_brick_n(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
             [__first1, __first2, __brick](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 __brick(__i, __j - __i, __first2 + (__i - __first1), _IsVector{});
             });
@@ -510,8 +510,8 @@ __pattern_walk3(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
             [__f, __first1, __first2, __first3](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 __internal::__brick_walk3(__i, __j, __first2 + (__i - __first1), __first3 + (__i - __first1), __f,
                                           _IsVector{});
@@ -538,10 +538,11 @@ __pattern_walk3(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardItera
         typedef typename ::std::iterator_traits<_ForwardIterator2>::reference _ReferenceType2;
         typedef typename ::std::iterator_traits<_ForwardIterator3>::reference _ReferenceType3;
 
-        __par_backend::__parallel_for_each(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __begin, __end,
-                                           [&](::std::tuple<_ReferenceType1, _ReferenceType2, _ReferenceType3> __val) {
-                                               __f(::std::get<0>(__val), ::std::get<1>(__val), ::std::get<2>(__val));
-                                           });
+        __par_backend<__backend_tag>::__parallel_for_each(
+            ::std::forward<_ExecutionPolicy>(__exec), __begin, __end,
+            [&](::std::tuple<_ReferenceType1, _ReferenceType2, _ReferenceType3> __val) {
+                __f(::std::get<0>(__val), ::std::get<1>(__val), ::std::get<2>(__val));
+            });
 
         //TODO: parallel_for_each does not allow to return correct iterator value according to the ::std::transform
         // implementation. Therefore, iterator value is calculated separately.
@@ -1327,8 +1328,8 @@ __pattern_copy_if(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _DifferenceType __m{};
-            __par_backend::__parallel_strict_scan(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
+            __par_backend<__backend_tag>::__parallel_strict_scan(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
                 [=](_DifferenceType __i, _DifferenceType __len) { // Reduce
                     return __internal::__brick_calc_mask_1<_DifferenceType>(__first + __i, __first + (__i + __len),
                                                                             __mask + __i, __pred, _IsVector{})
@@ -1390,8 +1391,8 @@ __pattern_count(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
         return _SizeType(0);
 
     return __internal::__except_handler([&]() {
-        return __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, _SizeType(0),
+        return __par_backend<__backend_tag>::__parallel_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, _SizeType(0),
             [__pred](_RandomAccessIterator __begin, _RandomAccessIterator __end, _SizeType __value) -> _SizeType {
                 return __value + __internal::__brick_count(__begin, __end, __pred, _IsVector{});
             },
@@ -1446,8 +1447,8 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     // 1. find a first iterator that should be removed
     return __internal::__except_handler([&]() {
         bool* __mask = __mask_buf.get();
-        _DifferenceType __min = __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), _DifferenceType(0), __n, __n,
+        _DifferenceType __min = __par_backend<__backend_tag>::__parallel_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), _DifferenceType(0), __n, __n,
             [__first, __mask, &__calc_mask](_DifferenceType __i, _DifferenceType __j,
                                             _DifferenceType __local_min) -> _DifferenceType {
                 // Create mask
@@ -1484,8 +1485,8 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         __mask += __min;
         _DifferenceType __m{};
         // 2. Elements that doesn't satisfy pred are moved to result
-        __par_backend::__parallel_strict_scan(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
+        __par_backend<__backend_tag>::__parallel_strict_scan(
+            ::std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
             [__mask](_DifferenceType __i, _DifferenceType __len) {
                 return __internal::__brick_count(
                     __mask + __i, __mask + __i + __len, [](bool __val) { return __val; }, _IsVector{});
@@ -1500,11 +1501,12 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
             [&__m](_DifferenceType __total) { __m = __total; });
 
         // 3. Elements from result are moved to [first, last)
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
-                                      __result + __m, [__result, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                                              __i, __j, __first + (__i - __result), _IsVector{});
-                                      });
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __result, __result + __m,
+            [__result, __first](_Tp* __i, _Tp* __j) {
+                __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                    __i, __j, __first + (__i - __result), _IsVector{});
+            });
         return __first + __m;
     });
 }
@@ -1608,8 +1610,8 @@ __pattern_unique_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
             return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
                 bool* __mask = __mask_buf.get();
                 _DifferenceType __m{};
-                __par_backend::__parallel_strict_scan(
-                    __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
+                __par_backend<__backend_tag>::__parallel_strict_scan(
+                    ::std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
                     [=](_DifferenceType __i, _DifferenceType __len) -> _DifferenceType { // Reduce
                         _DifferenceType __extra = 0;
                         if (__i == 0)
@@ -1715,8 +1717,8 @@ __pattern_reverse(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         return;
 
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + (__last - __first) / 2,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __first + (__last - __first) / 2,
             [__first, __last](_RandomAccessIterator __inner_first, _RandomAccessIterator __inner_last) {
                 __internal::__brick_reverse(__inner_first, __inner_last, __last - (__inner_first - __first),
                                             _IsVector{});
@@ -1771,8 +1773,8 @@ __pattern_reverse_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ra
         return __d_first;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             [__first, __len, __d_first](_RandomAccessIterator1 __inner_first, _RandomAccessIterator1 __inner_last) {
                 __internal::__brick_reverse_copy(__inner_first, __inner_last,
                                                  __d_first + (__len - (__inner_last - __first)), _IsVector{});
@@ -1858,23 +1860,25 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
         __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n - __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
-                                          [__middle, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_uninitialized_move(
-                                                  __b, __e, __result + (__b - __middle), _IsVector{});
-                                          });
+            __par_backend<__backend_tag>::__parallel_for(
+                ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
+                [__middle, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
+                    __internal::__brick_uninitialized_move(__b, __e, __result + (__b - __middle), _IsVector{});
+                });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
-                                          [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                                                  __b, __e, __b + (__last - __middle), _IsVector{});
-                                          });
+            __par_backend<__backend_tag>::__parallel_for(
+                ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
+                [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
+                    __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                        __b, __e, __b + (__last - __middle), _IsVector{});
+                });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
-                                          __result + (__n - __m), [__first, __result](_Tp* __b, _Tp* __e) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                                                  __b, __e, __first + (__b - __result), _IsVector{});
-                                          });
+            __par_backend<__backend_tag>::__parallel_for(
+                ::std::forward<_ExecutionPolicy>(__exec), __result, __result + (__n - __m),
+                [__first, __result](_Tp* __b, _Tp* __e) {
+                    __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                        __b, __e, __first + (__b - __result), _IsVector{});
+                });
 
             return __first + (__last - __middle);
         });
@@ -1884,23 +1888,25 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
         __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
-                                          [__first, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_uninitialized_move(
-                                                  __b, __e, __result + (__b - __first), _IsVector{});
-                                          });
+            __par_backend<__backend_tag>::__parallel_for(
+                ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
+                [__first, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
+                    __internal::__brick_uninitialized_move(__b, __e, __result + (__b - __first), _IsVector{});
+                });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
-                                          [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                                                  __b, __e, __first + (__b - __middle), _IsVector{});
-                                          });
+            __par_backend<__backend_tag>::__parallel_for(
+                ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
+                [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
+                    __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                        __b, __e, __first + (__b - __middle), _IsVector{});
+                });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
-                                          __result + __m, [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                                                  __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
-                                          });
+            __par_backend<__backend_tag>::__parallel_for(
+                ::std::forward<_ExecutionPolicy>(__exec), __result, __result + __m,
+                [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
+                    __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                        __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
+                });
 
             return __first + (__last - __middle);
         });
@@ -1951,8 +1957,8 @@ __pattern_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             [__first, __last, __middle, __result](_RandomAccessIterator1 __b, _RandomAccessIterator1 __e) {
                 __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy> __copy{};
                 if (__b > __middle)
@@ -2069,8 +2075,8 @@ __pattern_is_partitioned(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
 
         const _ReduceType __identity{__not_init, __last};
 
-        _ReduceType __result = __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __identity,
+        _ReduceType __result = __par_backend<__backend_tag>::__parallel_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __identity,
             [&__pred, __combine](_RandomAccessIterator __i, _RandomAccessIterator __j,
                                  _ReduceType __value) -> _ReduceType {
                 if (__value.__val == __broken)
@@ -2190,8 +2196,8 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
             // then we should swap the false part of left range and last part of true part of right range
             else if (__size2 > __size1)
             {
-                __par_backend::__parallel_for(
-                    __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size1,
+                __par_backend<__backend_tag>::__parallel_for(
+                    ::std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size1,
                     [__val1, __val2, __size1](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, (__val2.__pivot - __size1) + (__i - __val1.__pivot),
                                                         _IsVector{});
@@ -2201,8 +2207,8 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
             // else we should swap the first part of false part of left range and true part of right range
             else
             {
-                __par_backend::__parallel_for(
-                    __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size2,
+                __par_backend<__backend_tag>::__parallel_for(
+                    ::std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size2,
                     [__val1, __val2](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, __val2.__begin + (__i - __val1.__pivot), _IsVector{});
                     });
@@ -2210,8 +2216,8 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
             }
         };
 
-        _PartitionRange __result = __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init,
+        _PartitionRange __result = __par_backend<__backend_tag>::__parallel_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init,
             [__pred, __reductor](_RandomAccessIterator __i, _RandomAccessIterator __j,
                                  _PartitionRange __value) -> _PartitionRange {
                 //1. serial partition
@@ -2294,8 +2300,8 @@ __pattern_stable_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
             }
         };
 
-        _PartitionRange __result = __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init,
+        _PartitionRange __result = __par_backend<__backend_tag>::__parallel_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init,
             [&__pred, __reductor](_RandomAccessIterator __i, _RandomAccessIterator __j,
                                   _PartitionRange __value) -> _PartitionRange {
                 //1. serial stable_partition
@@ -2365,9 +2371,8 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
         return __internal::__except_handler([&__exec, __n, __first, __out_true, __out_false, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _ReturnType __m{};
-            __par_backend::__parallel_strict_scan(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n,
-                ::std::make_pair(_DifferenceType(0), _DifferenceType(0)),
+            __par_backend<__backend_tag>::__parallel_strict_scan(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, ::std::make_pair(_DifferenceType(0), _DifferenceType(0)),
                 [=](_DifferenceType __i, _DifferenceType __len) { // Reduce
                     return __internal::__brick_calc_mask_1<_DifferenceType>(__first + __i, __first + (__i + __len),
                                                                             __mask + __i, __pred, _IsVector{});
@@ -2410,8 +2415,8 @@ __pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_stable_sort(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+        __par_backend<__backend_tag>::__parallel_stable_sort(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
             [](_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
                 ::std::sort(__first, __last, __comp);
             },
@@ -2441,8 +2446,8 @@ __pattern_stable_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_stable_sort(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+        __par_backend<__backend_tag>::__parallel_stable_sort(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
             [](_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
                 ::std::stable_sort(__first, __last, __comp);
             },
@@ -2492,8 +2497,8 @@ __pattern_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_stable_sort(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __beg, __end, __cmp_f,
+        __par_backend<__backend_tag>::__parallel_stable_sort(
+            ::std::forward<_ExecutionPolicy>(__exec), __beg, __end, __cmp_f,
             [](auto __first, auto __last, auto __cmp) { ::std::sort(__first, __last, __cmp); }, __end - __beg);
     });
 }
@@ -2524,8 +2529,8 @@ __pattern_partial_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ra
         return;
 
     __except_handler([&]() {
-        __par_backend::__parallel_stable_sort(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+        __par_backend<__backend_tag>::__parallel_stable_sort(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
             [__n](_RandomAccessIterator __begin, _RandomAccessIterator __end, _Compare __comp) {
                 if (__n < __end - __begin)
                     ::std::partial_sort(__begin, __begin + __n, __end, __comp);
@@ -2568,8 +2573,8 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
     return __internal::__except_handler([&]() {
         if (__n2 >= __n1)
         {
-            __par_backend::__parallel_stable_sort(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __d_first, __d_first + __n1, __comp,
+            __par_backend<__backend_tag>::__parallel_stable_sort(
+                ::std::forward<_ExecutionPolicy>(__exec), __d_first, __d_first + __n1, __comp,
                 [__first, __d_first](_RandomAccessIterator2 __i, _RandomAccessIterator2 __j, _Compare __comp) {
                     _RandomAccessIterator1 __i1 = __first + (__i - __d_first);
                     _RandomAccessIterator1 __j1 = __first + (__j - __d_first);
@@ -2589,8 +2594,8 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
             __par_backend::__buffer<_ExecutionPolicy, _T1> __buf(__exec, __n1);
             _T1* __r = __buf.get();
 
-            __par_backend::__parallel_stable_sort(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n1, __comp,
+            __par_backend<__backend_tag>::__parallel_stable_sort(
+                ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n1, __comp,
                 [__n2, __first, __r](_T1* __i, _T1* __j, _Compare __comp) {
                     _RandomAccessIterator1 __it = __first + (__i - __r);
 
@@ -2609,16 +2614,16 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                 __n2);
 
             // 3. Move elements from temporary buffer to output
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
-                                          [__r, __d_first](_T1* __i, _T1* __j) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                                                  __i, __j, __d_first + (__i - __r), _IsVector{});
-                                          });
+            __par_backend<__backend_tag>::__parallel_for(
+                ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2, [__r, __d_first](_T1* __i, _T1* __j) {
+                    __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                        __i, __j, __d_first + (__i - __r), _IsVector{});
+                });
 
             if constexpr (!::std::is_trivially_destructible_v<_T1>)
-                __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
-                                              __r + __n1,
-                                              [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); });
+                __par_backend<__backend_tag>::__parallel_for(
+                    ::std::forward<_ExecutionPolicy>(__exec), __r + __n2, __r + __n1,
+                    [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); });
 
             return __d_first + __n2;
         }
@@ -2665,8 +2670,8 @@ __pattern_adjacent_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
         return __last;
 
     return __internal::__except_handler([&]() {
-        return __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __last,
+        return __par_backend<__backend_tag>::__parallel_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __last,
             [__last, __pred, __or_semantic](_RandomAccessIterator __begin, _RandomAccessIterator __end,
                                             _RandomAccessIterator __value) -> _RandomAccessIterator {
                 // TODO: investigate performance benefits from the use of shared variable for the result,
@@ -2797,11 +2802,12 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&__exec, __first, __last, &__value]() {
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                      [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
-                                          __internal::__brick_fill<__parallel_tag<_IsVector>, _ExecutionPolicy, _Tp>{
-                                              __value}(__begin, __end, _IsVector{});
-                                      });
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
+                __internal::__brick_fill<__parallel_tag<_IsVector>, _ExecutionPolicy, _Tp>{__value}(__begin, __end,
+                                                                                                    _IsVector{});
+            });
         return __last;
     });
 }
@@ -2883,10 +2889,10 @@ __pattern_generate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Random
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                      [__g](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
-                                          __internal::__brick_generate(__begin, __end, __g, _IsVector{});
-                                      });
+        __par_backend<__backend_tag>::__parallel_for(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                                     [__g](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
+                                                         __internal::__brick_generate(__begin, __end, __g, _IsVector{});
+                                                     });
         return __last;
     });
 }
@@ -3027,9 +3033,8 @@ __pattern_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_merge(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __d_first,
-            __comp,
+        __par_backend<__backend_tag>::__parallel_merge(
+            ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __d_first, __comp,
             [](_RandomAccessIterator1 __f1, _RandomAccessIterator1 __l1, _RandomAccessIterator2 __f2,
                _RandomAccessIterator2 __l2, _RandomAccessIterator3 __f3, _Compare __comp) {
                 return __internal::__brick_merge(__f1, __l1, __f2, __l2, __f3, __comp, _IsVector{});
@@ -3093,8 +3098,8 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
             return __internal::__brick_uninitialized_move(__first1, __last1, __first2, _IsVector{});
         };
 
-        __par_backend::__parallel_merge(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle, __middle, __last, __r, __comp,
+        __par_backend<__backend_tag>::__parallel_merge(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __middle, __middle, __last, __r, __comp,
             [__n, __move_values, __move_sequences](_RandomAccessIterator __f1, _RandomAccessIterator __l1,
                                                    _RandomAccessIterator __f2, _RandomAccessIterator __l2, _Tp* __f3,
                                                    _Compare __comp) {
@@ -3102,11 +3107,11 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
                                                     __move_sequences, __move_sequences);
                 return __f3 + (__l1 - __f1) + (__l2 - __f2);
             });
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n,
-                                      [__r, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                                              __i, __j, __first + (__i - __r), _IsVector{});
-                                      });
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n, [__r, __first](_Tp* __i, _Tp* __j) {
+                __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(__i, __j, __first + (__i - __r),
+                                                                                    _IsVector{});
+            });
     });
 }
 
@@ -3215,69 +3220,69 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
     __par_backend::__buffer<_ExecutionPolicy, _T> __buf(__exec, __size_func(__n1, __n2));
 
-    return __internal::__except_handler([&__exec, __n1, __first1, __last1, __first2, __last2, __result, __comp,
-                                         __size_func, __set_op, &__buf]() {
-        auto __tmp_memory = __buf.get();
-        _DifferenceType __m{};
-        auto __scan = [=](_DifferenceType, _DifferenceType, const _SetRange& __s) { // Scan
-            if (!__s.empty())
-                __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                    __tmp_memory + __s.__buf_pos, __tmp_memory + (__s.__buf_pos + __s.__len), __result + __s.__pos,
-                    _IsVector{});
-        };
-        __par_backend::__parallel_strict_scan(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n1, _SetRange{0, 0, 0}, //-1, 0},
-            [=](_DifferenceType __i, _DifferenceType __len) {                                    // Reduce
-                //[__b; __e) - a subrange of the first sequence, to reduce
-                _RandomAccessIterator1 __b = __first1 + __i, __e = __first1 + (__i + __len);
+    return __internal::__except_handler(
+        [&__exec, __n1, __first1, __last1, __first2, __last2, __result, __comp, __size_func, __set_op, &__buf]() {
+            auto __tmp_memory = __buf.get();
+            _DifferenceType __m{};
+            auto __scan = [=](_DifferenceType, _DifferenceType, const _SetRange& __s) { // Scan
+                if (!__s.empty())
+                    __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                        __tmp_memory + __s.__buf_pos, __tmp_memory + (__s.__buf_pos + __s.__len), __result + __s.__pos,
+                        _IsVector{});
+            };
+            __par_backend<__backend_tag>::__parallel_strict_scan(
+                ::std::forward<_ExecutionPolicy>(__exec), __n1, _SetRange{0, 0, 0}, //-1, 0},
+                [=](_DifferenceType __i, _DifferenceType __len) {                   // Reduce
+                    //[__b; __e) - a subrange of the first sequence, to reduce
+                    _RandomAccessIterator1 __b = __first1 + __i, __e = __first1 + (__i + __len);
 
-                //try searching for the first element which not equal to *__b
-                if (__b != __first1)
-                    __b = ::std::upper_bound(__b, __last1, *__b, __comp);
+                    //try searching for the first element which not equal to *__b
+                    if (__b != __first1)
+                        __b = ::std::upper_bound(__b, __last1, *__b, __comp);
 
-                //try searching for the first element which not equal to *__e
-                if (__e != __last1)
-                    __e = ::std::upper_bound(__e, __last1, *__e, __comp);
+                    //try searching for the first element which not equal to *__e
+                    if (__e != __last1)
+                        __e = ::std::upper_bound(__e, __last1, *__e, __comp);
 
-                //check is [__b; __e) empty
-                if (__e - __b < 1)
-                {
-                    _RandomAccessIterator2 __bb = __last2;
-                    if (__b != __last1)
+                    //check is [__b; __e) empty
+                    if (__e - __b < 1)
+                    {
+                        _RandomAccessIterator2 __bb = __last2;
+                        if (__b != __last1)
+                            __bb = ::std::lower_bound(__first2, __last2, *__b, __comp);
+
+                        const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
+                        return _SetRange{0, 0, __buf_pos};
+                    }
+
+                    //try searching for "corresponding" subrange [__bb; __ee) in the second sequence
+                    _RandomAccessIterator2 __bb = __first2;
+                    if (__b != __first1)
                         __bb = ::std::lower_bound(__first2, __last2, *__b, __comp);
 
+                    _RandomAccessIterator2 __ee = __last2;
+                    if (__e != __last1)
+                        __ee = ::std::lower_bound(__bb, __last2, *__e, __comp);
+
                     const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
-                    return _SetRange{0, 0, __buf_pos};
-                }
+                    auto __buffer_b = __tmp_memory + __buf_pos;
+                    auto __res = __set_op(__b, __e, __bb, __ee, __buffer_b, __comp);
 
-                //try searching for "corresponding" subrange [__bb; __ee) in the second sequence
-                _RandomAccessIterator2 __bb = __first2;
-                if (__b != __first1)
-                    __bb = ::std::lower_bound(__first2, __last2, *__b, __comp);
-
-                _RandomAccessIterator2 __ee = __last2;
-                if (__e != __last1)
-                    __ee = ::std::lower_bound(__bb, __last2, *__e, __comp);
-
-                const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
-                auto __buffer_b = __tmp_memory + __buf_pos;
-                auto __res = __set_op(__b, __e, __bb, __ee, __buffer_b, __comp);
-
-                return _SetRange{0, __res - __buffer_b, __buf_pos};
-            },
-            [](const _SetRange& __a, const _SetRange& __b) { // Combine
-                if (__b.__buf_pos > __a.__buf_pos || ((__b.__buf_pos == __a.__buf_pos) && !__b.empty()))
-                    return _SetRange{__a.__pos + __a.__len + __b.__pos, __b.__len, __b.__buf_pos};
-                return _SetRange{__b.__pos + __b.__len + __a.__pos, __a.__len, __a.__buf_pos};
-            },
-            __scan,                                     // Scan
-            [&__m, &__scan](const _SetRange& __total) { // Apex
-                //final scan
-                __scan(0, 0, __total);
-                __m = __total.__pos + __total.__len;
-            });
-        return __result + __m;
-    });
+                    return _SetRange{0, __res - __buffer_b, __buf_pos};
+                },
+                [](const _SetRange& __a, const _SetRange& __b) { // Combine
+                    if (__b.__buf_pos > __a.__buf_pos || ((__b.__buf_pos == __a.__buf_pos) && !__b.empty()))
+                        return _SetRange{__a.__pos + __a.__len + __b.__pos, __b.__len, __b.__buf_pos};
+                    return _SetRange{__b.__pos + __b.__len + __a.__pos, __a.__len, __a.__buf_pos};
+                },
+                __scan,                                     // Scan
+                [&__m, &__scan](const _SetRange& __total) { // Apex
+                    //final scan
+                    __scan(0, 0, __total);
+                    __m = __total.__pos + __total.__len;
+                });
+            return __result + __m;
+        });
 }
 
 //a shared parallel pattern for '__pattern_set_union' and '__pattern_set_symmetric_difference'
@@ -3313,8 +3318,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
     if (__left_bound_seq_1 == __last1)
     {
         //{1} < {2}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
-        __par_backend::__parallel_invoke(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        __par_backend<__backend_tag>::__parallel_invoke(
+            ::std::forward<_ExecutionPolicy>(__exec),
             [=] {
                 __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
                                                   __result, __copy_range);
@@ -3332,8 +3337,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
     if (__left_bound_seq_2 == __last2)
     {
         //{2} < {1}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
-        __par_backend::__parallel_invoke(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        __par_backend<__backend_tag>::__parallel_invoke(
+            ::std::forward<_ExecutionPolicy>(__exec),
             [=] {
                 __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
                                                   __result, __copy_range);
@@ -3350,8 +3355,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
     {
         auto __res_or = __result;
         __result += __m1; //we know proper offset due to [first1; left_bound_seq_1) < [first2; last2)
-        __par_backend::__parallel_invoke(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        __par_backend<__backend_tag>::__parallel_invoke(
+            ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first1; left_bound_seq_1)
             [=] {
                 __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1,
@@ -3372,8 +3377,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
     {
         auto __res_or = __result;
         __result += __m2; //we know proper offset due to [first2; left_bound_seq_2) < [first1; last1)
-        __par_backend::__parallel_invoke(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        __par_backend<__backend_tag>::__parallel_invoke(
+            ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first2; left_bound_seq_2)
             [=] {
                 __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first2,
@@ -3902,8 +3907,8 @@ __pattern_min_element(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
         return __first;
 
     return __internal::__except_handler([&]() {
-        return __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, /*identity*/ __last,
+        return __par_backend<__backend_tag>::__parallel_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, /*identity*/ __last,
             [=](_RandomAccessIterator __begin, _RandomAccessIterator __end,
                 _RandomAccessIterator __init) -> _RandomAccessIterator {
                 const _RandomAccessIterator __subresult =
@@ -3971,8 +3976,8 @@ __pattern_minmax_element(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
     return __internal::__except_handler([&]() {
         typedef ::std::pair<_RandomAccessIterator, _RandomAccessIterator> _Result;
 
-        return __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        return __par_backend<__backend_tag>::__parallel_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             /*identity*/ ::std::make_pair(__last, __last),
             [=, &__comp](_RandomAccessIterator __begin, _RandomAccessIterator __end, _Result __init) -> _Result {
                 const _Result __subresult = __internal::__brick_minmax_element(__begin, __end, __comp, _IsVector{});
@@ -4286,11 +4291,11 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
         //1. n >= size/2; there is enough memory to 'total' parallel copying
         if (__n >= __mid)
         {
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, __size,
-                                          [__first, __n](_DiffType __i, _DiffType __j) {
-                                              __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                                                  __first + __i, __first + __j, __first + __i - __n, _IsVector{});
-                                          });
+            __par_backend<__backend_tag>::__parallel_for(
+                ::std::forward<_ExecutionPolicy>(__exec), __n, __size, [__first, __n](_DiffType __i, _DiffType __j) {
+                    __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(__first + __i, __first + __j,
+                                                                                __first + __i - __n, _IsVector{});
+                });
         }
         else //2. n < size/2; there is not enough memory to parallel copying; doing parallel copying by n elements
         {
@@ -4298,11 +4303,11 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
             for (auto __k = __n; __k < __size; __k += __n)
             {
                 auto __end = ::std::min(__k + __n, __size);
-                __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __k, __end,
-                                              [__first, __n](_DiffType __i, _DiffType __j) {
-                                                  __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
-                                                      __first + __i, __first + __j, __first + __i - __n, _IsVector{});
-                                              });
+                __par_backend<__backend_tag>::__parallel_for(
+                    ::std::forward<_ExecutionPolicy>(__exec), __k, __end, [__first, __n](_DiffType __i, _DiffType __j) {
+                        __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(__first + __i, __first + __j,
+                                                                                    __first + __i - __n, _IsVector{});
+                    });
             }
         }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1324,7 +1324,7 @@ __pattern_copy_if(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(1) < __n)
     {
-        __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
         return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _DifferenceType __m{};
@@ -1443,7 +1443,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     _DifferenceType __n = __last - __first;
-    __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
+    oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
     // 1. find a first iterator that should be removed
     return __internal::__except_handler([&]() {
         bool* __mask = __mask_buf.get();
@@ -1480,7 +1480,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         __n -= __min;
         __first += __min;
 
-        __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n);
+        oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n);
         _Tp* __result = __buf.get();
         __mask += __min;
         _DifferenceType __m{};
@@ -1604,7 +1604,7 @@ __pattern_unique_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(2) < __n)
     {
-        __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
         if (_DifferenceType(2) < __n)
         {
             return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
@@ -1857,7 +1857,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
     auto __m = __middle - __first;
     if (__m <= __n / 2)
     {
-        __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n - __m);
+        oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n - __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
             __par_backend<__backend_tag>::__parallel_for(
@@ -1885,7 +1885,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
     }
     else
     {
-        __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __m);
+        oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
             __par_backend<__backend_tag>::__parallel_for(
@@ -2367,7 +2367,7 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(1) < __n)
     {
-        __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
         return __internal::__except_handler([&__exec, __n, __first, __out_true, __out_false, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _ReturnType __m{};
@@ -2591,7 +2591,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
         {
             typedef typename ::std::iterator_traits<_RandomAccessIterator1>::value_type _T1;
             typedef typename ::std::iterator_traits<_RandomAccessIterator2>::value_type _T2;
-            __par_backend_buffer<__backend_tag, _ExecutionPolicy, _T1> __buf(__exec, __n1);
+            oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, _T1> __buf(__exec, __n1);
             _T1* __r = __buf.get();
 
             __par_backend<__backend_tag>::__parallel_stable_sort(
@@ -3087,7 +3087,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     auto __n = __last - __first;
-    __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n);
+    oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n);
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
@@ -3218,7 +3218,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     const _DifferenceType __n1 = __last1 - __first1;
     const _DifferenceType __n2 = __last2 - __first2;
 
-    __par_backend_buffer<__backend_tag, _ExecutionPolicy, _T> __buf(__exec, __size_func(__n1, __n2));
+    oneapi::dpl::__par_backend_buffer<__backend_tag, _ExecutionPolicy, _T> __buf(__exec, __size_func(__n1, __n2));
 
     return __internal::__except_handler(
         [&__exec, __n1, __first1, __last1, __first2, __last2, __result, __comp, __size_func, __set_op, &__buf]() {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1443,7 +1443,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     _DifferenceType __n = __last - __first;
-    __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool>  __mask_buf(__exec, __n);
+    __par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
     // 1. find a first iterator that should be removed
     return __internal::__except_handler([&]() {
         bool* __mask = __mask_buf.get();
@@ -2591,7 +2591,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
         {
             typedef typename ::std::iterator_traits<_RandomAccessIterator1>::value_type _T1;
             typedef typename ::std::iterator_traits<_RandomAccessIterator2>::value_type _T2;
-            __par_backend_buffer<__backend_tag, _ExecutionPolicy, _T1 > __buf(__exec, __n1);
+            __par_backend_buffer<__backend_tag, _ExecutionPolicy, _T1> __buf(__exec, __n1);
             _T1* __r = __buf.get();
 
             __par_backend<__backend_tag>::__parallel_stable_sort(
@@ -3087,7 +3087,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     auto __n = __last - __first;
-    __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp > __buf(__exec, __n);
+    __par_backend_buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n);
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
@@ -3218,7 +3218,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     const _DifferenceType __n1 = __last1 - __first1;
     const _DifferenceType __n2 = __last2 - __first2;
 
-    __par_backend_buffer<__backend_tag, _ExecutionPolicy, _T > __buf(__exec, __size_func(__n1, __n2));
+    __par_backend_buffer<__backend_tag, _ExecutionPolicy, _T> __buf(__exec, __size_func(__n1, __n2));
 
     return __internal::__except_handler(
         [&__exec, __n1, __first1, __last1, __first2, __last2, __result, __comp, __size_func, __set_op, &__buf]() {

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -399,8 +399,8 @@ __pattern_for_loop_n(_ExecutionPolicy&& __exec, _Ip __first, _Size __n, _Functio
 
     using __backend_tag = typename oneapi::dpl::__internal::__parallel_tag<_IsVector>::__backend_tag;
     oneapi::dpl::__internal::__except_handler([&]() {
-        return __par_backend::__parallel_reduce(
-                   __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), _Size(0), __n, __identity,
+        return __par_backend<__backend_tag>::__parallel_reduce(
+                   ::std::forward<_ExecutionPolicy>(__exec), _Size(0), __n, __identity,
                    [__is_vector, __first, __f](_Size __i, _Size __j, __pack_type __value) {
                        const auto __subseq_start = __first + __i;
                        const auto __length = __j - __i;
@@ -435,8 +435,8 @@ __pattern_for_loop_n(_ExecutionPolicy&& __exec, _Ip __first, _Size __n, _Functio
 
     using __backend_tag = typename oneapi::dpl::__internal::__parallel_tag<_IsVector>::__backend_tag;
     oneapi::dpl::__internal::__except_handler([&]() {
-        return __par_backend::__parallel_reduce(
-                   __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), _Size(0), __n, __identity,
+        return __par_backend<__backend_tag>::__parallel_reduce(
+                   ::std::forward<_ExecutionPolicy>(__exec), _Size(0), __n, __identity,
                    [__is_vector, __first, __f, __stride](_Size __i, _Size __j, __pack_type __value) {
                        const auto __subseq_start = __first + __i * __stride;
                        const auto __length = __j - __i;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1021,7 +1021,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __last - __first);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __last - __first);
     auto __copy_first = __buf.get();
 
     auto __copy_last = __pattern_copy_if(__tag, __exec, __first, __last, __copy_first, __not_pred<_Predicate>{__pred});
@@ -1046,7 +1046,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __last - __first);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __last - __first);
     auto __copy_first = __buf.get();
     auto __copy_last = __pattern_unique_copy(__tag, __exec, __first, __last, __copy_first, __pred);
 
@@ -1224,7 +1224,7 @@ __pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __ex
     assert(__first < __middle && __middle < __last);
 
     auto __n = __last - __first;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __n);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __n);
     auto __copy_first = __buf.get();
     auto __copy_last = __copy_first + __n;
 
@@ -1315,8 +1315,8 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
 
     auto __n = __last - __first;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __true_buf(__exec, __n);
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __false_buf(__exec, __n);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __true_buf(__exec, __n);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __false_buf(__exec,
     auto __true_result = __true_buf.get();
     auto __false_result = __false_buf.get();
 
@@ -1522,8 +1522,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         // - create a temporary buffer and copy all the elements from the input buffer there
         // - run partial sort on the temporary buffer
         // - copy k elements from the temporary buffer to the output buffer.
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __in_size);
-
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __in_size);
         auto __buf_first = __buf.get();
 
         auto __buf_last = __pattern_walk2</*_IsSync=*/::std::false_type>(
@@ -1644,7 +1643,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
-    auto __temp_buf = oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _Tp>(__exec, __n);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _Tp>(__exec, __n);
 
     auto __temp_rng_w =
         oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::write>(__temp_buf.get_buffer());
@@ -1735,7 +1734,7 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _F
         __comp, __n1, __n2};
 
     // temporary buffer to store boolean mask
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);
 
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator1>();
@@ -1864,7 +1863,7 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     // temporary buffer to store intermediate result
     const auto __n2 = __last2 - __first2;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __diff(__exec, __n2);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __diff(__exec, __n2);
     auto __buf = __diff.get();
 
     //1. Calc difference {2} \ {1}
@@ -1945,10 +1944,10 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
 
     // temporary buffers to store intermediate result
     const auto __n1 = __last1 - __first1;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __diff_1(__exec, __n1);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __diff_1(__exec, __n1);
     auto __buf_1 = __diff_1.get();
     const auto __n2 = __last2 - __first2;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __diff_2(__exec, __n2);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __diff_2(__exec, __n2);
     auto __buf_2 = __diff_2.get();
 
     //1. Calc difference {1} \ {2}

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -354,7 +354,7 @@ __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range
     _DataAcc __get_data_op;
     _MaskAssigner __add_mask_op;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __rng1.size());
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, int32_t> __mask_buf(__exec, __rng1.size());
 
     auto __res =
         oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_scan_base(
@@ -408,7 +408,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
 
     auto __copy_last_id = __ranges::__pattern_copy_if(__tag, __exec, __rng, __copy_rng, __not_pred<_Predicate>{__pred},
@@ -457,7 +457,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto res_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
     auto res = __ranges::__pattern_unique_copy(__tag, __exec, __rng, res_rng, __pred,
                                                oneapi::dpl::__internal::__pstl_assign());
@@ -706,11 +706,12 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
     // Round 1: reduce with extra indices added to avoid long segments
     // TODO: At threshold points check if the key is equal to the key at the previous threshold point, indicating a long sequence.
     // Skip a round of copy_if and reduces if there are none.
-    auto __idx = oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n).get_buffer();
+    auto __idx =
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, __diff_type>(__exec, __n).get_buffer();
     auto __tmp_out_keys =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __key_type>(__exec, __n).get_buffer();
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, __key_type>(__exec, __n).get_buffer();
     auto __tmp_out_values =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __val_type>(__exec, __n).get_buffer();
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, __val_type>(__exec, __n).get_buffer();
 
     // Replicating first element of keys view to be able to compare (i-1)-th and (i)-th key with aligned sequences,
     //  dropping the last key for the i-1 sequence.

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -46,9 +46,9 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     if (__n > 0)
     {
-        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
-                                                          ::std::forward<_Ranges>(__rngs)...)
+        oneapi::dpl::__par_backend<_BackendTag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
+            ::std::forward<_Ranges>(__rngs)...)
             .wait();
     }
 }
@@ -105,8 +105,8 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
+    return !oneapi::dpl::__par_backend<_BackendTag>::__parallel_find_or(
+        ::std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
         oneapi::dpl::__par_backend_hetero::__parallel_or_tag{},
         oneapi::dpl::__ranges::zip_view(::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2)));
 }
@@ -126,8 +126,7 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&&
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_find_or(
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
         _Predicate{__pred}, _TagType{}, ::std::forward<_Range>(__rng));
@@ -156,8 +155,7 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
     using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_Range1>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_find_or(
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
         _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
@@ -180,8 +178,7 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
 
     //TODO: To check whether it makes sense to iterate over the second sequence in case of __rng1.size() < __rng2.size()
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_find_or(
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
         _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
@@ -199,8 +196,7 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& 
         return false;
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_find_or(
         __par_backend_hetero::make_wrapped_policy<oneapi::dpl::__par_backend_hetero::__or_policy_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
         _Predicate{__pred}, oneapi::dpl::__par_backend_hetero::__parallel_or_tag{}, ::std::forward<_Range>(__rng));
@@ -237,8 +233,7 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_find_or(
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<
             oneapi::dpl::__par_backend_hetero::__find_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
         _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
@@ -300,10 +295,9 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, _TagType{},
-        oneapi::dpl::__ranges::zip_view(__rng1, __rng2));
+    auto result = oneapi::dpl::__par_backend<_BackendTag>::__parallel_find_or(
+        ::std::forward<_ExecutionPolicy>(__exec), _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}},
+        _TagType{}, oneapi::dpl::__ranges::zip_view(__rng1, __rng2));
 
     // inverted conditional because of
     // reorder_predicate in glue_algorithm_impl.h
@@ -326,9 +320,9 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& _
         return (__predicate(__acc[__gidx]) ? 1 : 0);
     };
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
-                                                                          ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_reduce<
+               _ReduceValueType, ::std::true_type /*is_commutative*/>(
+               ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
                unseq_backend::__no_init_value{}, // no initial value
                ::std::forward<_Range>(__rng))
         .get();
@@ -363,8 +357,8 @@ __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __rng1.size());
 
     auto __res =
-        __par_backend_hetero::__parallel_transform_scan_base(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_scan_base(
+            ::std::forward<_ExecutionPolicy>(__exec),
             oneapi::dpl::__ranges::zip_view(
                 __rng1, oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
                             __mask_buf.get_buffer())),
@@ -521,9 +515,9 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ran
     }
     else
     {
-        __par_backend_hetero::__parallel_merge(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-                                               ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2),
-                                               ::std::forward<_Range3>(__rng3), __comp)
+        oneapi::dpl::__par_backend<_BackendTag>::__parallel_merge(
+            ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2),
+            ::std::forward<_Range3>(__rng3), __comp)
             .wait();
     }
 
@@ -539,8 +533,8 @@ void
 __pattern_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     if (__rng.size() >= 2)
-        __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-                                                     ::std::forward<_Range>(__rng), __comp, __proj)
+        oneapi::dpl::__par_backend<_BackendTag>::__parallel_stable_sort(
+            ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __comp, __proj)
             .wait();
 }
 
@@ -572,13 +566,12 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
     };
     auto __transform_fn = [](auto __gidx, auto __acc) { return _ReduceValueType{__gidx, __acc[__gidx]}; };
 
-    auto __ret_idx =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
-                                                                       ::std::false_type /*is_commutative*/>(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
-            unseq_backend::__no_init_value{}, // no initial value
-            ::std::forward<_Range>(__rng))
-            .get();
+    auto __ret_idx = oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_reduce<
+                         _ReduceValueType, ::std::false_type /*is_commutative*/>(
+                         ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+                         unseq_backend::__no_init_value{}, // no initial value
+                         ::std::forward<_Range>(__rng))
+                         .get();
 
     using ::std::get;
     return get<0>(__ret_idx);
@@ -623,13 +616,12 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
         return _ReduceValueType{__gidx, __gidx, __acc[__gidx], __acc[__gidx]};
     };
 
-    _ReduceValueType __ret =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
-                                                                       ::std::false_type /*is_commutative*/>(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
-            unseq_backend::__no_init_value{}, // no initial value
-            ::std::forward<_Range>(__rng))
-            .get();
+    _ReduceValueType __ret = oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_reduce<
+                                 _ReduceValueType, ::std::false_type /*is_commutative*/>(
+                                 ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+                                 unseq_backend::__no_init_value{}, // no initial value
+                                 ::std::forward<_Range>(__rng))
+                                 .get();
 
     using ::std::get;
     return ::std::make_pair(get<0>(__ret), get<1>(__ret));
@@ -753,8 +745,8 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         unseq_backend::__brick_assign_key_position{});
 
     //reduce by segment
-    oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce1_wrapper>(__exec),
+    oneapi::dpl::__par_backend<_BackendTag>::__parallel_for(
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce1_wrapper>(__exec),
         unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__n)>(__binary_op, __n), __intermediate_result_end,
         oneapi::dpl::__ranges::take_view_simple(experimental::ranges::views::all_read(__idx),
                                                 __intermediate_result_end),
@@ -794,8 +786,7 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         unseq_backend::__brick_assign_key_position{});
 
     //reduce by segment
-    oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{},
+    oneapi::dpl::__par_backend<_BackendTag>::__parallel_for(
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce2_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
         unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__intermediate_result_end)>(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -57,7 +57,7 @@ namespace dpl
 namespace __backend
 {
 template <>
-struct __backend_impl<oneapi::dpl::__internal::__device_backend_tag>
+struct __backend_impl<oneapi::dpl::__internal::__device_backend_tag>        // 15
 {
     // Tag for __parallel_find_or for or-semantic
     struct __parallel_or_tag
@@ -89,7 +89,7 @@ struct __backend_impl<oneapi::dpl::__internal::__device_backend_tag>
     static auto
     __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs);
 
-    // 3
+    // 2
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinaryOperation,
               typename _InitType, typename _LocalScan, typename _GroupScan, typename _GlobalScan>
     static auto
@@ -97,77 +97,78 @@ struct __backend_impl<oneapi::dpl::__internal::__device_backend_tag>
                                    _BinaryOperation __binary_op, _InitType __init, _LocalScan __local_scan,
                                    _GroupScan __group_scan, _GlobalScan __global_scan);
 
-    // 3.1
+    // 3
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation,
               typename _InitType, typename _BinaryOperation, typename _Inclusive>
     static auto
     __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __in_rng, _Range2&& __out_rng, ::std::size_t __n,
                               _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op, _Inclusive);
 
-    // 3.2
+    // 4
     template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _CreateMaskOp,
               typename _CopyByMaskOp>
     static auto
     __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n,
                          _CreateMaskOp __create_mask_op, _CopyByMaskOp __copy_by_mask_op);
 
+    // 5
     template <typename _Tp, typename _Commutative, typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp,
               typename _InitType, typename... _Ranges>
     static auto
     __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _TransformOp __transform_op,
                                 _InitType __init, _Ranges&&... __rngs);
 
-    // 3.3
+    // 6
     template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _Pred>
     static auto
     __parallel_copy_if(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _Pred __pred);
 
-    // 4
+    // 7
     template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
     static std::conditional_t<std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
                               oneapi::dpl::__internal::__difference_t<
                                   typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>
     __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs);
 
-    // 4.1
+    // 8
     template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Brick>
     static bool
     __parallel_or(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last, _Iterator2 __s_first,
                   _Iterator2 __s_last, _Brick __f);
 
-    // 4.2
+    // 9
     template <typename _ExecutionPolicy, typename _Iterator, typename _Brick>
     static bool
     __parallel_or(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f);
 
-    // 4.3
+    // 10
     template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Brick, typename _IsFirst>
     static _Iterator1
     __parallel_find(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last, _Iterator2 __s_first,
                     _Iterator2 __s_last, _Brick __f, _IsFirst);
 
-    // 4.4
+    // 11
     template <typename _ExecutionPolicy, typename _Iterator, typename _Brick, typename _IsFirst>
     static _Iterator
     __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f, _IsFirst);
 
-    // 5
+    // 12
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare>
     static auto
     __parallel_merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp);
 
-    // 10
+    // 13
     template <typename _ExecutionPolicy, typename _Event, typename _Range1, typename _Range2, typename _BinHashMgr>
     static auto
     __parallel_histogram(_ExecutionPolicy&& __exec, const _Event& __init_event, _Range1&& __input, _Range2&& __bins,
                          const _BinHashMgr& __binhash_manager);
 
-    // 11
+    // 14
     template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj>
     static auto
     __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare, _Proj __proj);
 
-    // 12
+    // 15
     template <typename _ExecutionPolicy, typename _Iterator, typename _Compare>
     static auto
     __parallel_partial_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __mid, _Iterator __last,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -981,7 +981,7 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
     _MaskAssigner __add_mask_op;
 
     // temporary buffer to store boolean mask
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n);
+    oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, int32_t> __mask_buf(__exec, __n);
 
     return __parallel_transform_scan_base(
         __backend_tag, ::std::forward<_ExecutionPolicy>(__exec),
@@ -1666,7 +1666,7 @@ struct __parallel_sort_submitter<_IdType, __internal::__optional_kernel_name<_Le
         });
 
         // 2. Merge sorting
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _Tp> __temp_buf(__exec, __n);
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _Tp> __temp_buf(__exec, __n);
         auto __temp = __temp_buf.get_buffer();
         bool __data_in_temp = false;
         _IdType __n_sorted = __leaf;
@@ -1788,7 +1788,7 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
         _Size __n = __rng.size();
         assert(__n > 1);
 
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _Tp> __temp_buf(__exec, __n);
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _Tp> __temp_buf(__exec, __n);
         auto __temp = __temp_buf.get_buffer();
         _PRINT_INFO_IN_DEBUG_MODE(__exec);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -44,9 +44,11 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<oneapi::dpl::__internal::__fpga_backend_tag>      // 2 + 15 (base)
-    : __backend_impl<oneapi::dpl::__internal::__device_backend_tag>
+struct __backend_impl<oneapi::dpl::__internal::__fpga_backend_tag> : __backend_impl<oneapi::dpl::__internal::__device_backend_tag>
 {
+    template <typename _ExecutionPolicy, typename _T>
+    using __buffer = oneapi::dpl::__backend::__device_backend_details::__internal::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _T>;
+
     template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
     static auto
     __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs);
@@ -57,7 +59,7 @@ struct __backend_impl<oneapi::dpl::__internal::__fpga_backend_tag>      // 2 + 1
                          const _BinHashMgr& __binhash_manager);
 };
 
-namespace __fpga_backend_detail
+namespace __fpga_backend_details
 {
 
 // Please see the comment for __parallel_for_submitter for optional kernel name explanation
@@ -91,7 +93,7 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
     }
 };
 
-} // namespace __fpga_backend_detail
+} // namespace __fpga_backend_details
 
 //------------------------------------------------------------------------
 // parallel_for
@@ -106,7 +108,7 @@ __backend_impl<oneapi::dpl::__internal::__fpga_backend_tag>::__parallel_for(_Exe
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using __parallel_for_name = __internal::__kernel_name_provider<_CustomName>;
 
-    return __fpga_backend_detail::__parallel_for_fpga_submitter<__parallel_for_name>()(
+    return __fpga_backend_details::__parallel_for_fpga_submitter<__parallel_for_name>()(
         std::forward<_ExecutionPolicy>(__exec), __brick, __count, std::forward<_Ranges>(__rngs)...);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -44,7 +44,7 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<oneapi::dpl::__internal::__fpga_backend_tag>
+struct __backend_impl<oneapi::dpl::__internal::__fpga_backend_tag>      // 2 + 15 (base)
     : __backend_impl<oneapi::dpl::__internal::__device_backend_tag>
 {
     template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -428,7 +428,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
 
         auto __private_histograms =
-            oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _bin_type>(__exec, __segments * __num_bins)
+            oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _bin_type>(__exec, __segments * __num_bins)
                 .get_buffer();
 
         return __exec.queue().submit([&](auto& __h) {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -829,7 +829,7 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
         sycl::buffer<::std::uint32_t, 1> __tmp_buf{sycl::range<1>(__tmp_buf_size)};
 
         // memory for storing values sorted for an iteration
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueT> __out_buffer_holder{__exec, __n};
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _ExecutionPolicy, _ValueT> __out_buffer_holder{__exec, __n};
         auto __out_rng = oneapi::dpl::__ranges::all_view<_ValueT, __par_backend_hetero::access_mode::read_write>(
             __out_buffer_holder.get_buffer());
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -759,8 +759,7 @@ struct __parallel_radix_sort_iteration
 //-----------------------------------------------------------------------
 template <bool __is_ascending, typename _Range, typename _ExecutionPolicy, typename _Proj>
 auto
-__parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range&& __in_rng,
-                      _Proj __proj)
+__parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj)
 {
     const ::std::size_t __n = __in_rng.size();
     assert(__n > 1);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -37,7 +37,7 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __par_backend_hetero
+namespace __device_backend_details
 {
 //------------------------------------------------------------------------
 // radix sort: bitwise order-preserving conversions to unsigned integrals
@@ -850,7 +850,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
     return __future(__event);
 }
 
-} // namespace __par_backend_hetero
+} // namespace __device_backend_details
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -23,7 +23,7 @@
 //{
 //namespace dpl
 //{
-//namespace __par_backend_hetero
+//namespace __device_backend_details
 //{
 
 template <typename... _Name>
@@ -310,7 +310,7 @@ struct __subgroup_radix_sort
     };
 };
 
-//} // namespace __par_backend_hetero
+//} // namespace __device_backend_details
 //} // namespace dpl
 //} // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -134,7 +134,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
               typename... _Ranges>
     auto
-    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, const _Size __n,
+    operator()(_ExecutionPolicy&& __exec, const _Size __n,
                const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs) const
     {
@@ -170,8 +170,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
 template <typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename _ExecutionPolicy, typename _Size,
           typename _ReduceOp, typename _TransformOp, typename _InitType, typename... _Ranges>
 auto
-__parallel_transform_reduce_small_impl(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
-                                       _ExecutionPolicy&& __exec, const _Size __n, const _Size __work_group_size,
+__parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, const _Size __n, const _Size __work_group_size,
                                        const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                                        _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
@@ -180,7 +179,7 @@ __parallel_transform_reduce_small_impl(oneapi::dpl::__internal::__device_backend
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__reduce_small_kernel<_CustomName>>;
 
     return __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize, _ReduceKernel>()(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size, __iters_per_work_item,
+        std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size, __iters_per_work_item,
         __reduce_op, __transform_op, __init, std::forward<_Ranges>(__rngs)...);
 }
 
@@ -197,7 +196,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp,
               typename _ExecutionPolicy2, typename... _Ranges>
     auto
-    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, const _Size __n,
+    operator()(_ExecutionPolicy&& __exec, const _Size __n,
                const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _TransformOp __transform_op, __result_and_scratch_storage<_ExecutionPolicy2, _Tp> __scratch_container,
                _Ranges&&... __rngs) const
@@ -244,7 +243,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _InitType,
               typename _ExecutionPolicy2>
     auto
-    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, sycl::event& __reduce_event,
+    operator()(_ExecutionPolicy&& __exec, sycl::event& __reduce_event,
                const _Size __n, const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _InitType __init, __result_and_scratch_storage<_ExecutionPolicy2, _Tp> __scratch_container) const
     {
@@ -285,8 +284,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
 template <typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename _ExecutionPolicy, typename _Size,
           typename _ReduceOp, typename _TransformOp, typename _InitType, typename... _Ranges>
 auto
-__parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
-                                     _ExecutionPolicy&& __exec, const _Size __n, const _Size __work_group_size,
+__parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, const _Size __n, const _Size __work_group_size,
                                      const _Size __iters_per_work_item_device_kernel,
                                      const _Size __iters_per_work_item_work_group_kernel, _ReduceOp __reduce_op,
                                      _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
@@ -304,7 +302,7 @@ __parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_t
 
     sycl::event __reduce_event =
         __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _VecSize, _ReduceDeviceKernel>()(
-            __backend_tag, __exec, __n, __work_group_size, __iters_per_work_item_device_kernel, __reduce_op,
+            __exec, __n, __work_group_size, __iters_per_work_item_device_kernel, __reduce_op,
             __transform_op, __scratch_container, std::forward<_Ranges>(__rngs)...);
 
     // __n_groups preliminary results from the device kernel.
@@ -321,7 +319,7 @@ struct __parallel_transform_reduce_impl
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
               typename... _Ranges>
     static auto
-    submit(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Size __n, _Size __work_group_size,
+    submit(_ExecutionPolicy&& __exec, _Size __n, _Size __work_group_size,
            const _Size __iters_per_work_item, _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init,
            _Ranges&&... __rngs)
     {
@@ -365,20 +363,20 @@ struct __parallel_transform_reduce_impl
         {
             __reduce_event = __exec.queue().submit([&, __is_first, __offset_1, __offset_2, __n,
                                                     __n_groups](sycl::handler& __cgh) {
-                __cgh.depends_on(__reduce_event);
-                auto __temp_acc = __scratch_container.__get_scratch_acc(__cgh);
-                auto __res_acc = __scratch_container.__get_result_acc(__cgh);
+                    __cgh.depends_on(__reduce_event);
+                    auto __temp_acc = __scratch_container.__get_scratch_acc(__cgh);
+                    auto __res_acc = __scratch_container.__get_result_acc(__cgh);
 
                 // get an access to data under SYCL buffer
                 oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
                 std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
                 __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
-                __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
+                    __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
-                __cgh.parallel_for<_ReduceKernel>(
+                    __cgh.parallel_for<_ReduceKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
-                    __kernel,
+                        __kernel,
 #endif
                     sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                       sycl::range<1>(__work_group_size)),
@@ -395,34 +393,34 @@ struct __parallel_transform_reduce_impl
                         _Size __n_items;
                         const bool __is_full = __n == __size_per_work_group * __n_groups;
                         __lazy_ctor_storage<_Tp> __result;
-                        if (__is_first)
-                        {
+                            if (__is_first)
+                            {
                             __transform_pattern1(__item_id, __n, __iters_per_work_item, /*global_offset*/ (_Size)0,
                                                  __is_full, __n_groups, __result, __rngs...);
                             __n_items = __transform_pattern1.output_size(__n, __work_group_size, __iters_per_work_item);
-                        }
-                        else
-                        {
+                            }
+                            else
+                            {
                             __transform_pattern2(__item_id, __n, __iters_per_work_item, __offset_2, __is_full,
                                                  __n_groups, __result, __temp_ptr);
                             __n_items = __transform_pattern2.output_size(__n, __work_group_size, __iters_per_work_item);
-                        }
-                        // 2. Reduce within work group using local memory
-                        __result.__v = __reduce_pattern(__item_id, __n_items, __result.__v, __temp_local);
-                        if (__local_idx == 0)
-                        {
-                            // final reduction
-                            if (__n_groups == 1)
-                            {
-                                __reduce_pattern.apply_init(__init, __result.__v);
-                                __res_ptr[0] = __result.__v;
                             }
+                            // 2. Reduce within work group using local memory
+                            __result.__v = __reduce_pattern(__item_id, __n_items, __result.__v, __temp_local);
+                            if (__local_idx == 0)
+                            {
+                                // final reduction
+                                if (__n_groups == 1)
+                                {
+                                    __reduce_pattern.apply_init(__init, __result.__v);
+                                    __res_ptr[0] = __result.__v;
+                                }
 
-                            __temp_ptr[__offset_1 + __group_idx] = __result.__v;
-                        }
-                        __result.__v.~_Tp();
-                    });
-            });
+                                __temp_ptr[__offset_1 + __group_idx] = __result.__v;
+                            }
+                            __result.__v.~_Tp();
+                        });
+                });
             __is_first = false;
             std::swap(__offset_1, __offset_2);
             __n = __n_groups;
@@ -432,6 +430,8 @@ struct __parallel_transform_reduce_impl
         return __future(__reduce_event, __scratch_container);
     }
 }; // struct __parallel_transform_reduce_impl
+
+} // namespace __par_backend_hetero
 
 // General version of parallel_transform_reduce.
 // The binary operator must be associative but commutativity is only required by some of the algorithms using
@@ -448,8 +448,11 @@ struct __parallel_transform_reduce_impl
 template <typename _Tp, typename _Commutative, typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp,
           typename _InitType, typename... _Ranges>
 auto
-__parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
-                            _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
+__backend_impl<oneapi::dpl::__internal::__device_backend_tag>::__parallel_transform_reduce(_ExecutionPolicy&& __exec,
+                                                                                           _ReduceOp __reduce_op,
+                                                                                           _TransformOp __transform_op,
+                                                                                           _InitType __init,
+                                                                                           _Ranges&&... __rngs)
 {
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     assert(__n > 0);
@@ -528,7 +531,6 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __back
         __reduce_op, __transform_op, __init, std::forward<_Ranges>(__rngs)...);
 }
 
-} // namespace __par_backend_hetero
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -32,7 +32,7 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __par_backend_hetero
+namespace __device_backend_details
 {
 
 template <typename... _Name>
@@ -431,7 +431,7 @@ struct __parallel_transform_reduce_impl
     }
 }; // struct __parallel_transform_reduce_impl
 
-} // namespace __par_backend_hetero
+} // namespace __device_backend_details
 
 // General version of parallel_transform_reduce.
 // The binary operator must be associative but commutativity is only required by some of the algorithms using

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -142,7 +142,7 @@ __kernel_sub_group_size(const _ExecutionPolicy& __policy, const sycl::kernel& __
 
 } // namespace __internal
 
-namespace __par_backend_hetero
+namespace __device_backend_details
 {
 
 // aliases for faster access to modes
@@ -449,9 +449,6 @@ struct __memobj_traits<_T*>
 };
 
 } // namespace __internal
-
-template <typename _ExecutionPolicy, typename _T>
-using __buffer = __internal::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _T>;
 
 template <typename T>
 struct __repacked_tuple
@@ -767,7 +764,7 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
     }
 };
 
-} // namespace __par_backend_hetero
+} // namespace __device_backend_details
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -33,7 +33,9 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __internal
+namespace __backend
+{
+namespace __device_backend_details
 {
 
 template <typename _BinHash>
@@ -101,7 +103,7 @@ __make_binhash_manager(_BinHash&& __bin_hash)
 
 template <typename _RandomAccessIterator>
 auto
-__make_binhash_manager(oneapi::dpl::__internal::__custom_boundary_binhash<_RandomAccessIterator>&& __bin_hash)
+__make_binhash_manager(__custom_boundary_binhash<_RandomAccessIterator>&& __bin_hash)
 {
     auto __buffer_lifetime_holder =
         oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read,
@@ -143,7 +145,7 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
         auto __fill_func = oneapi::dpl::__internal::fill_functor<_global_histogram_type>{_global_histogram_type{0}};
         //fill histogram bins with zeros
 
-        auto __init_event = __backend_impl<_BackendTag>::__parallel_for(
+        auto __event = __backend_impl<_BackendTag>::__parallel_for(
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__hist_fill_zeros_wrapper>(__exec),
             unseq_backend::walk_n<_ExecutionPolicy, decltype(__fill_func)>{__fill_func}, __num_bins, __bins);
 
@@ -169,7 +171,8 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
     }
 }
 
-} // namespace __internal
+} // namespace __device_backend_details
+} // namespace __backend
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -143,8 +143,8 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
         auto __fill_func = oneapi::dpl::__internal::fill_functor<_global_histogram_type>{_global_histogram_type{0}};
         //fill histogram bins with zeros
 
-        auto __init_event = oneapi::dpl::__par_backend_hetero::__parallel_for(
-            _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__hist_fill_zeros_wrapper>(__exec),
+        auto __init_event = __backend_impl<_BackendTag>::__parallel_for(
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__hist_fill_zeros_wrapper>(__exec),
             unseq_backend::walk_n<_ExecutionPolicy, decltype(__fill_func)>{__fill_func}, __num_bins, __bins);
 
         if (__n > 0)
@@ -157,8 +157,9 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
                                                         _RandomAccessIterator1>();
             auto __input_buf = __keep_input(__first, __last);
 
-            __parallel_histogram(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __init_event,
-                                 __input_buf.all_view(), ::std::move(__bins), __binhash_manager)
+            __backend_impl<_BackendTag>::__parallel_histogram(::std::forward<_ExecutionPolicy>(__exec), __init_event,
+                                                              __input_buf.all_view(), ::std::move(__bins),
+                                                              __binhash_manager)
                 .wait();
         }
         else

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -58,9 +58,9 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_reduce<
+               _RepackedTp, ::std::true_type /*is_commutative*/>(
+               ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                __buf1.all_view(), __buf2.all_view())
         .get();
@@ -86,9 +86,9 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_reduce<
+               _RepackedTp, ::std::true_type /*is_commutative*/>(
+               ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                __buf.all_view())
         .get();
@@ -144,9 +144,9 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
         auto __buf2 = __keep2(__result, __result + __n);
 
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n,
-            __unary_op, __init, __binary_op, _Inclusive{})
+        oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_scan(
+            ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n, __unary_op, __init,
+            __binary_op, _Inclusive{})
             .wait();
     }
     else
@@ -169,9 +169,8 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         auto __buf2 = __keep2(__first_tmp, __last_tmp);
 
         // Run main algorithm and save data into temporary buffer
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(_BackendTag{}, __policy, __buf1.all_view(),
-                                                                     __buf2.all_view(), __n, __unary_op, __init,
-                                                                     __binary_op, _Inclusive{})
+        oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_scan(
+            __policy, __buf1.all_view(), __buf2.all_view(), __n, __unary_op, __init, __binary_op, _Inclusive{})
             .wait();
 
         // Move data from temporary buffer into results
@@ -265,8 +264,8 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
 
         using _Function = unseq_backend::walk_adjacent_difference<_ExecutionPolicy, decltype(__fn)>;
 
-        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec, _Function{__fn}, __n,
-                                                          __buf1.all_view(), __buf2.all_view())
+        oneapi::dpl::__par_backend<_BackendTag>::__parallel_for(__exec, _Function{__fn}, __n,
+                                                                            __buf1.all_view(), __buf2.all_view())
             .wait();
     }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -162,7 +162,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         using _NewExecutionPolicy = decltype(__policy);
 
         // Create temporary buffer
-        oneapi::dpl::__par_backend_hetero::__buffer<_NewExecutionPolicy, _Type> __tmp_buf(__policy, __n);
+        oneapi::dpl::__par_backend_buffer<_BackendTag, _NewExecutionPolicy, _Type> __tmp_buf(__policy, __n);
         auto __first_tmp = __tmp_buf.get();
         auto __last_tmp = __first_tmp + __n;
         auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -49,9 +49,9 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _BinaryOperation2>;
     using _RepackedTp = oneapi::dpl::__par_backend_hetero::__repacked_tuple_t<_Tp>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_reduce<
+               _RepackedTp, ::std::true_type /*is_commutative*/>(
+               ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2))
         .get();
@@ -73,9 +73,9 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _UnaryOperation>;
     using _RepackedTp = oneapi::dpl::__par_backend_hetero::__repacked_tuple_t<_Tp>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
+    return oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_reduce<
+               _RepackedTp, ::std::true_type /*is_commutative*/>(
+               ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                ::std::forward<_Range>(__rng))
         .get();
@@ -105,9 +105,9 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     _NoAssign __no_assign_op;
     _NoOpFunctor __get_data_op;
 
-    oneapi::dpl::__par_backend_hetero::__parallel_transform_scan_base(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng1),
-        ::std::forward<_Range2>(__rng2), __binary_op, __init,
+    oneapi::dpl::__par_backend<_BackendTag>::__parallel_transform_scan_base(
+        ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2),
+        __binary_op, __init,
         // local scan
         unseq_backend::__scan<_Inclusive, _ExecutionPolicy, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner,
                               _NoOpFunctor, _InitType>{__binary_op, _UnaryFunctor{__unary_op}, __assign_op, __assign_op,

--- a/include/oneapi/dpl/pstl/histogram_binhash_utils.h
+++ b/include/oneapi/dpl/pstl/histogram_binhash_utils.h
@@ -27,7 +27,9 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __internal
+namespace __backend
+{
+namespace __device_backend_details
 {
 template <typename _T1, typename = void>
 struct __evenly_divided_binhash;
@@ -119,7 +121,8 @@ struct __custom_boundary_binhash
     }
 };
 
-} // end namespace __internal
+} // end namespace __device_backend_details
+} // end namespace __backend
 } // end namespace dpl
 } // end namespace oneapi
 

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -84,8 +84,8 @@ __pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
-        return __par_backend::__parallel_transform_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+        return __par_backend<__backend_tag>::__parallel_transform_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
             [__first1, __first2, __binary_op2](_RandomAccessIterator1 __i) mutable {
                 return __binary_op2(*__i, *(__first2 + (__i - __first1)));
             },
@@ -149,8 +149,8 @@ __pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
-        return __par_backend::__parallel_transform_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        return __par_backend<__backend_tag>::__parallel_transform_reduce(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             [__unary_op](_RandomAccessIterator __i) mutable { return __unary_op(*__i); }, __init, __binary_op,
             [__unary_op, __binary_op](_RandomAccessIterator __i, _RandomAccessIterator __j, _Tp __init) {
                 return __internal::__brick_transform_reduce(__i, __j, __init, __binary_op, __unary_op, _IsVector{});
@@ -262,8 +262,8 @@ __pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_transform_scan(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __last - __first,
+        __par_backend<__backend_tag>::__parallel_transform_scan(
+            ::std::forward<_ExecutionPolicy>(__exec), __last - __first,
             [__first, __unary_op](_DifferenceType __i) mutable { return __unary_op(__first[__i]); }, __init,
             __binary_op,
             [__first, __unary_op, __binary_op](_DifferenceType __i, _DifferenceType __j, _Tp __init) {
@@ -299,8 +299,8 @@ __pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
     }
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_strict_scan(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, __init,
+        __par_backend<__backend_tag>::__parallel_strict_scan(
+            ::std::forward<_ExecutionPolicy>(__exec), __n, __init,
             [__first, __unary_op, __binary_op, __result](_DifferenceType __i, _DifferenceType __len) {
                 return __internal::__brick_transform_scan(__first + __i, __first + (__i + __len), __result + __i,
                                                           __unary_op, _Tp{}, __binary_op, _Inclusive(), _IsVector{})
@@ -399,8 +399,8 @@ __pattern_adjacent_difference(__parallel_tag<_IsVector>, _ExecutionPolicy&& __ex
     *__d_first = *__first;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last - 1,
+        __par_backend<__backend_tag>::__parallel_for(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last - 1,
             [&__op, __d_first, __first](_RandomAccessIterator1 __b, _RandomAccessIterator1 __e) {
                 _RandomAccessIterator2 __d_b = __d_first + (__b - __first);
                 __internal::__brick_walk3(

--- a/include/oneapi/dpl/pstl/omp/parallel_for.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for.h
@@ -52,7 +52,7 @@ __parallel_for_body(_Index __first, _Index __last, _Fp __f)
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
 __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
-                                                                             _Index __last, _Fp __f)
+                                                                           _Index __last, _Fp __f)
 {
     if (omp_in_parallel())
     {

--- a/include/oneapi/dpl/pstl/omp/parallel_for.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for.h
@@ -24,23 +24,25 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __omp_backend
+namespace __backend
 {
-
+namespace __omp_backend_details
+{
 template <class _Index, class _Fp>
 void
 __parallel_for_body(_Index __first, _Index __last, _Fp __f)
 {
     // initial partition of the iteration space into chunks
-    auto __policy = oneapi::dpl::__omp_backend::__chunk_partitioner(__first, __last);
+    auto __policy = ::oneapi::dpl::__backend::__omp_backend_details::__chunk_partitioner(__first, __last);
 
     // To avoid over-subscription we use taskloop for the nested parallelism
     _PSTL_PRAGMA(omp taskloop untied mergeable)
     for (std::size_t __chunk = 0; __chunk < __policy.__n_chunks; ++__chunk)
     {
-        oneapi::dpl::__omp_backend::__process_chunk(__policy, __first, __chunk, __f);
+        ::oneapi::dpl::__backend::__omp_backend_details::__process_chunk(__policy, __first, __chunk, __f);
     }
 }
+} // namespace __omp_backend_details
 
 //------------------------------------------------------------------------
 // Notation:
@@ -49,24 +51,28 @@ __parallel_for_body(_Index __first, _Index __last, _Fp __f)
 
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
-__parallel_for(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f)
+__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
+                                                                             _Index __last, _Fp __f)
 {
     if (omp_in_parallel())
     {
         // we don't create a nested parallel region in an existing parallel
         // region: just create tasks
-        oneapi::dpl::__omp_backend::__parallel_for_body(__first, __last, __f);
+        oneapi::dpl::__backend::__omp_backend_details::__parallel_for_body(__first, __last, __f);
     }
     else
     {
         // in any case (nested or non-nested) one parallel region is created and
         // only one thread creates a set of tasks
         _PSTL_PRAGMA(omp parallel)
-        _PSTL_PRAGMA(omp single nowait) { oneapi::dpl::__omp_backend::__parallel_for_body(__first, __last, __f); }
+        _PSTL_PRAGMA(omp single nowait)
+        {
+            oneapi::dpl::__backend::__omp_backend_details::__parallel_for_body(__first, __last, __f);
+        }
     }
 }
 
-} // namespace __omp_backend
+} // namespace __backend
 } // namespace dpl
 } // namespace oneapi
 #endif // _ONEDPL_INTERNAL_OMP_PARALLEL_FOR_H

--- a/include/oneapi/dpl/pstl/omp/parallel_for.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for.h
@@ -51,7 +51,7 @@ __parallel_for_body(_Index __first, _Index __last, _Fp __f)
 
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
-__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
                                                                              _Index __last, _Fp __f)
 {
     if (omp_in_parallel())

--- a/include/oneapi/dpl/pstl/omp/parallel_for.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for.h
@@ -33,13 +33,13 @@ void
 __parallel_for_body(_Index __first, _Index __last, _Fp __f)
 {
     // initial partition of the iteration space into chunks
-    auto __policy = ::oneapi::dpl::__backend::__omp_backend_details::__chunk_partitioner(__first, __last);
+    auto __policy = __chunk_partitioner(__first, __last);
 
     // To avoid over-subscription we use taskloop for the nested parallelism
     _PSTL_PRAGMA(omp taskloop untied mergeable)
     for (std::size_t __chunk = 0; __chunk < __policy.__n_chunks; ++__chunk)
     {
-        ::oneapi::dpl::__backend::__omp_backend_details::__process_chunk(__policy, __first, __chunk, __f);
+        __process_chunk(__policy, __first, __chunk, __f);
     }
 }
 } // namespace __omp_backend_details
@@ -58,7 +58,7 @@ __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for(_Exec
     {
         // we don't create a nested parallel region in an existing parallel
         // region: just create tasks
-        oneapi::dpl::__backend::__omp_backend_details::__parallel_for_body(__first, __last, __f);
+        __omp_backend_details::__parallel_for_body(__first, __last, __f);
     }
     else
     {
@@ -67,7 +67,7 @@ __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for(_Exec
         _PSTL_PRAGMA(omp parallel)
         _PSTL_PRAGMA(omp single nowait)
         {
-            oneapi::dpl::__backend::__omp_backend_details::__parallel_for_body(__first, __last, __f);
+            __omp_backend_details::__parallel_for_body(__first, __last, __f);
         }
     }
 }

--- a/include/oneapi/dpl/pstl/omp/parallel_for_each.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for_each.h
@@ -46,7 +46,7 @@ __parallel_for_each_body(_ForwardIterator __first, _ForwardIterator __last, _Fp 
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
-__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
                                                                                   _ForwardIterator __first,
                                                                                   _ForwardIterator __last, _Fp __f)
 {

--- a/include/oneapi/dpl/pstl/omp/parallel_for_each.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for_each.h
@@ -22,9 +22,10 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __omp_backend
+namespace __backend
 {
-
+namespace __omp_backend_details
+{
 template <class _ForwardIterator, class _Fp>
 void
 __parallel_for_each_body(_ForwardIterator __first, _ForwardIterator __last, _Fp __f)
@@ -41,28 +42,33 @@ __parallel_for_each_body(_ForwardIterator __first, _ForwardIterator __last, _Fp 
         __f(*__iter);
     }
 }
+} // namespace __omp_backend_details
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
-__parallel_for_each(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _ForwardIterator __first,
-                    _ForwardIterator __last, _Fp __f)
+__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
+                                                                                  _ForwardIterator __first,
+                                                                                  _ForwardIterator __last, _Fp __f)
 {
     if (omp_in_parallel())
     {
         // we don't create a nested parallel region in an existing parallel
         // region: just create tasks
-        oneapi::dpl::__omp_backend::__parallel_for_each_body(__first, __last, __f);
+        oneapi::dpl::__backend::__omp_backend_details::__parallel_for_each_body(__first, __last, __f);
     }
     else
     {
         // in any case (nested or non-nested) one parallel region is created and
         // only one thread creates a set of tasks
         _PSTL_PRAGMA(omp parallel)
-        _PSTL_PRAGMA(omp single nowait) { oneapi::dpl::__omp_backend::__parallel_for_each_body(__first, __last, __f); }
+        _PSTL_PRAGMA(omp single nowait)
+        {
+            oneapi::dpl::__backend::__omp_backend_details::__parallel_for_each_body(__first, __last, __f);
+        }
     }
 }
 
-} // namespace __omp_backend
+} // namespace __backend
 } // namespace dpl
 } // namespace oneapi
 #endif // _ONEDPL_INTERNAL_OMP_PARALLEL_FOR_EACH_H

--- a/include/oneapi/dpl/pstl/omp/parallel_for_each.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for_each.h
@@ -47,8 +47,8 @@ __parallel_for_each_body(_ForwardIterator __first, _ForwardIterator __last, _Fp 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
 __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
-                                                                                  _ForwardIterator __first,
-                                                                                  _ForwardIterator __last, _Fp __f)
+                                                                                _ForwardIterator __first,
+                                                                                _ForwardIterator __last, _Fp __f)
 {
     if (omp_in_parallel())
     {

--- a/include/oneapi/dpl/pstl/omp/parallel_for_each.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for_each.h
@@ -54,7 +54,7 @@ __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for_each(
     {
         // we don't create a nested parallel region in an existing parallel
         // region: just create tasks
-        oneapi::dpl::__backend::__omp_backend_details::__parallel_for_each_body(__first, __last, __f);
+        __omp_backend_details::__parallel_for_each_body(__first, __last, __f);
     }
     else
     {
@@ -63,7 +63,7 @@ __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_for_each(
         _PSTL_PRAGMA(omp parallel)
         _PSTL_PRAGMA(omp single nowait)
         {
-            oneapi::dpl::__backend::__omp_backend_details::__parallel_for_each_body(__first, __last, __f);
+            __omp_backend_details::__parallel_for_each_body(__first, __last, __f);
         }
     }
 }

--- a/include/oneapi/dpl/pstl/omp/parallel_invoke.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_invoke.h
@@ -22,9 +22,10 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __omp_backend
+namespace __backend
 {
-
+namespace __omp_backend_details
+{
 template <typename _F1, typename _F2>
 void
 __parallel_invoke_body(_F1&& __f1, _F2&& __f2)
@@ -35,24 +36,28 @@ __parallel_invoke_body(_F1&& __f1, _F2&& __f2)
         _PSTL_PRAGMA(omp task untied mergeable) { std::forward<_F2>(__f2)(); }
     }
 }
+}
 
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
-__parallel_invoke(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _F1&& __f1, _F2&& __f2)
+__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
+                                                                                _F2&& __f2)
 {
     if (omp_in_parallel())
     {
-        oneapi::dpl::__omp_backend::__parallel_invoke_body(std::forward<_F1>(__f1), std::forward<_F2>(__f2));
+        oneapi::dpl::__backend::__omp_backend_details::__parallel_invoke_body(std::forward<_F1>(__f1),
+                                                                              std::forward<_F2>(__f2));
     }
     else
     {
         _PSTL_PRAGMA(omp parallel)
         _PSTL_PRAGMA(omp single nowait)
-        oneapi::dpl::__omp_backend::__parallel_invoke_body(std::forward<_F1>(__f1), std::forward<_F2>(__f2));
+        oneapi::dpl::__backend::__omp_backend_details::__parallel_invoke_body(std::forward<_F1>(__f1),
+                                                                              std::forward<_F2>(__f2));
     }
 }
 
-} // namespace __omp_backend
+} // namespace __backend
 } // namespace dpl
 } // namespace oneapi
 #endif // _ONEDPL_INTERNAL_OMP_PARALLEL_INVOKE_H

--- a/include/oneapi/dpl/pstl/omp/parallel_invoke.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_invoke.h
@@ -40,7 +40,7 @@ __parallel_invoke_body(_F1&& __f1, _F2&& __f2)
 
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
-__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
                                                                                 _F2&& __f2)
 {
     if (omp_in_parallel())

--- a/include/oneapi/dpl/pstl/omp/parallel_invoke.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_invoke.h
@@ -36,12 +36,12 @@ __parallel_invoke_body(_F1&& __f1, _F2&& __f2)
         _PSTL_PRAGMA(omp task untied mergeable) { std::forward<_F2>(__f2)(); }
     }
 }
-}
+} // namespace __omp_backend_details
 
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
 __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
-                                                                                _F2&& __f2)
+                                                                              _F2&& __f2)
 {
     if (omp_in_parallel())
     {

--- a/include/oneapi/dpl/pstl/omp/parallel_invoke.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_invoke.h
@@ -45,15 +45,13 @@ __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_invoke(_E
 {
     if (omp_in_parallel())
     {
-        oneapi::dpl::__backend::__omp_backend_details::__parallel_invoke_body(std::forward<_F1>(__f1),
-                                                                              std::forward<_F2>(__f2));
+        __omp_backend_details::__parallel_invoke_body(std::forward<_F1>(__f1), std::forward<_F2>(__f2));
     }
     else
     {
         _PSTL_PRAGMA(omp parallel)
         _PSTL_PRAGMA(omp single nowait)
-        oneapi::dpl::__backend::__omp_backend_details::__parallel_invoke_body(std::forward<_F1>(__f1),
-                                                                              std::forward<_F2>(__f2));
+        __omp_backend_details::__parallel_invoke_body(std::forward<_F1>(__f1), std::forward<_F2>(__f2));
     }
 }
 

--- a/include/oneapi/dpl/pstl/omp/parallel_merge.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_merge.h
@@ -73,7 +73,7 @@ __parallel_merge_body(std::size_t __size_x, std::size_t __size_y, _RandomAccessI
 template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
 void
-__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_merge(
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_merge(
     _ExecutionPolicy&& /*__exec*/, _RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe,
     _RandomAccessIterator2 __ys, _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs, _Compare __comp,
     _LeafMerge __leaf_merge)

--- a/include/oneapi/dpl/pstl/omp/parallel_merge.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_merge.h
@@ -58,13 +58,13 @@ __parallel_merge_body(std::size_t __size_x, std::size_t __size_y, _RandomAccessI
 
     _PSTL_PRAGMA(omp task untied mergeable default(none)
                      firstprivate(__xs, __xm, __ys, __ym, __zs, __comp, __leaf_merge))
-    oneapi::dpl::__backend::__omp_backend_details::__parallel_merge_body(__xm - __xs, __ym - __ys, __xs, __xm, __ys, __ym, __zs,
-                                                                 __comp, __leaf_merge);
+    oneapi::dpl::__backend::__omp_backend_details::__parallel_merge_body(__xm - __xs, __ym - __ys, __xs, __xm, __ys,
+                                                                         __ym, __zs, __comp, __leaf_merge);
 
     _PSTL_PRAGMA(omp task untied mergeable default(none)
                      firstprivate(__xm, __xe, __ym, __ye, __zm, __comp, __leaf_merge))
-    oneapi::dpl::__backend::__omp_backend_details::__parallel_merge_body(__xe - __xm, __ye - __ym, __xm, __xe, __ym, __ye, __zm,
-                                                                 __comp, __leaf_merge);
+    oneapi::dpl::__backend::__omp_backend_details::__parallel_merge_body(__xe - __xm, __ye - __ym, __xm, __xe, __ym,
+                                                                         __ye, __zm, __comp, __leaf_merge);
 
     _PSTL_PRAGMA(omp taskwait)
 }

--- a/include/oneapi/dpl/pstl/omp/parallel_merge.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_merge.h
@@ -34,7 +34,7 @@ __parallel_merge_body(std::size_t __size_x, std::size_t __size_y, _RandomAccessI
                       _RandomAccessIterator3 __zs, _Compare __comp, _LeafMerge __leaf_merge)
 {
 
-    if (__size_x + __size_y <= ::oneapi::dpl::__backend::__omp_backend_details::__default_chunk_size)
+    if (__size_x + __size_y <= __default_chunk_size)
     {
         __leaf_merge(__xs, __xe, __ys, __ye, __zs, __comp);
         return;
@@ -58,13 +58,11 @@ __parallel_merge_body(std::size_t __size_x, std::size_t __size_y, _RandomAccessI
 
     _PSTL_PRAGMA(omp task untied mergeable default(none)
                      firstprivate(__xs, __xm, __ys, __ym, __zs, __comp, __leaf_merge))
-    oneapi::dpl::__backend::__omp_backend_details::__parallel_merge_body(__xm - __xs, __ym - __ys, __xs, __xm, __ys,
-                                                                         __ym, __zs, __comp, __leaf_merge);
+    __parallel_merge_body(__xm - __xs, __ym - __ys, __xs, __xm, __ys, __ym, __zs, __comp, __leaf_merge);
 
     _PSTL_PRAGMA(omp task untied mergeable default(none)
                      firstprivate(__xm, __xe, __ym, __ye, __zm, __comp, __leaf_merge))
-    oneapi::dpl::__backend::__omp_backend_details::__parallel_merge_body(__xe - __xm, __ye - __ym, __xm, __xe, __ym,
-                                                                         __ye, __zm, __comp, __leaf_merge);
+    __parallel_merge_body(__xe - __xm, __ye - __ym, __xm, __xe, __ym, __ye, __zm, __comp, __leaf_merge);
 
     _PSTL_PRAGMA(omp taskwait)
 }
@@ -88,16 +86,16 @@ __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_merge(
 
     if (omp_in_parallel())
     {
-        oneapi::dpl::__backend::__omp_backend_details::__parallel_merge_body(__size_x, __size_y, __xs, __xe, __ys, __ye,
-                                                                             __zs, __comp, __leaf_merge);
+        __omp_backend_details::__parallel_merge_body(__size_x, __size_y, __xs, __xe, __ys, __ye, __zs, __comp,
+                                                     __leaf_merge);
     }
     else
     {
         _PSTL_PRAGMA(omp parallel)
         {
             _PSTL_PRAGMA(omp single nowait)
-            oneapi::dpl::__backend::__omp_backend_details::__parallel_merge_body(__size_x, __size_y, __xs, __xe, __ys,
-                                                                                 __ye, __zs, __comp, __leaf_merge);
+            __omp_backend_details::__parallel_merge_body(__size_x, __size_y, __xs, __xe, __ys, __ye, __zs, __comp,
+                                                         __leaf_merge);
         }
     }
 }

--- a/include/oneapi/dpl/pstl/omp/parallel_reduce.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_reduce.h
@@ -54,9 +54,11 @@ __parallel_reduce_body(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Value, typename _RealBody, typename _Reduction>
 _Value
-__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_reduce(
-    _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Value __identity,
-    _RealBody __real_body, _Reduction __reduction)
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_reduce(_ExecutionPolicy&&,
+                                                                              _RandomAccessIterator __first,
+                                                                              _RandomAccessIterator __last,
+                                                                              _Value __identity, _RealBody __real_body,
+                                                                              _Reduction __reduction)
 {
     // We don't create a nested parallel region in an existing parallel region:
     // just create tasks.

--- a/include/oneapi/dpl/pstl/omp/parallel_reduce.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_reduce.h
@@ -22,9 +22,10 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __omp_backend
+namespace __backend
 {
-
+namespace __omp_backend_details
+{
 template <class _RandomAccessIterator, class _Value, typename _RealBody, typename _Reduction>
 _Value
 __parallel_reduce_body(_RandomAccessIterator __first, _RandomAccessIterator __last, _Value __identity,
@@ -43,6 +44,7 @@ __parallel_reduce_body(_RandomAccessIterator __first, _RandomAccessIterator __la
 
     return __reduce(__v1, __v2);
 }
+} // namespace __omp_backend_details
 
 //------------------------------------------------------------------------
 // Notation:
@@ -52,15 +54,16 @@ __parallel_reduce_body(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Value, typename _RealBody, typename _Reduction>
 _Value
-__parallel_reduce(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _RandomAccessIterator __first,
-                  _RandomAccessIterator __last, _Value __identity, _RealBody __real_body, _Reduction __reduction)
+__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_reduce(
+    _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Value __identity,
+    _RealBody __real_body, _Reduction __reduction)
 {
     // We don't create a nested parallel region in an existing parallel region:
     // just create tasks.
     if (omp_in_parallel())
     {
-        return oneapi::dpl::__omp_backend::__parallel_reduce_body(__first, __last, __identity, __real_body,
-                                                                  __reduction);
+        return oneapi::dpl::__backend::__omp_backend_details::__parallel_reduce_body(__first, __last, __identity,
+                                                                                     __real_body, __reduction);
     }
 
     // In any case (nested or non-nested) one parallel region is created and only
@@ -70,14 +73,14 @@ __parallel_reduce(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&
     _PSTL_PRAGMA(omp parallel)
     _PSTL_PRAGMA(omp single nowait)
     {
-        __res =
-            oneapi::dpl::__omp_backend::__parallel_reduce_body(__first, __last, __identity, __real_body, __reduction);
+        __res = oneapi::dpl::__backend::__omp_backend_details::__parallel_reduce_body(__first, __last, __identity,
+                                                                                      __real_body, __reduction);
     }
 
     return __res;
 }
 
-} // namespace __omp_backend
+} // namespace __backend
 } // namespace dpl
 } // namespace oneapi
 #endif // _ONEDPL_INTERNAL_OMP_PARALLEL_REDUCE_H

--- a/include/oneapi/dpl/pstl/omp/parallel_reduce.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_reduce.h
@@ -54,7 +54,7 @@ __parallel_reduce_body(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Value, typename _RealBody, typename _Reduction>
 _Value
-__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_reduce(
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_reduce(
     _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Value __identity,
     _RealBody __real_body, _Reduction __reduction)
 {

--- a/include/oneapi/dpl/pstl/omp/parallel_reduce.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_reduce.h
@@ -64,8 +64,7 @@ __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_reduce(_E
     // just create tasks.
     if (omp_in_parallel())
     {
-        return oneapi::dpl::__backend::__omp_backend_details::__parallel_reduce_body(__first, __last, __identity,
-                                                                                     __real_body, __reduction);
+        return __omp_backend_details::__parallel_reduce_body(__first, __last, __identity, __real_body, __reduction);
     }
 
     // In any case (nested or non-nested) one parallel region is created and only
@@ -75,8 +74,7 @@ __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_reduce(_E
     _PSTL_PRAGMA(omp parallel)
     _PSTL_PRAGMA(omp single nowait)
     {
-        __res = oneapi::dpl::__backend::__omp_backend_details::__parallel_reduce_body(__first, __last, __identity,
-                                                                                      __real_body, __reduction);
+        __res = __omp_backend_details::__parallel_reduce_body(__first, __last, __identity, __real_body, __reduction);
     }
 
     return __res;

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -48,12 +48,12 @@ __upsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsize
         _Index __k = __split(__m);
         oneapi::dpl::__backend::__omp_backend_details::__parallel_invoke_body(
             [=] {
-                oneapi::dpl::__backend::__omp_backend_details::__upsweep(__i, __k, __tilesize, __r, __tilesize, __reduce,
-                                                                 __combine);
+                oneapi::dpl::__backend::__omp_backend_details::__upsweep(__i, __k, __tilesize, __r, __tilesize,
+                                                                         __reduce, __combine);
             },
             [=] {
                 oneapi::dpl::__backend::__omp_backend_details::__upsweep(__i + __k, __m - __k, __tilesize, __r + __k,
-                                                                 __lastsize, __reduce, __combine);
+                                                                         __lastsize, __reduce, __combine);
             });
         if (__m == 2 * __k)
             __r[__m - 1] = __combine(__r[__k - 1], __r[__m - 1]);
@@ -72,15 +72,15 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
         const _Index __k = __split(__m);
         oneapi::dpl::__backend::__omp_backend_details::__parallel_invoke_body(
             [=] {
-                oneapi::dpl::__backend::__omp_backend_details::__downsweep(__i, __k, __tilesize, __r, __tilesize, __initial,
-                                                                   __combine, __scan);
+                oneapi::dpl::__backend::__omp_backend_details::__downsweep(__i, __k, __tilesize, __r, __tilesize,
+                                                                           __initial, __combine, __scan);
             },
             // Assumes that __combine never throws.
             // TODO: Consider adding a requirement for user functors to be constant.
             [=, &__combine] {
-                oneapi::dpl::__backend::__omp_backend_details::__downsweep(__i + __k, __m - __k, __tilesize, __r + __k,
-                                                                   __lastsize, __combine(__initial, __r[__k - 1]),
-                                                                   __combine, __scan);
+                oneapi::dpl::__backend::__omp_backend_details::__downsweep(
+                    __i + __k, __m - __k, __tilesize, __r + __k, __lastsize, __combine(__initial, __r[__k - 1]),
+                    __combine, __scan);
             });
     }
 }
@@ -95,13 +95,12 @@ __parallel_strict_scan_body(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial
     const _Index __slack = 4;
     _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
     _Index __m = (__n - 1) / __tilesize;
-    oneapi::dpl::__backend::__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__buffer<_ExecutionPolicy,
-                                                                                                   _Tp>
+    oneapi::dpl::__backend::__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__buffer<_ExecutionPolicy, _Tp>
         __buf(::std::forward<_ExecutionPolicy>(__exec), __m + 1);
     _Tp* __r = __buf.get();
 
     oneapi::dpl::__backend::__omp_backend_details::__upsweep(_Index(0), _Index(__m + 1), __tilesize, __r,
-                                                     __n - __m * __tilesize, __reduce, __combine);
+                                                             __n - __m * __tilesize, __reduce, __combine);
 
     std::size_t __k = __m + 1;
     _Tp __t = __r[__k - 1];
@@ -112,16 +111,16 @@ __parallel_strict_scan_body(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial
 
     __apex(__combine(__initial, __t));
     oneapi::dpl::__backend::__omp_backend_details::__downsweep(_Index(0), _Index(__m + 1), __tilesize, __r,
-                                                       __n - __m * __tilesize, __initial, __combine, __scan);
+                                                               __n - __m * __tilesize, __initial, __combine, __scan);
 }
 } // namespace __omp_backend_details
 
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
 __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&& __exec,
-                                                                                     _Index __n, _Tp __initial,
-                                                                                     _Rp __reduce, _Cp __combine,
-                                                                                     _Sp __scan, _Ap __apex)
+                                                                                   _Index __n, _Tp __initial,
+                                                                                   _Rp __reduce, _Cp __combine,
+                                                                                   _Sp __scan, _Ap __apex)
 {
     if (__n <= ::oneapi::dpl::__backend::__omp_backend_details::__default_chunk_size)
     {

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -95,7 +95,7 @@ __parallel_strict_scan_body(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial
     const _Index __slack = 4;
     _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
     _Index __m = (__n - 1) / __tilesize;
-    oneapi::dpl::__backend::__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__buffer<_ExecutionPolicy,
+    oneapi::dpl::__backend::__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__buffer<_ExecutionPolicy,
                                                                                                    _Tp>
         __buf(::std::forward<_ExecutionPolicy>(__exec), __m + 1);
     _Tp* __r = __buf.get();
@@ -118,7 +118,7 @@ __parallel_strict_scan_body(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial
 
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
-__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&& __exec,
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&& __exec,
                                                                                      _Index __n, _Tp __initial,
                                                                                      _Rp __reduce, _Cp __combine,
                                                                                      _Sp __scan, _Ap __apex)

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -85,8 +85,8 @@ __parallel_strict_scan_body(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial
     const _Index __slack = 4;
     _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
     _Index __m = (__n - 1) / __tilesize;
-    oneapi::dpl::__backend::__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__buffer<_ExecutionPolicy, _Tp>
-        __buf(::std::forward<_ExecutionPolicy>(__exec), __m + 1);
+    oneapi::dpl::__par_backend_buffer<oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy, _Tp> __buf(
+        ::std::forward<_ExecutionPolicy>(__exec), __m + 1);
     _Tp* __r = __buf.get();
 
     __upsweep(_Index(0), _Index(__m + 1), __tilesize, __r, __n - __m * __tilesize, __reduce, __combine);

--- a/include/oneapi/dpl/pstl/omp/parallel_stable_partial_sort.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_stable_partial_sort.h
@@ -22,7 +22,9 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __omp_backend
+namespace __backend
+{
+namespace __omp_backend_details
 {
 
 template <typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
@@ -34,7 +36,8 @@ __parallel_stable_partial_sort(_RandomAccessIterator __xs, _RandomAccessIterator
     __leaf_sort(__xs, __xe, __comp);
 }
 
-} // namespace __omp_backend
+} // namespace __omp_backend_details
+} // namespace __backend
 } // namespace dpl
 } // namespace oneapi
 #endif // _ONEDPL_INTERNAL_OMP_PARALLEL_STABLE_PARTIAL_SORT_H

--- a/include/oneapi/dpl/pstl/omp/parallel_stable_sort.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_stable_sort.h
@@ -59,12 +59,12 @@ __parallel_move_range(_RandomAccessIterator __first1, _RandomAccessIterator __la
     _PSTL_PRAGMA(omp taskloop)
     for (std::size_t __chunk = 0; __chunk < __policy.__n_chunks; ++__chunk)
     {
-        oneapi::dpl::__backend::__omp_backend_details::__process_chunk(__policy, __first1, __chunk,
-                                                               [&](auto __chunk_first, auto __chunk_last) {
-                                                                   auto __chunk_offset = __chunk_first - __first1;
-                                                                   auto __output_it = __d_first + __chunk_offset;
-                                                                   std::move(__chunk_first, __chunk_last, __output_it);
-                                                               });
+        oneapi::dpl::__backend::__omp_backend_details::__process_chunk(
+            __policy, __first1, __chunk, [&](auto __chunk_first, auto __chunk_last) {
+                auto __chunk_offset = __chunk_first - __first1;
+                auto __output_it = __d_first + __chunk_offset;
+                std::move(__chunk_first, __chunk_last, __output_it);
+            });
     }
 
     return __d_first + __size;
@@ -77,7 +77,7 @@ struct __move_range
     operator()(_RandomAccessIterator __first1, _RandomAccessIterator __last1, _OutputIterator __d_first) const
     {
         return oneapi::dpl::__backend::__omp_backend_details::__sort_details::__parallel_move_range(__first1, __last1,
-                                                                                            __d_first);
+                                                                                                    __d_first);
     }
 };
 } // namespace __sort_details
@@ -120,7 +120,7 @@ __parallel_stable_sort_body(_RandomAccessIterator __xs, _RandomAccessIterator __
 
         // Move the values from __output_data back in the original source range.
         oneapi::dpl::__backend::__omp_backend_details::__sort_details::__parallel_move_range(__output_data.begin(),
-                                                                                     __output_data.end(), __xs);
+                                                                                             __output_data.end(), __xs);
     }
 }
 } // namespace __omp_backend_details

--- a/include/oneapi/dpl/pstl/omp/parallel_stable_sort.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_stable_sort.h
@@ -127,7 +127,7 @@ __parallel_stable_sort_body(_RandomAccessIterator __xs, _RandomAccessIterator __
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
 void
-__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_stable_sort(
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_stable_sort(
     _ExecutionPolicy&& /*__exec*/, _RandomAccessIterator __xs, _RandomAccessIterator __xe, _Compare __comp,
     _LeafSort __leaf_sort, std::size_t __nsort /*= 0*/)
 {

--- a/include/oneapi/dpl/pstl/omp/parallel_transform_reduce.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_transform_reduce.h
@@ -88,7 +88,7 @@ __transform_reduce_body(_RandomAccessIterator __first, _RandomAccessIterator __l
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryOp, class _Value, class _Combiner,
           class _Reduction>
 _Value
-__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_transform_reduce(
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_transform_reduce(
     _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _UnaryOp __unary_op, _Value __init,
     _Combiner __combiner, _Reduction __reduction)
 {

--- a/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
@@ -22,19 +22,22 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __omp_backend
+namespace __backend
 {
 
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
 _Tp
-__parallel_transform_scan(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _Index __n, _Up /* __u */,
-                          _Tp __init, _Cp /* __combine */, _Rp /* __brick_reduce */, _Sp __scan)
+__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&, _Index __n,
+                                                                                        _Up /* __u */, _Tp __init,
+                                                                                        _Cp /* __combine */,
+                                                                                        _Rp /* __brick_reduce */,
+                                                                                        _Sp __scan)
 {
     // TODO: parallelize this function.
     return __scan(_Index(0), __n, __init);
 }
 
-} // namespace __omp_backend
+} // namespace __backend
 } // namespace dpl
 } // namespace oneapi
 #endif // _ONEDPL_INTERNAL_OMP_PARALLEL_TRANSFORM_SCAN_H

--- a/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
@@ -27,7 +27,7 @@ namespace __backend
 
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
 _Tp
-__backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&, _Index __n,
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&, _Index __n,
                                                                                         _Up /* __u */, _Tp __init,
                                                                                         _Cp /* __combine */,
                                                                                         _Rp /* __brick_reduce */,

--- a/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
@@ -28,10 +28,10 @@ namespace __backend
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
 _Tp
 __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&, _Index __n,
-                                                                                        _Up /* __u */, _Tp __init,
-                                                                                        _Cp /* __combine */,
-                                                                                        _Rp /* __brick_reduce */,
-                                                                                        _Sp __scan)
+                                                                                      _Up /* __u */, _Tp __init,
+                                                                                      _Cp /* __combine */,
+                                                                                      _Rp /* __brick_reduce */,
+                                                                                      _Sp __scan)
 {
     // TODO: parallelize this function.
     return __scan(_Index(0), __n, __init);

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -41,24 +41,10 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __omp_backend
+namespace __backend
 {
-
-//------------------------------------------------------------------------
-// use to cancel execution
-//------------------------------------------------------------------------
-inline void
-__cancel_execution(oneapi::dpl::__internal::__omp_backend_tag)
+namespace __omp_backend_details
 {
-    // TODO: Figure out how to make cancellation work.
-}
-
-//------------------------------------------------------------------------
-// raw buffer
-//------------------------------------------------------------------------
-
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
 // Preliminary size of each chunk: requires further discussion
 constexpr std::size_t __default_chunk_size = 2048;
@@ -153,7 +139,8 @@ __process_chunk(const __chunk_metrics& __metrics, _Iterator __base, _Index __chu
     __f(__first, __last);
 }
 
-} // namespace __omp_backend
+} // namespace __omp_backend_details
+} // namespace __backend
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -19,13 +19,10 @@
 // Select a parallel backend
 #if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND && _ONEDPL_TBB_AVAILABLE)
 #    define _ONEDPL_PAR_BACKEND_TBB 1
-#    include "parallel_backend_tbb.h"
 #elif ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && _ONEDPL_OPENMP_AVAILABLE)
 #    define _ONEDPL_PAR_BACKEND_OPENMP 1
-#    include "parallel_backend_omp.h"
 #else
 #    define _ONEDPL_PAR_BACKEND_SERIAL 1
-#    include "parallel_backend_serial.h"
 #endif
 
 namespace oneapi
@@ -42,6 +39,10 @@ struct __backend_impl;
 } // namespace __backend
 } // namespace dpl
 } // namespace oneapi
+
+#include "parallel_backend_serial.h"
+#include "parallel_backend_tbb.h"
+#include "parallel_backend_omp.h"
 
 #if _ONEDPL_BACKEND_SYCL
 #    include "hetero/dpcpp/parallel_backend_sycl.h"

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -64,7 +64,7 @@ using __par_backend = oneapi::dpl::__backend::__backend_impl<__backend_tag>;
 template <typename __backend_tag, typename _ExecutionPolicy, typename _Tp>
 using __par_backend_buffer = typename __par_backend<__backend_tag>::template __buffer<_ExecutionPolicy, _Tp>;
 
-} // __internal
+} // namespace __internal
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -54,15 +54,16 @@ namespace oneapi
 {
 namespace dpl
 {
-#if _ONEDPL_PAR_BACKEND_TBB
-namespace __par_backend = __tbb_backend;
-#elif _ONEDPL_PAR_BACKEND_OPENMP
-namespace __par_backend = __omp_backend;
-#elif _ONEDPL_PAR_BACKEND_SERIAL
-namespace __par_backend = __serial_backend;
-#else
-#    error "Parallel backend was not specified"
-#endif
+namespace __internal
+{
+
+template <typename __backend_tag>
+using __par_backend = oneapi::dpl::__backend::__backend_impl<__backend_tag>;
+
+template <typename __backend_tag, typename _ExecutionPolicy, typename _Tp>
+using __par_backend_buffer = typename __par_backend<__backend_tag>::template __buffer<_ExecutionPolicy, _Tp>;
+
+} // __internal
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -28,6 +28,21 @@
 #    include "parallel_backend_serial.h"
 #endif
 
+namespace oneapi
+{
+namespace dpl
+{
+namespace __backend
+{
+
+// Template for backend implementations
+template <typename __backend_tag>
+struct __backend_impl;
+
+} // namespace __backend
+} // namespace dpl
+} // namespace oneapi
+
 #if _ONEDPL_BACKEND_SYCL
 #    include "hetero/dpcpp/parallel_backend_sycl.h"
 #    if _ONEDPL_FPGA_DEVICE

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -55,8 +55,6 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __internal
-{
 
 template <typename __backend_tag>
 using __par_backend = oneapi::dpl::__backend::__backend_impl<__backend_tag>;
@@ -64,7 +62,6 @@ using __par_backend = oneapi::dpl::__backend::__backend_impl<__backend_tag>;
 template <typename __backend_tag, typename _ExecutionPolicy, typename _Tp>
 using __par_backend_buffer = typename __par_backend<__backend_tag>::template __buffer<_ExecutionPolicy, _Tp>;
 
-} // namespace __internal
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/parallel_backend_omp.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_omp.h
@@ -18,6 +18,79 @@
 #ifndef _ONEDPL_PARALLEL_BACKEND_OMP_H
 #define _ONEDPL_PARALLEL_BACKEND_OMP_H
 
+#include "execution_defs.h"
+
+namespace oneapi
+{
+namespace dpl
+{
+namespace __backend
+{
+
+template <>
+struct __backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>
+{
+    template <typename _ExecutionPolicy, typename _Tp>
+    using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
+
+    static void
+    __cancel_execution()
+    {
+        // TODO: Figure out how to make cancellation work.
+    }
+
+    template <class _ExecutionPolicy, class _Index, class _Fp>
+    static void
+    __parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f);
+
+    template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
+    static void
+    __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Fp __f);
+
+    template <class _ExecutionPolicy, typename _F1, typename _F2>
+    static void
+    __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2);
+
+    template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
+              typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
+    static void
+    __parallel_merge(_ExecutionPolicy&& /*__exec*/, _RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe,
+                     _RandomAccessIterator2 __ys, _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs,
+                     _Compare __comp, _LeafMerge __leaf_merge);
+
+    template <class _ExecutionPolicy, class _RandomAccessIterator, class _Value, typename _RealBody,
+              typename _Reduction>
+    static _Value
+    __parallel_reduce(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                      _Value __identity, _RealBody __real_body, _Reduction __reduction);
+
+    template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp,
+              typename _Ap>
+    static void
+    __parallel_strict_scan(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine,
+                           _Sp __scan, _Ap __apex);
+
+    template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
+    static void
+    __parallel_stable_sort(_ExecutionPolicy&& /*__exec*/, _RandomAccessIterator __xs, _RandomAccessIterator __xe,
+                           _Compare __comp, _LeafSort __leaf_sort, std::size_t __nsort = 0);
+
+    template <class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryOp, class _Value, class _Combiner,
+              class _Reduction>
+    static _Value
+    __parallel_transform_reduce(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                                _UnaryOp __unary_op, _Value __init, _Combiner __combiner, _Reduction __reduction);
+
+    template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
+    static _Tp
+    __parallel_transform_scan(_ExecutionPolicy&&, _Index __n, _Up /* __u */, _Tp __init, _Cp /* __combine */,
+                              _Rp /* __brick_reduce */, _Sp __scan);
+};
+
+} // namespace __backend
+} // namespace dpl
+} // namespace oneapi
+
 //------------------------------------------------------------------------
 // parallel_invoke
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/parallel_backend_omp.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_omp.h
@@ -28,7 +28,7 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<::oneapi::dpl::__internal::__omp_backend_tag>
+struct __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>
 {
     template <typename _ExecutionPolicy, typename _Tp>
     using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;

--- a/include/oneapi/dpl/pstl/parallel_backend_omp.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_omp.h
@@ -28,29 +28,34 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>
+struct __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>       // 10
 {
     template <typename _ExecutionPolicy, typename _Tp>
     using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
+    // 1
     static void
     __cancel_execution()
     {
         // TODO: Figure out how to make cancellation work.
     }
 
+    // 2
     template <class _ExecutionPolicy, class _Index, class _Fp>
     static void
     __parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f);
 
+    // 3
     template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
     static void
     __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Fp __f);
 
+    // 4
     template <class _ExecutionPolicy, typename _F1, typename _F2>
     static void
     __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2);
 
+    // 5
     template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
               typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
     static void
@@ -58,29 +63,34 @@ struct __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>
                      _RandomAccessIterator2 __ys, _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs,
                      _Compare __comp, _LeafMerge __leaf_merge);
 
+    // 6
     template <class _ExecutionPolicy, class _RandomAccessIterator, class _Value, typename _RealBody,
               typename _Reduction>
     static _Value
     __parallel_reduce(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
                       _Value __identity, _RealBody __real_body, _Reduction __reduction);
 
+    // 7
     template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp,
               typename _Ap>
     static void
     __parallel_strict_scan(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine,
                            _Sp __scan, _Ap __apex);
 
+    // 8
     template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
     static void
     __parallel_stable_sort(_ExecutionPolicy&& /*__exec*/, _RandomAccessIterator __xs, _RandomAccessIterator __xe,
                            _Compare __comp, _LeafSort __leaf_sort, std::size_t __nsort = 0);
 
+    // 9
     template <class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryOp, class _Value, class _Combiner,
               class _Reduction>
     static _Value
     __parallel_transform_reduce(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
                                 _UnaryOp __unary_op, _Value __init, _Combiner __combiner, _Reduction __reduction);
 
+    // 10
     template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
     static _Tp
     __parallel_transform_scan(_ExecutionPolicy&&, _Index __n, _Up /* __u */, _Tp __init, _Cp /* __combine */,

--- a/include/oneapi/dpl/pstl/parallel_backend_omp.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_omp.h
@@ -28,34 +28,26 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>       // 10
+struct __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>
 {
     template <typename _ExecutionPolicy, typename _Tp>
     using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
-    // 1
     static void
-    __cancel_execution()
-    {
-        // TODO: Figure out how to make cancellation work.
-    }
+    __cancel_execution();
 
-    // 2
     template <class _ExecutionPolicy, class _Index, class _Fp>
     static void
     __parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f);
 
-    // 3
     template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
     static void
     __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Fp __f);
 
-    // 4
     template <class _ExecutionPolicy, typename _F1, typename _F2>
     static void
     __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2);
 
-    // 5
     template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
               typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
     static void
@@ -63,39 +55,40 @@ struct __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>       // 10
                      _RandomAccessIterator2 __ys, _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs,
                      _Compare __comp, _LeafMerge __leaf_merge);
 
-    // 6
     template <class _ExecutionPolicy, class _RandomAccessIterator, class _Value, typename _RealBody,
               typename _Reduction>
     static _Value
     __parallel_reduce(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
                       _Value __identity, _RealBody __real_body, _Reduction __reduction);
 
-    // 7
     template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp,
               typename _Ap>
     static void
     __parallel_strict_scan(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine,
                            _Sp __scan, _Ap __apex);
 
-    // 8
     template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
     static void
     __parallel_stable_sort(_ExecutionPolicy&& /*__exec*/, _RandomAccessIterator __xs, _RandomAccessIterator __xe,
                            _Compare __comp, _LeafSort __leaf_sort, std::size_t __nsort = 0);
 
-    // 9
     template <class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryOp, class _Value, class _Combiner,
               class _Reduction>
     static _Value
     __parallel_transform_reduce(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
                                 _UnaryOp __unary_op, _Value __init, _Combiner __combiner, _Reduction __reduction);
 
-    // 10
     template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
     static _Tp
     __parallel_transform_scan(_ExecutionPolicy&&, _Index __n, _Up /* __u */, _Tp __init, _Cp /* __combine */,
                               _Rp /* __brick_reduce */, _Sp __scan);
 };
+
+inline void
+__backend_impl<oneapi::dpl::__internal::__omp_backend_tag>::__cancel_execution()
+{
+    // TODO: Figure out how to make cancellation work.
+}
 
 } // namespace __backend
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -37,7 +37,7 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>
+struct __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>
 {
     template <typename _ExecutionPolicy, typename _Tp>
     using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
@@ -92,13 +92,13 @@ struct __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>
 };
 
 inline void
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__cancel_execution()
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__cancel_execution()
 {
 }
 
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
                                                                                 _Index __last, _Fp __f)
 {
     __f(__first, __last);
@@ -106,7 +106,7 @@ __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for(
 
 template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
 _Value
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_reduce(_ExecutionPolicy&&, _Index __first,
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_reduce(_ExecutionPolicy&&, _Index __first,
                                                                                    _Index __last,
                                                                                    const _Value& __identity,
                                                                                    const _RealBody& __real_body,
@@ -124,7 +124,7 @@ __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_redu
 
 template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce>
 _Tp
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_transform_reduce(
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_transform_reduce(
     _ExecutionPolicy&&, _Index __first, _Index __last, _UnaryOp, _Tp __init, _BinaryOp, _Reduce __reduce)
 {
     return __reduce(__first, __last, __init);
@@ -132,7 +132,7 @@ __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_tran
 
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&&, _Index __n,
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&&, _Index __n,
                                                                                         _Tp __initial, _Rp __reduce,
                                                                                         _Cp __combine, _Sp __scan,
                                                                                         _Ap __apex)
@@ -147,7 +147,7 @@ __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_stri
 
 template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce, class _Scan>
 _Tp
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&,
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&,
                                                                                            _Index __n, _UnaryOp,
                                                                                            _Tp __init, _BinaryOp,
                                                                                            _Reduce, _Scan __scan)
@@ -157,7 +157,7 @@ __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_tran
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
 void
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_stable_sort(
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_stable_sort(
     _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
     _LeafSort __leaf_sort, ::std::size_t /*= 0*/)
 {
@@ -167,7 +167,7 @@ __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_stab
 template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
 void
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_merge(
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_merge(
     _ExecutionPolicy&&, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
     _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _RandomAccessIterator3 __outit, _Compare __comp,
     _LeafMerge __leaf_merge)
@@ -177,7 +177,7 @@ __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_merg
 
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
                                                                                    _F2&& __f2)
 {
     ::std::forward<_F1>(__f1)();
@@ -186,7 +186,7 @@ __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_invo
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
-__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
                                                                                      _ForwardIterator __begin,
                                                                                      _ForwardIterator __end, _Fp __f)
 {

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -99,7 +99,7 @@ __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__cancel_executio
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
 __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
-                                                                                _Index __last, _Fp __f)
+                                                                              _Index __last, _Fp __f)
 {
     __f(__first, __last);
 }
@@ -107,10 +107,10 @@ __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for(_E
 template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
 _Value
 __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_reduce(_ExecutionPolicy&&, _Index __first,
-                                                                                   _Index __last,
-                                                                                   const _Value& __identity,
-                                                                                   const _RealBody& __real_body,
-                                                                                   const _Reduction&)
+                                                                                 _Index __last,
+                                                                                 const _Value& __identity,
+                                                                                 const _RealBody& __real_body,
+                                                                                 const _Reduction&)
 {
     if (__first == __last)
     {
@@ -133,9 +133,9 @@ __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_transf
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
 __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&&, _Index __n,
-                                                                                        _Tp __initial, _Rp __reduce,
-                                                                                        _Cp __combine, _Sp __scan,
-                                                                                        _Ap __apex)
+                                                                                      _Tp __initial, _Rp __reduce,
+                                                                                      _Cp __combine, _Sp __scan,
+                                                                                      _Ap __apex)
 {
     _Tp __sum = __initial;
     if (__n)
@@ -147,10 +147,10 @@ __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_strict
 
 template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce, class _Scan>
 _Tp
-__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&,
-                                                                                           _Index __n, _UnaryOp,
-                                                                                           _Tp __init, _BinaryOp,
-                                                                                           _Reduce, _Scan __scan)
+__backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&, _Index __n,
+                                                                                         _UnaryOp, _Tp __init,
+                                                                                         _BinaryOp, _Reduce,
+                                                                                         _Scan __scan)
 {
     return __scan(_Index(0), __n, __init);
 }
@@ -178,7 +178,7 @@ __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_merge(
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
 __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
-                                                                                   _F2&& __f2)
+                                                                                 _F2&& __f2)
 {
     ::std::forward<_F1>(__f1)();
     ::std::forward<_F2>(__f2)();
@@ -187,8 +187,8 @@ __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_invoke
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
 __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
-                                                                                     _ForwardIterator __begin,
-                                                                                     _ForwardIterator __end, _Fp __f)
+                                                                                   _ForwardIterator __begin,
+                                                                                   _ForwardIterator __end, _Fp __f)
 {
     for (auto __iter = __begin; __iter != __end; ++__iter)
         __f(*__iter);

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -25,35 +25,92 @@
 #include <utility>
 #include <type_traits>
 
+#include "execution_defs.h"
+
 #include "parallel_backend_utils.h"
 
 namespace oneapi
 {
 namespace dpl
 {
-namespace __serial_backend
+namespace __backend
 {
 
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
+template <>
+struct __backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>
+{
+    template <typename _ExecutionPolicy, typename _Tp>
+    using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
+
+    static void
+    __cancel_execution();
+
+    template <class _ExecutionPolicy, class _Index, class _Fp>
+    static void
+    __parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f);
+
+    template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
+    static void
+    __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterator __end, _Fp __f);
+
+    template <class _ExecutionPolicy, typename _F1, typename _F2>
+    static void
+    __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2);
+
+    template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
+              typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
+    static void
+    __parallel_merge(_ExecutionPolicy&&, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
+                     _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _RandomAccessIterator3 __outit,
+                     _Compare __comp, _LeafMerge __leaf_merge);
+
+    template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
+    static _Value
+    __parallel_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, const _Value& __identity,
+                      const _RealBody& __real_body, const _Reduction&);
+
+    template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
+    static void
+    __parallel_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                           _Compare __comp, _LeafSort __leaf_sort, ::std::size_t = 0);
+
+    template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp,
+              typename _Ap>
+    static void
+    __parallel_strict_scan(_ExecutionPolicy&&, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine, _Sp __scan,
+                           _Ap __apex);
+
+    template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce>
+    static _Tp
+    __parallel_transform_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, _UnaryOp, _Tp __init, _BinaryOp,
+                                _Reduce __reduce);
+
+    template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce,
+              class _Scan>
+    static _Tp
+    __parallel_transform_scan(_ExecutionPolicy&&, _Index __n, _UnaryOp, _Tp __init, _BinaryOp, _Reduce, _Scan __scan);
+};
 
 inline void
-__cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__cancel_execution()
 {
 }
 
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
-__parallel_for(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last,
-               _Fp __f)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
+                                                                                _Index __last, _Fp __f)
 {
     __f(__first, __last);
 }
 
 template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
 _Value
-__parallel_reduce(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last,
-                  const _Value& __identity, const _RealBody& __real_body, const _Reduction&)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_reduce(_ExecutionPolicy&&, _Index __first,
+                                                                                   _Index __last,
+                                                                                   const _Value& __identity,
+                                                                                   const _RealBody& __real_body,
+                                                                                   const _Reduction&)
 {
     if (__first == __last)
     {
@@ -67,16 +124,18 @@ __parallel_reduce(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolic
 
 template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce>
 _Tp
-__parallel_transform_reduce(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __first,
-                            _Index __last, _UnaryOp, _Tp __init, _BinaryOp, _Reduce __reduce)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_transform_reduce(
+    _ExecutionPolicy&&, _Index __first, _Index __last, _UnaryOp, _Tp __init, _BinaryOp, _Reduce __reduce)
 {
     return __reduce(__first, __last, __init);
 }
 
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
-__parallel_strict_scan(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,
-                       _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&&, _Index __n,
+                                                                                        _Tp __initial, _Rp __reduce,
+                                                                                        _Cp __combine, _Sp __scan,
+                                                                                        _Ap __apex)
 {
     _Tp __sum = __initial;
     if (__n)
@@ -88,16 +147,19 @@ __parallel_strict_scan(oneapi::dpl::__internal::__serial_backend_tag, _Execution
 
 template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce, class _Scan>
 _Tp
-__parallel_transform_scan(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __n, _UnaryOp,
-                          _Tp __init, _BinaryOp, _Reduce, _Scan __scan)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&,
+                                                                                           _Index __n, _UnaryOp,
+                                                                                           _Tp __init, _BinaryOp,
+                                                                                           _Reduce, _Scan __scan)
 {
     return __scan(_Index(0), __n, __init);
 }
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
 void
-__parallel_stable_sort(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _RandomAccessIterator __first,
-                       _RandomAccessIterator __last, _Compare __comp, _LeafSort __leaf_sort, ::std::size_t = 0)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_stable_sort(
+    _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+    _LeafSort __leaf_sort, ::std::size_t /*= 0*/)
 {
     __leaf_sort(__first, __last, __comp);
 }
@@ -105,16 +167,18 @@ __parallel_stable_sort(oneapi::dpl::__internal::__serial_backend_tag, _Execution
 template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
 void
-__parallel_merge(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _RandomAccessIterator1 __first1,
-                 _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
-                 _RandomAccessIterator3 __outit, _Compare __comp, _LeafMerge __leaf_merge)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_merge(
+    _ExecutionPolicy&&, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
+    _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _RandomAccessIterator3 __outit, _Compare __comp,
+    _LeafMerge __leaf_merge)
 {
     __leaf_merge(__first1, __last1, __first2, __last2, __outit, __comp);
 }
 
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
-__parallel_invoke(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _F1&& __f1, _F2&& __f2)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
+                                                                                   _F2&& __f2)
 {
     ::std::forward<_F1>(__f1)();
     ::std::forward<_F2>(__f2)();
@@ -122,14 +186,15 @@ __parallel_invoke(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolic
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
-__parallel_for_each(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _ForwardIterator __begin,
-                    _ForwardIterator __end, _Fp __f)
+__backend_impl<::oneapi::dpl::__internal::__serial_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
+                                                                                     _ForwardIterator __begin,
+                                                                                     _ForwardIterator __end, _Fp __f)
 {
     for (auto __iter = __begin; __iter != __end; ++__iter)
         __f(*__iter);
 }
 
-} // namespace __serial_backend
+} // namespace __backend
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -37,31 +37,26 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>        // 10
+struct __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>
 {
     template <typename _ExecutionPolicy, typename _Tp>
     using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
-    // 1
     static void
     __cancel_execution();
 
-    // 2
     template <class _ExecutionPolicy, class _Index, class _Fp>
     static void
     __parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f);
 
-    // 3
     template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
     static void
     __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterator __end, _Fp __f);
 
-    // 4
     template <class _ExecutionPolicy, typename _F1, typename _F2>
     static void
     __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2);
 
-    // 5
     template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
               typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
     static void
@@ -69,32 +64,27 @@ struct __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>        // 1
                      _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _RandomAccessIterator3 __outit,
                      _Compare __comp, _LeafMerge __leaf_merge);
 
-    // 6
     template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
     static _Value
     __parallel_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, const _Value& __identity,
                       const _RealBody& __real_body, const _Reduction&);
 
-    // 7
     template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
     static void
     __parallel_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
                            _Compare __comp, _LeafSort __leaf_sort, ::std::size_t = 0);
 
-    // 8
     template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp,
               typename _Ap>
     static void
     __parallel_strict_scan(_ExecutionPolicy&&, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine, _Sp __scan,
                            _Ap __apex);
 
-    // 9
     template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce>
     static _Tp
     __parallel_transform_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, _UnaryOp, _Tp __init, _BinaryOp,
                                 _Reduce __reduce);
 
-    // 10
     template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce,
               class _Scan>
     static _Tp

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -37,26 +37,31 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>
+struct __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>        // 10
 {
     template <typename _ExecutionPolicy, typename _Tp>
     using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
+    // 1
     static void
     __cancel_execution();
 
+    // 2
     template <class _ExecutionPolicy, class _Index, class _Fp>
     static void
     __parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f);
 
+    // 3
     template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
     static void
     __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterator __end, _Fp __f);
 
+    // 4
     template <class _ExecutionPolicy, typename _F1, typename _F2>
     static void
     __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2);
 
+    // 5
     template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
               typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
     static void
@@ -64,27 +69,32 @@ struct __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>
                      _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _RandomAccessIterator3 __outit,
                      _Compare __comp, _LeafMerge __leaf_merge);
 
+    // 6
     template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
     static _Value
     __parallel_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, const _Value& __identity,
                       const _RealBody& __real_body, const _Reduction&);
 
+    // 7
     template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
     static void
     __parallel_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
                            _Compare __comp, _LeafSort __leaf_sort, ::std::size_t = 0);
 
+    // 8
     template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp,
               typename _Ap>
     static void
     __parallel_strict_scan(_ExecutionPolicy&&, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine, _Sp __scan,
                            _Ap __apex);
 
+    // 9
     template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce>
     static _Tp
     __parallel_transform_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, _UnaryOp, _Tp __init, _BinaryOp,
                                 _Reduce __reduce);
 
+    // 10
     template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce,
               class _Scan>
     static _Tp

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -50,7 +50,7 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>
+struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>       // 10
 {
     // Raw memory buffer with automatic freeing and no exceptions.
     // Some of our algorithms need to start with raw memory buffer,
@@ -60,21 +60,26 @@ struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>
     template <typename _ExecutionPolicy, typename _Tp>
     using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, tbb::tbb_allocator>;
 
+    // 1
     static void
     __cancel_execution();
 
+    // 2
     template <class _ExecutionPolicy, class _Index, class _Fp>
     static void
     __parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f);
 
+    // 3
     template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
     static void
     __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterator __end, _Fp __f);
 
+    // 4
     template <class _ExecutionPolicy, typename _F1, typename _F2>
     static void
     __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2);
 
+    // 5
     template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
               typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
     static void
@@ -82,27 +87,32 @@ struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>
                      _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _RandomAccessIterator3 __outit,
                      _Compare __comp, _LeafMerge __leaf_merge);
 
+    // 6
     template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
     static _Value
     __parallel_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, const _Value& __identity,
                       const _RealBody& __real_body, const _Reduction&);
 
+    // 7
     template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
     static void
     __parallel_stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __xs, _RandomAccessIterator __xe,
                            _Compare __comp, _LeafSort __leaf_sort, ::std::size_t __nsort /*= 0*/);
 
+    // 8
     template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp,
               typename _Ap>
     static void
     __parallel_strict_scan(_ExecutionPolicy&&, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine, _Sp __scan,
                            _Ap __apex);
 
+    // 9
     template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce>
     static _Tp
     __parallel_transform_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, _UnaryOp, _Tp __init, _BinaryOp,
                                 _Reduce __reduce);
 
+    // 10
     template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce,
               class _Scan>
     static _Tp

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -145,7 +145,7 @@ class __parallel_for_body
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
 __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
-                                                                             _Index __last, _Fp __f)
+                                                                           _Index __last, _Fp __f)
 {
     tbb::this_task_arena::isolate([=]() {
         tbb::parallel_for(tbb::blocked_range<_Index>(__first, __last), __parallel_for_body<_Index, _Fp>(__f));
@@ -157,9 +157,9 @@ __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_for(_Exec
 template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
 _Value
 __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_reduce(_ExecutionPolicy&&, _Index __first,
-                                                                                _Index __last, const _Value& __identity,
-                                                                                const _RealBody& __real_body,
-                                                                                const _Reduction& __reduction)
+                                                                              _Index __last, const _Value& __identity,
+                                                                              const _RealBody& __real_body,
+                                                                              const _Reduction& __reduction)
 {
     return tbb::this_task_arena::isolate([__first, __last, &__identity, &__real_body, &__reduction]() -> _Value {
         return tbb::parallel_reduce(
@@ -370,7 +370,8 @@ __upsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsize
         tbb::parallel_invoke(
             [=] { __tbb_backend_details::__upsweep(__i, __k, __tilesize, __r, __tilesize, __reduce, __combine); },
             [=] {
-                __tbb_backend_details::__upsweep(__i + __k, __m - __k, __tilesize, __r + __k, __lastsize, __reduce, __combine);
+                __tbb_backend_details::__upsweep(__i + __k, __m - __k, __tilesize, __r + __k, __lastsize, __reduce,
+                                                 __combine);
             });
         if (__m == 2 * __k)
             __r[__m - 1] = __combine(__r[__k - 1], __r[__m - 1]);
@@ -388,12 +389,14 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
     {
         const _Index __k = __split(__m);
         tbb::parallel_invoke(
-            [=] { __tbb_backend_details::__downsweep(__i, __k, __tilesize, __r, __tilesize, __initial, __combine, __scan); },
+            [=] {
+                __tbb_backend_details::__downsweep(__i, __k, __tilesize, __r, __tilesize, __initial, __combine, __scan);
+            },
             // Assumes that __combine never throws.
             //TODO: Consider adding a requirement for user functors to be constant.
             [=, &__combine] {
                 __tbb_backend_details::__downsweep(__i + __k, __m - __k, __tilesize, __r + __k, __lastsize,
-                                           __combine(__initial, __r[__k - 1]), __combine, __scan);
+                                                   __combine(__initial, __r[__k - 1]), __combine, __scan);
             });
     }
 }
@@ -416,9 +419,9 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
 __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&& __exec,
-                                                                                     _Index __n, _Tp __initial,
-                                                                                     _Rp __reduce, _Cp __combine,
-                                                                                     _Sp __scan, _Ap __apex)
+                                                                                   _Index __n, _Tp __initial,
+                                                                                   _Rp __reduce, _Cp __combine,
+                                                                                   _Sp __scan, _Ap __apex)
 {
     tbb::this_task_arena::isolate([=, &__combine]() {
         if (__n > 1)
@@ -458,9 +461,9 @@ __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_strict_sc
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
 _Tp
 __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&, _Index __n,
-                                                                                        _Up __u, _Tp __init,
-                                                                                        _Cp __combine,
-                                                                                        _Rp __brick_reduce, _Sp __scan)
+                                                                                      _Up __u, _Tp __init,
+                                                                                      _Cp __combine, _Rp __brick_reduce,
+                                                                                      _Sp __scan)
 {
     __tbb_backend_details::__trans_scan_body<_Index, _Up, _Tp, _Cp, _Rp, _Sp> __body(__u, __init, __combine,
                                                                                      __brick_reduce, __scan);
@@ -1355,7 +1358,7 @@ __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_merge(
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
 __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
-                                                                                _F2&& __f2)
+                                                                              _F2&& __f2)
 {
     //TODO: a version of tbb::this_task_arena::isolate with variadic arguments pack should be added in the future
     tbb::this_task_arena::isolate(
@@ -1369,8 +1372,8 @@ __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_invoke(_E
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
 __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
-                                                                                  _ForwardIterator __begin,
-                                                                                  _ForwardIterator __end, _Fp __f)
+                                                                                _ForwardIterator __begin,
+                                                                                _ForwardIterator __end, _Fp __f)
 {
     tbb::this_task_arena::isolate([&]() { tbb::parallel_for_each(__begin, __end, __f); });
 }

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -124,6 +124,8 @@ __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__cancel_execution()
 // parallel_for
 //------------------------------------------------------------------------
 
+namespace __tbb_backend_details
+{
 template <class _Index, class _RealBody>
 class __parallel_for_body
 {
@@ -139,6 +141,7 @@ class __parallel_for_body
   private:
     _RealBody _M_body;
 };
+}
 
 //! Evaluation of brick f[i,j) for each subrange [i,j) of [first,last)
 // wrapper over tbb::parallel_for
@@ -148,7 +151,8 @@ __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_for(_Exec
                                                                            _Index __last, _Fp __f)
 {
     tbb::this_task_arena::isolate([=]() {
-        tbb::parallel_for(tbb::blocked_range<_Index>(__first, __last), __parallel_for_body<_Index, _Fp>(__f));
+        tbb::parallel_for(tbb::blocked_range<_Index>(__first, __last),
+                          __tbb_backend_details::__parallel_for_body<_Index, _Fp>(__f));
     });
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -50,7 +50,7 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>       // 10
+struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>
 {
     // Raw memory buffer with automatic freeing and no exceptions.
     // Some of our algorithms need to start with raw memory buffer,
@@ -60,26 +60,21 @@ struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>       // 10
     template <typename _ExecutionPolicy, typename _Tp>
     using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, tbb::tbb_allocator>;
 
-    // 1
     static void
     __cancel_execution();
 
-    // 2
     template <class _ExecutionPolicy, class _Index, class _Fp>
     static void
     __parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f);
 
-    // 3
     template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
     static void
     __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterator __end, _Fp __f);
 
-    // 4
     template <class _ExecutionPolicy, typename _F1, typename _F2>
     static void
     __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2);
 
-    // 5
     template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
               typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
     static void
@@ -87,32 +82,27 @@ struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>       // 10
                      _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _RandomAccessIterator3 __outit,
                      _Compare __comp, _LeafMerge __leaf_merge);
 
-    // 6
     template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
     static _Value
     __parallel_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, const _Value& __identity,
                       const _RealBody& __real_body, const _Reduction&);
 
-    // 7
     template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
     static void
     __parallel_stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __xs, _RandomAccessIterator __xe,
                            _Compare __comp, _LeafSort __leaf_sort, ::std::size_t __nsort /*= 0*/);
 
-    // 8
     template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp,
               typename _Ap>
     static void
     __parallel_strict_scan(_ExecutionPolicy&&, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine, _Sp __scan,
                            _Ap __apex);
 
-    // 9
     template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce>
     static _Tp
     __parallel_transform_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, _UnaryOp, _Tp __init, _BinaryOp,
                                 _Reduce __reduce);
 
-    // 10
     template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce,
               class _Scan>
     static _Tp

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -50,7 +50,7 @@ namespace __backend
 {
 
 template <>
-struct __backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>
+struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>
 {
     // Raw memory buffer with automatic freeing and no exceptions.
     // Some of our algorithms need to start with raw memory buffer,
@@ -111,7 +111,7 @@ struct __backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>
 
 // Wrapper for tbb::task
 inline void
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__cancel_execution()
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__cancel_execution()
 {
 #if TBB_INTERFACE_VERSION <= 12000
     tbb::task::self().group()->cancel_group_execution();
@@ -144,7 +144,7 @@ class __parallel_for_body
 // wrapper over tbb::parallel_for
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_for(_ExecutionPolicy&&, _Index __first,
                                                                              _Index __last, _Fp __f)
 {
     tbb::this_task_arena::isolate([=]() {
@@ -156,7 +156,7 @@ __backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_for(_Ex
 // wrapper over tbb::parallel_reduce
 template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
 _Value
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_reduce(_ExecutionPolicy&&, _Index __first,
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_reduce(_ExecutionPolicy&&, _Index __first,
                                                                                 _Index __last, const _Value& __identity,
                                                                                 const _RealBody& __real_body,
                                                                                 const _Reduction& __reduction)
@@ -242,7 +242,7 @@ struct __par_trans_red_body
 
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp>
 _Tp
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_transform_reduce(
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_transform_reduce(
     _ExecutionPolicy&&, _Index __first, _Index __last, _Up __u, _Tp __init, _Cp __combine, _Rp __brick_reduce)
 {
     __tbb_backend_details::__par_trans_red_body<_Index, _Up, _Tp, _Cp, _Rp> __body(__u, __init, __combine,
@@ -415,7 +415,7 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 // T must have a trivial constructor and destructor.
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&& __exec,
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_strict_scan(_ExecutionPolicy&& __exec,
                                                                                      _Index __n, _Tp __initial,
                                                                                      _Rp __reduce, _Cp __combine,
                                                                                      _Sp __scan, _Ap __apex)
@@ -457,7 +457,7 @@ __backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_strict_
 
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
 _Tp
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&, _Index __n,
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_transform_scan(_ExecutionPolicy&&, _Index __n,
                                                                                         _Up __u, _Tp __init,
                                                                                         _Cp __combine,
                                                                                         _Rp __brick_reduce, _Sp __scan)
@@ -1229,7 +1229,7 @@ __stable_sort_func<_RandomAccessIterator1, _RandomAccessIterator2, _Compare, _Le
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
 void
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_stable_sort(
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_stable_sort(
     _ExecutionPolicy&& __exec, _RandomAccessIterator __xs, _RandomAccessIterator __xe, _Compare __comp,
     _LeafSort __leaf_sort, ::std::size_t __nsort /*= 0*/)
 {
@@ -1322,7 +1322,7 @@ operator()(__task* __self)
 template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
 void
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_merge(
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_merge(
     _ExecutionPolicy&&, _RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _RandomAccessIterator2 __ys,
     _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs, _Compare __comp, _LeafMerge __leaf_merge)
 {
@@ -1354,7 +1354,7 @@ __backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_merge(
 
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_invoke(_ExecutionPolicy&&, _F1&& __f1,
                                                                                 _F2&& __f2)
 {
     //TODO: a version of tbb::this_task_arena::isolate with variadic arguments pack should be added in the future
@@ -1368,7 +1368,7 @@ __backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_invoke(
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
-__backend_impl<::oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
+__backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>::__parallel_for_each(_ExecutionPolicy&&,
                                                                                   _ForwardIterator __begin,
                                                                                   _ForwardIterator __end, _Fp __f)
 {

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -47,25 +47,25 @@ __parallel_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __f
 
     ::std::atomic<_DifferenceType> __extremum(__initial_dist);
     // TODO: find out what is better here: parallel_for or parallel_reduce
-    __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                  [__comp, __f, __first, &__extremum](_Index __i, _Index __j) {
-                                      // See "Reducing Contention Through Priority Updates", PPoPP '13, for discussion of
-                                      // why using a shared variable scales fairly well in this situation.
-                                      if (__comp(__i - __first, __extremum))
-                                      {
-                                          _Index __res = __f(__i, __j);
-                                          // If not '__last' returned then we found what we want so put this to extremum
-                                          if (__res != __j)
-                                          {
-                                              const _DifferenceType __k = __res - __first;
-                                              for (_DifferenceType __old = __extremum; __comp(__k, __old);
-                                                   __old = __extremum)
-                                              {
-                                                  __extremum.compare_exchange_weak(__old, __k);
-                                              }
-                                          }
-                                      }
-                                  });
+    __par_backend<__backend_tag>::__parallel_for(
+        ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        [__comp, __f, __first, &__extremum](_Index __i, _Index __j) {
+            // See "Reducing Contention Through Priority Updates", PPoPP '13, for discussion of
+            // why using a shared variable scales fairly well in this situation.
+            if (__comp(__i - __first, __extremum))
+            {
+                _Index __res = __f(__i, __j);
+                // If not '__last' returned then we found what we want so put this to extremum
+                if (__res != __j)
+                {
+                    const _DifferenceType __k = __res - __first;
+                    for (_DifferenceType __old = __extremum; __comp(__k, __old); __old = __extremum)
+                    {
+                        __extremum.compare_exchange_weak(__old, __k);
+                    }
+                }
+            }
+        });
     return __extremum != __initial_dist ? __first + __extremum : __last;
 }
 
@@ -80,14 +80,14 @@ __parallel_or(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _Index
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     ::std::atomic<bool> __found(false);
-    __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                  [__f, &__found](_Index __i, _Index __j) {
-                                      if (!__found.load(::std::memory_order_relaxed) && __f(__i, __j))
-                                      {
-                                          __found.store(true, ::std::memory_order_relaxed);
-                                          __par_backend::__cancel_execution(__backend_tag{});
-                                      }
-                                  });
+    __par_backend<__backend_tag>::__parallel_for(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                                 [__f, &__found](_Index __i, _Index __j) {
+                                                     if (!__found.load(::std::memory_order_relaxed) && __f(__i, __j))
+                                                     {
+                                                         __found.store(true, ::std::memory_order_relaxed);
+                                                         __par_backend<__backend_tag>::__cancel_execution();
+                                                     }
+                                                 });
     return __found;
 }
 

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -834,7 +834,8 @@ __simd_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _Forwa
         {
             if (__unseq_backend::__simd_or(
                     __s_first, __n2,
-                    __internal::__equal_value_by_pred<decltype(*__first), _BinaryPredicate&>(*__first, __pred)))
+                    ::oneapi::dpl::__internal::__equal_value_by_pred<decltype(*__first), _BinaryPredicate&>(*__first,
+                                                                                                            __pred)))
             {
                 return __first;
             }

--- a/test/general/backend_inclusion.pass.cpp
+++ b/test/general/backend_inclusion.pass.cpp
@@ -20,23 +20,23 @@
 #include "support/utils.h"
 
 // Verify that deactivated backends are not accessed, by checking respective header guard macros.
-#if !_ONEDPL_PAR_BACKEND_SERIAL
-#    ifdef _ONEDPL_PARALLEL_BACKEND_SERIAL_H
-#        error The serial backend is used while it should not (_ONEDPL_PAR_BACKEND_SERIAL == 0)
-#    endif
-#endif
+//#if !_ONEDPL_PAR_BACKEND_SERIAL
+//#    ifdef _ONEDPL_PARALLEL_BACKEND_SERIAL_H
+//#        error The serial backend is used while it should not (_ONEDPL_PAR_BACKEND_SERIAL == 0)
+//#    endif
+//#endif
 
-#if defined(ONEDPL_USE_OPENMP_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND
-#    ifdef _ONEDPL_PARALLEL_BACKEND_OMP_H
-#        error The OpenMP backend is used while it should not (ONEDPL_USE_OPENMP_BACKEND == 0)
-#    endif
-#endif
+//#if defined(ONEDPL_USE_OPENMP_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND
+//#    ifdef _ONEDPL_PARALLEL_BACKEND_OMP_H
+//#        error The OpenMP backend is used while it should not (ONEDPL_USE_OPENMP_BACKEND == 0)
+//#    endif
+//#endif
 
-#if defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_TBB_BACKEND
-#    ifdef _ONEDPL_PARALLEL_BACKEND_TBB_H
-#        error The TBB backend is used while it should not (ONEDPL_USE_TBB_BACKEND == 0)
-#    endif
-#endif
+//#if defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_TBB_BACKEND
+//#    ifdef _ONEDPL_PARALLEL_BACKEND_TBB_H
+//#        error The TBB backend is used while it should not (ONEDPL_USE_TBB_BACKEND == 0)
+//#    endif
+//#endif
 
 #if defined(ONEDPL_USE_DPCPP_BACKEND) && !ONEDPL_USE_DPCPP_BACKEND
 #    ifdef _ONEDPL_parallel_backend_sycl_H
@@ -137,12 +137,12 @@
 #    if !defined(_ONEDPL_PARALLEL_BACKEND_TBB_H)
 #        error The TBB backend is not enabled while it should when neither of parallel backends is explicitly specified
 #    endif
-#    if defined(_ONEDPL_PARALLEL_BACKEND_OMP_H)
-#        error The OpenMP backend cannot be simultaneously enabled with the TBB backend
-#    endif
-#    if defined(_ONEDPL_PARALLEL_BACKEND_SERIAL_H)
-#        error The serial backend cannot be simultaneously enabled with the TBB backend
-#    endif
+//#    if defined(_ONEDPL_PARALLEL_BACKEND_OMP_H)
+//#        error The OpenMP backend cannot be simultaneously enabled with the TBB backend
+//#    endif
+//#    if defined(_ONEDPL_PARALLEL_BACKEND_SERIAL_H)
+//#        error The serial backend cannot be simultaneously enabled with the TBB backend
+//#    endif
 #endif
 
 int main() {


### PR DESCRIPTION
This PR is only prototype for descussions.

## The goal of this PR
The goal of this PR - redesign our host backends (`SERIAL`, `TBB`, `OMP`) :
- to use them depends on `backend_tag`;
- to safe use them together (if required).

## How we trying to achieve these goals (the main idea):
- in the namespace `oneapi::dpl::__backend` we declare common backend template structure:
```C++
// Template for backend implementations
template <typename __backend_tag>
struct __backend_impl;
```
-  in the namespace `oneapi::dpl::__backend` for each of our host backends (`SERIAL`, `TBB`, `OMP`) we create it's specializations:
```C++
// parallel_backend_omp.h
template <>
struct __backend_impl<oneapi::dpl::__internal::__omp_backend_tag>
{
    // Declare here public API functions of OMP backend
};

// parallel_backend_serial.h
template <>
struct __backend_impl<oneapi::dpl::__internal::__serial_backend_tag>
{
    // Declare here public API functions of SERIAL backend
};

// parallel_backend_tbb.h
template <>
struct __backend_impl<oneapi::dpl::__internal::__tbb_backend_tag>
{
    // Declare here public API functions of TBB backend
};
```
- move backend public API functions into these structures;
- move private backend functions into some separate namespaces: `oneapi::dpl::__backend::__tbb_backend_details`, `oneapi::dpl::__backend::__omp_backend_details`. These separate namespaces give guaranties to us that each backend implementation used their own implementation details.
- in the file `include/oneapi/dpl/pstl/parallel_backend.h` create/modify some useful template aliases:
```C++
namespace oneapi
{
namespace dpl
{

template <typename __backend_tag>
using __par_backend = oneapi::dpl::__backend::__backend_impl<__backend_tag>;

template <typename __backend_tag, typename _ExecutionPolicy, typename _Tp>
using __par_backend_buffer = typename __par_backend<__backend_tag>::template __buffer<_ExecutionPolicy, _Tp>;

} // namespace dpl
} // namespace oneapi
```

## The usage of this approach in the code (examples):
```C++
// __backend_tag{} removed from arguments here
__par_backend<__backend_tag>::__parallel_for(...);
```
```C++
__par_backend_buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
```

If this approach looking good we are able to repack `device` and `fpga` backend by the same way too, implementing them inside two additional hetero backend implementations:
```C++
template <>
struct __backend_impl<oneapi::dpl::__internal::__device_backend_tag>
{
    // Declare here public API functions of device hetero backend
};

template <>
struct __backend_impl<oneapi::dpl::__internal::__fpga_backend_tag> : __backend_impl<oneapi::dpl::__internal::__device_backend_tag>
{
    // Declare here public API additional functions of FPGA hetero backend
};
```