### PR TITLE
[KT] Remove algorithms from oneapi::dpl::experimental::kt::esimd

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -172,18 +172,4 @@ radix_sort_by_key(sycl::queue __q, _KeysIterator1 __keys_first, _KeysIterator1 _
 
 } // namespace oneapi::dpl::experimental::kt::gpu::esimd
 
-namespace oneapi::dpl::experimental::kt
-{
-namespace esimd
-#if !defined(__SYCL_DEVICE_ONLY__)
-    [[deprecated("Use of oneapi::dpl::experimental::kt::esimd namespace is deprecated "
-                 "and will be removed in a future release. "
-                 "Use oneapi::dpl::experimental::kt::gpu::esimd instead")]]
-#endif
-{
-using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort;
-using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key;
-} // namespace oneapi::dpl::experimental::kt::esimd
-} // namespace oneapi::dpl::experimental::kt
-
 #endif // _ONEDPL_KT_ESIMD_RADIX_SORT_H

--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -123,18 +123,9 @@ test_sycl_iterators(sycl::queue q, std::size_t size, KernelParam param)
     std::stable_sort(std::begin(ref), std::end(ref), Compare<T, IsAscending>{});
     {
         sycl::buffer<T> buf(input.data(), input.size());
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-        // Deprecated namespace is used deliberatelly to make sure the functionality is still available
-        oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(q, oneapi::dpl::begin(buf), oneapi::dpl::end(buf),
-                                                                      param)
+        oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(q, oneapi::dpl::begin(buf), oneapi::dpl::end(buf),
+                                                                           param)
             .wait();
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     }
 
     std::string msg = "wrong results with oneapi::dpl::begin/end, n: " + std::to_string(size);


### PR DESCRIPTION
The namespace `oneapi::dpl::experimental::kt::esimd` has been deprecated in favour of `oneapi::dpl::experimental::kt::gpu::esimd` since 2022.6 release. Let's remove it.