### PR TITLE
Re-implement SYCL backend `parallel_for` to improve bandwidth utilization

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -42,13 +42,11 @@ __pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-    auto __view = __buf.all_view();
-
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__view)>{
+        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__buf.all_view())>{
             __f, static_cast<std::size_t>(__n)},
-        __n, __view);
+        __n, __buf.all_view());
     return __future_obj;
 }
 
@@ -69,14 +67,11 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
-    auto __view1 = __buf1.all_view();
-    auto __view2 = __buf2.all_view();
-
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2)>{
-            __f, static_cast<std::size_t>(__n)},
-        __n, __view1, __view2);
+        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
+                                                decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
+        __n, __buf1.all_view(), __buf2.all_view());
 
     return __future.__make_future(__first2 + __n);
 }
@@ -100,15 +95,12 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator3>();
     auto __buf3 = __keep3(__first3, __first3 + __n);
 
-    auto __view1 = __buf1.all_view();
-    auto __view2 = __buf2.all_view();
-    auto __view3 = __buf3.all_view();
-
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2),
-                                                decltype(__view3)>{__f, static_cast<size_t>(__n)},
-        __n, __view1, __view2, __view3);
+        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
+                                                decltype(__buf2.all_view()), decltype(__buf3.all_view())>{
+            __f, static_cast<size_t>(__n)},
+        __n, __buf1.all_view(), __buf2.all_view(), __buf3.all_view());
 
     return __future.__make_future(__first3 + __n);
 }

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -96,7 +96,7 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __buf3 = __keep3(__first3, __first3 + __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
                                                 decltype(__buf2.all_view()), decltype(__buf3.all_view())>{
             __f, static_cast<size_t>(__n)},

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -47,7 +47,7 @@ __pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__view)>{
-            {}, __f, static_cast<std::size_t>(__n)},
+            __f, static_cast<std::size_t>(__n)},
         __n, __view);
     return __future_obj;
 }
@@ -75,7 +75,7 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2)>{
-            {}, __f, static_cast<std::size_t>(__n)},
+            __f, static_cast<std::size_t>(__n)},
         __n, __view1, __view2);
 
     return __future.__make_future(__first2 + __n);
@@ -107,7 +107,7 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2),
-                                                decltype(__view3)>{{}, __f, static_cast<size_t>(__n)},
+                                                decltype(__view3)>{__f, static_cast<size_t>(__n)},
         __n, __view1, __view2, __view3);
 
     return __future.__make_future(__first3 + __n);

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -46,7 +46,8 @@ __pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__view)>{{}, __f, std::size_t(__n)},
+        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__view)>{
+            {}, __f, static_cast<std::size_t>(__n)},
         __n, __view);
     return __future_obj;
 }
@@ -74,7 +75,7 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2)>{
-            {}, __f, std::size_t(__n)},
+            {}, __f, static_cast<std::size_t>(__n)},
         __n, __view1, __view2);
 
     return __future.__make_future(__first2 + __n);
@@ -106,7 +107,7 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2),
-                                                decltype(__view3)>{{}, __f, size_t(__n)},
+                                                decltype(__view3)>{{}, __f, static_cast<size_t>(__n)},
         __n, __view1, __view2, __view3);
 
     return __future.__make_future(__first3 + __n);

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -39,13 +39,13 @@ enum class search_algorithm
 
 #if _ONEDPL_BACKEND_SYCL
 template <typename Comp, typename T, typename _Range, search_algorithm func>
-struct custom_brick : oneapi::dpl::unseq_backend::walk_scalar_base<_Range>
+struct __custom_brick : oneapi::dpl::unseq_backend::walk_scalar_base<_Range>
 {
     Comp comp;
     T size;
     bool use_32bit_indexing;
 
-    custom_brick(Comp comp, T size, bool use_32bit_indexing)
+    __custom_brick(Comp comp, T size, bool use_32bit_indexing)
         : comp(comp), size(size), use_32bit_indexing(use_32bit_indexing)
     {
     }
@@ -167,7 +167,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
     __bknd::__parallel_for(
         _BackendTag{}, ::std::forward<decltype(policy)>(policy),
-        custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::lower_bound>{
+        __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::lower_bound>{
             comp, size, use_32bit_indexing},
         value_size, zip_vw)
         .__deferrable_wait();
@@ -200,7 +200,7 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
     __bknd::__parallel_for(
         _BackendTag{}, std::forward<decltype(policy)>(policy),
-        custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::upper_bound>{
+        __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::upper_bound>{
             comp, size, use_32bit_indexing},
         value_size, zip_vw)
         .__deferrable_wait();
@@ -233,7 +233,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
     __bknd::__parallel_for(
         _BackendTag{}, std::forward<decltype(policy)>(policy),
-        custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::binary_search>{
+        __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::binary_search>{
             comp, size, use_32bit_indexing},
         value_size, zip_vw)
         .__deferrable_wait();

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -46,7 +46,7 @@ struct __custom_brick : oneapi::dpl::unseq_backend::walk_scalar_base<_Range>
     bool use_32bit_indexing;
 
     __custom_brick(Comp comp, T size, bool use_32bit_indexing)
-        : comp(comp), size(size), use_32bit_indexing(use_32bit_indexing)
+        : comp(std::move(comp)), size(size), use_32bit_indexing(use_32bit_indexing)
     {
     }
 

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -45,6 +45,11 @@ struct custom_brick : oneapi::dpl::unseq_backend::walk_scalar_base<_Range>
     T size;
     bool use_32bit_indexing;
 
+    custom_brick(Comp comp, T size, bool use_32bit_indexing)
+        : comp(comp), size(size), use_32bit_indexing(use_32bit_indexing)
+    {
+    }
+
     template <typename _Size, typename _ItemId, typename _Acc>
     void
     search_impl(_ItemId idx, _Acc acc) const
@@ -163,7 +168,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     __bknd::__parallel_for(
         _BackendTag{}, ::std::forward<decltype(policy)>(policy),
         custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::lower_bound>{
-            {}, comp, size, use_32bit_indexing},
+            comp, size, use_32bit_indexing},
         value_size, zip_vw)
         .__deferrable_wait();
     return result + value_size;
@@ -196,7 +201,7 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     __bknd::__parallel_for(
         _BackendTag{}, std::forward<decltype(policy)>(policy),
         custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::upper_bound>{
-            {}, comp, size, use_32bit_indexing},
+            comp, size, use_32bit_indexing},
         value_size, zip_vw)
         .__deferrable_wait();
     return result + value_size;
@@ -229,7 +234,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     __bknd::__parallel_for(
         _BackendTag{}, std::forward<decltype(policy)>(policy),
         custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::binary_search>{
-            {}, comp, size, use_32bit_indexing},
+            comp, size, use_32bit_indexing},
         value_size, zip_vw)
         .__deferrable_wait();
     return result + value_size;

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -76,7 +76,7 @@ struct custom_brick : oneapi::dpl::unseq_backend::walk_scalar_base<_Range>
     }
     template <typename _IsFull, typename _ItemId, typename _Acc>
     void
-    __scalar_path(_IsFull, _ItemId idx, _Acc acc) const
+    __scalar_path_impl(_IsFull, _ItemId idx, _Acc acc) const
     {
         if (use_32bit_indexing)
             search_impl<std::uint32_t>(idx, acc);
@@ -87,7 +87,7 @@ struct custom_brick : oneapi::dpl::unseq_backend::walk_scalar_base<_Range>
     void
     operator()(_IsFull __is_full, _ItemId idx, _Acc acc) const
     {
-        __scalar_path(__is_full, idx, acc);
+        __scalar_path_impl(__is_full, idx, acc);
     }
 };
 #endif

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -60,7 +60,7 @@ __pattern_walk1(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, __exec,
         unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__view)>{
-            {}, __f, static_cast<std::size_t>(__n)},
+            __f, static_cast<std::size_t>(__n)},
         __n, __view)
         .__deferrable_wait();
 }
@@ -111,7 +111,7 @@ __pattern_walk2(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2)>{
-            {}, __f, static_cast<std::size_t>(__n)},
+            __f, static_cast<std::size_t>(__n)},
         __n, __view1, __view2);
 
     // Call no wait, wait or deferrable wait depending on _WaitMode
@@ -157,7 +157,7 @@ __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Forw
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::__brick_swap<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2)>{
-            {}, __f, static_cast<std::size_t>(__n)},
+            __f, static_cast<std::size_t>(__n)},
         __n, __view1, __view2);
     __future.wait(__par_backend_hetero::__deferrable_mode{});
     return __first2 + __n;
@@ -194,7 +194,7 @@ __pattern_walk3(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2),
-                                                decltype(__view3)>{{}, __f, static_cast<std::size_t>(__n)},
+                                                decltype(__view3)>{__f, static_cast<std::size_t>(__n)},
         __n, __view1, __view2, __view3)
         .__deferrable_wait();
 
@@ -1599,7 +1599,7 @@ __pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::__reverse_functor<typename std::iterator_traits<_Iterator>::difference_type,
-                                         decltype(__buf.all_view())>{{}, __n},
+                                         decltype(__buf.all_view())>{__n},
         __n / 2, __buf.all_view())
         .__deferrable_wait();
 }
@@ -1628,7 +1628,7 @@ __pattern_reverse_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bi
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::__reverse_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
-                                      decltype(__view1), decltype(__view2)>{{}, __n},
+                                      decltype(__view1), decltype(__view2)>{__n},
         __n, __view1, __view2)
         .__deferrable_wait();
 
@@ -1671,7 +1671,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec),
         unseq_backend::__rotate_copy<typename std::iterator_traits<_Iterator>::difference_type, decltype(__view),
-                                     decltype(__temp_rng_w)>{{}, __n, __shift},
+                                     decltype(__temp_rng_w)>{__n, __shift},
         __n, __view, __temp_rng_w);
 
     //An explicit wait isn't required here because we are working with a temporary sycl::buffer and sycl accessors and
@@ -1680,9 +1680,9 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     using _Function = __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>;
     auto __temp_rng_rw =
         oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::read_write>(__temp_buf.get_buffer());
-    auto __brick = unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__temp_rng_rw),
-                                                           decltype(__buf.all_view())>{
-        {}, _Function{}, static_cast<std::size_t>(__n)};
+    auto __brick =
+        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__temp_rng_rw),
+                                                decltype(__buf.all_view())>{_Function{}, static_cast<std::size_t>(__n)};
     oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __brick,
                                                       __n, __temp_rng_rw, __buf.all_view())
         .__deferrable_wait();
@@ -1721,7 +1721,7 @@ __pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bid
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::__rotate_copy<typename ::std::iterator_traits<_BidirectionalIterator>::difference_type,
-                                     decltype(__view1), decltype(__view2)>{{}, __n, __shift},
+                                     decltype(__view1), decltype(__view2)>{__n, __shift},
         __n, __view1, __view2)
         .__deferrable_wait();
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -111,7 +111,7 @@ __pattern_walk2(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2)>{
-            {}, __f, size_t(__n)},
+            {}, __f, static_cast<std::size_t>(__n)},
         __n, __view1, __view2);
 
     // Call no wait, wait or deferrable wait depending on _WaitMode
@@ -157,7 +157,7 @@ __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Forw
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::__brick_swap<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2)>{
-            {}, __f, size_t(__n)},
+            {}, __f, static_cast<std::size_t>(__n)},
         __n, __view1, __view2);
     __future.wait(__par_backend_hetero::__deferrable_mode{});
     return __first2 + __n;
@@ -192,9 +192,9 @@ __pattern_walk3(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
     auto __view3 = __buf3.all_view();
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__view1), decltype(__view2),
-                                                decltype(__view3)>{{}, __f, size_t(__n)},
+                                                decltype(__view3)>{{}, __f, static_cast<std::size_t>(__n)},
         __n, __view1, __view2, __view3)
         .__deferrable_wait();
 
@@ -1597,8 +1597,8 @@ __pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__reverse_functor<typename ::std::iterator_traits<_Iterator>::difference_type,
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        unseq_backend::__reverse_functor<typename std::iterator_traits<_Iterator>::difference_type,
                                          decltype(__buf.all_view())>{{}, __n},
         __n / 2, __buf.all_view())
         .__deferrable_wait();
@@ -1626,8 +1626,8 @@ __pattern_reverse_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bi
     auto __view1 = __buf1.all_view();
     auto __view2 = __buf2.all_view();
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__reverse_copy<typename ::std::iterator_traits<_BidirectionalIterator>::difference_type,
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        unseq_backend::__reverse_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
                                       decltype(__view1), decltype(__view2)>{{}, __n},
         __n, __view1, __view2)
         .__deferrable_wait();
@@ -1670,7 +1670,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     const auto __shift = __new_first - __first;
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec),
-        unseq_backend::__rotate_copy<typename ::std::iterator_traits<_Iterator>::difference_type, decltype(__view),
+        unseq_backend::__rotate_copy<typename std::iterator_traits<_Iterator>::difference_type, decltype(__view),
                                      decltype(__temp_rng_w)>{{}, __n, __shift},
         __n, __view, __temp_rng_w);
 
@@ -1683,7 +1683,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     auto __brick = unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__temp_rng_rw),
                                                            decltype(__buf.all_view())>{
         {}, _Function{}, static_cast<std::size_t>(__n)};
-    oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __brick,
+    oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __brick,
                                                       __n, __temp_rng_rw, __buf.all_view())
         .__deferrable_wait();
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1079,8 +1079,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
 
     // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
     // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
-    // Note that we specify a read_write access mode on the input sequence due to data dependencies.
-    // We never actually read from the sequence, so there is no risk when ran with the vectorized path of
+    // We never actually write to the sequence, so there is no risk when ran with the vectorized path of
     // walk2_vector_or_scalars. For more info, please see the comment above __pattern_walk2 and
     // https://github.com/uxlfoundation/oneDPL/issues/1272.
     return __pattern_walk2</*_WaitMode*/ __par_backend_hetero::__deferrable_mode,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1986,7 +1986,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
 
         auto __brick =
             unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__src), decltype(__dst)>{
-                {}, _Function{}, static_cast<std::size_t>(__size_res)};
+                _Function{}, static_cast<std::size_t>(__size_res)};
 
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                           __brick, __size_res, __src, __dst)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -140,7 +140,7 @@ __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Forw
                _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f)
 {
     auto __n = __last1 - __first1;
-    if (__n <= 0)
+    if (__n == 0)
         return __first2;
 
     auto __keep1 =

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1704,7 +1704,7 @@ __pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bid
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__rotate_copy<typename ::std::iterator_traits<_BidirectionalIterator>::difference_type,
+        unseq_backend::__rotate_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
                                      decltype(__buf1.all_view()), decltype(__buf2.all_view())>{__n, __shift},
         __n, __buf1.all_view(), __buf2.all_view())
         .__deferrable_wait();

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -135,7 +135,7 @@ _ForwardIterator2
 __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
                _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f)
 {
-    auto __n = __last1 - __first1;
+    const auto __n = __last1 - __first1;
     if (__n == 0)
         return __first2;
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -177,23 +177,23 @@ __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Rang
         const std::size_t __n = __rng1.size();
         auto __exec1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(
             std::forward<_ExecutionPolicy>(__exec));
-        auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
+        oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, std::move(__exec1),
             unseq_backend::__brick_swap<decltype(__exec1), _Function, std::decay_t<_Range1>, std::decay_t<_Range2>>{
                 __f, __n},
-            __n, __rng1, __rng2);
-        __future.wait(__par_backend_hetero::__deferrable_mode{});
+            __n, __rng1, __rng2)
+            .__deferrable_wait();
         return __n;
     }
     const std::size_t __n = __rng2.size();
     auto __exec2 =
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(std::forward<_ExecutionPolicy>(__exec));
-    auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
+    oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::move(__exec2),
         unseq_backend::__brick_swap<decltype(__exec2), _Function, std::decay_t<_Range2>, std::decay_t<_Range1>>{__f,
                                                                                                                 __n},
-        __n, __rng2, __rng1);
-    __future.wait(__par_backend_hetero::__deferrable_mode{});
+        __n, __rng2, __rng1)
+        .__deferrable_wait();
     return __n;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -175,22 +175,24 @@ __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Rang
     if (__rng1.size() <= __rng2.size())
     {
         std::size_t __n = __rng1.size();
-        auto __exec1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(std::forward<_ExecutionPolicy>(__exec));
+        auto __exec1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(
+            std::forward<_ExecutionPolicy>(__exec));
         auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, std::move(__exec1),
-            unseq_backend::__brick_swap<decltype(__exec1), _Function, _Range1, _Range2>{
+            unseq_backend::__brick_swap<decltype(__exec1), _Function, std::decay_t<_Range1>, std::decay_t<_Range2>>{
                 {}, __f, __n},
             __n, __rng1, __rng2);
         __future.wait(__par_backend_hetero::__deferrable_mode{});
         return __n;
     }
     std::size_t __n = __rng2.size();
-    auto __exec2 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(std::forward<_ExecutionPolicy>(__exec));
+    auto __exec2 =
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(std::forward<_ExecutionPolicy>(__exec));
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
-            _BackendTag{}, std::move(__exec2),
-            unseq_backend::__brick_swap<decltype(__exec2), _Function, _Range2, _Range1>{
-                {}, __f, __n},
-            __n, __rng2, __rng1);
+        _BackendTag{}, std::move(__exec2),
+        unseq_backend::__brick_swap<decltype(__exec2), _Function, std::decay_t<_Range2>, std::decay_t<_Range1>>{
+            {}, __f, __n},
+        __n, __rng2, __rng1);
     __future.wait(__par_backend_hetero::__deferrable_mode{});
     return __n;
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -65,7 +65,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                 unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
-                    {}, __f, static_cast<std::size_t>(__n)},
+                    __f, static_cast<std::size_t>(__n)},
                 __n, ::std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
@@ -74,7 +74,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                 unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
-                    {}, __f, static_cast<std::size_t>(__n)},
+                    __f, static_cast<std::size_t>(__n)},
                 __n, ::std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
@@ -83,7 +83,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                 unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
-                    {}, __f, static_cast<std::size_t>(__n)},
+                    __f, static_cast<std::size_t>(__n)},
                 __n, ::std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
@@ -180,7 +180,7 @@ __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Rang
         auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, std::move(__exec1),
             unseq_backend::__brick_swap<decltype(__exec1), _Function, std::decay_t<_Range1>, std::decay_t<_Range2>>{
-                {}, __f, __n},
+                __f, __n},
             __n, __rng1, __rng2);
         __future.wait(__par_backend_hetero::__deferrable_mode{});
         return __n;
@@ -190,8 +190,8 @@ __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Rang
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(std::forward<_ExecutionPolicy>(__exec));
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::move(__exec2),
-        unseq_backend::__brick_swap<decltype(__exec2), _Function, std::decay_t<_Range2>, std::decay_t<_Range1>>{
-            {}, __f, __n},
+        unseq_backend::__brick_swap<decltype(__exec2), _Function, std::decay_t<_Range2>, std::decay_t<_Range1>>{__f,
+                                                                                                                __n},
         __n, __rng2, __rng1);
     __future.wait(__par_backend_hetero::__deferrable_mode{});
     return __n;
@@ -660,8 +660,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_wrapper>(
                 std::forward<_ExecutionPolicy>(__exec)),
             unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _CopyBrick, std::decay_t<_Range1>,
-                                                    std::decay_t<_Range2>>{
-                {}, _CopyBrick{}, static_cast<std::size_t>(__n)},
+                                                    std::decay_t<_Range2>>{_CopyBrick{}, static_cast<std::size_t>(__n)},
             __n, std::forward<_Range1>(__rng), std::forward<_Range2>(__result))
             .get();
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -63,28 +63,28 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         if constexpr (__num_ranges == 1)
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
-                _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+                _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                 unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
                     __f, static_cast<std::size_t>(__n)},
-                __n, ::std::forward<_Ranges>(__rngs)...)
+                __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
         else if constexpr (__num_ranges == 2)
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
-                _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+                _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                 unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
                     __f, static_cast<std::size_t>(__n)},
-                __n, ::std::forward<_Ranges>(__rngs)...)
+                __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
         else
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
-                _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+                _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                 unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
                     __f, static_cast<std::size_t>(__n)},
-                __n, ::std::forward<_Ranges>(__rngs)...)
+                __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -174,7 +174,7 @@ __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Rang
 {
     if (__rng1.size() <= __rng2.size())
     {
-        std::size_t __n = __rng1.size();
+        const std::size_t __n = __rng1.size();
         auto __exec1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(
             std::forward<_ExecutionPolicy>(__exec));
         auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
@@ -185,7 +185,7 @@ __pattern_swap(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Rang
         __future.wait(__par_backend_hetero::__deferrable_mode{});
         return __n;
     }
-    std::size_t __n = __rng2.size();
+    const std::size_t __n = __rng2.size();
     auto __exec2 =
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(std::forward<_ExecutionPolicy>(__exec));
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -28,7 +28,6 @@
 #include <cmath>
 #include <limits>
 #include <cstdint>
-#include <tuple>
 
 #include "../../iterator_impl.h"
 #include "../../execution_impl.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -129,16 +129,10 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     static std::size_t
     __estimate_best_start_size(const _ExecutionPolicy& __exec, _Fp __brick)
     {
-        // To ensure that the large submitter gets tested on all devices, set the switch point to 10,000 only when compiling
-        // oneDPL tests.
-#if TEST_FOR_ALGORITHM_LARGE_SUBMITTER
-        return 10000;
-#else
         const std::size_t __work_group_size =
             oneapi::dpl::__internal::__max_work_group_size(__exec, __max_work_group_size);
         const std::uint32_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
         return __work_group_size * _Fp::__preferred_iters_per_item * __max_cu;
-#endif
     }
 
     template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -146,14 +146,15 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
         auto __event = __exec.queue().submit([__rngs..., __brick, __work_group_size, __count](sycl::handler& __cgh) {
             //get an access to data under SYCL buffer:
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
-            constexpr static std::uint16_t __iters_per_work_item = _Fp::__preferred_iters_per_item;
+            constexpr std::uint8_t __iters_per_work_item = _Fp::__preferred_iters_per_item;
+            constexpr std::uint8_t __vector_size = _Fp::__preferred_vector_size;
             const std::size_t __num_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                __count, (__work_group_size * _Fp::__preferred_vector_size * __iters_per_work_item));
+                __count, (__work_group_size * __vector_size * __iters_per_work_item));
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range(sycl::range<1>(__num_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item</*dim=*/1> __item) {
-                    auto [__idx, __stride, __is_full] = __stride_recommender(
-                        __item, __count, __iters_per_work_item, _Fp::__preferred_vector_size, __work_group_size);
+                    auto [__idx, __stride, __is_full] =
+                        __stride_recommender(__item, __count, __iters_per_work_item, __vector_size, __work_group_size);
                     __strided_loop<__iters_per_work_item> __execute_loop{static_cast<std::size_t>(__count)};
                     if (__is_full)
                     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -196,7 +196,9 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
             // by our all / guard views interfere with compiler vectorization. At this point, we have ensured that
             // input is contiguous and can be operated on directly. The begin() function for these views will return a
             // pointer which is passed to the kernel.
-            if constexpr (_Fp::__can_vectorize)
+            //
+            // For buffers, pointers cannot be grabbed from an accessor outside of a kernel, so we have to fallback.
+            if constexpr (_Fp::__can_vectorize && (oneapi::dpl::__ranges::__is_passed_directly_range<std::decay_t<_Ranges>>::value && ...))
             {
                 return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
                                            std::forward<_Ranges>(__rngs).begin()...);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-//===-- parallel_backend_sycl_for.h --------------------------------===//
+//===-- parallel_backend_sycl_for.h ---------------------------------------===//
 //
 // Copyright (C) Intel Corporation
 //

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -192,22 +192,9 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
     {
         if (__count >= __large_submitter::__estimate_best_start_size(__exec, __brick))
         {
-            // Passing begin() of each range is needed for the icpx compiler to vectorize. The indirection introduced
-            // by our all / guard views interfere with compiler vectorization. At this point, we have ensured that
-            // input is contiguous and can be operated on directly. The begin() function for these views will return a
-            // pointer which is passed to the kernel.
-            //
-            // For buffers, pointers cannot be grabbed from an accessor outside of a kernel, so we have to fallback.
-            if constexpr (_Fp::__can_vectorize && (oneapi::dpl::__ranges::__is_passed_directly_range<std::decay_t<_Ranges>>::value && ...))
-            {
-                return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
-                                           std::forward<_Ranges>(__rngs).begin()...);
-            }
-            else
-            {
-                return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
-                                           std::forward<_Ranges>(__rngs)...);
-            }
+
+            return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
+                                       std::forward<_Ranges>(__rngs)...);
         }
     }
     return __small_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -92,13 +92,13 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     __stride_recommender(const sycl::nd_item<1>& __item, std::size_t __count, std::size_t __iters_per_work_item,
                          std::size_t __adj_elements_per_work_item, std::size_t __work_group_size)
     {
+        const std::size_t __work_group_id = __item.get_group().get_group_linear_id();
         if constexpr (oneapi::dpl::__internal::__is_spirv_target_v)
         {
             const __dpl_sycl::__sub_group __sub_group = __item.get_sub_group();
             const std::uint32_t __sub_group_size = __sub_group.get_local_linear_range();
             const std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
             const std::uint32_t __sub_group_local_id = __sub_group.get_local_linear_id();
-            const std::size_t __work_group_id = __item.get_group().get_group_linear_id();
 
             const std::size_t __sub_group_start_idx =
                 __iters_per_work_item * __adj_elements_per_work_item *
@@ -112,8 +112,8 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
         }
         else
         {
-            const std::size_t __work_group_start_idx = __item.get_group().get_group_linear_id() * __work_group_size *
-                                                       __iters_per_work_item * __adj_elements_per_work_item;
+            const std::size_t __work_group_start_idx =
+                __work_group_id * __work_group_size * __iters_per_work_item * __adj_elements_per_work_item;
             const std::size_t __work_item_idx =
                 __work_group_start_idx + __item.get_local_linear_id() * __adj_elements_per_work_item;
             const bool __is_full_work_group =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -192,8 +192,20 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
     {
         if (__count >= __large_submitter::__estimate_best_start_size(__exec, __brick))
         {
-            return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
-                                       std::forward<_Ranges>(__rngs)...);
+            // Passing begin() of each range is needed for the icpx compiler to vectorize. The indirection introduced
+            // by our all / guard views interfere with compiler vectorization. At this point, we have ensured that
+            // input is contiguous and can be operated on directly. The begin() function for these views will return a
+            // pointer which is passed to the kernel.
+            if constexpr (_Fp::__can_vectorize)
+            {
+                return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
+                                           std::forward<_Ranges>(__rngs).begin()...);
+            }
+            else
+            {
+                return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
+                                           std::forward<_Ranges>(__rngs)...);
+            }
         }
     }
     return __small_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -89,8 +89,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     // device.
     static inline std::tuple<std::size_t, std::size_t, bool>
     __stride_recommender(const sycl::nd_item<1>& __item, std::size_t __count, std::size_t __iters_per_work_item,
-                         std::size_t __adj_elements_per_work_item,
-                         std::size_t __work_group_size)
+                         std::size_t __adj_elements_per_work_item, std::size_t __work_group_size)
     {
         if constexpr (oneapi::dpl::__internal::__is_spirv_target_v)
         {
@@ -101,20 +100,27 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
             const std::size_t __work_group_id = __item.get_group().get_group_linear_id();
 
             const std::size_t __sub_group_start_idx =
-                __iters_per_work_item * __adj_elements_per_work_item * (__work_group_id * __work_group_size + __sub_group_size * __sub_group_id);
+                __iters_per_work_item * __adj_elements_per_work_item *
+                (__work_group_id * __work_group_size + __sub_group_size * __sub_group_id);
             const bool __is_full_sub_group =
-                __sub_group_start_idx + __iters_per_work_item * __adj_elements_per_work_item * __sub_group_size <= __count;
-            const std::size_t __work_item_idx = __sub_group_start_idx + __adj_elements_per_work_item * __sub_group_local_id;
-            return std::make_tuple(__work_item_idx, __adj_elements_per_work_item * __sub_group_size, __is_full_sub_group);
+                __sub_group_start_idx + __iters_per_work_item * __adj_elements_per_work_item * __sub_group_size <=
+                __count;
+            const std::size_t __work_item_idx =
+                __sub_group_start_idx + __adj_elements_per_work_item * __sub_group_local_id;
+            return std::make_tuple(__work_item_idx, __adj_elements_per_work_item * __sub_group_size,
+                                   __is_full_sub_group);
         }
         else
         {
-            const std::size_t __work_group_start_idx =
-                __item.get_group().get_group_linear_id() * __work_group_size * __iters_per_work_item * __adj_elements_per_work_item;
-            const std::size_t __work_item_idx = __work_group_start_idx + __item.get_local_linear_id() * __adj_elements_per_work_item;
+            const std::size_t __work_group_start_idx = __item.get_group().get_group_linear_id() * __work_group_size *
+                                                       __iters_per_work_item * __adj_elements_per_work_item;
+            const std::size_t __work_item_idx =
+                __work_group_start_idx + __item.get_local_linear_id() * __adj_elements_per_work_item;
             const bool __is_full_work_group =
-                __work_group_start_idx + __iters_per_work_item * __work_group_size * __adj_elements_per_work_item <= __count;
-            return std::make_tuple(__work_item_idx, __work_group_size * __adj_elements_per_work_item, __is_full_work_group);
+                __work_group_start_idx + __iters_per_work_item * __work_group_size * __adj_elements_per_work_item <=
+                __count;
+            return std::make_tuple(__work_item_idx, __work_group_size * __adj_elements_per_work_item,
+                                   __is_full_work_group);
         }
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cassert>
 #include <type_traits>
 #include <tuple>
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -66,7 +66,7 @@ struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name..
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
             __cgh.parallel_for<_Name...>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item_id) {
-                auto __idx = __item_id.get_linear_id();
+                const std::size_t __idx = __item_id.get_linear_id();
                 // For small inputs, do not vectorize or perform multiple iterations per work item. Spread input evenly
                 // across compute units.
                 __brick.__scalar_path_impl(std::true_type{}, __idx, __rngs...);
@@ -153,7 +153,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range(sycl::range<1>(__num_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item</*dim=*/1> __item) {
-                    auto [__idx, __stride, __is_full] =
+                    const auto [__idx, __stride, __is_full] =
                         __stride_recommender(__item, __count, __iters_per_work_item, __vector_size, __work_group_size);
                     __strided_loop<__iters_per_work_item> __execute_loop{static_cast<std::size_t>(__count)};
                     if (__is_full)
@@ -193,7 +193,6 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
     {
         if (__count >= __large_submitter::__estimate_best_start_size(__exec, __brick))
         {
-
             return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
                                        std::forward<_Ranges>(__rngs)...);
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -69,7 +69,7 @@ struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name..
                 auto __idx = __item_id.get_linear_id();
                 // For small inputs, do not vectorize or perform multiple iterations per work item. Spread input evenly
                 // across compute units.
-                __brick.__scalar_path(std::true_type{}, __idx, __rngs...);
+                __brick.__scalar_path_impl(std::true_type{}, __idx, __rngs...);
             });
         });
         return __future(__event);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -194,10 +194,10 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
     {
         if (__count >= __large_submitter::__estimate_best_start_size(__exec, __brick))
         {
-          return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
-                                     std::forward<_Ranges>(__rngs)...);
-         }
-     }
+            return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
+                                       std::forward<_Ranges>(__rngs)...);
+        }
+    }
     return __small_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
                                std::forward<_Ranges>(__rngs)...);
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -70,7 +70,7 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
 #pragma unroll(::std::decay <_ExecutionPolicy>::type::unroll_factor)
                 for (auto __idx = 0; __idx < __count; ++__idx)
                 {
-                    __brick.__scalar_path(std::true_type{}, __idx, __rngs...);
+                    __brick.__scalar_path_impl(std::true_type{}, __idx, __rngs...);
                 }
             });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -70,7 +70,7 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
 #pragma unroll(::std::decay <_ExecutionPolicy>::type::unroll_factor)
                 for (auto __idx = 0; __idx < __count; ++__idx)
                 {
-                    __brick(__idx, __rngs...);
+                    __brick.__scalar_path(std::true_type{}, __idx, __rngs...);
                 }
             });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -901,14 +901,13 @@ __bypass_sycl_kernel_not_supported(const sycl::exception& __e)
         throw;
 }
 
-// For use with __lazy_ctor_storage
-struct __lazy_load_op
+struct __scalar_load_op
 {
     template <typename _IdxType1, typename _IdxType2, typename _SourceAcc, typename _DestAcc>
     void
     operator()(_IdxType1 __idx_source, _IdxType2 __idx_dest, _SourceAcc __source_acc, _DestAcc __dest_acc) const
     {
-        __dest_acc[__idx_dest].__setup(__source_acc[__idx_source]);
+        __dest_acc[__idx_dest] = __source_acc[__idx_source];
     }
 };
 
@@ -936,9 +935,8 @@ struct __vector_load
     }
 };
 
-// For use with __lazy_ctor_storage
 template <typename _TransformOp>
-struct __lazy_store_transform_op
+struct __scalar_store_transform_op
 {
     _TransformOp __transform;
     // Unary transformations into an output buffer
@@ -946,7 +944,7 @@ struct __lazy_store_transform_op
     void
     operator()(_IdxType1 __idx_source, _IdxType2 __idx_dest, _SourceAcc __source_acc, _DestAcc __dest_acc) const
     {
-        __transform(__source_acc[__idx_source].__v, __dest_acc[__idx_dest]);
+        __transform(__source_acc[__idx_source], __dest_acc[__idx_dest]);
     }
     // Binary transformations into an output buffer
     template <typename _IdxType1, typename _IdxType2, typename _Source1Acc, typename _Source2Acc, typename _DestAcc>
@@ -954,7 +952,7 @@ struct __lazy_store_transform_op
     operator()(_IdxType1 __idx_source, _IdxType2 __idx_dest, _Source1Acc __source1_acc, _Source2Acc __source2_acc,
                _DestAcc __dest_acc) const
     {
-        __transform(__source1_acc[__idx_source].__v, __source2_acc[__idx_source].__v, __dest_acc[__idx_dest]);
+        __transform(__source1_acc[__idx_source], __source2_acc[__idx_source], __dest_acc[__idx_dest]);
     }
 };
 
@@ -1022,14 +1020,14 @@ struct __vector_reverse
     {
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint8_t __i = 0; __i < __vec_size / 2; ++__i)
-            std::swap(__array[__i].__v, __array[__vec_size - __i - 1].__v);
+            std::swap(__array[__i], __array[__vec_size - __i - 1]);
     }
     template <typename _Idx, typename _Array>
     void
     operator()(/*__is_full*/ std::false_type, const _Idx __elements_to_process, _Array __array) const
     {
         for (std::uint8_t __i = 0; __i < __elements_to_process / 2; ++__i)
-            std::swap(__array[__i].__v, __array[__elements_to_process - __i - 1].__v);
+            std::swap(__array[__i], __array[__elements_to_process - __i - 1]);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -903,11 +903,12 @@ __bypass_sycl_kernel_not_supported(const sycl::exception& __e)
 
 struct __scalar_load_op
 {
+    oneapi::dpl::__internal::__pstl_assign __assigner;
     template <typename _IdxType1, typename _IdxType2, typename _SourceAcc, typename _DestAcc>
     void
     operator()(_IdxType1 __idx_source, _IdxType2 __idx_dest, _SourceAcc __source_acc, _DestAcc __dest_acc) const
     {
-        __dest_acc[__idx_dest] = __source_acc[__idx_source];
+        __assigner(__source_acc[__idx_source], __dest_acc[__idx_dest]);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -957,6 +957,8 @@ struct __scalar_store_transform_op
     }
 };
 
+// TODO: Consider unifying the implementations of __vector_walk, __vector_load, __vector_store, and potentially
+// __strided_loop with some common, generic utility
 template <std::uint8_t __vec_size>
 struct __vector_walk
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -586,7 +586,7 @@ namespace oneapi::dpl::internal
 enum class search_algorithm;
 
 template <typename Comp, typename T, typename _Range, search_algorithm func>
-struct custom_brick;
+struct __custom_brick;
 
 template <typename T, typename Predicate>
 struct replace_if_fun;
@@ -606,7 +606,7 @@ class transform_if_stencil_fun;
 } // namespace oneapi::dpl::internal
 
 template <typename Comp, typename T, typename _Range, oneapi::dpl::internal::search_algorithm func>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::custom_brick, Comp, T, _Range, func)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::__custom_brick, Comp, T, _Range, func)>
     : oneapi::dpl::__internal::__are_all_device_copyable<Comp, T>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -217,7 +217,8 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
             __raw_ptr2);
         // 3. Explicitly call destructor of lazy union type
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
+            __rng1_vector);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
@@ -273,9 +274,11 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
             __rng2_vector, __raw_ptr3);
         // 3. Explicitly call destructors of lazy union type
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
+            __rng1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng2_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2>::__get_callable_deleter(),
+            __rng2_vector);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
@@ -362,7 +365,8 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
             __rng2[0] = __rng1_vector[0].__v;
         // 3. Delete temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
+            __rng1_vector);
     }
     template <typename _IsFull, typename _ItemId>
     void
@@ -1199,9 +1203,11 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
             __rng_right_vector, __rng_pointer);
         // 4. Call destructors of temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng_left_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
+            __rng_left_vector);
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng_right_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
+            __rng_right_vector);
     }
     template <typename _IsFull, typename _Idx>
     void
@@ -1272,7 +1278,8 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         }
         // 3. Cleanup
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
+            __rng1_vector);
     }
     template <typename _IsFull, typename _Idx>
     void
@@ -1327,7 +1334,8 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             __rng1_vector, __rng2_pointer);
         // 3. Delete temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
+            __rng1_vector);
     }
     template <typename _IsFull, typename _Idx>
     void
@@ -1540,9 +1548,11 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
             __raw_ptr2);
         // 3. Explicitly call destructor of lazy union type
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
+            __rng1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng2_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2>::__get_callable_deleter(),
+            __rng2_vector);
     }
 
     template <typename _IsFull, typename _Idx>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -168,7 +168,7 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
 
     template <typename _IsFull, typename _ItemId>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
+    __vector_path_impl(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
     {
         // This is needed to enable vectorization
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, __idx, __f,
@@ -178,7 +178,7 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
     template <typename _IsFull, typename _ItemId>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, _Range __rng) const
+    __scalar_path_impl(_IsFull, const _ItemId __idx, _Range __rng) const
     {
         __f(__rng[__idx]);
     }
@@ -188,9 +188,9 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
     operator()(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng);
+            __vector_path_impl(__is_full, __idx, __rng);
         else
-            __scalar_path(__is_full, __idx, __rng);
+            __scalar_path_impl(__is_full, __idx, __rng);
     }
 };
 
@@ -207,7 +207,7 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
 
     template <typename _IsFull, typename _ItemId>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
+    __vector_path_impl(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
     {
         using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng1_vector[__base_t::__preferred_vector_size];
@@ -227,7 +227,7 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
     template <typename _IsFull, typename _ItemId>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path_impl(_IsFull, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
     {
 
         __f(__rng1[__idx], __rng2[__idx]);
@@ -238,9 +238,9 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
     operator()(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
     }
 };
 
@@ -257,7 +257,7 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
 
     template <typename _IsFull, typename _ItemId>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
+    __vector_path_impl(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
     {
         using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
         using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;
@@ -285,7 +285,7 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
     template <typename _IsFull, typename _ItemId>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
+    __scalar_path_impl(_IsFull, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
     {
 
         __f(__rng1[__idx], __rng2[__idx], __rng3[__idx]);
@@ -296,9 +296,9 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
     operator()(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2, __rng3);
+            __vector_path_impl(__is_full, __idx, __rng1, __rng2, __rng3);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2, __rng3);
+            __scalar_path_impl(__is_full, __idx, __rng1, __rng2, __rng3);
     }
 };
 
@@ -335,7 +335,7 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
 
     template <typename _IsFull, typename _ItemId>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path_impl(_IsFull, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         // just copy an element if it is the first one
         if (__idx == 0)
@@ -345,7 +345,7 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
     }
     template <typename _IsFull, typename _ItemId>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __vector_path_impl(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size + 1];
@@ -375,9 +375,9 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
     operator()(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
     }
 };
 
@@ -1170,7 +1170,7 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
 
     template <typename _IsFull, typename _Idx>
     void
-    __vector_path(_IsFull __is_full, const _Idx __left_start_idx, _Range __rng) const
+    __vector_path_impl(_IsFull __is_full, const _Idx __left_start_idx, _Range __rng) const
     {
         std::size_t __n = __size;
         std::size_t __midpoint = __size / 2;
@@ -1217,7 +1217,7 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
     }
     template <typename _IsFull, typename _Idx>
     void
-    __scalar_path(_IsFull, const _Idx __idx, _Range __rng) const
+    __scalar_path_impl(_IsFull, const _Idx __idx, _Range __rng) const
     {
         using ::std::swap;
         swap(__rng[__idx], __rng[__size - __idx - 1]);
@@ -1227,9 +1227,9 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
     operator()(_IsFull __is_full, const _Idx __idx, _Range __rng) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng);
+            __vector_path_impl(__is_full, __idx, __rng);
         else
-            __scalar_path(__is_full, __idx, __rng);
+            __scalar_path_impl(__is_full, __idx, __rng);
     }
 };
 
@@ -1249,13 +1249,13 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
 
     template <typename _IsFull, typename _Idx>
     void
-    __scalar_path(_IsFull, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path_impl(_IsFull, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         __rng2[__idx] = __rng1[__size - __idx - 1];
     }
     template <typename _IsFull, typename _Idx>
     void
-    __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __vector_path_impl(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         std::size_t __n = __size;
         std::size_t __remaining_elements = __idx >= __n ? 0 : __n - __idx;
@@ -1293,9 +1293,9 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     operator()(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
     }
 };
 
@@ -1316,7 +1316,7 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
 
     template <typename _IsFull, typename _Idx>
     void
-    __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __vector_path_impl(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         _Idx __shifted_idx = __shift + __idx;
         _Idx __wrapped_idx = __shifted_idx % __size;
@@ -1349,7 +1349,7 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     }
     template <typename _IsFull, typename _Idx>
     void
-    __scalar_path(_IsFull, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path_impl(_IsFull, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         __rng2[__idx] = __rng1[(__shift + __idx) % __size];
     }
@@ -1358,9 +1358,9 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     operator()(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
     }
 };
 
@@ -1451,7 +1451,7 @@ struct __brick_shift_left
 
     template <typename _IsFull, typename _ItemId>
     void
-    __scalar_path(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
+    __scalar_path_impl(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
     {
         const _DiffType __i = __idx - __n; //loop invariant
         for (_DiffType __k = __n; __k < __size; __k += __n)
@@ -1465,7 +1465,7 @@ struct __brick_shift_left
     void
     operator()(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
     {
-        __scalar_path(__is_full, __idx, __rng);
+        __scalar_path_impl(__is_full, __idx, __rng);
     }
 };
 
@@ -1501,8 +1501,8 @@ struct __brick_reduce_idx : public walk_scalar_base<_Range>
     }
     template <typename _IsFull, typename _ItemId, typename _ReduceIdx, typename _Values, typename _OutValues>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, const _ReduceIdx& __segment_starts, const _Values& __values,
-                  _OutValues& __out_values) const
+    __scalar_path_impl(_IsFull, const _ItemId __idx, const _ReduceIdx& __segment_starts, const _Values& __values,
+                       _OutValues& __out_values) const
     {
         using __value_type = decltype(__segment_starts[__idx]);
         __value_type __segment_end =
@@ -1514,7 +1514,7 @@ struct __brick_reduce_idx : public walk_scalar_base<_Range>
     operator()(_IsFull __is_full, const _ItemId __idx, const _ReduceIdx& __segment_starts, const _Values& __values,
                _OutValues& __out_values) const
     {
-        __scalar_path(__is_full, __idx, __segment_starts, __values, __out_values);
+        __scalar_path_impl(__is_full, __idx, __segment_starts, __values, __out_values);
     }
 
   private:
@@ -1537,7 +1537,7 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
 
     template <typename _IsFull, typename _ItemId>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
+    __vector_path_impl(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
     {
         using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
         using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;
@@ -1569,7 +1569,7 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
 
     template <typename _IsFull, typename _Idx>
     void
-    __scalar_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path_impl(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         __f(__rng1[__idx], __rng2[__idx]);
     }
@@ -1579,9 +1579,9 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
     operator()(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1429,7 +1429,7 @@ struct __brick_shift_left
     constexpr static std::uint8_t __max_vector_size = 4;
 
   public:
-    // We cannot process multiple iterations per work-item without leading to race conditions
+    // Multiple iterations per item are manually procssed in the brick with a nd-range strided approach.
     constexpr static std::uint8_t __preferred_iters_per_item = 1;
     constexpr static bool __can_vectorize =
         oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Range>>::value &&

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -119,19 +119,20 @@ template <typename... _Ranges>
 class walk_vector_or_scalar_base
 {
     using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
-    constexpr static std::uint16_t __min_type_size =
+    constexpr static std::uint8_t __min_type_size =
         oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
-    constexpr static std::uint16_t __bytes_per_item = 16;
-
+    // Empirically determined 'bytes-in-flight' to maximize bandwidth utilization
+    constexpr static std::uint8_t __bytes_per_item = 16;
+    // Maximum size supported by compilers to generate vector instructions
+    constexpr static std::uint8_t __max_vector_size = 4;
   public:
     constexpr static bool __can_vectorize =
         (oneapi::dpl::__ranges::__is_vectorizable_range<_Ranges>::value && ...) &&
         (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
-    constexpr static std::uint16_t __preferred_vector_size =
-        __can_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(4, __min_type_size) : 1;
-    // To achieve full bandwidth utilization, multiple iterations need to be processed by a work item
-    constexpr static std::uint16_t __preferred_iters_per_item =
+    constexpr static std::uint8_t __preferred_vector_size =
+        __can_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
+    constexpr static std::uint8_t __preferred_iters_per_item =
         __bytes_per_item / (__min_type_size * __preferred_vector_size);
 };
 
@@ -139,15 +140,17 @@ class walk_vector_or_scalar_base
 template <typename... _Ranges>
 class walk_scalar_base
 {
-    using _ValueType =
-        oneapi::dpl::__internal::__min_nested_type_size<std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>>;
-
+    using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
+    constexpr static std::uint8_t __min_type_size =
+        oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
+    constexpr static std::uint8_t __bytes_per_item = 16;
   public:
     constexpr static bool __can_vectorize = false;
     // With no vectorization, the vector size is 1
-    constexpr static std::uint16_t __preferred_vector_size = 1;
+    constexpr static std::uint8_t __preferred_vector_size = 1;
     // To achieve full bandwidth utilization, multiple iterations need to be processed by a work item
-    constexpr static std::uint16_t __preferred_iters_per_item = 16 / (sizeof(_ValueType) * __preferred_vector_size);
+    constexpr static std::uint8_t __preferred_iters_per_item =
+        __bytes_per_item / (__min_type_size * __preferred_vector_size);
 };
 
 template <typename _ExecutionPolicy, typename _F, typename _Range>
@@ -324,51 +327,51 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
 
     template <typename _IsFull, typename _ItemId>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, const _Range1 __acc_src, _Range2 __acc_dst) const
+    __scalar_path(_IsFull, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         // just copy an element if it is the first one
         if (__idx == 0)
-            __acc_dst[__idx] = __acc_src[__idx];
+            __rng2[__idx] = __rng1[__idx];
         else
-            __f(__acc_src[__idx + (-1)], __acc_src[__idx], __acc_dst[__idx]);
+            __f(__rng1[__idx + (-1)], __rng1[__idx], __rng2[__idx]);
     }
     template <typename _IsFull, typename _ItemId>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, const _Range1 __acc_src, _Range2 __acc_dst) const
+    __vector_path(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
-        auto __acc_src_ptr = __acc_src.begin();
-        auto __acc_dst_ptr = __acc_dst.begin();
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __src_vector[__base_t::__preferred_vector_size + 1];
+        auto __rng1_ptr = __rng1.begin();
+        auto __rng2_ptr = __rng2.begin();
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size + 1];
         // 1. Establish a vector of __preferred_vector_size + 1 where a scalar load is performed on the first element
         // followed by a vector load of the specified length.
         if (__idx != 0)
-            __src_vector[0].__setup(__acc_src_ptr[__idx - 1]);
+            __rng1_vector[0].__setup(__rng1_ptr[__idx - 1]);
         else
-            __src_vector[0].__setup(__acc_src_ptr[0]);
+            __rng1_vector[0].__setup(__rng1_ptr[0]);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc_src_ptr,
-            &__src_vector[1]);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1_ptr,
+            &__rng1_vector[1]);
         // 2. Perform a vector store of __preferred_vector_size adjacent differences.
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __src_vector,
-            &__src_vector[1], __acc_dst_ptr);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
+            &__rng1_vector[1], __rng2_ptr);
         // A dummy value is first written to global memory followed by an overwrite for the first index. Pulling the vector loads / stores into an if branch
         // to better handle this results in performance degradation.
         if (__idx == 0)
-            __acc_dst[0] = __src_vector[0].__v;
+            __rng2[0] = __rng1_vector[0].__v;
         // 3. Delete temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __src_vector);
+            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
     }
-    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2>
+    template <typename _IsFull, typename _ItemId>
     void
-    operator()(_IsFull __is_full, const _ItemId __idx, const _Acc1& __acc_src, _Acc2& __acc_dst) const
+    operator()(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __acc_src, __acc_dst);
+            __vector_path(__is_full, __idx, __rng1, __rng2);
         else
-            __scalar_path(__is_full, __idx, __acc_src, __acc_dst);
+            __scalar_path(__is_full, __idx, __rng1, __rng2);
     }
 };
 
@@ -1154,11 +1157,11 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
     using __base_t = walk_vector_or_scalar_base<_Range>;
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
     _Size __size;
-    template <typename _IsFull, typename _Idx, typename _Accessor>
+    template <typename _IsFull, typename _Idx>
     void
-    __vector_path(_IsFull __is_full, const _Idx __left_start_idx, _Accessor __acc) const
+    __vector_path(_IsFull __is_full, const _Idx __left_start_idx, _Range __rng) const
     {
-        auto __acc_pointer = __acc.begin();
+        auto __rng_pointer = __rng.begin();
         std::size_t __n = __size;
         std::size_t __midpoint = __size / 2;
         // If our start is passed the midpoint, then immediately leave as it is guaranteed to be processed by another
@@ -1171,50 +1174,50 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
         // 1. Load two vectors that we want to swap: one from the left half of the buffer and one from the right
         const _Idx __right_start_idx = __size - __left_start_idx - __base_t::__preferred_vector_size;
 
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc_left_vector[__base_t::__preferred_vector_size];
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc_right_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng_left_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng_right_vector[__base_t::__preferred_vector_size];
 
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __left_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc_pointer,
-            __acc_left_vector);
+            __is_full, __left_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng_pointer,
+            __rng_left_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __right_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc_pointer,
-            __acc_right_vector);
+            __is_full, __right_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng_pointer,
+            __rng_right_vector);
         // 2. Reverse vectors in registers. Note that due to indices we have chosen, there will always be a full vector of elements to load
         oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-            std::true_type{}, __left_start_idx, __acc_left_vector);
+            std::true_type{}, __left_start_idx, __rng_left_vector);
         oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-            std::true_type{}, __right_start_idx, __acc_right_vector);
+            std::true_type{}, __right_start_idx, __rng_right_vector);
         // 3. Store the left-half vector to the corresponding right-half indices and vice versa
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __right_start_idx,
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-            __acc_left_vector, __acc_pointer);
+            __rng_left_vector, __rng_pointer);
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __left_start_idx,
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-            __acc_right_vector, __acc_pointer);
+            __rng_right_vector, __rng_pointer);
         // 4. Call destructors of temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __acc_left_vector);
+            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng_left_vector);
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __acc_right_vector);
+            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng_right_vector);
     }
-    template <typename _IsFull, typename _Idx, typename _Accessor>
+    template <typename _IsFull, typename _Idx>
     void
-    __scalar_path(_IsFull, const _Idx __idx, _Accessor __acc) const
+    __scalar_path(_IsFull, const _Idx __idx, _Range __rng) const
     {
         using ::std::swap;
-        swap(__acc[__idx], __acc[__size - __idx - 1]);
+        swap(__rng[__idx], __rng[__size - __idx - 1]);
     }
-    template <typename _IsFull, typename _Idx, typename _Accessor>
+    template <typename _IsFull, typename _Idx>
     void
-    operator()(_IsFull __is_full, const _Idx __idx, _Accessor __acc) const
+    operator()(_IsFull __is_full, const _Idx __idx, _Range __rng) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __acc);
+            __vector_path(__is_full, __idx, __rng);
         else
-            __scalar_path(__is_full, __idx, __acc);
+            __scalar_path(__is_full, __idx, __rng);
     }
 };
 
@@ -1230,55 +1233,55 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
 
     template <typename _IsFull, typename _Idx>
     void
-    __scalar_path(_IsFull, const _Idx __idx, const _Range1 __acc1, _Range2 __acc2) const
+    __scalar_path(_IsFull, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
-        __acc2[__idx] = __acc1[__size - __idx - 1];
+        __rng2[__idx] = __rng1[__size - __idx - 1];
     }
     template <typename _IsFull, typename _Idx>
     void
-    __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __acc1, _Range2 __acc2) const
+    __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
-        auto __acc1_pointer = __acc1.begin();
-        auto __acc2_pointer = __acc2.begin();
+        auto __rng1_pointer = __rng1.begin();
+        auto __rng2_pointer = __rng2.begin();
         std::size_t __n = __size;
         std::size_t __remaining_elements = __idx >= __n ? 0 : __n - __idx;
         std::size_t __elements_to_process =
             std::min(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
         const _Idx __output_start = __size - __idx - __elements_to_process;
         // 1. Load vector to reverse
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc1_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size];
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc1_pointer,
-            __acc1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1_pointer,
+            __rng1_vector);
         // 2, 3. Reverse in registers and flip the location of the vector in the output buffer
         if (__elements_to_process == __base_t::__preferred_vector_size)
         {
             oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-                std::true_type{}, __elements_to_process, __acc1_vector);
+                std::true_type{}, __elements_to_process, __rng1_vector);
             oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
                 __is_full, __output_start,
                 oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-                __acc1_vector, __acc2_pointer);
+                __rng1_vector, __rng2_pointer);
         }
         else
         {
             oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-                std::false_type{}, __elements_to_process, __acc1_vector);
-            for (std::uint16_t __i = 0; __i < __elements_to_process; ++__i)
-                __acc2_pointer[__output_start + __i] = __acc1_vector[__i].__v;
+                std::false_type{}, __elements_to_process, __rng1_vector);
+            for (std::uint8_t __i = 0; __i < __elements_to_process; ++__i)
+                __rng2_pointer[__output_start + __i] = __rng1_vector[__i].__v;
         }
         // 3. Cleanup
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __acc1_vector);
+            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
     }
-    template <typename _IsFull, typename _Idx, typename _AccessorSrc, typename _AccessorDst>
+    template <typename _IsFull, typename _Idx>
     void
-    operator()(_IsFull __is_full, const _Idx __idx, const _AccessorSrc __acc1, _AccessorDst __acc2) const
+    operator()(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __acc1, __acc2);
+            __vector_path(__is_full, __idx, __rng1, __rng2);
         else
-            __scalar_path(__is_full, __idx, __acc1, __acc2);
+            __scalar_path(__is_full, __idx, __rng1, __rng2);
     }
 };
 
@@ -1292,22 +1295,22 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
     _Size __size;
     _Size __shift;
-    template <typename _IsFull, typename _Idx, typename _AccessorSrc, typename _AccessorDst>
+    template <typename _IsFull, typename _Idx>
     void
-    __vector_path(_IsFull __is_full, const _Idx __idx, const _AccessorSrc __acc1, _AccessorDst __acc2) const
+    __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
-        auto __acc1_pointer = __acc1.begin();
-        auto __acc2_pointer = __acc2.begin();
+        auto __rng1_pointer = __rng1.begin();
+        auto __rng2_pointer = __rng2.begin();
         _Idx __shifted_idx = __shift + __idx;
         _Idx __wrapped_idx = __shifted_idx % __size;
         std::size_t __n = __size;
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc1_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size];
         //1. Vectorize loads only if we know the wrap around point is beyond the current vector elements to process
         if (__wrapped_idx + __base_t::__preferred_vector_size <= __size)
         {
             oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-                __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc1_pointer,
-                __acc1_vector);
+                __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1_pointer,
+                __rng1_vector);
         }
         else
         {
@@ -1315,32 +1318,32 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             std::size_t __elements_to_process =
                 std::min(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
             for (std::uint16_t __i = 0; __i != __elements_to_process; ++__i)
-                __acc1_vector[__i].__setup(__acc1_pointer[(__shifted_idx + __i) % __size]);
+                __rng1_vector[__i].__setup(__rng1_pointer[(__shifted_idx + __i) % __size]);
         }
         // 2. Store the rotation
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx,
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-            __acc1_vector, __acc2_pointer);
+            __rng1_vector, __rng2_pointer);
         // 3. Delete temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __acc1_vector);
+            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
     }
     template <typename _IsFull, typename _Idx>
     void
-    __scalar_path(_IsFull, const _Idx __idx, const _Range1 __acc1, _Range2 __acc2) const
+    __scalar_path(_IsFull, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
 
-        __acc2[__idx] = __acc1[(__shift + __idx) % __size];
+        __rng2[__idx] = __rng1[(__shift + __idx) % __size];
     }
     template <typename _IsFull, typename _Idx>
     void
-    operator()(_IsFull __is_full, const _Idx __idx, const _Range1 __acc1, _Range2 __acc2) const
+    operator()(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __acc1, __acc2);
+            __vector_path(__is_full, __idx, __rng1, __rng2);
         else
-            __scalar_path(__is_full, __idx, __acc1, __acc2);
+            __scalar_path(__is_full, __idx, __rng1, __rng2);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -219,7 +219,7 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
             __rng2);
         // 3. Explicitly call destructor of lazy union type
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n - __idx}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
             __rng1_vector);
     }
@@ -274,10 +274,10 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
             __rng2_vector, __rng3);
         // 3. Explicitly call destructors of lazy union type
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n - __idx}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
             __rng1_vector);
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n - __idx}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2>::__get_callable_deleter(),
             __rng2_vector);
     }
@@ -366,7 +366,7 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
         if (__idx == 0)
             __rng2[0] = __rng1_vector[0].__v;
         // 3. Delete temporary storage
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n - __idx}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
             __rng1_vector);
     }
@@ -1259,7 +1259,7 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     {
         std::size_t __n = __size;
         std::size_t __remaining_elements = __idx >= __n ? 0 : __n - __idx;
-        std::size_t __elements_to_process =
+        std::uint8_t __elements_to_process =
             std::min(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
         const _Idx __output_start = __size - __idx - __elements_to_process;
         // 1. Load vector to reverse
@@ -1270,7 +1270,7 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         if (__elements_to_process == __base_t::__preferred_vector_size)
         {
             oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-                std::true_type{}, __elements_to_process, __rng1_vector);
+                __is_full, __elements_to_process, __rng1_vector);
             oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
                 __is_full, __output_start,
                 oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
@@ -1284,7 +1284,7 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
                 __rng2[__output_start + __i] = __rng1_vector[__i].__v;
         }
         // 3. Cleanup
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__remaining_elements}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
             __rng1_vector);
     }
@@ -1343,7 +1343,7 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
             __rng1_vector, __rng2);
         // 3. Delete temporary storage
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n - __idx}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
             __rng1_vector);
     }
@@ -1559,10 +1559,10 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
             __rng2);
         // 3. Explicitly call destructor of lazy union type
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n - __idx}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
             __rng1_vector);
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n - __idx}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2>::__get_callable_deleter(),
             __rng2_vector);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1267,13 +1267,13 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size];
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng1, __rng1_vector);
+        oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
+            __is_full, __elements_to_process, __rng1_vector);
         // 2, 3. Reverse in registers and flip the location of the vector in the output buffer
-        if (__elements_to_process == __base_t::__preferred_vector_size)
+        if constexpr (_IsFull::value)
         {
-            oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-                __is_full, __elements_to_process, __rng1_vector);
             oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
-                __is_full, __output_start,
+                std::true_type{}, __output_start,
                 oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
                 __rng1_vector, __rng2);
         }
@@ -1283,8 +1283,6 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             // The last few elements in the buffer are reversed into the beginning of the buffer. However,
             // __vector_store would believe that we always have a full vector length of elements due to the starting
             // index having greater than __preferred_vector_size elements until the end of the buffer.
-            oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-                std::false_type{}, __elements_to_process, __rng1_vector);
             for (std::uint8_t __i = 0; __i < __elements_to_process; ++__i)
                 __rng2[__output_start + __i] = __rng1_vector[__i].__v;
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -347,10 +347,7 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
         _ValueType __rng1_vector[__base_t::__preferred_vector_size + 1];
         // 1. Establish a vector of __preferred_vector_size + 1 where a scalar load is performed on the first element
         // followed by a vector load of the specified length.
-        if (__idx != 0)
-            __assigner(__rng1[__idx - 1], __rng1_vector[0]);
-        else
-            __assigner(__rng1[0], __rng1_vector[0]);
+        __assigner(__idx != 0 ? __rng1[__idx - 1] : __rng1[0], __rng1_vector[0]);
         typename __base_t::__vec_load_t{__n}(__is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_load_op{},
                                              __rng1, &__rng1_vector[1]);
         // 2. Perform a vector store of __preferred_vector_size adjacent differences.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1429,7 +1429,7 @@ struct __brick_shift_left
     constexpr static std::uint8_t __max_vector_size = 4;
 
   public:
-    // Multiple iterations per item are manually procssed in the brick with a nd-range strided approach.
+    // Multiple iterations per item are manually processed in the brick with a nd-range strided approach.
     constexpr static std::uint8_t __preferred_iters_per_item = 1;
     constexpr static bool __can_vectorize =
         oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Range>>::value &&
@@ -1473,8 +1473,11 @@ struct __brick_shift_left
             }
             else
             {
-                // The last sub-group should process its elements serially even with a full vector to minimize branch
-                // divergence.
+                // Some items within a sub-group may still have a full vector length to process even if _IsFull is
+                // false by intentional design of __stride_recommender. While these are vectorizable, this will result
+                // in branch divergence and masked execution of both vectorized and serial paths for all items in the
+                // sub-group which may worsen performance. Instead, have each item in the sub-group process its work
+                // serially.
                 for (_DiffType __j = 0; __j < std::min(std::size_t{__preferred_vector_size}, __n - __idx); ++__j)
                     if (__read_offset + __j < __size)
                         __rng[__write_offset + __j] = __rng[__read_offset + __j];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1453,13 +1453,13 @@ struct __brick_shift_left
             const _DiffType __write_offset = __k + __i;
             if constexpr (_IsFull::value)
             {
-                if (__k + __idx + __preferred_vector_size <= __size)
+                if (__read_offset + __preferred_vector_size <= __size)
                 {
                     _ValueType __rng_vector[__preferred_vector_size];
                     __vec_load(std::true_type{}, __read_offset, __load_op, __rng, __rng_vector);
                     __vec_store(std::true_type{}, __write_offset, __store_op, __rng_vector, __rng);
                 }
-                else if (__k + __idx < __size)
+                else if (__read_offset < __size)
                 {
                     const std::size_t __num_remaining = __size - __read_offset;
                     for (_DiffType __j = 0; __j < __num_remaining; ++__j)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1157,8 +1157,8 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
     void
     __vector_path_impl(_IsFull, const std::size_t __left_start_idx, _Range __rng) const
     {
-        std::size_t __n = __size;
-        std::size_t __midpoint = __size / 2;
+        const std::size_t __n = __size;
+        const std::size_t __midpoint = __size / 2;
 
         // In the below implementation, we see that _IsFull is ignored in favor of std::true_type{} in all cases.
         // This relaxation is due to the fact that in-place reverse launches work only over the first half of the
@@ -1238,9 +1238,9 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     void
     __vector_path_impl(_IsFull __is_full, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
-        std::size_t __n = __size;
-        std::size_t __remaining_elements = __n - __idx;
-        std::uint8_t __elements_to_process =
+        const std::size_t __n = __size;
+        const std::size_t __remaining_elements = __n - __idx;
+        const std::uint8_t __elements_to_process =
             std::min(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
         const std::size_t __output_start = __size - __idx - __elements_to_process;
         // 1. Load vector to reverse
@@ -1300,9 +1300,9 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     void
     __vector_path_impl(_IsFull __is_full, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
-        std::size_t __shifted_idx = __shift + __idx;
-        std::size_t __wrapped_idx = __shifted_idx % __size;
-        std::size_t __n = __size;
+        const std::size_t __shifted_idx = __shift + __idx;
+        const std::size_t __wrapped_idx = __shifted_idx % __size;
+        const std::size_t __n = __size;
         _ValueType __rng1_vector[__base_t::__preferred_vector_size];
         //1. Vectorize loads only if we know the wrap around point is beyond the current vector elements to process
         if (__wrapped_idx + __base_t::__preferred_vector_size <= __n)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -166,32 +166,30 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
   public:
     walk1_vector_or_scalar(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
+    __vector_path(_IsFull __is_full, const _ItemId __idx, _Acc __acc) const
     {
-        // This is needed to enable vectorization
-        auto __raw_ptr = __rng.begin();
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, __idx, __f,
-                                                                                                 __raw_ptr);
+                                                                                                 __acc);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, _Range __rng) const
+    __scalar_path(_IsFull, const _ItemId __idx, _Acc __acc) const
     {
-        __f(__rng[__idx]);
+        __f(__acc[__idx]);
     }
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc>
     void
-    operator()(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
+    operator()(_IsFull __is_full, const _ItemId __idx, _Acc __acc) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng);
+            __vector_path(__is_full, __idx, __acc);
         else
-            __scalar_path(__is_full, __idx, __rng);
+            __scalar_path(__is_full, __idx, __acc);
     }
 };
 
@@ -199,6 +197,7 @@ template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Ra
 struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
   private:
+    using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;
     std::size_t __n;
@@ -206,47 +205,44 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
   public:
     walk2_vectors_or_scalars(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
+    __vector_path(_IsFull __is_full, const _ItemId __idx, _Acc1 __acc1, _Acc2 __acc2) const
     {
-        using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
         // This is needed for the icpx compiler to vectorize. The indirection introduced by our all / guard views interfere
         // with compiler vectorization. At this point, we have ensured that input is contiguous and can be operated on as a raw pointer. The
         // begin() function for these views will return a pointer.
-        auto __raw_ptr1 = __rng1.begin();
-        auto __raw_ptr2 = __rng2.begin();
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng1_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __acc1_vector[__base_t::__preferred_vector_size];
         // 1. Load input into a vector
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc1, __acc1_vector);
         // 2. Apply functor to vector and store into global memory
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
-            __raw_ptr2);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __acc1_vector,
+            __acc2);
         // 3. Explicitly call destructor of lazy union type
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
-            __rng1_vector);
+            __acc1_vector);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path(_IsFull, const _ItemId __idx, _Acc1 __acc1, _Acc2 __acc2) const
     {
 
-        __f(__rng1[__idx], __rng2[__idx]);
+        __f(__acc1[__idx], __acc2[__idx]);
     }
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2>
     void
-    operator()(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const _ItemId __idx, _Acc1 __acc1, _Acc2 __acc2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path(__is_full, __idx, __acc1, __acc2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path(__is_full, __idx, __acc1, __acc2);
     }
 };
 
@@ -254,6 +250,8 @@ template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Ra
 struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2, _Range3>
 {
   private:
+    using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
+    using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2, _Range3>;
     _F __f;
     std::size_t __n;
@@ -261,56 +259,47 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
   public:
     walk3_vectors_or_scalars(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2, typename _Acc3>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
+    __vector_path(_IsFull __is_full, const _ItemId __idx, _Acc1 __acc1, _Acc2 __acc2, _Acc3 __acc3) const
     {
-        using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
-        using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;
-        // This is needed for the icpx compiler to vectorize. The indirection introduced by our views interfere
-        // with compiler vectorization. At this point, we have ensured that input is contiguous and can be operated on
-        // as a raw pointer.
-        auto __raw_ptr1 = __rng1.begin();
-        auto __raw_ptr2 = __rng2.begin();
-        auto __raw_ptr3 = __rng3.begin();
-
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng1_vector[__base_t::__preferred_vector_size];
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2> __rng2_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __acc1_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2> __acc2_vector[__base_t::__preferred_vector_size];
         // 1. Load inputs into vectors
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc1, __acc1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr2, __rng2_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc2, __acc2_vector);
         // 2. Apply binary functor to vector and store into global memory
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
-            __rng2_vector, __raw_ptr3);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __acc1_vector,
+            __acc2_vector, __acc3);
         // 3. Explicitly call destructors of lazy union type
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
-            __rng1_vector);
+            __acc1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2>::__get_callable_deleter(),
-            __rng2_vector);
+            __acc2_vector);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2, typename _Acc3>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
+    __scalar_path(_IsFull, const _ItemId __idx, _Acc1 __acc1, _Acc2 __acc2, _Acc3 __acc3) const
     {
 
-        __f(__rng1[__idx], __rng2[__idx], __rng3[__idx]);
+        __f(__acc1[__idx], __acc2[__idx], __acc3[__idx]);
     }
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2, typename _Acc3>
     void
-    operator()(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
+    operator()(_IsFull __is_full, const _ItemId __idx, _Acc1 __acc1, _Acc2 __acc2, _Acc3 __acc3) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2, __rng3);
+            __vector_path(__is_full, __idx, __acc1, __acc2, __acc3);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2, __rng3);
+            __scalar_path(__is_full, __idx, __acc1, __acc2, __acc3);
     }
 };
 
@@ -345,54 +334,50 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
   public:
     walk_adjacent_difference(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2>
     void
-    __scalar_path(_IsFull, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path(_IsFull, const _ItemId __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
         // just copy an element if it is the first one
         if (__idx == 0)
-            __rng2[__idx] = __rng1[__idx];
+            __acc2[__idx] = __acc1[__idx];
         else
-            __f(__rng1[__idx + (-1)], __rng1[__idx], __rng2[__idx]);
+            __f(__acc1[__idx + (-1)], __acc1[__idx], __acc2[__idx]);
     }
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __vector_path(_IsFull __is_full, const _ItemId __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
-        auto __rng1_ptr = __rng1.begin();
-        auto __rng2_ptr = __rng2.begin();
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size + 1];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc1_vector[__base_t::__preferred_vector_size + 1];
         // 1. Establish a vector of __preferred_vector_size + 1 where a scalar load is performed on the first element
         // followed by a vector load of the specified length.
         if (__idx != 0)
-            __rng1_vector[0].__setup(__rng1_ptr[__idx - 1]);
+            __acc1_vector[0].__setup(__acc1[__idx - 1]);
         else
-            __rng1_vector[0].__setup(__rng1_ptr[0]);
+            __acc1_vector[0].__setup(__acc1[0]);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1_ptr,
-            &__rng1_vector[1]);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc1, &__acc1_vector[1]);
         // 2. Perform a vector store of __preferred_vector_size adjacent differences.
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
-            &__rng1_vector[1], __rng2_ptr);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __acc1_vector,
+            &__acc1_vector[1], __acc2);
         // A dummy value is first written to global memory followed by an overwrite for the first index. Pulling the vector loads / stores into an if branch
         // to better handle this results in performance degradation.
         if (__idx == 0)
-            __rng2[0] = __rng1_vector[0].__v;
+            __acc2[0] = __acc1_vector[0].__v;
         // 3. Delete temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
-            __rng1_vector);
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(), __acc1);
     }
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2>
     void
-    operator()(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const _ItemId __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path(__is_full, __idx, __acc1, __acc2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path(__is_full, __idx, __acc1, __acc2);
     }
 };
 
@@ -1183,11 +1168,10 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
   public:
     __reverse_functor(_Size __size) : __size(__size) {}
 
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc>
     void
-    __vector_path(_IsFull __is_full, const _Idx __left_start_idx, _Range __rng) const
+    __vector_path(_IsFull __is_full, const _Idx __left_start_idx, _Acc __acc) const
     {
-        auto __rng_pointer = __rng.begin();
         std::size_t __n = __size;
         std::size_t __midpoint = __size / 2;
         // If our start is passed the midpoint, then immediately leave as it is guaranteed to be processed by another
@@ -1200,52 +1184,52 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
         // 1. Load two vectors that we want to swap: one from the left half of the buffer and one from the right
         const _Idx __right_start_idx = __size - __left_start_idx - __base_t::__preferred_vector_size;
 
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng_left_vector[__base_t::__preferred_vector_size];
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng_right_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc_left_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc_right_vector[__base_t::__preferred_vector_size];
 
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __left_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng_pointer,
-            __rng_left_vector);
+            __is_full, __left_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc,
+            __acc_left_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __right_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng_pointer,
-            __rng_right_vector);
+            __is_full, __right_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc,
+            __acc_right_vector);
         // 2. Reverse vectors in registers. Note that due to indices we have chosen, there will always be a full vector of elements to load
         oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-            std::true_type{}, __left_start_idx, __rng_left_vector);
+            std::true_type{}, __left_start_idx, __acc_left_vector);
         oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-            std::true_type{}, __right_start_idx, __rng_right_vector);
+            std::true_type{}, __right_start_idx, __acc_right_vector);
         // 3. Store the left-half vector to the corresponding right-half indices and vice versa
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __right_start_idx,
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-            __rng_left_vector, __rng_pointer);
+            __acc_left_vector, __acc);
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __left_start_idx,
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-            __rng_right_vector, __rng_pointer);
+            __acc_right_vector, __acc);
         // 4. Call destructors of temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
-            __rng_left_vector);
+            __acc_left_vector);
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
-            __rng_right_vector);
+            __acc_right_vector);
     }
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc>
     void
-    __scalar_path(_IsFull, const _Idx __idx, _Range __rng) const
+    __scalar_path(_IsFull, const _Idx __idx, _Acc __acc) const
     {
-        using ::std::swap;
-        swap(__rng[__idx], __rng[__size - __idx - 1]);
+        using std::swap;
+        swap(__acc[__idx], __acc[__size - __idx - 1]);
     }
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc>
     void
-    operator()(_IsFull __is_full, const _Idx __idx, _Range __rng) const
+    operator()(_IsFull __is_full, const _Idx __idx, _Acc __acc) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng);
+            __vector_path(__is_full, __idx, __acc);
         else
-            __scalar_path(__is_full, __idx, __rng);
+            __scalar_path(__is_full, __idx, __acc);
     }
 };
 
@@ -1263,58 +1247,55 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
   public:
     __reverse_copy(_Size __size) : __size(__size) {}
 
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc1, typename _Acc2>
     void
-    __scalar_path(_IsFull, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path(_IsFull, const _Idx __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
-        __rng2[__idx] = __rng1[__size - __idx - 1];
+        __acc2[__idx] = __acc1[__size - __idx - 1];
     }
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc1, typename _Acc2>
     void
-    __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __vector_path(_IsFull __is_full, const _Idx __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
-        auto __rng1_pointer = __rng1.begin();
-        auto __rng2_pointer = __rng2.begin();
         std::size_t __n = __size;
         std::size_t __remaining_elements = __idx >= __n ? 0 : __n - __idx;
         std::size_t __elements_to_process =
             std::min(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
         const _Idx __output_start = __size - __idx - __elements_to_process;
         // 1. Load vector to reverse
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc1_vector[__base_t::__preferred_vector_size];
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1_pointer,
-            __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc1, __acc1_vector);
         // 2, 3. Reverse in registers and flip the location of the vector in the output buffer
         if (__elements_to_process == __base_t::__preferred_vector_size)
         {
             oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-                std::true_type{}, __elements_to_process, __rng1_vector);
+                std::true_type{}, __elements_to_process, __acc1_vector);
             oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
                 __is_full, __output_start,
                 oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-                __rng1_vector, __rng2_pointer);
+                __acc1_vector, __acc2);
         }
         else
         {
             oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
-                std::false_type{}, __elements_to_process, __rng1_vector);
+                std::false_type{}, __elements_to_process, __acc1_vector);
             for (std::uint8_t __i = 0; __i < __elements_to_process; ++__i)
-                __rng2_pointer[__output_start + __i] = __rng1_vector[__i].__v;
+                __acc2[__output_start + __i] = __acc1_vector[__i].__v;
         }
         // 3. Cleanup
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
-            __rng1_vector);
+            __acc1_vector);
     }
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc1, typename _Acc2>
     void
-    operator()(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const _Idx __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path(__is_full, __idx, __acc1, __acc2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path(__is_full, __idx, __acc1, __acc2);
     }
 };
 
@@ -1333,22 +1314,20 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
   public:
     __rotate_copy(_Size __size, _Size __shift) : __size(__size), __shift(__shift) {}
 
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc1, typename _Acc2>
     void
-    __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __vector_path(_IsFull __is_full, const _Idx __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
-        auto __rng1_pointer = __rng1.begin();
-        auto __rng2_pointer = __rng2.begin();
         _Idx __shifted_idx = __shift + __idx;
         _Idx __wrapped_idx = __shifted_idx % __size;
         std::size_t __n = __size;
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc1_vector[__base_t::__preferred_vector_size];
         //1. Vectorize loads only if we know the wrap around point is beyond the current vector elements to process
         if (__wrapped_idx + __base_t::__preferred_vector_size <= __size)
         {
             oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-                __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1_pointer,
-                __rng1_vector);
+                __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc1,
+                __acc1_vector);
         }
         else
         {
@@ -1356,32 +1335,32 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             std::size_t __elements_to_process =
                 std::min(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
             for (std::uint16_t __i = 0; __i != __elements_to_process; ++__i)
-                __rng1_vector[__i].__setup(__rng1_pointer[(__shifted_idx + __i) % __size]);
+                __acc1_vector[__i].__setup(__acc1[(__shifted_idx + __i) % __size]);
         }
         // 2. Store the rotation
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx,
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-            __rng1_vector, __rng2_pointer);
+            __acc1_vector, __acc2);
         // 3. Delete temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
-            __rng1_vector);
+            __acc1_vector);
     }
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc1, typename _Acc2>
     void
-    __scalar_path(_IsFull, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path(_IsFull, const _Idx __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
-        __rng2[__idx] = __rng1[(__shift + __idx) % __size];
+        __acc2[__idx] = __acc1[(__shift + __idx) % __size];
     }
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc1, typename _Acc2>
     void
-    operator()(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const _Idx __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path(__is_full, __idx, __acc1, __acc2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path(__is_full, __idx, __acc1, __acc2);
     }
 };
 
@@ -1549,6 +1528,8 @@ template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Ra
 struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
   private:
+    using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
+    using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;
     std::size_t __n;
@@ -1556,55 +1537,48 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
   public:
     __brick_swap(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _ItemId, typename _Acc1, typename _Acc2>
     void
-    __vector_path(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
+    __vector_path(_IsFull __is_full, const _ItemId __idx, _Acc1 __acc1, _Acc2 __acc2) const
     {
-        using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
-        using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;
-        // This is needed for the icpx compiler to vectorize. The indirection introduced by our all / guard views interfere
-        // with compiler vectorization. At this point, we have ensured that input is contiguous and can be operated on as a raw pointer. The
-        // begin() function for these views will return a pointer.
-        auto __raw_ptr1 = __rng1.begin();
-        auto __raw_ptr2 = __rng2.begin();
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng1_vector[__base_t::__preferred_vector_size];
-        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng2_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __acc1_vector[__base_t::__preferred_vector_size];
+        oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __acc2_vector[__base_t::__preferred_vector_size];
         // 1. Load inputs into vectors
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc1, __acc1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr2, __rng2_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc2, __acc2_vector);
         // 2. Swap the two ranges
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng2_vector,
-            __raw_ptr1);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __acc2_vector,
+            __acc1);
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
-            __raw_ptr2);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __acc1_vector,
+            __acc2);
         // 3. Explicitly call destructor of lazy union type
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
-            __rng1_vector);
+            __acc1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2>::__get_callable_deleter(),
-            __rng2_vector);
+            __acc2_vector);
     }
 
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc1, typename _Acc2>
     void
-    __scalar_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    __scalar_path(_IsFull __is_full, const _Idx __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
-        __f(__rng1[__idx], __rng2[__idx]);
+        __f(__acc1[__idx], __acc2[__idx]);
     }
 
-    template <typename _IsFull, typename _Idx>
+    template <typename _IsFull, typename _Idx, typename _Acc1, typename _Acc2>
     void
-    operator()(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const _Idx __idx, const _Acc1 __acc1, _Acc2 __acc2) const
     {
         if constexpr (__base_t::__can_vectorize)
-            __vector_path(__is_full, __idx, __rng1, __rng2);
+            __vector_path(__is_full, __idx, __acc1, __acc2);
         else
-            __scalar_path(__is_full, __idx, __rng1, __rng2);
+            __scalar_path(__is_full, __idx, __acc1, __acc2);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1294,16 +1294,16 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     _Size __shift;
     template <typename _IsFull, typename _Idx, typename _AccessorSrc, typename _AccessorDst>
     void
-    __vector_path(_IsFull __is_full, const _Idx __idx, const _AccessorSrc& __acc1, _AccessorDst& __acc2) const
+    __vector_path(_IsFull __is_full, const _Idx __idx, const _AccessorSrc __acc1, _AccessorDst __acc2) const
     {
         auto __acc1_pointer = __acc1.begin();
         auto __acc2_pointer = __acc2.begin();
         _Idx __shifted_idx = __shift + __idx;
         _Idx __wrapped_idx = __shifted_idx % __size;
-        std::size_t __n = __shift;
+        std::size_t __n = __size;
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __acc1_vector[__base_t::__preferred_vector_size];
         //1. Vectorize loads only if we know the wrap around point is beyond the current vector elements to process
-        if (__wrapped_idx + __base_t::__preferred_vector_size < __size)
+        if (__wrapped_idx + __base_t::__preferred_vector_size <= __size)
         {
             oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
                 __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __acc1_pointer,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1267,9 +1267,10 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size];
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng1, __rng1_vector);
+        // 2. Reverse in registers
         oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
             __is_full, __elements_to_process, __rng1_vector);
-        // 2, 3. Reverse in registers and flip the location of the vector in the output buffer
+        // 3. Flip the location of the vector in the output buffer
         if constexpr (_IsFull::value)
         {
             oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -175,7 +175,6 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
     void
     __scalar_path(_IsFull, const _ItemId __idx, _Range __rng) const
     {
-
         __f(__rng[__idx]);
     }
 
@@ -1341,7 +1340,6 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     void
     __scalar_path(_IsFull, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
-
         __rng2[__idx] = __rng1[(__shift + __idx) % __size];
     }
     template <typename _IsFull, typename _Idx>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1511,9 +1511,9 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
   public:
     __brick_swap(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull>
     void
-    __vector_path_impl(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
+    __vector_path_impl(_IsFull __is_full, const std::size_t __idx, _Range1 __rng1, _Range2 __rng2) const
     {
         using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
         using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -170,7 +170,6 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
     void
     __vector_path_impl(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
     {
-        // This is needed to enable vectorization
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, __idx, __f,
                                                                                                  __rng);
     }
@@ -213,7 +212,7 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng1_vector[__base_t::__preferred_vector_size];
         // 1. Load input into a vector
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng1, __rng1_vector);
         // 2. Apply functor to vector and store into global memory
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
@@ -266,9 +265,9 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2> __rng2_vector[__base_t::__preferred_vector_size];
         // 1. Load inputs into vectors
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng1, __rng1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng2, __rng2_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng2, __rng2_vector);
         // 2. Apply binary functor to vector and store into global memory
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
@@ -356,7 +355,7 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
         else
             __rng1_vector[0].__setup(__rng1[0]);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, &__rng1_vector[1]);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng1, &__rng1_vector[1]);
         // 2. Perform a vector store of __preferred_vector_size adjacent differences.
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
@@ -1188,10 +1187,9 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng_right_vector[__base_t::__preferred_vector_size];
 
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __left_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng,
-            __rng_left_vector);
+            __is_full, __left_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng, __rng_left_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __right_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng,
+            __is_full, __right_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng,
             __rng_right_vector);
         // 2. Reverse vectors in registers. Note that due to indices we have chosen, there will always be a full vector of elements to load
         oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
@@ -1265,7 +1263,7 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         // 1. Load vector to reverse
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size];
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng1, __rng1_vector);
         // 2, 3. Reverse in registers and flip the location of the vector in the output buffer
         if (__elements_to_process == __base_t::__preferred_vector_size)
         {
@@ -1326,8 +1324,7 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         if (__wrapped_idx + __base_t::__preferred_vector_size <= __size)
         {
             oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-                __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1,
-                __rng1_vector);
+                __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng1, __rng1_vector);
         }
         else
         {
@@ -1541,16 +1538,13 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
     {
         using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
         using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;
-        // This is needed for the icpx compiler to vectorize. The indirection introduced by our all / guard views interfere
-        // with compiler vectorization. At this point, we have ensured that input is contiguous and can be operated on as a raw pointer. The
-        // begin() function for these views will return a pointer.
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng1_vector[__base_t::__preferred_vector_size];
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng2_vector[__base_t::__preferred_vector_size];
         // 1. Load inputs into vectors
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng1, __rng1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng2, __rng2_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_op{}, __rng2, __rng2_vector);
         // 2. Swap the two ranges
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng2_vector,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -171,9 +171,8 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
     __vector_path(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
     {
         // This is needed to enable vectorization
-        auto __raw_ptr = __rng.begin();
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, __idx, __f,
-                                                                                                 __raw_ptr);
+                                                                                                 __rng);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
@@ -211,19 +210,14 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
     __vector_path(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
     {
         using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
-        // This is needed for the icpx compiler to vectorize. The indirection introduced by our all / guard views interfere
-        // with compiler vectorization. At this point, we have ensured that input is contiguous and can be operated on as a raw pointer. The
-        // begin() function for these views will return a pointer.
-        auto __raw_ptr1 = __rng1.begin();
-        auto __raw_ptr2 = __rng2.begin();
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng1_vector[__base_t::__preferred_vector_size];
         // 1. Load input into a vector
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, __rng1_vector);
         // 2. Apply functor to vector and store into global memory
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
-            __raw_ptr2);
+            __rng2);
         // 3. Explicitly call destructor of lazy union type
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
@@ -267,24 +261,18 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
     {
         using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
         using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;
-        // This is needed for the icpx compiler to vectorize. The indirection introduced by our views interfere
-        // with compiler vectorization. At this point, we have ensured that input is contiguous and can be operated on
-        // as a raw pointer.
-        auto __raw_ptr1 = __rng1.begin();
-        auto __raw_ptr2 = __rng2.begin();
-        auto __raw_ptr3 = __rng3.begin();
 
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng1_vector[__base_t::__preferred_vector_size];
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType2> __rng2_vector[__base_t::__preferred_vector_size];
         // 1. Load inputs into vectors
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, __rng1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr2, __rng2_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng2, __rng2_vector);
         // 2. Apply binary functor to vector and store into global memory
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
-            __rng2_vector, __raw_ptr3);
+            __rng2_vector, __rng3);
         // 3. Explicitly call destructors of lazy union type
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),
@@ -360,22 +348,19 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
     __vector_path(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
-        auto __rng1_ptr = __rng1.begin();
-        auto __rng2_ptr = __rng2.begin();
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size + 1];
         // 1. Establish a vector of __preferred_vector_size + 1 where a scalar load is performed on the first element
         // followed by a vector load of the specified length.
         if (__idx != 0)
-            __rng1_vector[0].__setup(__rng1_ptr[__idx - 1]);
+            __rng1_vector[0].__setup(__rng1[__idx - 1]);
         else
-            __rng1_vector[0].__setup(__rng1_ptr[0]);
+            __rng1_vector[0].__setup(__rng1[0]);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1_ptr,
-            &__rng1_vector[1]);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, &__rng1_vector[1]);
         // 2. Perform a vector store of __preferred_vector_size adjacent differences.
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
-            &__rng1_vector[1], __rng2_ptr);
+            &__rng1_vector[1], __rng2);
         // A dummy value is first written to global memory followed by an overwrite for the first index. Pulling the vector loads / stores into an if branch
         // to better handle this results in performance degradation.
         if (__idx == 0)
@@ -1187,7 +1172,6 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
     void
     __vector_path(_IsFull __is_full, const _Idx __left_start_idx, _Range __rng) const
     {
-        auto __rng_pointer = __rng.begin();
         std::size_t __n = __size;
         std::size_t __midpoint = __size / 2;
         // If our start is passed the midpoint, then immediately leave as it is guaranteed to be processed by another
@@ -1204,10 +1188,10 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng_right_vector[__base_t::__preferred_vector_size];
 
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __left_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng_pointer,
+            __is_full, __left_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng,
             __rng_left_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __right_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng_pointer,
+            __is_full, __right_start_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng,
             __rng_right_vector);
         // 2. Reverse vectors in registers. Note that due to indices we have chosen, there will always be a full vector of elements to load
         oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
@@ -1218,11 +1202,11 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __right_start_idx,
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-            __rng_left_vector, __rng_pointer);
+            __rng_left_vector, __rng);
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __left_start_idx,
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-            __rng_right_vector, __rng_pointer);
+            __rng_right_vector, __rng);
         // 4. Call destructors of temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
@@ -1273,8 +1257,6 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     void
     __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
-        auto __rng1_pointer = __rng1.begin();
-        auto __rng2_pointer = __rng2.begin();
         std::size_t __n = __size;
         std::size_t __remaining_elements = __idx >= __n ? 0 : __n - __idx;
         std::size_t __elements_to_process =
@@ -1283,8 +1265,7 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         // 1. Load vector to reverse
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType> __rng1_vector[__base_t::__preferred_vector_size];
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1_pointer,
-            __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, __rng1_vector);
         // 2, 3. Reverse in registers and flip the location of the vector in the output buffer
         if (__elements_to_process == __base_t::__preferred_vector_size)
         {
@@ -1293,14 +1274,14 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
                 __is_full, __output_start,
                 oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-                __rng1_vector, __rng2_pointer);
+                __rng1_vector, __rng2);
         }
         else
         {
             oneapi::dpl::__par_backend_hetero::__vector_reverse<__base_t::__preferred_vector_size>{}(
                 std::false_type{}, __elements_to_process, __rng1_vector);
             for (std::uint8_t __i = 0; __i < __elements_to_process; ++__i)
-                __rng2_pointer[__output_start + __i] = __rng1_vector[__i].__v;
+                __rng2[__output_start + __i] = __rng1_vector[__i].__v;
         }
         // 3. Cleanup
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
@@ -1337,8 +1318,6 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
     void
     __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
     {
-        auto __rng1_pointer = __rng1.begin();
-        auto __rng2_pointer = __rng2.begin();
         _Idx __shifted_idx = __shift + __idx;
         _Idx __wrapped_idx = __shifted_idx % __size;
         std::size_t __n = __size;
@@ -1347,7 +1326,7 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         if (__wrapped_idx + __base_t::__preferred_vector_size <= __size)
         {
             oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-                __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1_pointer,
+                __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1,
                 __rng1_vector);
         }
         else
@@ -1356,13 +1335,13 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             std::size_t __elements_to_process =
                 std::min(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
             for (std::uint16_t __i = 0; __i != __elements_to_process; ++__i)
-                __rng1_vector[__i].__setup(__rng1_pointer[(__shifted_idx + __i) % __size]);
+                __rng1_vector[__i].__setup(__rng1[(__shifted_idx + __i) % __size]);
         }
         // 2. Store the rotation
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx,
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
-            __rng1_vector, __rng2_pointer);
+            __rng1_vector, __rng2);
         // 3. Delete temporary storage
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType>::__get_callable_deleter(),
@@ -1565,22 +1544,20 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
         // This is needed for the icpx compiler to vectorize. The indirection introduced by our all / guard views interfere
         // with compiler vectorization. At this point, we have ensured that input is contiguous and can be operated on as a raw pointer. The
         // begin() function for these views will return a pointer.
-        auto __raw_ptr1 = __rng1.begin();
-        auto __raw_ptr2 = __rng2.begin();
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng1_vector[__base_t::__preferred_vector_size];
         oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1> __rng2_vector[__base_t::__preferred_vector_size];
         // 1. Load inputs into vectors
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr1, __rng1_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng1, __rng1_vector);
         oneapi::dpl::__par_backend_hetero::__vector_load<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __raw_ptr2, __rng2_vector);
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_load_transform_op{}, __rng2, __rng2_vector);
         // 2. Swap the two ranges
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng2_vector,
-            __raw_ptr1);
+            __rng1);
         oneapi::dpl::__par_backend_hetero::__vector_store<__base_t::__preferred_vector_size>{__n}(
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
-            __raw_ptr2);
+            __rng2);
         // 3. Explicitly call destructor of lazy union type
         oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
             __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage<_ValueType1>::__get_callable_deleter(),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -119,12 +119,12 @@ template <typename... _Ranges>
 class walk_vector_or_scalar_base
 {
     using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
-    constexpr static std::uint8_t __min_type_size =
-        oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
+    constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
     // Empirically determined 'bytes-in-flight' to maximize bandwidth utilization
     constexpr static std::uint8_t __bytes_per_item = 16;
     // Maximum size supported by compilers to generate vector instructions
     constexpr static std::uint8_t __max_vector_size = 4;
+
   public:
     constexpr static bool __can_vectorize =
         (oneapi::dpl::__ranges::__is_vectorizable_range<_Ranges>::value && ...) &&
@@ -141,9 +141,9 @@ template <typename... _Ranges>
 class walk_scalar_base
 {
     using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
-    constexpr static std::uint8_t __min_type_size =
-        oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
+    constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
     constexpr static std::uint8_t __bytes_per_item = 16;
+
   public:
     constexpr static bool __can_vectorize = false;
     // With no vectorization, the vector size is 1
@@ -166,8 +166,8 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
     {
         // This is needed to enable vectorization
         auto __raw_ptr = __rng.begin();
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
-            __is_full, __idx, __f, __raw_ptr);
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, __idx, __f,
+                                                                                                 __raw_ptr);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
@@ -216,8 +216,8 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
             __raw_ptr2);
         // 3. Explicitly call destructor of lazy union type
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-             oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
@@ -272,10 +272,10 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
             __is_full, __idx, oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<_F>{__f}, __rng1_vector,
             __rng2_vector, __raw_ptr3);
         // 3. Explicitly call destructors of lazy union type
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng2_vector);
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng2_vector);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
@@ -361,8 +361,8 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
         if (__idx == 0)
             __rng2[0] = __rng1_vector[0].__v;
         // 3. Delete temporary storage
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
     }
     template <typename _IsFull, typename _ItemId>
     void
@@ -1198,10 +1198,10 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
             __rng_right_vector, __rng_pointer);
         // 4. Call destructors of temporary storage
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng_left_vector);
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng_right_vector);
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng_left_vector);
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng_right_vector);
     }
     template <typename _IsFull, typename _Idx>
     void
@@ -1271,8 +1271,8 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
                 __rng2_pointer[__output_start + __i] = __rng1_vector[__i].__v;
         }
         // 3. Cleanup
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
     }
     template <typename _IsFull, typename _Idx>
     void
@@ -1326,8 +1326,8 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             oneapi::dpl::__par_backend_hetero::__lazy_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
             __rng1_vector, __rng2_pointer);
         // 3. Delete temporary storage
-        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(__is_full, 0,
-            oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
+        oneapi::dpl::__par_backend_hetero::__vector_walk<__base_t::__preferred_vector_size>{__n}(
+            __is_full, 0, oneapi::dpl::__internal::__lazy_ctor_storage_deleter{}, __rng1_vector);
     }
     template <typename _IsFull, typename _Idx>
     void

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1158,7 +1158,6 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
     __vector_path_impl(_IsFull, const std::size_t __left_start_idx, _Range __rng) const
     {
         const std::size_t __n = __size;
-        const std::size_t __midpoint = __size / 2;
 
         // In the below implementation, we see that _IsFull is ignored in favor of std::true_type{} in all cases.
         // This relaxation is due to the fact that in-place reverse launches work only over the first half of the

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -128,7 +128,7 @@ struct walk_vector_or_scalar_base
 
   public:
     constexpr static bool __can_vectorize =
-        (oneapi::dpl::__ranges::__is_vectorizable_range<_Ranges>::value && ...) &&
+        (oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Ranges>>::value && ...) &&
         (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
     constexpr static std::uint8_t __preferred_vector_size =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -158,9 +158,13 @@ struct walk_scalar_base
 template <typename _ExecutionPolicy, typename _F, typename _Range>
 struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
 {
+  private:
     using __base_t = walk_vector_or_scalar_base<_Range>;
     _F __f;
     std::size_t __n;
+
+  public:
+    walk1_vector_or_scalar(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
     template <typename _IsFull, typename _ItemId>
     void
@@ -194,9 +198,13 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
+  private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;
     std::size_t __n;
+
+  public:
+    walk2_vectors_or_scalars(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
     template <typename _IsFull, typename _ItemId>
     void
@@ -245,9 +253,13 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2, typename _Range3>
 struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2, _Range3>
 {
+  private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2, _Range3>;
     _F __f;
     std::size_t __n;
+
+  public:
+    walk3_vectors_or_scalars(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
     template <typename _IsFull, typename _ItemId>
     void
@@ -325,9 +337,13 @@ struct walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
+  private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;
     std::size_t __n;
+
+  public:
+    walk_adjacent_difference(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
 
     template <typename _IsFull, typename _ItemId>
     void
@@ -1159,9 +1175,14 @@ struct __brick_includes
 template <typename _Size, typename _Range>
 struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
 {
+  private:
     using __base_t = walk_vector_or_scalar_base<_Range>;
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
     _Size __size;
+
+  public:
+    __reverse_functor(_Size __size) : __size(__size) {}
+
     template <typename _IsFull, typename _Idx>
     void
     __vector_path(_IsFull __is_full, const _Idx __left_start_idx, _Range __rng) const
@@ -1234,9 +1255,13 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
 template <typename _Size, typename _Range1, typename _Range2>
 struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
+  private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
     _Size __size;
+
+  public:
+    __reverse_copy(_Size __size) : __size(__size) {}
 
     template <typename _IsFull, typename _Idx>
     void
@@ -1299,10 +1324,15 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
 template <typename _Size, typename _Range1, typename _Range2>
 struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
+  private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
     _Size __size;
     _Size __shift;
+
+  public:
+    __rotate_copy(_Size __size, _Size __shift) : __size(__size), __shift(__shift) {}
+
     template <typename _IsFull, typename _Idx>
     void
     __vector_path(_IsFull __is_full, const _Idx __idx, const _Range1 __rng1, _Range2 __rng2) const
@@ -1518,9 +1548,14 @@ struct __brick_reduce_idx : public walk_scalar_base<_Range>
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
+  private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;
     std::size_t __n;
+
+  public:
+    __brick_swap(_F __f, std::size_t __n) : __f(__f), __n(__n) {}
+
     template <typename _IsFull, typename _ItemId>
     void
     __vector_path(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1311,10 +1311,9 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         {
             // A single point of non-contiguity within the rotation operation. Manually process the loop here as the
             // access pattern becomes non-vectorizable.
-            std::size_t __remaining_elements = __n - __idx;
-            std::uint8_t __elements_to_process =
-                std::min(std::size_t{__base_t::__preferred_vector_size}, __remaining_elements);
-            for (std::uint8_t __i = 0; __i != __elements_to_process; ++__i)
+            std::uint8_t __remaining_elements = __n - __idx;
+            std::uint8_t __elements_to_process = std::min(__base_t::__preferred_vector_size, __remaining_elements);
+            for (std::uint8_t __i = 0; __i < __elements_to_process; ++__i)
                 __rng1_vector[__i] = __rng1[(__shifted_idx + __i) % __size];
         }
         // 2. Store the rotation

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -116,8 +116,9 @@ struct walk_n
 // Base class which establishes tuning parameters including vectorization / scalar path decider at compile time
 // for walk / for based algorithms
 template <typename... _Ranges>
-class walk_vector_or_scalar_base
+struct walk_vector_or_scalar_base
 {
+  private:
     using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
     constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
     // Empirically determined 'bytes-in-flight' to maximize bandwidth utilization
@@ -138,8 +139,9 @@ class walk_vector_or_scalar_base
 
 // Path that intentionally disables vectorization for algorithms with a scattered access pattern (e.g. binary_search)
 template <typename... _Ranges>
-class walk_scalar_base
+struct walk_scalar_base
 {
+  private:
     using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
     constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
     constexpr static std::uint8_t __bytes_per_item = 16;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -19,7 +19,7 @@
 #include <iterator>
 #include <type_traits>
 #if _ONEDPL_CPP20_RANGES_PRESENT && _ONEDPL_CPP20_CONCEPTS_PRESENT
-#   include <ranges> // std::ranges::contiguous_range
+#include <ranges> // std::ranges::contiguous_range
 #endif
 
 #include "../../utils_ranges.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -791,7 +791,7 @@ struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<oneapi::dpl::di
 
 // For any other iterator over a guard_view, use contiguous iterator concepts
 template <typename _Iterator>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<_Iterator>> : std::true_type
+struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<_Iterator>>
 {
     constexpr static bool value =
 #if _ONEDPL_CPP20_RANGES_PRESENT && _ONEDPL_CPP20_CONCEPTS_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -19,7 +19,7 @@
 #include <iterator>
 #include <type_traits>
 #if _ONEDPL_CPP20_RANGES_PRESENT && _ONEDPL_CPP20_CONCEPTS_PRESENT
-#include <ranges> // std::ranges::contiguous_range
+#   include <ranges> // std::ranges::contiguous_range
 #endif
 
 #include "../../utils_ranges.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -758,10 +758,19 @@ __select_backend(const execution::fpga_policy<_Factor, _KernelName>&, _Ranges&&.
 }
 #endif
 
-// Check the outer view type type to see if we can vectorize. Any non-contiguous inputs (e.g. reverse
-// views, permutation views, etc.) cannot be vectorized. If C++20 ranges are present, then we can
-// use the std::ranges::contiguous_range concept.
-template <typename _Rng, typename = void>
+// TODO: At some point with C++20, we should implement this with concepts to more easily support the less common edge
+// cases (e.g. a pipe over a counting iterator which is non-contiguous). For now, vectorization is primarily based on
+// range contiguity with specialization for internal views and guard views over internal iterators.
+// The following cases enable vectorization for a range:
+// 1. With C++20 concepts, the range satisfies std::ranges::contiguous_range.
+// 2. With C++17 nanoranges, the range satisfies __nanorange::nano::ranges::contiguous_range. Note that a view over
+// a SYCL buffer satisfies this concept along with pipe views that maintain access contiguity.
+// 3. The range is a guard view over an iterator with no global memory access: counting_iterator and discard_iterator
+// 4. The range is one of our internal, vectorizable range types: drop_view_simple, take_view_simple, or
+// transform_view_simple
+
+// Base case: check contiguous range properties
+template <typename _Rng>
 struct __is_vectorizable_range
 {
     constexpr static bool value =
@@ -771,48 +780,18 @@ struct __is_vectorizable_range
         __nanorange::nano::ranges::contiguous_range<_Rng>;
 };
 
-// Guard view specializations
-// Counting iterator does not go through global memory but does not disable vectorization elsewhere.
+// Basic guard view specializations - views which are not contiguous but do not interact with global memory
 template <typename _Ip>
 struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<oneapi::dpl::counting_iterator<_Ip>>> : std::true_type
 {
 };
 
-// Discard iterator does not go through global memory but does not disable vectorization elsewhere.
 template <>
 struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<oneapi::dpl::discard_iterator>> : std::true_type
 {
 };
 
-template <typename _Pointer>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<_Pointer>,
-                               std::enable_if_t<std::is_pointer_v<_Pointer>>> : std::true_type
-{
-};
-
-// For any non-pointer iterator over a guard_view, use contiguous iterator concepts
-template <typename _Iterator>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<_Iterator>,
-                               std::enable_if_t<!std::is_pointer_v<_Iterator>>>
-{
-    constexpr static bool value =
-#if _ONEDPL_CPP20_RANGES_PRESENT && _ONEDPL_CPP20_CONCEPTS_PRESENT
-        std::contiguous_iterator<_Iterator> ||
-#endif
-        // std::vector iterators are not contiguous with nanorange so a separate check is necessary
-        __nanorange::nano::contiguous_iterator<_Iterator> ||
-        oneapi::dpl::__internal::__is_known_usm_vector_iter_v<_Iterator>;
-};
-
-// If all_view is passed, then we are processing a sycl::buffer directly which is contiguous and can
-// be used.
-template <typename _T, sycl::access::mode _AccMode, __dpl_sycl::__target _Target,
-          sycl::access::placeholder _Placeholder>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::all_view<_T, _AccMode, _Target, _Placeholder>> : std::true_type
-{
-};
-
-// Recursive view specializations - views which we need to search inwards to identify if it is vectorizable
+// Recursive view specializations - internal views which we need to search inwards to identify if it is vectorizable
 template <typename _Rng, typename _F>
 struct __is_vectorizable_range<oneapi::dpl::__ranges::transform_view_simple<_Rng, _F>> : __is_vectorizable_range<_Rng>
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -782,16 +782,6 @@ struct __is_vectorizable_range<oneapi::dpl::__ranges::all_view<_Args...>> : std:
 {
 };
 
-template <typename _Rng>
-struct __is_passed_directly_range : std::false_type
-{
-};
-
-template <typename... _Args>
-struct __is_passed_directly_range<oneapi::dpl::__ranges::guard_view<_Args...>> : std::true_type
-{
-};
-
 } // namespace __ranges
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -782,6 +782,16 @@ struct __is_vectorizable_range<oneapi::dpl::__ranges::all_view<_Args...>> : std:
 {
 };
 
+template <typename _Rng>
+struct __is_passed_directly_range : std::false_type
+{
+};
+
+template <typename... _Args>
+struct __is_passed_directly_range<oneapi::dpl::__ranges::guard_view<_Args...>> : std::true_type
+{
+};
+
 } // namespace __ranges
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -771,14 +771,14 @@ struct __is_vectorizable_range
 #endif
 };
 // If the outer view is a guard view, then the input is passed directly as a pointer and we can use.
-template <typename... _Args>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<_Args...>> : std::true_type
+template <typename _Iterator>
+struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<_Iterator>> : std::true_type
 {
 };
 // If all_view is passed, then we are processing a sycl::buffer directly which is contiguous and can
 // be used.
-template <typename... _Args>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::all_view<_Args...>> : std::true_type
+template <typename _T, sycl::access::mode _AccMode, __dpl_sycl::__target _Target, sycl::access::placeholder _Placeholder>
+struct __is_vectorizable_range<oneapi::dpl::__ranges::all_view<_T, _AccMode, _Target, _Placeholder>> : std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -777,7 +777,8 @@ struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<_Iterator>> : s
 };
 // If all_view is passed, then we are processing a sycl::buffer directly which is contiguous and can
 // be used.
-template <typename _T, sycl::access::mode _AccMode, __dpl_sycl::__target _Target, sycl::access::placeholder _Placeholder>
+template <typename _T, sycl::access::mode _AccMode, __dpl_sycl::__target _Target,
+          sycl::access::placeholder _Placeholder>
 struct __is_vectorizable_range<oneapi::dpl::__ranges::all_view<_T, _AccMode, _Target, _Placeholder>> : std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -144,7 +144,7 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
         auto __init_event = oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__hist_fill_zeros_wrapper>(__exec),
             unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, decltype(__fill_func), decltype(__bins)>{
-                {}, __fill_func, static_cast<std::size_t>(__num_bins)},
+                __fill_func, static_cast<std::size_t>(__num_bins)},
             __num_bins, __bins);
 
         if (__n > 0)

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -270,7 +270,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
                                                                   decltype(__view2)>;
 
         oneapi::dpl::__par_backend_hetero::__parallel_for(
-            _BackendTag{}, __exec, _Function{{}, __fn, static_cast<std::size_t>(__n)}, __n, __view1, __view2)
+            _BackendTag{}, __exec, _Function{__fn, static_cast<std::size_t>(__n)}, __n, __view1, __view2)
             .__deferrable_wait();
     }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -263,14 +263,13 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
             oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator2>();
         auto __buf2 = __keep2(__d_first, __d_last);
 
-        auto __view1 = __buf1.all_view();
-        auto __view2 = __buf2.all_view();
+        using _Function =
+            unseq_backend::walk_adjacent_difference<_ExecutionPolicy, decltype(__fn), decltype(__buf1.all_view()),
+                                                    decltype(__buf2.all_view())>;
 
-        using _Function = unseq_backend::walk_adjacent_difference<_ExecutionPolicy, decltype(__fn), decltype(__view1),
-                                                                  decltype(__view2)>;
-
-        oneapi::dpl::__par_backend_hetero::__parallel_for(
-            _BackendTag{}, __exec, _Function{__fn, static_cast<std::size_t>(__n)}, __n, __view1, __view2)
+        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec,
+                                                          _Function{__fn, static_cast<std::size_t>(__n)}, __n,
+                                                          __buf1.all_view(), __buf2.all_view())
             .__deferrable_wait();
     }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -785,11 +785,12 @@ union __lazy_ctor_storage
     }
 };
 
-// Utility to explicitly call the destructor of __lazy_ctor_storage as a callback functor 
+// Utility to explicitly call the destructor of __lazy_ctor_storage as a callback functor
 struct __lazy_ctor_storage_deleter
 {
     template <typename _Tp>
-    void operator()(__lazy_ctor_storage<_Tp> __storage) const
+    void
+    operator()(__lazy_ctor_storage<_Tp> __storage) const
     {
         __storage.__destroy();
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -783,11 +783,6 @@ union __lazy_ctor_storage
     {
         __v.~_Tp();
     }
-    static auto
-    __get_callable_deleter()
-    {
-        return [](__lazy_ctor_storage& __storage) { __storage.__destroy(); };
-    }
 };
 
 // To implement __min_nested_type_size, a general utility with an internal tuple

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -783,16 +783,10 @@ union __lazy_ctor_storage
     {
         __v.~_Tp();
     }
-};
-
-// Utility to explicitly call the destructor of __lazy_ctor_storage as a callback functor
-struct __lazy_ctor_storage_deleter
-{
-    template <typename _Tp>
-    void
-    operator()(__lazy_ctor_storage<_Tp> __storage) const
+    static auto
+    __get_callable_deleter()
     {
-        __storage.__destroy();
+        return [](__lazy_ctor_storage& __storage) { __storage.__destroy(); };
     }
 };
 

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -45,12 +45,12 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<constant_iterator_device_copyable>,
                   "constant_iterator_device_copyable is not device copyable");
 
-    //custom_brick
+    //__custom_brick
     static_assert(
         sycl::is_device_copyable_v<
-            oneapi::dpl::internal::custom_brick<noop_device_copyable, int_device_copyable, range_device_copyable,
-                                                oneapi::dpl::internal::search_algorithm::lower_bound>>,
-        "custom_brick is not device copyable with device copyable types");
+            oneapi::dpl::internal::__custom_brick<noop_device_copyable, int_device_copyable, range_device_copyable,
+                                                  oneapi::dpl::internal::search_algorithm::lower_bound>>,
+        "__custom_brick is not device copyable with device copyable types");
     //replace_if_fun
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::internal::replace_if_fun<int_device_copyable, noop_device_copyable>>,
@@ -324,11 +324,11 @@ test_non_device_copyable()
     static_assert(!sycl::is_device_copyable_v<constant_iterator_non_device_copyable>, "iterator is device copyable");
     static_assert(!sycl::is_device_copyable_v<range_non_device_copyable>, "range_non_device_copyable is device copyable");
 
-    //custom_brick
-    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::internal::custom_brick<
+    //__custom_brick
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::internal::__custom_brick<
                       noop_device_copyable, int_non_device_copyable, range_non_device_copyable,
                       oneapi::dpl::internal::search_algorithm::lower_bound>>,
-                  "custom_brick is device copyable with non device copyable types");
+                  "__custom_brick is device copyable with non device copyable types");
     //replace_if_fun
     static_assert(!sycl::is_device_copyable_v<
                       oneapi::dpl::internal::replace_if_fun<int_device_copyable, noop_non_device_copyable>>,

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -69,7 +69,7 @@ template <typename T>
 void
 test()
 {
-    const ::std::size_t max_len = 100000;
+    const std::size_t max_len = TestUtils::get_pattern_for_max_n();
 
     Sequence<T> actual(max_len);
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -82,7 +82,7 @@ template <typename T1, typename T2>
 void
 test()
 {
-    const ::std::size_t max_len = 100000;
+    const std::size_t max_len = TestUtils::get_pattern_for_max_n();
     Sequence<T2> actual(max_len);
     Sequence<T1> data(max_len, [](::std::size_t i) { return T1(i); });
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
@@ -125,8 +125,9 @@ template <typename T, typename Convert>
 void
 test(T trash, Convert convert)
 {
+    size_t max_n = TestUtils::get_pattern_for_max_n();
     // Try sequences of various lengths.
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         // count is number of output elements, plus a handful
         // more for sake of detecting buffer overruns.

--- a/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
@@ -101,7 +101,7 @@ int
 main()
 {
 
-    const ::std::size_t N = 100000;
+    const std::size_t N = TestUtils::get_pattern_for_max_n();
 
     for (::std::size_t n = 0; n < N; n = n < 16 ? n + 1 : size_t(3.1415 * n))
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
@@ -82,7 +82,8 @@ template <typename T>
 void
 test_generate_by_type()
 {
-    for (size_t n = 0; n <= 100000; n = n < 16 ? n + 1 : size_t(3.1415 * n))
+    size_t max_n = TestUtils::get_pattern_for_max_n();
+    for (size_t n = 0; n <= max_n; n = n < 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<T> in(n, [](size_t) -> T { return T(0); }); //fill by zero
 
@@ -123,6 +124,7 @@ struct test_non_const_generate_n
 int
 main()
 {
+    test_generate_by_type<std::uint8_t>();
     test_generate_by_type<std::int32_t>();
     test_generate_by_type<float64_t>();
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -114,7 +114,7 @@ template <typename T1, typename T2, typename Pred>
 void
 test(Pred pred)
 {
-    const ::std::size_t max_len = 100000;
+    const std::size_t max_len = TestUtils::get_pattern_for_max_n();
 
     const T1 value = T1(0);
     const T1 new_value = T1(666);

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
@@ -75,8 +75,9 @@ template <typename T, typename Convert, typename Predicate>
 void
 test(T trash, const T& old_value, const T& new_value, Predicate pred, Convert convert)
 {
+    const size_t max_n = TestUtils::get_pattern_for_max_n();
     // Try sequences of various lengths.
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<T> in(n, [&](size_t k) -> T { return convert(n ^ k); });
         Sequence<T> out(n, [=](size_t) { return trash; });

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -132,7 +132,7 @@ template <typename T>
 void
 test()
 {
-    const std::int32_t max_len = 100000;
+    const std::int32_t max_len = TestUtils::get_pattern_for_max_n();
 
     Sequence<T> actual(max_len, [](::std::size_t i) { return T(i); });
     Sequence<T> data(max_len, [](::std::size_t i) { return T(i); });

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate_copy.pass.cpp
@@ -100,7 +100,7 @@ void
 test()
 {
 
-    const ::std::size_t max_len = 100000;
+    const std::size_t max_len = TestUtils::get_pattern_for_max_n();
 
     Sequence<T2> actual(max_len, [](::std::size_t i) { return T1(i); });
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -84,7 +84,7 @@ struct test_shift
 
         auto ptr = dt_helper.get_data();
         auto het_res =
-            algo(TestUtils::make_device_policy<USMKernelName<Algo, _ValueType>>(::std::forward<Policy>(exec)), ptr,
+            algo(TestUtils::make_device_policy<USMKernelName<Algo, _ValueType>>(std::forward<Policy>(exec)), ptr,
                  ptr + m, n);
         _DiffType res_idx = het_res - ptr;
 
@@ -100,8 +100,8 @@ struct test_shift
     operator()(Policy&& exec, It first, typename ::std::iterator_traits<It>::difference_type m,
         It first_exp, typename ::std::iterator_traits<It>::difference_type n, Algo algo)
     {
-        using _ValueType = typename ::std::iterator_traits<It>::value_type;
-        using _DiffType = typename ::std::iterator_traits<It>::difference_type;
+        using _ValueType = typename std::iterator_traits<It>::value_type;
+        using _DiffType = typename std::iterator_traits<It>::difference_type;
         auto buffer_policy = TestUtils::make_device_policy<BufferKernelName<_ValueType, Algo>>(exec);
         //1.1 run a test with hetero policy and host itertors
         auto res = algo(buffer_policy, first, first + m, n);

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -225,14 +225,13 @@ main()
     const int threads_to_use = std::min(max_threads, int(32));
     omp_set_num_threads(threads_to_use);
 #endif
+    using ValueType = ::std::int32_t;
 
     const ::std::size_t N = 100000;
     for (long m = 0; m < N; m = m < 16 ? m + 1 : long(3.1415 * m))
         for (long n = 0; n < N; n = n < 16 ? n + 1 : long(3.1415 * n))
     {
-       test_shift_by_type<std::uint8_t>(m, n);
-       test_shift_by_type<std::uint16_t>(m, n);
-       test_shift_by_type<std::int32_t>(m, n);
+       test_shift_by_type<ValueType>(m, n);
     }
 
     return TestUtils::done();

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-//===-- shift_left.pass.cpp -----------------------------------------------===//
+//===-- shift_left_right.pass.cpp -----------------------------------------------===//
 //
 // Copyright (C) Intel Corporation
 //
@@ -40,8 +40,11 @@
 #include <omp.h> // omp_get_max_threads, omp_set_num_threads
 #endif
 
-template<typename Name>
-struct USM;
+template <typename... Name>
+struct USMKernelName;
+
+template <typename... Name>
+struct BufferKernelName;
 
 struct test_shift
 {
@@ -80,7 +83,9 @@ struct test_shift
         TestUtils::usm_data_transfer<alloc_type, _ValueType> dt_helper(queue, first, m);
 
         auto ptr = dt_helper.get_data();
-        auto het_res = algo(TestUtils::make_device_policy<USM<Algo>>(::std::forward<Policy>(exec)), ptr, ptr + m, n);
+        auto het_res =
+            algo(TestUtils::make_device_policy<USMKernelName<Algo, _ValueType>>(::std::forward<Policy>(exec)), ptr,
+                 ptr + m, n);
         _DiffType res_idx = het_res - ptr;
 
         //3.2 check result
@@ -95,13 +100,13 @@ struct test_shift
     operator()(Policy&& exec, It first, typename ::std::iterator_traits<It>::difference_type m,
         It first_exp, typename ::std::iterator_traits<It>::difference_type n, Algo algo)
     {
-        //1.1 run a test with hetero policy and host itertors
-        auto res = algo(::std::forward<Policy>(exec), first, first + m, n);
-        //1.2 check result
-        algo.check(res, first, m, first_exp, n);
-
         using _ValueType = typename ::std::iterator_traits<It>::value_type;
         using _DiffType = typename ::std::iterator_traits<It>::difference_type;
+        auto buffer_policy = TestUtils::make_device_policy<BufferKernelName<_ValueType, Algo>>(exec);
+        //1.1 run a test with hetero policy and host itertors
+        auto res = algo(buffer_policy, first, first + m, n);
+        //1.2 check result
+        algo.check(res, first, m, first_exp, n);
 
         //2.1 run a test with hetero policy and hetero itertors
         _DiffType res_idx(0);
@@ -112,7 +117,7 @@ struct test_shift
 
             auto het_begin = oneapi::dpl::begin(buf);
 
-            auto het_res = algo(::std::forward<Policy>(exec), het_begin, het_begin + m, n);
+            auto het_res = algo(buffer_policy, het_begin, het_begin + m, n);
             res_idx = het_res - het_begin;
         }
         //2.2 check result
@@ -121,7 +126,7 @@ struct test_shift
 #if _PSTL_SYCL_TEST_USM
         //3. run a test with hetero policy and USM shared/device memory pointers
         test_usm<sycl::usm::alloc::shared>(exec, first, m, first_exp, n, algo);
-        test_usm<sycl::usm::alloc::device>(exec, first, m, first_exp, n, algo);
+        test_usm<sycl::usm::alloc::device>(std::forward<Policy>(exec), first, m, first_exp, n, algo);
 #endif
     }
 #endif
@@ -208,10 +213,10 @@ test_shift_by_type(Size m, Size n)
     TestUtils::Sequence<T> in(m, [](::std::size_t v) -> T { return T(v); }); //fill data
 
 #ifdef _PSTL_TEST_SHIFT_LEFT
-    TestUtils::invoke_on_all_policies<0>()(test_shift(), in.begin(), m, orig.begin(), n, shift_left_algo{});
+    TestUtils::invoke_on_all_policies()(test_shift(), in.begin(), m, orig.begin(), n, shift_left_algo{});
 #endif
 #ifdef _PSTL_TEST_SHIFT_RIGHT
-    TestUtils::invoke_on_all_policies<1>()(test_shift(), in.begin(), m, orig.begin(), n, shift_right_algo{});
+    TestUtils::invoke_on_all_policies()(test_shift(), in.begin(), m, orig.begin(), n, shift_right_algo{});
 #endif
 }
 
@@ -240,8 +245,8 @@ main()
     const std::size_t quarter_shift = 250111;
     const std::size_t three_quarters_shift = 750203;
     test_shift_by_type<std::uint8_t>(large_n, quarter_shift);
-    test_shift_by_type<std::uint16_t>(large_n, quarter_shift);
     test_shift_by_type<std::uint8_t>(three_quarters_shift, large_n);
+    test_shift_by_type<std::uint16_t>(large_n, quarter_shift);
 #endif
 
     return TestUtils::done();

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -233,6 +233,16 @@ main()
     {
        test_shift_by_type<ValueType>(m, n);
     }
+#if TEST_DPCPP_BACKEND_PRESENT
+    // Test both paths of the vectorized implementation in the SYCL backend. Use shift factors that will not divide
+    // into the vector size to assess edge case handling.
+    const std::size_t large_n = 1000000;
+    const std::size_t quarter_shift = 250111;
+    const std::size_t three_quarters_shift = 750203;
+    test_shift_by_type<std::uint8_t>(large_n, quarter_shift);
+    test_shift_by_type<std::uint16_t>(large_n, quarter_shift);
+    test_shift_by_type<std::uint8_t>(three_quarters_shift, large_n);
+#endif
 
     return TestUtils::done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
@@ -132,7 +132,7 @@ main()
 {
     test<wrapper<std::uint16_t>>();
     test<wrapper<float32_t>>();
-    test<std::int8_t>();
+    test<std::uint8_t>();
     test<std::int32_t>();
     test<float64_t>();
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
@@ -115,7 +115,7 @@ template <typename T>
 void
 test()
 {
-    const ::std::size_t max_len = 100000;
+    const std::size_t max_len = TestUtils::get_pattern_for_max_n();
 
     Sequence<T> data(max_len);
     Sequence<T> actual(max_len);

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -104,7 +104,7 @@ test(Predicate pred, _IteratorAdapter adap = {})
 #if PSTL_USE_DEBUG && ONEDPL_USE_OPENMP_BACKEND
         10000;
 #else
-        100000;
+        TestUtils::get_pattern_for_max_n();
 #endif
     for (size_t n = 0; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
@@ -84,7 +84,8 @@ template <::std::size_t CallNumber, typename Tin, typename Tout, typename _Op = 
 void
 test()
 {
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    size_t max_n = TestUtils::get_pattern_for_max_n();
+    for (size_t n = 0; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<Tin> in(n, [](std::int32_t k) { return k % 5 != 1 ? 3 * k - 7 : 0; });
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
@@ -86,7 +86,7 @@ void
 test()
 {
     const size_t max_n = TestUtils::get_pattern_for_max_n();
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<T> in_out(n, Gen<T>());
         Sequence<T> expected(n, Gen<T>());

--- a/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
@@ -85,6 +85,7 @@ template <typename T>
 void
 test()
 {
+    const size_t max_n = TestUtils::get_pattern_for_max_n();
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<T> in_out(n, Gen<T>());

--- a/test/parallel_api/algorithm/alg.nonmodifying/transform_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/transform_if.pass.cpp
@@ -162,7 +162,8 @@ void
 test()
 {
     const ::std::int64_t init_val = 999;
-    for (size_t n = 1; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    const size_t max_n = TestUtils::get_pattern_for_max_n();
+    for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         {
             Sequence<_Type> in1(n, [=](size_t k) { return (3 * k) % std::numeric_limits<_Type>::max(); });
@@ -196,7 +197,8 @@ void
 test_inplace()
 {
     const ::std::int64_t init_val = 999;
-    for (size_t n = 1; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    const size_t max_n = TestUtils::get_pattern_for_max_n();
+    for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         {
             Sequence<_Type> in1(n, [=](size_t k) { return k % std::numeric_limits<_Type>::max(); });

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -139,7 +139,7 @@ template <typename T1, typename T2, typename Pred>
 void
 test(Pred pred)
 {
-    const ::std::size_t max_len = 100000;
+    const std::size_t max_len = TestUtils::get_pattern_for_max_n();
 
     const T2 value = T2(77);
     const T1 trash = T1(31);

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -165,7 +165,6 @@ int
 main()
 {
     test<std::uint8_t, std::uint32_t>([](std::uint32_t a, std::uint32_t b) { return a - b; });
-    test<std::uint8_t, std::uint8_t>([](std::uint8_t a, std::uint8_t b) { return a > b ? a - b : b - a; });
     test<std::uint16_t, std::uint16_t>([](std::uint16_t a, std::uint16_t b) { return a > b ? a - b : b - a; });
     test<std::int32_t, std::int64_t>([](std::int64_t a, std::int64_t b) { return a / (b + 1); });
     test<std::int64_t, float32_t>([](float32_t a, float32_t b) { return (a + b) / 2; });

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -274,6 +274,4 @@
 // Intel(R) oneAPI DPC++/C++ compiler produces 'Unexpected kernel lambda size issue' error
 #define _PSTL_LAMBDA_PTR_TO_MEMBER_WINDOWS_BROKEN (_MSC_VER && TEST_DPCPP_BACKEND_PRESENT && __INTEL_LLVM_COMPILER < 20250200)
 
-#define TEST_FOR_ALGORITHM_LARGE_SUBMITTER TEST_DPCPP_BACKEND_PRESENT
-
 #endif // _TEST_CONFIG_H

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1013,6 +1013,26 @@ generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
         input[j] = input[i];
     }
 }
+
+// Utility that models __estimate_best_start_size in the SYCL backend parallel_for
+// to ensure large enough inputs are used to test the large submitter path.
+// A multiplier to the max n is added to ensure we get a few separate test inputs for
+// this path.
+std::size_t
+get_pattern_for_max_n()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    sycl::queue q = TestUtils::get_test_queue();
+    sycl::device d = q.get_device();
+    constexpr std::size_t max_iters_per_item = 16;
+    constexpr std::size_t multiplier = 4;
+    return multiplier * max_iters_per_item * d.get_info<sycl::info::device::max_work_group_size>() *
+           d.get_info<sycl::info::device::max_compute_units>();
+#else
+    return TestUtils::max_n;
+#endif
+}
+
 } /* namespace TestUtils */
 
 #endif // _UTILS_H

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1026,8 +1026,10 @@ get_pattern_for_max_n()
     sycl::device d = q.get_device();
     constexpr std::size_t max_iters_per_item = 16;
     constexpr std::size_t multiplier = 4;
-    return multiplier * max_iters_per_item * d.get_info<sycl::info::device::max_work_group_size>() *
-           d.get_info<sycl::info::device::max_compute_units>();
+    std::size_t __max_n = multiplier * max_iters_per_item * d.get_info<sycl::info::device::max_work_group_size>() *
+                          d.get_info<sycl::info::device::max_compute_units>();
+    __max_n = std::min(std::size_t{10000000}, __max_n);
+    return __max_n;
 #else
     return TestUtils::max_n;
 #endif

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1026,7 +1026,8 @@ get_pattern_for_max_n()
     sycl::device d = q.get_device();
     constexpr std::size_t max_iters_per_item = 16;
     constexpr std::size_t multiplier = 4;
-    std::size_t __max_n = multiplier * max_iters_per_item * d.get_info<sycl::info::device::max_work_group_size>() *
+    constexpr std::size_t max_work_group_size = 512;
+    std::size_t __max_n = multiplier * max_iters_per_item * max_work_group_size *
                           d.get_info<sycl::info::device::max_compute_units>();
     __max_n = std::min(std::size_t{10000000}, __max_n);
     return __max_n;


### PR DESCRIPTION
**High Level Description**
This PR improves hardware bandwidth utilization of oneDPL's SYCL backend parallel for pattern through two ideas:
- Process multiple input iterations per work-item which involves a switch to a nd_range kernel combined with a sub / work group strided indexing approach.
- To generate wide loads for small types, implement a path that vectorizes loads / stores by processing adjacent indices within a single work item. This is combined with the above approach to maximize hardware bandwidth utilization. Vectorization is only applied to fundamental types of size less than 4 (e.g. uint16_t, uint8_t) under a contiguous container.
 
**Implementation Details**
- Parallel for bricks have been reworked in the following manner:
    - Each brick contains a pack of ranges within its template parameters to define tuning parameters.
    - The following static integral members are defined (implemented with inheritance):
        - __can_vectorize
        - __preferred_vector_size (1 if __can_vectorize is false)
        - __preferred_iters_per_item
    - The following public member functions are defined
        - __scalar_path (for small input sizes this member function is explicitly called)
        - __vector_path (optional for algorithms that are not vectorizable e.g. `binary_search`)
        - An overloaded function call operator which dispatches to the appropriate strategy

To implement this approach, the parallel for kernel rewrite from https://github.com/oneapi-src/oneDPL/pull/1870 was adopted with additional changes to handle vectorization paths. Additionally, generic vectorization and strided loop utilities have been defined with the intention for these to be applicable in other portions of the codebase as well. Tests have been expanded to ensure coverage of vectorization paths.

This PR will supersedes https://github.com/oneapi-src/oneDPL/pull/1870. Initially, the plan was to merge this PR into 1870 but after comparing the diff, I believe the most straightforward approach will be to target this directly to main.