### PR TITLE
Change repo organization from oneapi-src to uxlfoundation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,12 @@
 
 We welcome community contributions to oneAPI DPC++ Library (oneDPL). You can:
 
-- Submit your changes directly with a [pull request](https://github.com/oneapi-src/oneDPL/pulls).
-- Log a bug or feedback with an [issue](https://github.com/oneapi-src/oneDPL/issues).
+- Submit your changes directly with a [pull request](https://github.com/uxlfoundation/oneDPL/pulls).
+- Log a bug or feedback with an [issue](https://github.com/uxlfoundation/oneDPL/issues).
 
 # License
 
-oneDPL is licensed under the terms in [LICENSE](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt).
+oneDPL is licensed under the terms in [LICENSE](https://github.com/uxlfoundation/oneDPL/blob/main/LICENSE.txt).
 By contributing to the project, you agree to the license and copyright terms therein and
 release your contribution under these terms.
 
@@ -23,7 +23,7 @@ your change directly to the repository:
   [validation testing](#validation-testing).
 - Submit a
   [pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) into the
-  main branch. You may add a description of your contribution into [CREDITS.txt](https://github.com/oneapi-src/oneDPL/blob/main/CREDITS.txt).
+  main branch. You may add a description of your contribution into [CREDITS.txt](https://github.com/uxlfoundation/oneDPL/blob/main/CREDITS.txt).
 - Contributors that would like to open branches directly in the oneDPL repo instead of working via fork may request
   write access to the repository by contacting project maintainers on
   [UXL Foundation Slack](https://slack-invite.uxlfoundation.org/) using the
@@ -31,7 +31,7 @@ your change directly to the repository:
 
 # Coding Conventions
 
-Running clang-format is required, except in the [test folder](https://github.com/oneapi-src/oneDPL/tree/main/test).
+Running clang-format is required, except in the [test folder](https://github.com/uxlfoundation/oneDPL/tree/main/test).
 
 # Validation Testing
 
@@ -66,6 +66,6 @@ ctest --output-on-failure --timeout 1200 -R ^reduce.pass$ # Add -R testname (e.g
 
 Before submitting a PR to the oneDPL repository please run the tests that exercise the code you have updated. If you need help identifying those tests please
 check with the maintainers on [UXL Foundation Slack](https://slack-invite.uxlfoundation.org/) using the [#onedpl](https://uxlfoundation.slack.com/channels/onedpl) channel
-or ask a question through [GitHub issues](https://github.com/oneapi-src/oneDPL/issues).
+or ask a question through [GitHub issues](https://github.com/uxlfoundation/oneDPL/issues).
 
-For more details on configurations available for oneDPL testing see the [CMake README](https://github.com/oneapi-src/oneDPL/blob/main/cmake/README.md).
+For more details on configurations available for oneDPL testing see the [CMake README](https://github.com/uxlfoundation/oneDPL/blob/main/cmake/README.md).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # oneAPI DPC++ Library (oneDPL) <img align="right" width="200" height="100" src=https://github.com/uxlfoundation/artwork/blob/main/foundation/uxl-foundation-logo-horizontal-color.svg>
-[![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE.txt) [![oneDPL CI](https://github.com/oneapi-src/oneDPL/actions/workflows/ci-testing.yml/badge.svg)](https://github.com/oneapi-src/oneDPL/actions/workflows/ci-testing.yml?query=branch%3Amaster)
-[![Join the community on GitHub Discussions](https://badgen.net/badge/join%20the%20discussion/on%20github/blue?icon=github)](https://github.com/oneapi-src/oneDPL/discussions)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/oneapi-src/oneDPL/badge)](https://securityscorecards.dev/viewer/?uri=github.com/oneapi-src/oneDPL)
+[![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE.txt) [![oneDPL CI](https://github.com/uxlfoundation/oneDPL/actions/workflows/ci-testing.yml/badge.svg)](https://github.com/uxlfoundation/oneDPL/actions/workflows/ci-testing.yml?query=branch%3Amaster)
+[![Join the community on GitHub Discussions](https://badgen.net/badge/join%20the%20discussion/on%20github/blue?icon=github)](https://github.com/uxlfoundation/oneDPL/discussions)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/uxlfoundation/oneDPL/badge)](https://securityscorecards.dev/viewer/?uri=github.com/uxlfoundation/oneDPL)
 
 oneDPL is part of the [UXL Foundation] and is an implementation of the
 [oneAPI specification] for the oneDPL component.
@@ -19,10 +19,10 @@ Install the Intel® oneAPI Base Toolkit (Base Kit) to use oneDPL. Refer to the s
 for more information.
 
 ## Release Information
-Visit the latest [Release Notes](https://github.com/oneapi-src/oneDPL/blob/main/documentation/release_notes.rst).
+Visit the latest [Release Notes](https://github.com/uxlfoundation/oneDPL/blob/main/documentation/release_notes.rst).
 
 ## License
-oneDPL is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt).
+oneDPL is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/uxlfoundation/oneDPL/blob/main/LICENSE.txt).
 Refer to the [LICENSE](licensing/LICENSE.txt) file for the full license text and copyright notice.
 
 ## Security
@@ -31,17 +31,17 @@ for information on how to report a potential security issue or vulnerability.
 You can also view the [Security Policy](SECURITY.md).
 
 ## Contributing
-See [CONTRIBUTING.md](https://github.com/oneapi-src/oneDPL/blob/main/CONTRIBUTING.md) for details.
+See [CONTRIBUTING.md](https://github.com/uxlfoundation/oneDPL/blob/main/CONTRIBUTING.md) for details.
 
 ## Documentation
 
-See the full documentation set for [oneDPL](https://oneapi-src.github.io/oneDPL).
+See the full documentation set for [oneDPL](https://uxlfoundation.github.io/oneDPL).
 
 ## Samples
 You can find oneDPL samples at the [oneDPL Samples](https://github.com/oneapi-src/oneAPI-samples/tree/master/Libraries/oneDPL) page.
 
 ## Support and Contribution
-Please report issues and suggestions via [GitHub issues](https://github.com/oneapi-src/oneDPL/issues).
+Please report issues and suggestions via [GitHub issues](https://github.com/uxlfoundation/oneDPL/issues).
 
 You can also contact oneDPL developers via [UXL Foundation Slack](https://slack-invite.uxlfoundation.org/) using
 the [#onedpl](https://uxlfoundation.slack.com/channels/onedpl) channel.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,6 @@ If you have any suggestions on how this Policy could be improved, submit
 an issue or a pull request to this repository. **Do not** report
 potential vulnerabilities or security flaws via a pull request.
 
-[1]: https://github.com/oneapi-src/oneDPL/releases/latest
-[2]: https://github.com/oneapi-src/oneDPL/security/advisories/new
-[3]: https://github.com/oneapi-src/oneDPL/security/advisories
+[1]: https://github.com/uxlfoundation/oneDPL/releases/latest
+[2]: https://github.com/uxlfoundation/oneDPL/security/advisories/new
+[3]: https://github.com/uxlfoundation/oneDPL/security/advisories

--- a/documentation/CHANGES.rst
+++ b/documentation/CHANGES.rst
@@ -577,6 +577,6 @@ Known Issues and Limitations
 .. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types compared with
    ``std::less`` or ``std::greater``, otherwise Merge sort.
 .. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
-.. _`oneDPL Guide`: https://oneapi-src.github.io/oneDPL/index.html
-.. _`Tested Standard C++ API`: https://oneapi-src.github.io/oneDPL/api_for_dpcpp_kernels/tested_standard_cpp_api.html#tested-standard-c-api-reference
-.. _`Macros`: https://oneapi-src.github.io/oneDPL/macros.html
+.. _`oneDPL Guide`: https://uxlfoundation.github.io/oneDPL/index.html
+.. _`Tested Standard C++ API`: https://uxlfoundation.github.io/oneDPL/api_for_dpcpp_kernels/tested_standard_cpp_api.html#tested-standard-c-api-reference
+.. _`Macros`: https://uxlfoundation.github.io/oneDPL/macros.html

--- a/documentation/library_guide/_templates/layout.html
+++ b/documentation/library_guide/_templates/layout.html
@@ -7,7 +7,7 @@
         var wapLocalCode = 'us-en'; // Dynamically set per localized site, see mapping table for values
         var wapSection = "oneapi-dpl"; // WAP team will give you a unique section for your site
         // Load TMS
-        if(document.location.href.includes("oneapi-src.github.io")){
+        if(document.location.href.includes("uxlfoundation.github.io")){
         (function () {
         var url = 'https://www.intel.com/content/dam/www/global/wap/tms-loader.js'; // WAP file URL
         var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true; po.src = url;

--- a/documentation/library_guide/conf.py
+++ b/documentation/library_guide/conf.py
@@ -113,7 +113,7 @@ html_theme_options = {
     #'collapse_navigation': False,  # Collapse navigation (False makes it tree-like)
     #'navigation_depth': 4  # Depth of the headers shown in the navigation bar
     #'display_version': True,  # Display the docs version
-    'repository_url': 'https://github.com/oneapi-src/oneDPL',
+    'repository_url': 'https://github.com/uxlfoundation/oneDPL',
     'path_to_docs': 'documentation/library_guide',
     'use_issues_button': True,
     'use_edit_page_button': True,

--- a/documentation/library_guide/index.rst
+++ b/documentation/library_guide/index.rst
@@ -6,7 +6,7 @@ provide high-productivity APIs to developers, which can minimize SYCL* programmi
 efforts across devices for high performance parallel applications.
 
 For general information, refer to the `oneDPL GitHub* repository
-<https://github.com/oneapi-src/oneDPL>`_.
+<https://github.com/uxlfoundation/oneDPL>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/documentation/library_guide/introduction/onedpl_gsg.rst
+++ b/documentation/library_guide/introduction/onedpl_gsg.rst
@@ -12,7 +12,7 @@ programming efforts across devices for high performance parallel applications.
 * Macros
 
 
-For general information about |onedpl_short|, visit the `oneDPL GitHub* repository <https://github.com/oneapi-src/oneDPL>`_,
+For general information about |onedpl_short|, visit the `oneDPL GitHub* repository <https://github.com/uxlfoundation/oneDPL>`_,
 or visit the |onedpl_library_guide|_ and the `Intel® oneAPI DPC++ Library main page
 <https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-library.html>`_.
 

--- a/documentation/library_guide/notices_disclaimers.rst
+++ b/documentation/library_guide/notices_disclaimers.rst
@@ -20,7 +20,7 @@ License
 
 oneDPL is licensed under Apache License Version 2.0 with LLVM exceptions. 
 
-Refer to the `LICENSE <https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt>`_ file for the full license text and copyright notice.
+Refer to the `LICENSE <https://github.com/uxlfoundation/oneDPL/blob/main/LICENSE.txt>`_ file for the full license text and copyright notice.
 
 
 

--- a/documentation/library_guide/onedpl_gsg.rst
+++ b/documentation/library_guide/onedpl_gsg.rst
@@ -12,7 +12,7 @@ programming efforts across devices for high performance parallel applications.
 * Macros
 
 
-For general information about |onedpl_short|, visit the `oneDPL GitHub* repository <https://github.com/oneapi-src/oneDPL>`_,
+For general information about |onedpl_short|, visit the `oneDPL GitHub* repository <https://github.com/uxlfoundation/oneDPL>`_,
 or visit the |onedpl_library_guide|_ and the `Intel® oneAPI DPC++ Library main page
 <https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-library.html>`_.
 

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -848,11 +848,11 @@ Known Issues and Limitations
 
 .. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types and
    ``sycl::half`` (since oneDPL 2022.6) compared with ``std::less`` or ``std::greater``, otherwise Merge sort.
-.. _`oneDPL Guide`: https://oneapi-src.github.io/oneDPL/index.html
+.. _`oneDPL Guide`: https://uxlfoundation.github.io/oneDPL/index.html
 .. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
-.. _`restrictions and known limitations`: https://oneapi-src.github.io/oneDPL/introduction.html#restrictions.
-.. _`Tested Standard C++ API`: https://oneapi-src.github.io/oneDPL/api_for_sycl_kernels/tested_standard_cpp_api.html#tested-standard-c-api-reference
-.. _`Macros`: https://oneapi-src.github.io/oneDPL/macros.html
-.. _`2022.0 Changes`: https://oneapi-src.github.io/oneDPL/oneDPL_2022.0_changes.html
+.. _`restrictions and known limitations`: https://uxlfoundation.github.io/oneDPL/introduction.html#restrictions.
+.. _`Tested Standard C++ API`: https://uxlfoundation.github.io/oneDPL/api_for_sycl_kernels/tested_standard_cpp_api.html#tested-standard-c-api-reference
+.. _`Macros`: https://uxlfoundation.github.io/oneDPL/macros.html
+.. _`2022.0 Changes`: https://uxlfoundation.github.io/oneDPL/oneDPL_2022.0_changes.html
 .. _`sycl device copyable`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable
 .. _`oneAPI DPC++ Library Manual Migration Guide`: https://www.intel.com/content/www/us/en/developer/articles/guide/oneapi-dpcpp-library-manual-migration.html 

--- a/examples/convex_hull/README.md
+++ b/examples/convex_hull/README.md
@@ -25,7 +25,7 @@ Correctness of the convex hull is checked by `std::any_of` algorithm using `coun
 
 ## License
 
-This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
+This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/uxlfoundation/oneDPL/blob/main/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
 
 ## Building the 'Convex hull' Program
 

--- a/examples/dot_product/README.md
+++ b/examples/dot_product/README.md
@@ -11,7 +11,7 @@ This example contains the oneDPL-based implementation of dot product based on `s
 
 ## License
 
-This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
+This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/uxlfoundation/oneDPL/blob/main/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
 
 ## Building the 'Dot product' Program
 

--- a/jenkinsfiles/RHEL_Check.groovy
+++ b/jenkinsfiles/RHEL_Check.groovy
@@ -104,7 +104,7 @@ pipeline {
     parameters {
         string(name: 'Commit_id', defaultValue: 'None', description: '',)
         string(name: 'PR_number', defaultValue: 'None', description: '',)
-        string(name: 'Repository', defaultValue: 'oneapi-src/oneDPL', description: '',)
+        string(name: 'Repository', defaultValue: 'uxlfoundation/oneDPL', description: '',)
         string(name: 'User', defaultValue: 'None', description: '',)
         string(name: 'OneAPI_Package_Date', defaultValue: 'Default', description: '',)
         string(name: 'Base_branch', defaultValue: 'main', description: '',)

--- a/jenkinsfiles/UB18_Check.groovy
+++ b/jenkinsfiles/UB18_Check.groovy
@@ -104,7 +104,7 @@ pipeline {
     parameters {
         string(name: 'Commit_id', defaultValue: 'None', description: '',)
         string(name: 'PR_number', defaultValue: 'None', description: '',)
-        string(name: 'Repository', defaultValue: 'oneapi-src/oneDPL', description: '',)
+        string(name: 'Repository', defaultValue: 'uxlfoundation/oneDPL', description: '',)
         string(name: 'User', defaultValue: 'None', description: '',)
         string(name: 'OneAPI_Package_Date', defaultValue: 'Default', description: '',)
         string(name: 'Base_branch', defaultValue: 'main', description: '',)

--- a/jenkinsfiles/UB20_Check.groovy
+++ b/jenkinsfiles/UB20_Check.groovy
@@ -88,7 +88,7 @@ pipeline {
     parameters {
         string(name: 'Commit_id', defaultValue: 'None', description: '',)
         string(name: 'PR_number', defaultValue: 'None', description: '',)
-        string(name: 'Repository', defaultValue: 'oneapi-src/oneDPL', description: '',)
+        string(name: 'Repository', defaultValue: 'uxlfoundation/oneDPL', description: '',)
         string(name: 'User', defaultValue: 'None', description: '',)
         string(name: 'OneAPI_Package_Date', defaultValue: 'Default', description: '',)
         string(name: 'Base_branch', defaultValue: 'main', description: '',)

--- a/jenkinsfiles/Windows_Check.groovy
+++ b/jenkinsfiles/Windows_Check.groovy
@@ -113,7 +113,7 @@ pipeline {
     parameters {
         string(name: 'Commit_id', defaultValue: 'None', description: '',)
         string(name: 'PR_number', defaultValue: 'None', description: '',)
-        string(name: 'Repository', defaultValue: 'oneapi-src/oneDPL', description: '',)
+        string(name: 'Repository', defaultValue: 'uxlfoundation/oneDPL', description: '',)
         string(name: 'User', defaultValue: 'None', description: '',)
         string(name: 'OneAPI_Package_Date', defaultValue: 'Default', description: '',)
         string(name: 'Base_branch', defaultValue: 'main', description: '',)
@@ -200,7 +200,7 @@ pipeline {
                                     bat script: """
                                         d:
                                         cd ${env.WORKSPACE}
-                                        git clone https://github.com/oneapi-src/oneDPL.git src
+                                        git clone https://github.com/uxlfoundation/oneDPL.git src
                                         cd src
                                         git config --local --add remote.origin.fetch +refs/pull/${env.PR_number}/head:refs/remotes/origin/pr/${env.PR_number}
                                         git pull origin


### PR DESCRIPTION
This PR should be merged after the migration of the oneDPL repository to the UXL Foundation GitHub organization.  It corrects URLs in the documentation, examples, and Jenkins files (not currently used) to point to the correct location.