### PR TITLE
Avoid `if` call in the `__parallel_merge_submitter_large::run_parallel_merge()`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -322,8 +322,8 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
                     const _split_point_t<_IdType> __start =
                         __global_idx % __nd_range_params.steps_between_two_base_diags != 0
-                            ? __find_start_point(__rng1, __rng2, __base_diagonals_sp_global_ptr[__diagonal_idx],
-                                                 __base_diagonals_sp_global_ptr[__diagonal_idx + 1], __i_elem, __comp)
+                            ? __find_start_point_w(__rng1, __rng2, __base_diagonals_sp_global_ptr[__diagonal_idx],
+                                                   __base_diagonals_sp_global_ptr[__diagonal_idx + 1], __i_elem, __comp)
                             : __base_diagonals_sp_global_ptr[__diagonal_idx];
 
                     __serial_merge(__rng1, __rng2, __rng3, __start.first, __start.second, __i_elem,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -283,10 +283,10 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         });
     }
 
-    template <typename _Rng1, typename _Rng2, typename _Index, typename _Compare>
+    template <typename _Rng1, typename _Rng2, typename _Compare>
     inline static _split_point_t<_Index>
     __find_start_point_w(const _Rng1& __rng1, const _Rng2& __rng2, const _split_point_t<_IdType>& __sp_left,
-                         const _split_point_t<_IdType>& __sp_right, const _Index __i_elem, _Compare __comp)
+                         const _split_point_t<_IdType>& __sp_right, const _IdType __i_elem, _Compare __comp)
     {
         return _find_start_point(__rng1, __sp_left.first, __sp_right.first, __rng2, __sp_left.second, __sp_right.second,
                                  __i_elem, __comp);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -284,7 +284,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
     }
 
     template <typename _Rng1, typename _Rng2, typename _Compare>
-    inline static _split_point_t<_Index>
+    inline static _split_point_t<_IdType>
     __find_start_point_w(const _Rng1& __rng1, const _Rng2& __rng2, const _split_point_t<_IdType>& __sp_left,
                          const _split_point_t<_IdType>& __sp_right, const _IdType __i_elem, _Compare __comp)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -288,8 +288,8 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
     __find_start_point_w(const _Rng1& __rng1, const _Rng2& __rng2, const _split_point_t<_IdType>& __sp_left,
                          const _split_point_t<_IdType>& __sp_right, const _IdType __i_elem, _Compare __comp)
     {
-        return _find_start_point(__rng1, __sp_left.first, __sp_right.first, __rng2, __sp_left.second, __sp_right.second,
-                                 __i_elem, __comp);
+        return __find_start_point(__rng1, __sp_left.first, __sp_right.first, __rng2, __sp_left.second,
+                                  __sp_right.second, __i_elem, __comp);
     }
 
     // Process parallel merge


### PR DESCRIPTION
In this PR we remove additional `if` call from `__parallel_merge_submitter_large::run_parallel_merge()`
Our experience shows that it should work faster.