### PR TITLE
Fix spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ the [#onedpl](https://uxlfoundation.slack.com/channels/onedpl) channel.
 The oneDPL project is governed by the [UXL Foundation] and you can get involved in
 this project. Members can join the Open Source and Specification Working Group
 meetings to participate in discussions on the evolution of oneDPL and other oneAPI components
-governed by th [UXL Foundation]. See [How to Contribute] for more details.
+governed by the [UXL Foundation]. See [How to Contribute] for more details.
 
 You can also join the [mailing lists for the UXL Foundation] to be informed
 of when meetings are happening and receive the latest information and

--- a/documentation/library_guide/dynamic_selection_api/dynamic_load_policy.rst
+++ b/documentation/library_guide/dynamic_selection_api/dynamic_load_policy.rst
@@ -130,7 +130,7 @@ Simplified, expository implementation of the selection algorithm:
       auto least_loaded_resource = find_least_loaded(resources_);
       return selection_type{dynamic_load_policy<Backend>(*this), least_loaded};
     } else {
-      throw std::logic_error("select called before initialialization");
+      throw std::logic_error("select called before initialization");
     }
   }
 

--- a/examples/random/README.md
+++ b/examples/random/README.md
@@ -11,7 +11,7 @@ This example demonstrates how to use scalar and vector random number generation 
 
 ## License
 
-This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
+This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/uxlfoundation/oneDPL/blob/main/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
 
 ## Building the 'Random' Program for CPU and GPU
 

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
@@ -83,7 +83,7 @@ class __onesweep_memory_holder
     ::std::uint8_t* __m_raw_mem_ptr = nullptr;
     // Memory to store global histograms, where each stage has its own histogram
     _HistT* __m_global_hist_ptr = nullptr;
-    // Memory to store group historgrams, which contain offsets relative to "previous" groups
+    // Memory to store group histograms, which contain offsets relative to "previous" groups
     _HistT* __m_group_hist_ptr = nullptr;
     // Memory to store intermediate results of sorting
     _KeyT* __m_keys_ptr = nullptr;

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -728,7 +728,7 @@ class __merge_func
     _SizeType _M_zs;
     _Compare _M_comp;
     _LeafMerge _M_leaf_merge;
-    _SizeType _M_nsort; //number of elements to be sorted for partial_sort alforithm
+    _SizeType _M_nsort; //number of elements to be sorted for partial_sort algorithm
 
     static const _SizeType __merge_cut_off = _ONEDPL_MERGE_CUT_OFF;
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -111,7 +111,7 @@ struct check_minmaxelement_predicate
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         const ::std::pair<Iterator, Iterator> expect = ::std::minmax_element(begin, end);
         const ::std::pair<Iterator, Iterator> got_pred = ::std::minmax_element(exec, begin, end, ::std::less<T>());
-        EXPECT_TRUE(expect == got_pred, "wrong return result from minmax_element wuth predicate");
+        EXPECT_TRUE(expect == got_pred, "wrong return result from minmax_element with predicate");
     }
 };
 

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -239,7 +239,7 @@ public:
         const int r_size = max_n;
         process_data_in_out(r_size, r_size, std::forward<Policy>(exec), algo, checker, args...);
 
-        //test case size of input range is less than size of output and viceversa
+        //test case size of input range is less than size of output and vice-versa
         process_data_in_out(r_size/2, r_size, exec, algo, checker, args...);
         process_data_in_out(r_size, r_size/2, std::forward<Policy>(exec), algo, checker, args...);
     }

--- a/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
@@ -59,8 +59,8 @@ main()
     ::std::transform(data, data + max_n, expected, lambda1);
     ::std::transform(expected, expected + max_n, expected, expected, lambda2);
 
-    EXPECT_EQ_N(expected, data2, max_n, "wrong effect from trasnform2 with sycl ranges");
-    EXPECT_EQ_N(expected, data3, max_n, "wrong effect from trasnform2 with sycl buffer");
+    EXPECT_EQ_N(expected, data2, max_n, "wrong effect from transform2 with sycl ranges");
+    EXPECT_EQ_N(expected, data3, max_n, "wrong effect from transform2 with sycl buffer");
 #endif //_ENABLE_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
@@ -54,7 +54,7 @@ main()
     ::std::transform(data, data + max_n, expected, lambda1);
     ::std::transform(expected, expected + max_n, expected, expected, lambda2);
 
-    EXPECT_EQ_N(expected, data2, max_n, "wrong effect from trasnform2 with sycl ranges");
+    EXPECT_EQ_N(expected, data2, max_n, "wrong effect from transform2 with sycl ranges");
 #endif //_ENABLE_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -60,8 +60,8 @@ main()
     ::std::transform(data, data + max_n, expected, lambda1);
     ::std::transform(expected, expected + max_n, expected, lambda2);
 
-    EXPECT_EQ_N(expected, data2, max_n, "wrong effect from trasnform with sycl ranges");
-    EXPECT_EQ_N(expected, data3, max_n, "wrong effect from trasnform with sycl buffer");
+    EXPECT_EQ_N(expected, data2, max_n, "wrong effect from transform with sycl ranges");
+    EXPECT_EQ_N(expected, data3, max_n, "wrong effect from transform with sycl buffer");
 #endif //_ENABLE_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
@@ -55,7 +55,7 @@ main()
     ::std::transform(data, data + max_n, expected, lambda1);
     ::std::transform(expected, expected + max_n, expected, lambda2);
 
-    EXPECT_EQ_N(expected, data2, max_n, "wrong effect from trasnform with sycl ranges");
+    EXPECT_EQ_N(expected, data2, max_n, "wrong effect from transform with sycl ranges");
 #endif //_ENABLE_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -141,7 +141,7 @@ namespace TestUtils
             const auto device = deviceQueue.get_device();
 
             // We should run fncDoubleHasSupportInRuntime and fncDoubleHasntSupportInRuntime
-            // in two separate Kernels to have ability compile these Kernels separatelly
+            // in two separate Kernels to have ability compile these Kernels separately
             // by using Intel(R) oneAPI DPC++/C++ Compiler option -fsycl-device-code-split=per_kernel
             // which described at
             // https://www.intel.com/content/www/us/en/develop/documentation/oneapi-gpu-optimization-guide/top/compilation/jitting.html

--- a/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
+++ b/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
@@ -59,7 +59,7 @@ test(Function fnc, const std::vector<ValueType>& args, const char* message)
         });
     }
 
-    // Check results: compare resuls evaluated in Kernel and on host
+    // Check results: compare results evaluated in Kernel and on host
     for (size_t i = 0; i < args_count; ++i)
     {
         auto host_result = fnc(args[i]);

--- a/test/xpu_api/containers/sequences/array/zero_sized_arrays_g.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/zero_sized_arrays_g.pass.cpp
@@ -46,7 +46,7 @@ int
 main()
 {
     auto ret = kernel_test();
-    EXPECT_TRUE(ret, "Wrong result of work with in empty dpl::array in kernel_test");
+    EXPECT_TRUE(ret, "Wrong result of work with empty dpl::array in kernel_test");
 
     return TestUtils::done();
 }

--- a/test/xpu_api/containers/sequences/array/zero_sized_arrays_g.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/zero_sized_arrays_g.pass.cpp
@@ -46,7 +46,7 @@ int
 main()
 {
     auto ret = kernel_test();
-    EXPECT_TRUE(ret, "Wrong result of work with in emply dpl::array in kernel_test");
+    EXPECT_TRUE(ret, "Wrong result of work with in empty dpl::array in kernel_test");
 
     return TestUtils::done();
 }

--- a/test/xpu_api/utilities/meta/meta.rel/is_convertible.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.rel/is_convertible.pass.cpp
@@ -263,7 +263,7 @@ kernel_test()
     test_is_not_convertible<NonCopyable&, NonCopyable>();
 
     // Ensure that CannotInstantiate is not instantiated by is_convertible when it is not needed.
-    // For example CannotInstantiate is instatiated as a part of ADL lookup for arguments of type CannotInstantiate*.
+    // For example CannotInstantiate is instantiated as a part of ADL lookup for arguments of type CannotInstantiate*.
     static_assert(dpl::is_convertible<CannotInstantiate<int>*, CannotInstantiate<int>*>::value);
 
     return true;


### PR DESCRIPTION
The codespell scan on #1992 identified several spelling errors in the repository -- https://github.com/uxlfoundation/oneDPL/actions/runs/12658581533/job/35275850152?pr=1992

This PR corrects those errors and updates two URLs in documentation where the oneapi-src organization was not replaced with uxlfoundation.