### PR TITLE
Work around crashes and incorrect results in scan-based algorithms when compiling with -O0

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2498,7 +2498,7 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, cons
     }
 #endif
     return __parallel_reduce_by_segment_fallback(
-        oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__internal::__device_backend_tag{}, __exec,
         std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys),
         std::forward<_Range4>(__out_values), __binary_pred, __binary_op,
         oneapi::dpl::unseq_backend::__has_known_identity<_BinaryOperator, __val_type>{});

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1442,9 +1442,9 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
     using _CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, _Assign,
                                                   /*inclusive*/ std::true_type, 1>;
 
-    return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
-                                _CreateOp{__pred}, _CopyOp{_ReduceOp{}, __assign});
+    return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                                std::forward<_OutRng>(__out_rng), __n, _CreateOp{__pred},
+                                _CopyOp{_ReduceOp{}, __assign});
 }
 
 #if _ONEDPL_COMPILE_KERNEL

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2491,7 +2491,6 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, cons
                 auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan(
                     oneapi::dpl::__internal::__device_backend_tag{}, __exec, __keys, __values, __out_keys, __out_values,
                     __binary_pred, __binary_op);
-                __res.wait();
                 // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the
                 // past-the-end iterator pair of segmented reduction.
                 return std::get<0>(__res.get()) + 1;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1143,7 +1143,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
                         _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
                         /*_IsUniquePattern=*/std::false_type{});
                 },
-                oneapi::dpl::__par_backend_hetero::__bypass_sycl_kernel_not_supported{});
+                __bypass_sycl_kernel_not_supported{});
             if (__opt_return)
                 return __opt_return.value();
         }
@@ -1306,7 +1306,7 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
                                                         __n, _GenMask{__pred}, _WriteOp{_Assign{}},
                                                         /*_IsUniquePattern=*/std::true_type{});
             },
-            oneapi::dpl::__par_backend_hetero::__bypass_sycl_kernel_not_supported{});
+            __bypass_sycl_kernel_not_supported{});
         if (__opt_return)
             return __opt_return.value();
     }
@@ -1376,7 +1376,7 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
                                                         __n, _GenMask{__pred}, _WriteOp{},
                                                         /*_IsUniquePattern=*/std::false_type{});
             },
-            oneapi::dpl::__par_backend_hetero::__bypass_sycl_kernel_not_supported{});
+            __bypass_sycl_kernel_not_supported{});
         if (__opt_return)
             return __opt_return.value();
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1134,17 +1134,17 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
             using _ScanInputTransform = oneapi::dpl::__internal::__no_op;
             using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 
+            _GenInput __gen_transform{__unary_op};
             try
             {
-                _GenInput __gen_transform{__unary_op};
                 return __parallel_transform_reduce_then_scan(__backend_tag, __exec, __in_rng, __out_rng,
                                                              __gen_transform, __binary_op, __gen_transform,
                                                              _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
                                                              /*_IsUniquePattern=*/std::false_type{});
             }
-            catch (const sycl::exception& e)
+            catch (const sycl::exception& __e)
             {
-                __bypass_sycl_kernel_not_supported(e);
+                __bypass_sycl_kernel_not_supported(__e);
             }
         }
 #endif
@@ -1296,17 +1296,17 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
 #if _ONEDPL_COMPILE_KERNEL
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
+        using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
+        using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
         try
         {
-            using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
-            using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
             return __parallel_reduce_then_scan_copy(__backend_tag, __exec, __rng, __result, __n, _GenMask{__pred},
                                                     _WriteOp{_Assign{}},
                                                     /*_IsUniquePattern=*/std::true_type{});
         }
-        catch (const sycl::exception& e)
+        catch (const sycl::exception& __e)
         {
-            __bypass_sycl_kernel_not_supported(e);
+            __bypass_sycl_kernel_not_supported(__e);
         }
     }
 #endif
@@ -1364,18 +1364,18 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
 #if _ONEDPL_COMPILE_KERNEL
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
+        using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
+        using _WriteOp =
+            oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
         try
         {
-            using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
-            using _WriteOp =
-                oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
             return __parallel_reduce_then_scan_copy(__backend_tag, __exec, __rng, __result, __n, _GenMask{__pred},
                                                     _WriteOp{},
                                                     /*_IsUniquePattern=*/std::false_type{});
         }
-        catch (const sycl::exception& e)
+        catch (const sycl::exception& __e)
         {
-            __bypass_sycl_kernel_not_supported(e);
+            __bypass_sycl_kernel_not_supported(__e);
         }
     }
 #endif
@@ -1421,17 +1421,17 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
 #if _ONEDPL_COMPILE_KERNEL
     else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
+        using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
+        using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
         try
         {
-            using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
-            using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
             return __parallel_reduce_then_scan_copy(__backend_tag, __exec, __in_rng, __out_rng, __n, _GenMask{__pred},
                                                     _WriteOp{__assign},
                                                     /*_IsUniquePattern=*/std::false_type{});
         }
-        catch (const sycl::exception& e)
+        catch (const sycl::exception& __e)
         {
-            __bypass_sycl_kernel_not_supported(e);
+            __bypass_sycl_kernel_not_supported(__e);
         }
     }
 #endif
@@ -1546,9 +1546,9 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, c
             return __parallel_set_reduce_then_scan(__backend_tag, __exec, __rng1, __rng2, __result, __comp,
                                                    __is_op_difference);
         }
-        catch (const sycl::exception& e)
+        catch (const sycl::exception& __e)
         {
-            __bypass_sycl_kernel_not_supported(e);
+            __bypass_sycl_kernel_not_supported(__e);
         }
     }
 #endif
@@ -2495,9 +2495,9 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, cons
                 // past-the-end iterator pair of segmented reduction.
                 return std::get<0>(__res.get()) + 1;
             }
-            catch (const sycl::exception& e)
+            catch (const sycl::exception& __e)
             {
-                __bypass_sycl_kernel_not_supported(e);
+                __bypass_sycl_kernel_not_supported(__e);
             }
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1541,6 +1541,7 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _
                   _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
                   _IsOpDifference __is_op_difference)
 {
+#if _ONEDPL_COMPILER_KERNEL
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(
@@ -1553,6 +1554,7 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _
         if (__opt_return)
             return __opt_return.value();
     }
+#endif
     return __parallel_set_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
                                std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp,
                                __is_op_difference);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1090,6 +1090,20 @@ struct __write_to_id_if_else
     _Assign __assign;
 };
 
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
+// Templated alias to easily reference reduce-then-scan-copy kernels.
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _GenMask, typename _Size,
+          typename _WriteOp, typename _IsUniquePattern>
+using __reduce_then_scan_copy_kernels =
+    __reduce_then_scan_kernels<_ExecutionPolicy, _Range1, _Range2,
+                               /*_GenReduceInput=*/oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMask>,
+                               /*_ReduceOp=*/std::plus<_Size>,
+                               /*_GenScanInput=*/oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>,
+                               /*_ScanInputTransform=*/oneapi::dpl::__par_backend_hetero::__get_zeroth_element,
+                               _WriteOp, oneapi::dpl::unseq_backend::__no_init_value<_Size>,
+                               /*_Inclusive=*/std::true_type, _IsUniquePattern>;
+#endif
+
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation, typename _InitType,
           typename _BinaryOperation, typename _Inclusive>
 auto
@@ -1122,19 +1136,29 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
                     std::forward<_Range2>(__out_rng), __n, __unary_op, __init, __binary_op, _Inclusive{});
             }
         }
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
         if (__use_reduce_then_scan)
         {
             using _GenInput = oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation>;
             using _ScanInputTransform = oneapi::dpl::__internal::__no_op;
             using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 
+            // Compile the kernels to check if the sub-group size is 32. This should not be necessary per the SYCL spec
+            // but is needed to check for an IGC workaround for a hardware bug where kernels may be compiled with a
+            // sub-group size of 16 despite requiring 32. If the wrong sub-group size is used, then fallback to
+            // multi-pass scan.
             _GenInput __gen_transform{__unary_op};
-
-            return __parallel_transform_reduce_then_scan(
-                __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
-                std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform, _ScanInputTransform{},
-                _WriteOp{}, __init, _Inclusive{}, /*_IsUniquePattern=*/std::false_type{});
+            __reduce_then_scan_kernels<_ExecutionPolicy, _Range1, _Range2, decltype(__gen_transform), _BinaryOperation, decltype(__gen_transform), _ScanInputTransform,
+                                       _WriteOp, _InitType, _Inclusive, std::false_type> __kernels(__exec);
+            if (__kernels.__is_compiled_sg32())
+            {
+                return __parallel_transform_reduce_then_scan(
+                    __backend_tag, std::forward<_ExecutionPolicy>(__exec), __kernels, std::forward<_Range1>(__in_rng),
+                    std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
+                    _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{}, /*_IsUniquePattern=*/std::false_type{});
+            }
         }
+#endif
     }
 
     //else use multi pass scan implementation
@@ -1209,11 +1233,12 @@ struct __invoke_single_group_copy_if
     }
 };
 
-template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _GenMask,
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
+template <typename _ExecutionPolicy, typename _Kernels, typename _InRng, typename _OutRng, typename _Size, typename _GenMask,
           typename _WriteOp, typename _IsUniquePattern>
 auto
 __parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
-                                 _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _GenMask __generate_mask,
+                                 _Kernels& __kernels, _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _GenMask __generate_mask,
                                  _WriteOp __write_op, _IsUniquePattern __is_unique_pattern)
 {
     using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMask>;
@@ -1222,11 +1247,12 @@ __parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag _
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     return __parallel_transform_reduce_then_scan(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec), __kernels, std::forward<_InRng>(__in_rng),
         std::forward<_OutRng>(__out_rng), _GenReduceInput{__generate_mask}, _ReduceOp{}, _GenScanInput{__generate_mask},
         _ScanInputTransform{}, __write_op, oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
         /*_Inclusive=*/std::true_type{}, __is_unique_pattern);
 }
+#endif
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _CreateMaskOp,
           typename _CopyByMaskOp>
@@ -1279,30 +1305,37 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
     // can simply copy the input range to the output.
     assert(__n > 1);
 
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
-
-        return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
-                                                _GenMask{__pred}, _WriteOp{_Assign{}},
-                                                /*_IsUniquePattern=*/std::true_type{});
+        // Compile the kernels to check if the sub-group size is 32. This should not be necessary per the SYCL spec
+        // but is needed to check for an IGC workaround for a hardware bug where kernels may be compiled with a
+        // sub-group size of 16 despite requiring 32. If the wrong sub-group size is used, then fallback to
+        // multi-pass scan.
+        __reduce_then_scan_copy_kernels<_ExecutionPolicy, _Range1, _Range2, _GenMask,
+                                        oneapi::dpl::__internal::__difference_t<_Range1>, _WriteOp, std::true_type>
+            __kernels(__exec);
+        if (__kernels.__is_compiled_sg32())
+        {
+            return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), __kernels,
+                                                    std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
+                                                    _GenMask{__pred}, _WriteOp{_Assign{}},
+                                                    /*_IsUniquePattern=*/std::true_type{});
+        }
     }
-    else
-    {
+#endif
+    using _ReduceOp = std::plus<decltype(__n)>;
+    using _CreateOp =
+        oneapi::dpl::__internal::__create_mask_unique_copy<oneapi::dpl::__internal::__not_pred<_BinaryPredicate>,
+                                                           decltype(__n)>;
+    using _CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, _Assign, /*inclusive*/ std::true_type, 1>;
 
-        using _ReduceOp = std::plus<decltype(__n)>;
-        using _CreateOp =
-            oneapi::dpl::__internal::__create_mask_unique_copy<oneapi::dpl::__internal::__not_pred<_BinaryPredicate>,
-                                                               decltype(__n)>;
-        using _CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, _Assign, /*inclusive*/ std::true_type, 1>;
-
-        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
-                                    std::forward<_Range2>(__result), __n,
-                                    _CreateOp{oneapi::dpl::__internal::__not_pred<_BinaryPredicate>{__pred}},
-                                    _CopyOp{_ReduceOp{}, _Assign{}});
-    }
+    return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
+                                std::forward<_Range2>(__result), __n,
+                                _CreateOp{oneapi::dpl::__internal::__not_pred<_BinaryPredicate>{__pred}},
+                                _CopyOp{_ReduceOp{}, _Assign{}});
 }
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Range4,
@@ -1343,25 +1376,33 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
                           _Range1&& __rng, _Range2&& __result, _UnaryPredicate __pred)
 {
     oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng.size();
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
         using _WriteOp =
             oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
-
-        return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
-                                                _GenMask{__pred}, _WriteOp{}, /*_IsUniquePattern=*/std::false_type{});
+        // Compile the kernels to check if the sub-group size is 32. This should not be necessary per the SYCL spec
+        // but is needed to check for an IGC workaround for a hardware bug where kernels may be compiled with a
+        // sub-group size of 16 despite requiring 32. If the wrong sub-group size is used, then fallback to
+        // multi-pass scan.
+        __reduce_then_scan_copy_kernels<_ExecutionPolicy, _Range1, _Range2, _GenMask,
+                                        oneapi::dpl::__internal::__difference_t<_Range1>, _WriteOp, std::false_type>
+            __kernels(__exec);
+        if (__kernels.__is_compiled_sg32())
+        {
+            return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), __kernels,
+                                                    std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
+                                                    _GenMask{__pred}, _WriteOp{}, /*_IsUniquePattern=*/std::false_type{});
+        }
     }
-    else
-    {
-        using _ReduceOp = std::plus<decltype(__n)>;
-        using _CreateOp = unseq_backend::__create_mask<_UnaryPredicate, decltype(__n)>;
-        using _CopyOp = unseq_backend::__partition_by_mask<_ReduceOp, /*inclusive*/ std::true_type>;
+#endif
+    using _ReduceOp = std::plus<decltype(__n)>;
+    using _CreateOp = unseq_backend::__create_mask<_UnaryPredicate, decltype(__n)>;
+    using _CopyOp = unseq_backend::__partition_by_mask<_ReduceOp, /*inclusive*/ std::true_type>;
 
-        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
-                                    std::forward<_Range2>(__result), __n, _CreateOp{__pred}, _CopyOp{_ReduceOp{}});
-    }
+    return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
+                                std::forward<_Range2>(__result), __n, _CreateOp{__pred}, _CopyOp{_ReduceOp{}});
 }
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _Pred,
@@ -1395,27 +1436,35 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
             _SingleGroupInvoker{}, __n, std::forward<_ExecutionPolicy>(__exec), __n, std::forward<_InRng>(__in_rng),
             std::forward<_OutRng>(__out_rng), __pred, __assign);
     }
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
     else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
-
-        return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
-                                                _GenMask{__pred}, _WriteOp{__assign},
-                                                /*_IsUniquePattern=*/std::false_type{});
+        // Compile the kernels to check if the sub-group size is 32. This should not be necessary per the SYCL spec
+        // but is needed to check for an IGC workaround for a hardware bug where kernels may be compiled with a
+        // sub-group size of 16 despite requiring 32. If the wrong sub-group size is used, then fallback to
+        // multi-pass scan.
+        __reduce_then_scan_copy_kernels<_ExecutionPolicy, _InRng, _OutRng, _GenMask,
+                                        _Size, _WriteOp, std::false_type>
+            __kernels(__exec);
+        if (__kernels.__is_compiled_sg32())
+        {
+            return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), __kernels,
+                                                    std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
+                                                    _GenMask{__pred}, _WriteOp{__assign},
+                                                    /*_IsUniquePattern=*/std::false_type{});
+        }
     }
-    else
-    {
-        using _ReduceOp = std::plus<_Size>;
-        using _CreateOp = unseq_backend::__create_mask<_Pred, _Size>;
-        using _CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, _Assign,
-                                                      /*inclusive*/ std::true_type, 1>;
+#endif
+    using _ReduceOp = std::plus<_Size>;
+    using _CreateOp = unseq_backend::__create_mask<_Pred, _Size>;
+    using _CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, _Assign,
+                                                  /*inclusive*/ std::true_type, 1>;
 
-        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                    std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
-                                    _CreateOp{__pred}, _CopyOp{_ReduceOp{}, __assign});
-    }
+    return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
+                                _CreateOp{__pred}, _CopyOp{_ReduceOp{}, __assign});
 }
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1104,7 +1104,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
     if constexpr (std::is_trivially_copyable_v<_Type>)
     {
         bool __use_reduce_then_scan =
-#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL
             oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec);
 #else
             false;
@@ -1127,7 +1127,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
                     std::forward<_Range2>(__out_rng), __n, __unary_op, __init, __binary_op, _Inclusive{});
             }
         }
-#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL
         if (__use_reduce_then_scan)
         {
             using _GenInput = oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation>;
@@ -1219,7 +1219,7 @@ struct __invoke_single_group_copy_if
     }
 };
 
-#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _GenMask,
           typename _WriteOp, typename _IsUniquePattern>
 auto
@@ -1291,7 +1291,7 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
     // can simply copy the input range to the output.
     assert(__n > 1);
 
-#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto [__opt_return, _] = __handle_sync_sycl_exception([&] {
@@ -1318,7 +1318,7 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
                                 _CopyOp{_ReduceOp{}, _Assign{}});
 }
 
-#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Range4,
           typename _BinaryPredicate, typename _BinaryOperator>
 auto
@@ -1358,7 +1358,7 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
                           _Range1&& __rng, _Range2&& __result, _UnaryPredicate __pred)
 {
     oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng.size();
-#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto [__opt_return, _] = __handle_sync_sycl_exception([&] {
@@ -1413,7 +1413,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
             _SingleGroupInvoker{}, __n, std::forward<_ExecutionPolicy>(__exec), __n, std::forward<_InRng>(__in_rng),
             std::forward<_OutRng>(__out_rng), __pred, __assign);
     }
-#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL
     else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto [__opt_return, _] = __handle_sync_sycl_exception([&] {
@@ -1438,7 +1438,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
                                 _CreateOp{__pred}, _CopyOp{_ReduceOp{}, __assign});
 }
 
-#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
 auto
@@ -2472,8 +2472,7 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
 
     using __val_type = oneapi::dpl::__internal::__value_t<_Range2>;
     // Prior to icpx 2025.0, the reduce-then-scan path performs poorly and should be avoided.
-#if (!defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER >= 20250000) &&                                          \
-    (_ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT)
+#if (!defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER >= 20250000) && _ONEDPL_COMPILE_KERNEL
     if constexpr (std::is_trivially_copyable_v<__val_type>)
     {
         if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1135,12 +1135,11 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
             using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 
             auto __opt_return = __handle_sync_sycl_exception(
-                [=, &__exec, &__in_rng, &__out_rng] {
+                [=, &__exec] {
                     _GenInput __gen_transform{__unary_op};
                     return __parallel_transform_reduce_then_scan(
-                        __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
-                        std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
-                        _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
+                        __backend_tag, __exec, std::move(__in_rng), std::move(__out_rng), __gen_transform, __binary_op,
+                        __gen_transform, _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
                         /*_IsUniquePattern=*/std::false_type{});
                 },
                 __bypass_sycl_kernel_not_supported{});
@@ -1298,11 +1297,10 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(
-            [=, &__exec, &__rng, &__result] {
+            [=, &__exec] {
                 using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
                 using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
-                return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                        std::forward<_Range1>(__rng), std::forward<_Range2>(__result),
+                return __parallel_reduce_then_scan_copy(__backend_tag, __exec, std::move(__rng), std::move(__result),
                                                         __n, _GenMask{__pred}, _WriteOp{_Assign{}},
                                                         /*_IsUniquePattern=*/std::true_type{});
             },
@@ -1367,12 +1365,11 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(
-            [=, &__exec, &__rng, &__result] {
+            [=, &__exec] {
                 using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
                 using _WriteOp =
                     oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
-                return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                        std::forward<_Range1>(__rng), std::forward<_Range2>(__result),
+                return __parallel_reduce_then_scan_copy(__backend_tag, __exec, std::move(__rng), std::move(__result),
                                                         __n, _GenMask{__pred}, _WriteOp{},
                                                         /*_IsUniquePattern=*/std::false_type{});
             },
@@ -1424,13 +1421,12 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
     else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(
-            [=, &__exec, &__in_rng, &__out_rng] {
+            [=, &__exec] {
                 using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
                 using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
-                return __parallel_reduce_then_scan_copy(
-                    __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
-                    std::forward<_OutRng>(__out_rng), __n, _GenMask{__pred}, _WriteOp{__assign},
-                    /*_IsUniquePattern=*/std::false_type{});
+                return __parallel_reduce_then_scan_copy(__backend_tag, __exec, std::move(__in_rng),
+                                                        std::move(__out_rng), __n, _GenMask{__pred}, _WriteOp{__assign},
+                                                        /*_IsUniquePattern=*/std::false_type{});
             },
             __bypass_sycl_kernel_not_supported{});
         if (__opt_return)
@@ -1545,10 +1541,9 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(
-            [=, &__exec, &__rng1, &__rng2, &__result] {
-                return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                       std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                                                       std::forward<_Range3>(__result), __comp, __is_op_difference);
+            [=, &__exec] {
+                return __parallel_set_reduce_then_scan(__backend_tag, __exec, std::move(__rng1), std::move(__rng2),
+                                                       std::move(__result), __comp, __is_op_difference);
             },
             __bypass_sycl_kernel_not_supported{});
         if (__opt_return)
@@ -2491,12 +2486,10 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
         if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
         {
             auto __opt_return = __handle_sync_sycl_exception(
-                [=, &__exec, &__keys, &__values, &__out_keys, &__out_values] {
+                [=, &__exec] {
                     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan(
-                        oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
-                        std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
-                        std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values), __binary_pred,
-                        __binary_op);
+                        oneapi::dpl::__internal::__device_backend_tag{}, __exec, std::move(__keys), std::move(__values),
+                        std::move(__out_keys), std::move(__out_values), __binary_pred, __binary_op);
                     __res.wait();
                     // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the
                     // past-the-end iterator pair of segmented reduction.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1134,13 +1134,16 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
             using _ScanInputTransform = oneapi::dpl::__internal::__no_op;
             using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 
-            auto [__opt_return, _] = __handle_sync_sycl_exception([&] {
-                _GenInput __gen_transform{__unary_op};
-                return __parallel_transform_reduce_then_scan(
-                    __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
-                    std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
-                    _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{}, /*_IsUniquePattern=*/std::false_type{});
-            });
+            auto __opt_return = __handle_sync_sycl_exception(
+                [&] {
+                    _GenInput __gen_transform{__unary_op};
+                    return __parallel_transform_reduce_then_scan(
+                        __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
+                        std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
+                        _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
+                        /*_IsUniquePattern=*/std::false_type{});
+                },
+                oneapi::dpl::__par_backend_hetero::__bypass_sycl_kernel_not_supported{});
             if (__opt_return)
                 return __opt_return.value();
         }
@@ -1294,14 +1297,16 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
 #if _ONEDPL_COMPILE_KERNEL
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
-        auto [__opt_return, _] = __handle_sync_sycl_exception([&] {
-            using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
-            using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
-            return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                    std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
-                                                    _GenMask{__pred}, _WriteOp{_Assign{}},
-                                                    /*_IsUniquePattern=*/std::true_type{});
-        });
+        auto __opt_return = __handle_sync_sycl_exception(
+            [&] {
+                using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
+                using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
+                return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                                        std::forward<_Range1>(__rng), std::forward<_Range2>(__result),
+                                                        __n, _GenMask{__pred}, _WriteOp{_Assign{}},
+                                                        /*_IsUniquePattern=*/std::true_type{});
+            },
+            oneapi::dpl::__par_backend_hetero::__bypass_sycl_kernel_not_supported{});
         if (__opt_return)
             return __opt_return.value();
     }
@@ -1361,15 +1366,17 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
 #if _ONEDPL_COMPILE_KERNEL
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
-        auto [__opt_return, _] = __handle_sync_sycl_exception([&] {
-            using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
-            using _WriteOp =
-                oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
-            return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                    std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
-                                                    _GenMask{__pred}, _WriteOp{},
-                                                    /*_IsUniquePattern=*/std::false_type{});
-        });
+        auto __opt_return = __handle_sync_sycl_exception(
+            [&] {
+                using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
+                using _WriteOp =
+                    oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
+                return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                                        std::forward<_Range1>(__rng), std::forward<_Range2>(__result),
+                                                        __n, _GenMask{__pred}, _WriteOp{},
+                                                        /*_IsUniquePattern=*/std::false_type{});
+            },
+            oneapi::dpl::__par_backend_hetero::__bypass_sycl_kernel_not_supported{});
         if (__opt_return)
             return __opt_return.value();
     }
@@ -1416,14 +1423,16 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
 #if _ONEDPL_COMPILE_KERNEL
     else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
-        auto [__opt_return, _] = __handle_sync_sycl_exception([&] {
-            using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
-            using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
-            return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                    std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng),
-                                                    __n, _GenMask{__pred}, _WriteOp{__assign},
-                                                    /*_IsUniquePattern=*/std::false_type{});
-        });
+        auto __opt_return = __handle_sync_sycl_exception(
+            [&] {
+                using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
+                using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
+                return __parallel_reduce_then_scan_copy(
+                    __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                    std::forward<_OutRng>(__out_rng), __n, _GenMask{__pred}, _WriteOp{__assign},
+                    /*_IsUniquePattern=*/std::false_type{});
+            },
+            __bypass_sycl_kernel_not_supported{});
         if (__opt_return)
             return __opt_return.value();
     }
@@ -1534,11 +1543,13 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _
 {
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
-        auto [__opt_return, _] = __handle_sync_sycl_exception([&] {
-            return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                   std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                                                   std::forward<_Range3>(__result), __comp, __is_op_difference);
-        });
+        auto __opt_return = __handle_sync_sycl_exception(
+            [&] {
+                return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                                       std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                                                       std::forward<_Range3>(__result), __comp, __is_op_difference);
+            },
+            __bypass_sycl_kernel_not_supported{});
         if (__opt_return)
             return __opt_return.value();
     }
@@ -2477,16 +2488,19 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
     {
         if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
         {
-            auto [__opt_return, _] = __handle_sync_sycl_exception([&] {
-                auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan(
-                    oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
-                    std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys),
-                    std::forward<_Range4>(__out_values), __binary_pred, __binary_op);
-                __res.wait();
-                // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the
-                // past-the-end iterator pair of segmented reduction.
-                return std::get<0>(__res.get()) + 1;
-            });
+            auto __opt_return = __handle_sync_sycl_exception(
+                [&] {
+                    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan(
+                        oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
+                        std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
+                        std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values), __binary_pred,
+                        __binary_op);
+                    __res.wait();
+                    // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the
+                    // past-the-end iterator pair of segmented reduction.
+                    return std::get<0>(__res.get()) + 1;
+                },
+                __bypass_sycl_kernel_not_supported{});
             if (__opt_return)
                 return __opt_return.value();
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1135,7 +1135,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
             using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 
             auto __opt_return = __handle_sync_sycl_exception(
-                [&] {
+                [=, &__exec, &__in_rng, &__out_rng] {
                     _GenInput __gen_transform{__unary_op};
                     return __parallel_transform_reduce_then_scan(
                         __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
@@ -1298,7 +1298,7 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(
-            [&] {
+            [=, &__exec, &__rng, &__result] {
                 using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
                 using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
                 return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -1367,7 +1367,7 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(
-            [&] {
+            [=, &__exec, &__rng, &__result] {
                 using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
                 using _WriteOp =
                     oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
@@ -1424,7 +1424,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
     else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(
-            [&] {
+            [=, &__exec, &__in_rng, &__out_rng] {
                 using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
                 using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
                 return __parallel_reduce_then_scan_copy(
@@ -1544,7 +1544,7 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(
-            [&] {
+            [=, &__exec, &__rng1, &__rng2, &__result] {
                 return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
                                                        std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
                                                        std::forward<_Range3>(__result), __comp, __is_op_difference);
@@ -2489,7 +2489,7 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
         if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
         {
             auto __opt_return = __handle_sync_sycl_exception(
-                [&] {
+                [=, &__exec, &__keys, &__values, &__out_keys, &__out_values] {
                     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan(
                         oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
                         std::forward<_Range1>(__keys), std::forward<_Range2>(__values),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1534,7 +1534,7 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, c
                   _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
                   _IsOpDifference __is_op_difference)
 {
-#if _ONEDPL_COMPILER_KERNEL
+#if _ONEDPL_COMPILE_KERNEL
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         auto __opt_return = __handle_sync_sycl_exception(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -297,7 +297,7 @@ struct __parallel_reduce_then_scan_reduce_submitter
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
-            __cgh.parallel_for<_KernelName...>(
+            __cgh.parallel_for<_KernelName>(
                     __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                 _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 std::size_t __group_id = __ndi.get_group(0);
@@ -448,7 +448,7 @@ struct __parallel_reduce_then_scan_scan_submitter
             auto __res_acc =
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
-            __cgh.parallel_for<_KernelName...>(
+            __cgh.parallel_for<_KernelName>(
                     __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                 _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 _InitValueType* __res_ptr =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -877,5 +877,5 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
 } // namespace dpl
 } // namespace oneapi
 
-#endif
+#endif // _ONEDPL_COMPILE_KERNEL
 #endif // _ONEDPL_PARALLEL_BACKEND_SYCL_REDUCE_THEN_SCAN_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -300,7 +300,7 @@ struct __parallel_reduce_then_scan_reduce_submitter
             __cgh.use_kernel_bundle(__reduce_kernel.get_kernel_bundle());
 #endif
             __cgh.parallel_for<_KernelName>(
-#if !_ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if !_ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT && _ONEDPL_LIBSYCL_PROGRAM_PRESENT
                     __reduce_kernel,
 #endif
                     __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
@@ -456,7 +456,7 @@ struct __parallel_reduce_then_scan_scan_submitter
             __cgh.use_kernel_bundle(__scan_kernel.get_kernel_bundle());
 #endif
             __cgh.parallel_for<_KernelName>(
-#if !_ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
+#if !_ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT && _ONEDPL_LIBSYCL_PROGRAM_PRESENT
                     __scan_kernel,
 #endif
                     __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -765,9 +765,9 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
         __reduce_then_scan_scan_kernel, _CustomName, _InRng, _OutRng, _GenScanInput, _ScanInputTransform, _WriteOp,
         _InitType, _Inclusive, _IsUniquePattern>;
-    auto __kernels = __internal::__kernel_compiler<_ReduceKernel, _ScanKernel>::__compile(__exec);
-    sycl::kernel& __reduce_kernel = __kernels[0];
-    sycl::kernel& __scan_kernel = __kernels[1];
+    static auto __kernels = __internal::__kernel_compiler<_ReduceKernel, _ScanKernel>::__compile(__exec);
+    sycl::kernel __reduce_kernel = __kernels[0];
+    sycl::kernel __scan_kernel = __kernels[1];
 
     constexpr std::uint8_t __sub_group_size = 32;
     constexpr std::uint8_t __block_size_scale = std::max(std::size_t{1}, sizeof(double) / sizeof(_ValueType));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -717,36 +717,6 @@ struct __parallel_reduce_then_scan_scan_submitter
     _InitType __init;
 };
 
-// We accept a set of variadic types to disambiguate between the different scan kernels. The set
-// of template parameters for __parallel_transform_reduce_then_scan here is expected to be used.
-template <typename _ExecutionPolicy, typename... _ParamTypes>
-struct __reduce_then_scan_kernels
-{
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-    using _ReduceKernel =
-        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__reduce_then_scan_reduce_kernel,
-                                                                               _CustomName, _ParamTypes...>;
-    using _ScanKernel =
-        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__reduce_then_scan_scan_kernel,
-                                                                               _CustomName, _ParamTypes...>;
-    explicit __reduce_then_scan_kernels(const _ExecutionPolicy& __exec)
-        : __exec(__exec)
-        , __kernels(__internal::__kernel_compiler<_ReduceKernel, _ScanKernel>::__compile(__exec))
-    {
-    }
-    sycl::kernel __get_reduce_kernel() const { return __kernels[0]; }
-    sycl::kernel __get_scan_kernel() const { return __kernels[1]; }
-    bool __is_compiled_sg32() const
-    {
-        return oneapi::dpl::__internal::__kernel_sub_group_size(__exec, __get_reduce_kernel()) == std::uint32_t{32} &&
-               oneapi::dpl::__internal::__kernel_sub_group_size(__exec, __get_scan_kernel()) == std::uint32_t{32};
-    }
-private:
-    // idx 0 is the reduce kernel and idx 1 is the scan kernel
-    std::array<sycl::kernel, 2> __kernels;
-    const _ExecutionPolicy& __exec;
-};
-
 // reduce_then_scan requires subgroup size of 32, and performs well only on devices with fast coordinated subgroup
 // operations.  We do not want to run this scan on CPU targets, as they are not performant with this algorithm.
 template <typename _ExecutionPolicy>
@@ -767,18 +737,27 @@ __is_gpu_with_sg_32(const _ExecutionPolicy& __exec)
 // _ReduceOp - a binary function which is used in the reduction and scan operations
 // _WriteOp - a function which accepts output range, index, and output of `_GenScanInput` applied to the input range
 //            and performs the final write to output operation
-template <typename _ExecutionPolicy, typename _Kernels, typename _InRng, typename _OutRng, typename _GenReduceInput, typename _ReduceOp,
+template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _GenReduceInput, typename _ReduceOp,
           typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
           typename _Inclusive, typename _IsUniquePattern>
 auto
 __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
-                                      _Kernels& __kernels,
                                       _InRng&& __in_rng, _OutRng&& __out_rng, _GenReduceInput __gen_reduce_input,
                                       _ReduceOp __reduce_op, _GenScanInput __gen_scan_input,
                                       _ScanInputTransform __scan_input_transform, _WriteOp __write_op, _InitType __init,
                                       _Inclusive, _IsUniquePattern)
 {
     using _ValueType = typename _InitType::__value_type;
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+    using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
+        __reduce_then_scan_reduce_kernel, _CustomName, _InRng, _OutRng, _GenReduceInput, _ReduceOp, _InitType,
+        _Inclusive, _IsUniquePattern>;
+    using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
+        __reduce_then_scan_scan_kernel, _CustomName, _InRng, _OutRng, _GenScanInput, _ScanInputTransform, _WriteOp,
+        _InitType, _Inclusive, _IsUniquePattern>;
+    auto __kernels = __internal::__kernel_compiler<_ReduceKernel, _ScanKernel>::__compile(__exec);
+    sycl::kernel& __reduce_kernel = __kernels[0];
+    sycl::kernel& __scan_kernel = __kernels[1];
 
     constexpr std::uint8_t __sub_group_size = 32;
     constexpr std::uint8_t __block_size_scale = std::max(std::size_t{1}, sizeof(double) / sizeof(_ValueType));
@@ -828,11 +807,11 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     using _ReduceSubmitter =
         __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inputs_per_item, __inclusive,
                                                      __is_unique_pattern_v, _GenReduceInput, _ReduceOp, _InitType,
-                                                     typename _Kernels::_ReduceKernel>;
+                                                     _ReduceKernel>;
     using _ScanSubmitter =
         __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs_per_item, __inclusive,
                                                    __is_unique_pattern_v, _ReduceOp, _GenScanInput, _ScanInputTransform,
-                                                   _WriteOp, _InitType, typename _Kernels::_ScanKernel>;
+                                                   _WriteOp, _InitType, _ScanKernel>;
     _ReduceSubmitter __reduce_submitter{__max_inputs_per_block,
                                         __num_sub_groups_local,
                                         __num_sub_groups_global,
@@ -866,10 +845,10 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         auto __kernel_nd_range = sycl::nd_range<1>(__global_range, __local_range);
         // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
         __event = __reduce_submitter(__exec, __kernel_nd_range, __in_rng, __result_and_scratch, __event,
-                                     __inputs_per_sub_group, __inputs_per_item, __b, __kernels.__get_reduce_kernel());
+                                     __inputs_per_sub_group, __inputs_per_item, __b, __reduce_kernel);
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.
         __event = __scan_submitter(__exec, __kernel_nd_range, __in_rng, __out_rng, __result_and_scratch, __event,
-                                   __inputs_per_sub_group, __inputs_per_item, __b, __kernels.__get_scan_kernel());
+                                   __inputs_per_sub_group, __inputs_per_item, __b, __scan_kernel);
         __inputs_remaining -= std::min(__inputs_remaining, __block_size);
         // We only need to resize these parameters prior to the last block as it is the only non-full case.
         if (__b + 2 == __num_blocks)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <type_traits>
-#include <array>
 
 #include "sycl_defs.h"
 #include "parallel_backend_sycl_utils.h"
@@ -766,8 +765,8 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         __reduce_then_scan_scan_kernel, _CustomName, _InRng, _OutRng, _GenScanInput, _ScanInputTransform, _WriteOp,
         _InitType, _Inclusive, _IsUniquePattern>;
     static auto __kernels = __internal::__kernel_compiler<_ReduceKernel, _ScanKernel>::__compile(__exec);
-    sycl::kernel __reduce_kernel = __kernels[0];
-    sycl::kernel __scan_kernel = __kernels[1];
+    sycl::kernel& __reduce_kernel = __kernels[0];
+    sycl::kernel& __scan_kernel = __kernels[1];
 
     constexpr std::uint8_t __sub_group_size = 32;
     constexpr std::uint8_t __block_size_scale = std::max(std::size_t{1}, sizeof(double) / sizeof(_ValueType));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -16,9 +16,13 @@
 #ifndef _ONEDPL_PARALLEL_BACKEND_SYCL_REDUCE_THEN_SCAN_H
 #define _ONEDPL_PARALLEL_BACKEND_SYCL_REDUCE_THEN_SCAN_H
 
+// Kernel bundles are required to use this header
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
+
 #include <algorithm>
 #include <cstdint>
 #include <type_traits>
+#include <array>
 
 #include "sycl_defs.h"
 #include "parallel_backend_sycl_utils.h"
@@ -275,14 +279,7 @@ class __reduce_then_scan_scan_kernel;
 template <std::uint8_t __sub_group_size, std::uint16_t __max_inputs_per_item, bool __is_inclusive,
           bool __is_unique_pattern_v, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
           typename _KernelName>
-struct __parallel_reduce_then_scan_reduce_submitter;
-
-template <std::uint8_t __sub_group_size, std::uint16_t __max_inputs_per_item, bool __is_inclusive,
-          bool __is_unique_pattern_v, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
-          typename... _KernelName>
-struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inputs_per_item, __is_inclusive,
-                                                    __is_unique_pattern_v, _GenReduceInput, _ReduceOp, _InitType,
-                                                    __internal::__optional_kernel_name<_KernelName...>>
+struct __parallel_reduce_then_scan_reduce_submitter
 {
     // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
     // input buffer
@@ -291,7 +288,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
     operator()(_ExecutionPolicy&& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
-               const std::size_t __block_num) const
+               const std::size_t __block_num, sycl::kernel __reduce_kernel) const
     {
         using _InitValueType = typename _InitType::__value_type;
         return __exec.queue().submit([&, this](sycl::handler& __cgh) {
@@ -412,14 +409,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
 template <std::uint8_t __sub_group_size, std::uint16_t __max_inputs_per_item, bool __is_inclusive,
           bool __is_unique_pattern_v, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
           typename _WriteOp, typename _InitType, typename _KernelName>
-struct __parallel_reduce_then_scan_scan_submitter;
-
-template <std::uint8_t __sub_group_size, std::uint16_t __max_inputs_per_item, bool __is_inclusive,
-          bool __is_unique_pattern_v, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
-          typename _WriteOp, typename _InitType, typename... _KernelName>
-struct __parallel_reduce_then_scan_scan_submitter<
-    __sub_group_size, __max_inputs_per_item, __is_inclusive, __is_unique_pattern_v, _ReduceOp, _GenScanInput,
-    _ScanInputTransform, _WriteOp, _InitType, __internal::__optional_kernel_name<_KernelName...>>
+struct __parallel_reduce_then_scan_scan_submitter
 {
     using _InitValueType = typename _InitType::__value_type;
 
@@ -442,7 +432,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
     operator()(_ExecutionPolicy&& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
-               const std::size_t __block_num) const
+               const std::size_t __block_num, sycl::kernel __scan_kernel) const
     {
         std::uint32_t __inputs_in_block = std::min(__n - __block_num * __max_block_size, std::size_t{__max_block_size});
         std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
@@ -726,6 +716,34 @@ struct __parallel_reduce_then_scan_scan_submitter<
     _InitType __init;
 };
 
+// We accept a set of variadic types to disambiguate between the different scan kernels. The set
+// of template parameters for __parallel_transform_reduce_then_scan here is expected to be used.
+template <typename _ExecutionPolicy, typename... ParamTypes>
+struct __reduce_then_scan_kernels
+{
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+    using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
+        __reduce_then_scan_reduce_kernel, _CustomName, ParamTypes...>;
+    using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
+        __reduce_then_scan_scan_kernel, _CustomName, ParamTypes...>;
+    explicit __reduce_then_scan_kernels(const _ExecutionPolicy& __exec)
+        : __exec(__exec)
+        , __kernels(__internal::__kernel_compiler<_ReduceKernel, _ScanKernel>::__compile(__exec))
+    {
+    }
+    sycl::kernel __get_reduce_kernel() const { return __kernels[0]; }
+    sycl::kernel __get_scan_kernel() const { return __kernels[1]; }
+    bool __is_compiled_sg32() const
+    {
+        return oneapi::dpl::__internal::__kernel_sub_group_size(__exec, __get_reduce_kernel()) == std::uint32_t{32} &&
+               oneapi::dpl::__internal::__kernel_sub_group_size(__exec, __get_scan_kernel()) == std::uint32_t{32};
+    }
+private:
+    // idx 0 is the reduce kernel and idx 1 is the scan kernel
+    std::array<sycl::kernel, 2> __kernels;
+    const _ExecutionPolicy& __exec;
+};
+
 // reduce_then_scan requires subgroup size of 32, and performs well only on devices with fast coordinated subgroup
 // operations.  We do not want to run this scan on CPU targets, as they are not performant with this algorithm.
 template <typename _ExecutionPolicy>
@@ -746,21 +764,17 @@ __is_gpu_with_sg_32(const _ExecutionPolicy& __exec)
 // _ReduceOp - a binary function which is used in the reduction and scan operations
 // _WriteOp - a function which accepts output range, index, and output of `_GenScanInput` applied to the input range
 //            and performs the final write to output operation
-template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _GenReduceInput, typename _ReduceOp,
+template <typename _ExecutionPolicy, typename _Kernels, typename _InRng, typename _OutRng, typename _GenReduceInput, typename _ReduceOp,
           typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
           typename _Inclusive, typename _IsUniquePattern>
 auto
 __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+                                      _Kernels& __kernels,
                                       _InRng&& __in_rng, _OutRng&& __out_rng, _GenReduceInput __gen_reduce_input,
                                       _ReduceOp __reduce_op, _GenScanInput __gen_scan_input,
                                       _ScanInputTransform __scan_input_transform, _WriteOp __write_op, _InitType __init,
                                       _Inclusive, _IsUniquePattern)
 {
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-    using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_then_scan_reduce_kernel<_CustomName>>;
-    using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_then_scan_scan_kernel<_CustomName>>;
     using _ValueType = typename _InitType::__value_type;
 
     constexpr std::uint8_t __sub_group_size = 32;
@@ -811,11 +825,11 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     using _ReduceSubmitter =
         __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inputs_per_item, __inclusive,
                                                      __is_unique_pattern_v, _GenReduceInput, _ReduceOp, _InitType,
-                                                     _ReduceKernel>;
+                                                     typename _Kernels::_ReduceKernel>;
     using _ScanSubmitter =
         __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs_per_item, __inclusive,
                                                    __is_unique_pattern_v, _ReduceOp, _GenScanInput, _ScanInputTransform,
-                                                   _WriteOp, _InitType, _ScanKernel>;
+                                                   _WriteOp, _InitType, typename _Kernels::_ScanKernel>;
     _ReduceSubmitter __reduce_submitter{__max_inputs_per_block,
                                         __num_sub_groups_local,
                                         __num_sub_groups_global,
@@ -849,10 +863,10 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         auto __kernel_nd_range = sycl::nd_range<1>(__global_range, __local_range);
         // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
         __event = __reduce_submitter(__exec, __kernel_nd_range, __in_rng, __result_and_scratch, __event,
-                                     __inputs_per_sub_group, __inputs_per_item, __b);
+                                     __inputs_per_sub_group, __inputs_per_item, __b, __kernels.__get_reduce_kernel());
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.
         __event = __scan_submitter(__exec, __kernel_nd_range, __in_rng, __out_rng, __result_and_scratch, __event,
-                                   __inputs_per_sub_group, __inputs_per_item, __b);
+                                   __inputs_per_sub_group, __inputs_per_item, __b, __kernels.__get_scan_kernel());
         __inputs_remaining -= std::min(__inputs_remaining, __block_size);
         // We only need to resize these parameters prior to the last block as it is the only non-full case.
         if (__b + 2 == __num_blocks)
@@ -872,4 +886,5 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
 } // namespace dpl
 } // namespace oneapi
 
+#endif
 #endif // _ONEDPL_PARALLEL_BACKEND_SYCL_REDUCE_THEN_SCAN_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -758,6 +758,10 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
 {
     using _ValueType = typename _InitType::__value_type;
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+    // Note that __sub_group_size and __max_inputs_per_item are not included in kernel names. __sub_group_size
+    // is always constant (32) and __max_inputs_per_item is directly tied to the input type so these are not
+    // necessary to obtain a unique kernel name. However, if these compile time variables are adjusted in the
+    // future, then we need to be careful here to ensure unique kernel naming.
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
         __reduce_then_scan_reduce_kernel, _CustomName, _InRng, _OutRng, _GenReduceInput, _ReduceOp, _InitType,
         _Inclusive, _IsUniquePattern>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -19,18 +19,18 @@
 // Kernel compilation must be supported to properly work around hardware bug on certain iGPUs
 #if _ONEDPL_COMPILE_KERNEL
 
-#    include <algorithm>
-#    include <cstdint>
-#    include <type_traits>
-#    include <array>
+#include <algorithm>
+#include <cstdint>
+#include <type_traits>
+#include <array>
 
-#    include "sycl_defs.h"
-#    include "parallel_backend_sycl_utils.h"
-#    include "execution_sycl_defs.h"
-#    include "unseq_backend_sycl.h"
-#    include "utils_ranges_sycl.h"
+#include "sycl_defs.h"
+#include "parallel_backend_sycl_utils.h"
+#include "execution_sycl_defs.h"
+#include "unseq_backend_sycl.h"
+#include "utils_ranges_sycl.h"
 
-#    include "../../utils.h"
+#include "../../utils.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -287,7 +287,7 @@ struct __parallel_reduce_then_scan_reduce_submitter
     operator()(_ExecutionPolicy&& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
-               const std::size_t __block_num, sycl::kernel& __reduce_kernel) const
+               const std::size_t __block_num, const sycl::kernel& __reduce_kernel) const
     {
         using _InitValueType = typename _InitType::__value_type;
         return __exec.queue().submit([&, this](sycl::handler& __cgh) {
@@ -437,7 +437,7 @@ struct __parallel_reduce_then_scan_scan_submitter
     operator()(_ExecutionPolicy&& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
-               const std::size_t __block_num, sycl::kernel& __scan_kernel) const
+               const std::size_t __block_num, const sycl::kernel& __scan_kernel) const
     {
         std::uint32_t __inputs_in_block = std::min(__n - __block_num * __max_block_size, std::size_t{__max_block_size});
         std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
@@ -769,8 +769,8 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         __reduce_then_scan_scan_kernel, _CustomName, _InRng, _OutRng, _GenScanInput, _ReduceOp, _ScanInputTransform,
         _WriteOp, _InitType, _Inclusive, _IsUniquePattern>;
     static auto __kernels = __internal::__kernel_compiler<_ReduceKernel, _ScanKernel>::__compile(__exec);
-    sycl::kernel& __reduce_kernel = __kernels[0];
-    sycl::kernel& __scan_kernel = __kernels[1];
+    const sycl::kernel& __reduce_kernel = __kernels[0];
+    const sycl::kernel& __scan_kernel = __kernels[1];
 
     constexpr std::uint8_t __sub_group_size = 32;
     constexpr std::uint8_t __block_size_scale = std::max(std::size_t{1}, sizeof(double) / sizeof(_ValueType));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -762,8 +762,8 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         __reduce_then_scan_reduce_kernel, _CustomName, _InRng, _OutRng, _GenReduceInput, _ReduceOp, _InitType,
         _Inclusive, _IsUniquePattern>;
     using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        __reduce_then_scan_scan_kernel, _CustomName, _InRng, _OutRng, _GenScanInput, _ScanInputTransform, _WriteOp,
-        _InitType, _Inclusive, _IsUniquePattern>;
+        __reduce_then_scan_scan_kernel, _CustomName, _InRng, _OutRng, _GenScanInput, _ReduceOp, _ScanInputTransform,
+        _WriteOp, _InitType, _Inclusive, _IsUniquePattern>;
     static auto __kernels = __internal::__kernel_compiler<_ReduceKernel, _ScanKernel>::__compile(__exec);
     sycl::kernel& __reduce_kernel = __kernels[0];
     sycl::kernel& __scan_kernel = __kernels[1];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -875,7 +875,7 @@ __handle_sync_sycl_exception(_Callable __caller, _Handler __handler) -> std::opt
     }
     catch (const sycl::exception& __e)
     {
-        // Handle the error and return an empty optional with the encountered error code.
+        // Handle the error and return an empty std::optional
         __handler(__e);
         return {};
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -855,7 +855,7 @@ struct __bypass_sycl_kernel_not_supported
         // and rethrow the encountered exception if the two do not compare equal. However, the icpx compiler currently
         // returns a generic error code in violation of the SYCL spec which has a value of 7. If we are using the Intel
         // compiler, then compare the value of the error code. Otherwise, assume the implementation is spec compliant.
-#ifdef _ONEDPL_LIBSYCL_VERSION // Detects either icpx or the open-source intel/llvm compiler
+#if _ONEDPL_ICPX_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN
         if (__e.code().value() != 7)
             throw;
 #else // Generic SYCL compiler. Assume it is spec compliant.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -845,7 +845,7 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
 // This exception handler is intended to handle a software workaround by IGC for a hardware bug that
 // causes IGC to throw an exception for certain integrated graphics devices with -O0 compilation and
 // a required sub-group size of 32.
-void
+inline void
 __bypass_sycl_kernel_not_supported(const sycl::exception& __e)
 {
     // The SYCL spec compliant solution would be to compare __e.code() and sycl::errc::kernel_not_supported

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -857,10 +857,10 @@ struct __bypass_sycl_kernel_not_supported
         // compiler, then compare the value of the error code. Otherwise, assume the implementation is spec compliant.
 #ifdef _ONEDPL_LIBSYCL_VERSION // Detects either icpx or the open-source intel/llvm compiler
         if (__e.code().value() != 7)
-            throw __e;
+            throw;
 #else // Generic SYCL compiler. Assume it is spec compliant.
         if (__e.code() != sycl::errc::kernel_not_supported)
-            throw __e;
+            throw;
 #endif
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -21,6 +21,7 @@
 #include <type_traits>
 #include <tuple>
 #include <algorithm>
+#include <optional>
 
 #include "../../iterator_impl.h"
 
@@ -843,35 +844,40 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
 };
 
 // This exception handler is intended to handle a software workaround by IGC for a hardware bug that
-// causes IGC to throw a sycl::errc::kernel_not_supported exception for certain integrated graphics
-// devices.
+// causes IGC to throw an exception for certain integrated graphics devices with -O0 compilation and
+// a required sub-group size of 32.
 struct __bypass_sycl_kernel_not_supported
 {
     void
     operator()(const sycl::exception& __e) const
     {
-        // TODO: We are currently just suppressing any synchronous SYCL exception. The best solution
-        // would be to compare __e.code() and sycl::errc::kernel_not_supported and rethrow the encountered exception
-        // if the two do not compare equal. However, the icpx compiler currently returns a generic error code
-        // which is not compliant with the SYCL spec and this approach cannot be used until error code issue is
-        // resolved.
+        // The SYCL spec compliant solution would be to compare __e.code() and sycl::errc::kernel_not_supported
+        // and rethrow the encountered exception if the two do not compare equal. However, the icpx compiler currently
+        // returns a generic error code in violation of the SYCL spec which has a value of 7. If we are using the Intel
+        // compiler, then compare the value of the error code. Otherwise, assume the implementation is spec compliant.
+#ifdef _ONEDPL_LIBSYCL_VERSION // Detects either icpx or the open-source intel/llvm compiler
+        if (__e.code().value() != 7)
+            throw __e;
+#else // Generic SYCL compiler. Assume it is spec compliant.
+        if (__e.code() != sycl::errc::kernel_not_supported)
+            throw __e;
+#endif
     }
 };
 
-template <typename _Callable, typename _Handler = __bypass_sycl_kernel_not_supported>
+template <typename _Callable, typename _Handler>
 auto
-__handle_sync_sycl_exception(_Callable __caller, _Handler __handler = {})
-    -> std::tuple<std::optional<decltype(__caller())>, std::error_code>
+__handle_sync_sycl_exception(_Callable __caller, _Handler __handler) -> std::optional<decltype(__caller())>
 {
     try
     {
-        return std::make_tuple(__caller(), sycl::errc::success);
+        return __caller();
     }
     catch (const sycl::exception& __e)
     {
         // Handle the error and return an empty optional with the encountered error code.
         __handler(__e);
-        return std::make_tuple(std::optional<decltype(__caller())>{}, __e.code());
+        return {};
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -855,7 +855,7 @@ struct __bypass_sycl_kernel_not_supported
         // and rethrow the encountered exception if the two do not compare equal. However, the icpx compiler currently
         // returns a generic error code in violation of the SYCL spec which has a value of 7. If we are using the Intel
         // compiler, then compare the value of the error code. Otherwise, assume the implementation is spec compliant.
-#if _ONEDPL_ICPX_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN
+#if _ONEDPL_SYCL_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN
         if (__e.code().value() != 7)
             throw;
 #else // Generic SYCL compiler. Assume it is spec compliant.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -850,15 +850,16 @@ __bypass_sycl_kernel_not_supported(const sycl::exception& __e)
 {
     // The SYCL spec compliant solution would be to compare __e.code() and sycl::errc::kernel_not_supported
     // and rethrow the encountered exception if the two do not compare equal. However, the icpx compiler currently
-    // returns a generic error code in violation of the SYCL spec which has a value of 7. If we are using the Intel
-    // compiler, then compare the value of the error code. Otherwise, assume the implementation is spec compliant.
+    // returns a sycl::errc::build in violation of the SYCL spec. If we are using the Intel compiler, then compare
+    // to this error code. Otherwise, assume the implementation is spec compliant.
+    const std::error_code __kernel_not_supported_ec =
 #if _ONEDPL_SYCL_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN
-    if (__e.code().value() != 7)
-        throw;
+        sycl::errc::build;
 #else // Generic SYCL compiler. Assume it is spec compliant.
-    if (__e.code() != sycl::errc::kernel_not_supported)
-        throw;
+        sycl::errc::kernel_not_supported;
 #endif
+    if (__e.code() != __kernel_not_supported_ec)
+        throw;
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -21,6 +21,7 @@
 #include <type_traits>
 #include <tuple>
 #include <algorithm>
+#include <system_error>
 
 #include "../../iterator_impl.h"
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -108,6 +108,15 @@
 
 #define _ONEDPL_SYCL_DEVICE_COPYABLE_SPECIALIZATION_BROKEN (_ONEDPL_LIBSYCL_VERSION_LESS_THAN(70100))
 
+// Macro to check if the exception thrown when a kernel cannot be ran on a device does not align with
+// sycl::errc::kernel_not_supported as required by the SYCL spec. Detects the Intel DPC++ and open-source intel/llvm
+// compilers.
+#ifdef _ONEDPL_LIBSYCL_VERSION
+#    define _ONEDPL_ICPX_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN 1
+#else
+#    define _ONEDPL_ICPX_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN 0
+#endif
+
 // Macro to check if we are compiling for SPIR-V devices. This macro must only be used within
 // SYCL kernels for determining SPIR-V compilation. Using this macro on the host may lead to incorrect behavior.
 #ifndef _ONEDPL_DETECT_SPIRV_COMPILATION // Check if overridden for testing

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -111,7 +111,7 @@
 // Macro to check if the exception thrown when a kernel cannot be ran on a device does not align with
 // sycl::errc::kernel_not_supported as required by the SYCL spec. Detects the Intel DPC++ and open-source intel/llvm
 // compilers.
-#ifdef _ONEDPL_LIBSYCL_VERSION
+#if defined(_ONEDPL_LIBSYCL_VERSION) && (!defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER < 20250200)
 #    define _ONEDPL_ICPX_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN 1
 #else
 #    define _ONEDPL_ICPX_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN 0

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -110,12 +110,9 @@
 
 // Macro to check if the exception thrown when a kernel cannot be ran on a device does not align with
 // sycl::errc::kernel_not_supported as required by the SYCL spec. Detects the Intel DPC++ and open-source intel/llvm
-// compilers.
-#if defined(_ONEDPL_LIBSYCL_VERSION) && (!defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER < 20250200)
-#    define _ONEDPL_ICPX_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN 1
-#else
-#    define _ONEDPL_ICPX_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN 0
-#endif
+// compilers. No fix has been provided yet, but when the LIBSYCL major version is updated we can re-evaluate if we need
+// to extend it to future versions.
+#define _ONEDPL_SYCL_KERNEL_NOT_SUPPORTED_EXCEPTION_BROKEN (_ONEDPL_LIBSYCL_VERSION_LESS_THAN(90000))
 
 // Macro to check if we are compiling for SPIR-V devices. This macro must only be used within
 // SYCL kernels for determining SPIR-V compilation. Using this macro on the host may lead to incorrect behavior.

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -190,7 +190,9 @@ struct test_set_intersection
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_intersection(first1, last1, first2, last2, expect.begin());
-        auto res = ::std::set_intersection(exec, first1, last1, first2, last2, out.begin());
+        // TODO before merging: Why did create_new_policy_idx have to be added to avoid duplicate kernel names for set intersection only? Is there a bug
+        // in the reduce-then-scan kernel naming logic?
+        auto res = ::std::set_intersection(create_new_policy_idx<3>(exec), first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_intersection without comparator");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_intersection effect without comparator");

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -190,9 +190,7 @@ struct test_set_intersection
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_intersection(first1, last1, first2, last2, expect.begin());
-        // TODO before merging: Why did create_new_policy_idx have to be added to avoid duplicate kernel names for set intersection only? Is there a bug
-        // in the reduce-then-scan kernel naming logic?
-        auto res = ::std::set_intersection(create_new_policy_idx<3>(exec), first1, last1, first2, last2, out.begin());
+        auto res = ::std::set_intersection(exec, first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_intersection without comparator");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_intersection effect without comparator");


### PR DESCRIPTION
On certain integrated graphics architectures, sub-group sizes of 32 are not supported for kernels with certain properties when compiled with -O0 using the `icpx` compiler. The compiler is normally able to workaround this issue by compiling to a sub-group size of 16 instead. However, in cases in which an explicit sub-group size is required, then the compiler throws an exception at JIT time. This issue directly affects our reduce-then-scan implementation which has a required sub-group size of 32.

To properly work around this issue, several things must be done. Firstly, exception handling is implemented to catch this synchronous exception while re-throwing any other exceptions back to the user. Secondly, after discussion with compiler developers, kernel compilation must be separated from execution of the kernel to prevent corruption of the underlying `sycl::queue` that occurs when this exception is thrown after implicit buffer accessor dependencies around the kernel have been established. To do this, kernel bundles are used to first compile the kernel before executing. 