### PR TITLE
Bugfix for device copyable of unique copy helper

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -218,7 +218,8 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 };
 
 template <typename _Predicate, typename _ValueType>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__create_mask_unique_copy, _Predicate)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__create_mask_unique_copy, _Predicate,
+                                                       _ValueType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -218,9 +218,8 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 };
 
 template <typename _Predicate, typename _ValueType>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__create_mask_unique_copy, _Predicate,
-                                                       _ValueType)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate, _ValueType>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__create_mask_unique_copy, _Predicate)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate>
 {
 };
 

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -285,8 +285,7 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::adjacent_find_fn<noop_device_copyable>>,
                   "adjacent_find_fn is not device copyable with device copyable types");
     //__create_mask_unique_copy
-    static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::__internal::__create_mask_unique_copy<noop_device_copyable, int_device_copyable>>,
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__create_mask_unique_copy<noop_device_copyable>>,
                   "__create_mask_unique_copy is not device copyable with device copyable types");
     //tuple
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::tuple<int_device_copyable, int_device_copyable>>,
@@ -560,8 +559,7 @@ test_non_device_copyable()
 
     //__create_mask_unique_copy
     static_assert(
-        !sycl::is_device_copyable_v<
-            oneapi::dpl::__internal::__create_mask_unique_copy<noop_non_device_copyable, int_non_device_copyable>>,
+        !sycl::is_device_copyable_v<oneapi::dpl::__internal::__create_mask_unique_copy<noop_non_device_copyable>>,
         "__create_mask_unique_copy is device copyable with non device copyable types");
     //tuple
     static_assert(

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -285,8 +285,13 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::adjacent_find_fn<noop_device_copyable>>,
                   "adjacent_find_fn is not device copyable with device copyable types");
     //__create_mask_unique_copy
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__create_mask_unique_copy<noop_device_copyable>>,
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__internal::__create_mask_unique_copy<noop_device_copyable, int_device_copyable>>,
                   "__create_mask_unique_copy is not device copyable with device copyable types");
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__internal::__create_mask_unique_copy<noop_device_copyable,
+                      int_non_device_copyable>>,
+                  "__create_mask_unique_copy is incorrectly not device copyable because of non member field template arg");
     //tuple
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::tuple<int_device_copyable, int_device_copyable>>,
                   "tuple is not device copyable with device copyable types");
@@ -559,7 +564,8 @@ test_non_device_copyable()
 
     //__create_mask_unique_copy
     static_assert(
-        !sycl::is_device_copyable_v<oneapi::dpl::__internal::__create_mask_unique_copy<noop_non_device_copyable>>,
+        !sycl::is_device_copyable_v<
+            oneapi::dpl::__internal::__create_mask_unique_copy<noop_non_device_copyable, int_non_device_copyable>>,
         "__create_mask_unique_copy is device copyable with non device copyable types");
     //tuple
     static_assert(


### PR DESCRIPTION
The ValueType should not be necessary for device copyability because it is not a member field of the helper struct.  It is only the return value of the callable.  Therefore, we should not base device copyability on it.

(Not fixing any reported bug here, just saw this as I was looking at sycl traits for some use case ideas, but I believe it is correct.)