### PR TITLE
Modernize Tested API example, replace cl_int

### DIFF
--- a/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
@@ -36,7 +36,6 @@ Below is an example code that shows how to use ``oneapi::dpl::swap`` in SYCL dev
       return 0;
   }
 
-
 Use the following command to build and run the program (assuming it resides in the ``kernel_swap.cpp file``):
 
 .. code:: cpp

--- a/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
@@ -17,29 +17,24 @@ Below is an example code that shows how to use ``oneapi::dpl::swap`` in SYCL dev
   #include <oneapi/dpl/utility>
   #include <sycl/sycl.hpp>
   #include <iostream>
-  constexpr sycl::access::mode sycl_read_write = sycl::access::mode::read_write;
-  class KernelSwap;
-  void kernel_test() {    
-    sycl::queue deviceQueue;
-    sycl::range<1> numOfItems{2};
-    sycl::cl_int swap_num[2] = {4, 5};
-    std::cout << swap_num[0] << ", " << swap_num[1] << std::endl;
-    {
-    sycl::buffer<sycl::cl_int, 1> swap_buffer
-    (swap_num, numOfItems);
-    deviceQueue.submit([&](sycl::handler &cgh) {
-    auto swap_accessor = swap_buffer.get_access<sycl_read_write>(cgh);
-    cgh.single_task<class KernelSwap>([=]() {
-        int & num1 = swap_accessor[0];
-        int & num2 = swap_accessor[1];
-        oneapi::dpl::swap(num1, num2);
-        });
-    });
-    }
-    std::cout << swap_num[0] << ", " << swap_num[1] << std::endl;
-  }
-  int main() {
-      kernel_test();
+  #include <cstdint>
+
+  int main()
+  {
+      sycl::queue queue{};
+      constexpr std::uint32_t size = 2;
+      std::uint32_t data[size] = {4, 5};
+      std::cout << "Initial data: " << data[0] << ", " << data[1] << std::endl;
+      sycl::buffer<std::uint32_t> buffer(data, size);
+      queue.submit([&](sycl::handler& cgh) {
+          auto access = buffer.template get_access<sycl::access::mode::read_write>(cgh);
+          cgh.single_task<class KernelSwap>([=]() {
+              oneapi::dpl::swap(access[0], access[1]);
+          });
+      });
+      queue.wait();
+      auto host_access = buffer.template get_access<sycl::access::mode::read>();
+      std::cout << "After swap: " << host_access[0] << ", " << host_access[1] << std::endl;
       return 0;
   }
 
@@ -47,17 +42,14 @@ Use the following command to build and run the program (assuming it resides in t
 
 .. code:: cpp
 
-  dpcpp kernel_swap.cpp -o kernel_swap.exe
-
-  ./kernel_swap.exe
+  icpx -fsycl kernel_swap.cpp -o kernel_swap && ./kernel_swap
 
 The printed result is:
 
 .. code:: cpp
 
-  4, 5
-
-  5, 4
+  Initial data: 4, 5
+  After swap: 5, 4
 
 Tested Standard C++ API Reference
 =================================
@@ -468,11 +460,11 @@ libstdc++ (GNU)                               Provided with GCC*-7.5.0, GCC*-9.3
 libc++ (LLVM)                                 Provided with Clang*-11.0
 --------------------------------------------- ---------------------------------------------
 Microsoft Visual C++* (MSVC) Standard Library Provided with Microsoft Visual Studio* 2017;
-                                              Microsoft Visual Studio 2019; and Microsoft 
+                                              Microsoft Visual Studio 2019; and Microsoft
                                               Visual Studio 2022, version 17.0, preview 4.1.
-                                              
+
                                               .. Note::
-                                              
+
                                                  Support for Microsoft Visual Studio 2017 is
                                                  deprecated as of the Intel® oneAPI 2022.1
                                                  release, and will be removed in a future

--- a/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
@@ -31,8 +31,7 @@ Below is an example code that shows how to use ``oneapi::dpl::swap`` in SYCL dev
           cgh.single_task<class KernelSwap>([=]() {
               oneapi::dpl::swap(access[0], access[1]);
           });
-      });
-      queue.wait();
+      }).wait();
       auto host_access = buffer.template get_access<sycl::access::mode::read>();
       std::cout << "After swap: " << host_access[0] << ", " << host_access[1] << std::endl;
       return 0;

--- a/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
@@ -18,7 +18,6 @@ Below is an example code that shows how to use ``oneapi::dpl::swap`` in SYCL dev
   #include <sycl/sycl.hpp>
   #include <iostream>
   #include <cstdint>
-
   int main()
   {
       sycl::queue queue;
@@ -27,15 +26,16 @@ Below is an example code that shows how to use ``oneapi::dpl::swap`` in SYCL dev
       std::cout << "Initial data: " << data[0] << ", " << data[1] << std::endl;
       sycl::buffer<std::uint32_t> buffer(data, size);
       queue.submit([&](sycl::handler& cgh) {
-          auto access = buffer.template get_access<sycl::access::mode::read_write>(cgh);
+          auto access = buffer.get_access(cgh, sycl::read_write);
           cgh.single_task<class KernelSwap>([=]() {
               oneapi::dpl::swap(access[0], access[1]);
           });
       }).wait();
-      auto host_access = buffer.template get_access<sycl::access::mode::read>();
+      auto host_access = buffer.get_host_access(sycl::read_only);
       std::cout << "After swap: " << host_access[0] << ", " << host_access[1] << std::endl;
       return 0;
   }
+
 
 Use the following command to build and run the program (assuming it resides in the ``kernel_swap.cpp file``):
 

--- a/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
@@ -21,7 +21,7 @@ Below is an example code that shows how to use ``oneapi::dpl::swap`` in SYCL dev
 
   int main()
   {
-      sycl::queue queue{};
+      sycl::queue queue;
       constexpr std::uint32_t size = 2;
       std::uint32_t data[size] = {4, 5};
       std::cout << "Initial data: " << data[0] << ", " << data[1] << std::endl;

--- a/test/xpu_api/language.support/support.types/nullptr_t.pass.cpp
+++ b/test/xpu_api/language.support/support.types/nullptr_t.pass.cpp
@@ -26,6 +26,8 @@
 #include "support/test_macros.h"
 #include "support/utils.h"
 
+#include <cstdint>
+
 struct A
 {
     A(dpl::nullptr_t) {}
@@ -33,7 +35,7 @@ struct A
 
 template <class T>
 void
-test_conversions(cl_int& i)
+test_conversions(std::int32_t& i)
 {
     {
         T p = 0;
@@ -65,7 +67,7 @@ struct has_less<T, typename Voider<decltype(std::declval<T>() < nullptr)>::type>
 
 template <class T>
 void
-test_comparisons(cl_int& i)
+test_comparisons(std::int32_t& i)
 {
     T p = nullptr;
     i += (p == nullptr);
@@ -79,7 +81,7 @@ test_comparisons(cl_int& i)
 #    pragma clang diagnostic ignored "-Wnull-conversion"
 #endif
 void
-test_nullptr_conversions(cl_int& i)
+test_nullptr_conversions(std::int32_t& i)
 {
     // GCC does not accept this due to CWG Defect #1423
     // http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1423
@@ -106,7 +108,7 @@ main()
             cgh.single_task<class KernelTest1>([=]() {
                 static_assert(sizeof(dpl::nullptr_t) == sizeof(void*), "sizeof(dpl::nullptr_t) == sizeof(void*)");
 
-                cl_int i = 0;
+                std::int32_t i = 0;
                 {
                     test_conversions<dpl::nullptr_t>(i);
                     test_conversions<void*>(i);


### PR DESCRIPTION
The initial motivation was to replace `cl_int`, which should not be used, at least in a generic code parts due to being specific to OpenCL backend. Since it involves changing the Tested API example, I prefer to update other parts of it because it is outdated.