### PR TITLE
Fix compile error in `__serial_merge`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -148,11 +148,8 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
     _Index __rng1_idx = __start1;
     _Index __rng2_idx = __start2;
 
-    constexpr bool __is_the_same_types = std::is_same_v<decltype(__rng2[__rng2_idx]), decltype(__rng1[__rng1_idx])>;
-
     bool __rng1_idx_less_n1 = false;
     bool __rng2_idx_less_n2 = false;
-    bool __condition_state = false;
 
     for (_Index __rng3_idx = __start3; __rng3_idx < __rng3_idx_end; ++__rng3_idx)
     {
@@ -162,13 +159,8 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         // One of __rng1_idx_less_n1 and __rng2_idx_less_n2 should be true here
         // because 1) we should fill output data with elements from one of the input ranges
         // 2) we calculate __rng3_idx_end as std::min<_Index>(__rng1_size + __rng2_size, __chunk).
-        __condition_state =
-            ((__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])) ||
-             !__rng1_idx_less_n1);
-
-        if constexpr (__is_the_same_types)
-            __rng3[__rng3_idx] = __condition_state ? __rng2[__rng2_idx++] : __rng1[__rng1_idx++];
-        else if (__condition_state)
+        if ((__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])) ||
+            !__rng1_idx_less_n1)
             __rng3[__rng3_idx] = __rng2[__rng2_idx++];
         else
             __rng3[__rng3_idx] = __rng1[__rng1_idx++];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -148,7 +148,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
     _Index __rng1_idx = __start1;
     _Index __rng2_idx = __start2;
 
-    constexpr bool __is_the_same_types = std::is_same_v<decltype(__rng2[__rng2_idx]), decltype(__rng1[__rng1_idx]))>;
+    constexpr bool __is_the_same_types = std::is_same_v<decltype(__rng2[__rng2_idx]), decltype(__rng1[__rng1_idx])>;
 
     bool __rng1_idx_less_n1 = false;
     bool __rng2_idx_less_n2 = false;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -148,7 +148,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
     _Index __rng1_idx = __start1;
     _Index __rng2_idx = __start2;
 
-    using _Rng3ValueType = decltype(__rng3[__start3]);
+    using _Rng3ValueType = std::decay_t<decltype(__rng3[__start3])>;
 
     for (_Index __rng3_idx = __start3; __rng3_idx < __rng3_idx_end; ++__rng3_idx)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -148,6 +148,8 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
     _Index __rng1_idx = __start1;
     _Index __rng2_idx = __start2;
 
+    constexpr bool __is_the_same_types = std::is_same_v<decltype(__rng2[__rng2_idx]), decltype(__rng1[__rng1_idx]))>;
+
     bool __rng1_idx_less_n1 = false;
     bool __rng2_idx_less_n2 = false;
     bool __condition_state = false;
@@ -164,7 +166,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
             ((__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])) ||
              !__rng1_idx_less_n1);
 
-        if constexpr (std::is_same_v<decltype(__rng2[__rng2_idx++]), decltype(__rng1[__rng1_idx++]))>)
+        if constexpr (__is_the_same_types)
             __rng3[__rng3_idx] = __condition_state ? __rng2[__rng2_idx++] : __rng1[__rng1_idx++];
         else if (__condition_state)
             __rng3[__rng3_idx] = __rng2[__rng2_idx++];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -156,7 +156,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         // One of __rng1_idx_less_n1 and __rng2_idx_less_n2 should be true here
         // because 1) we should fill output data with elements from one of the input ranges
         // 2) we calculate __rng3_idx_end as std::min<_Index>(__rng1_size + __rng2_size, __chunk).
-        if ((__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])) ||
+        if (__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]) ||
             !__rng1_idx_less_n1)
             __rng3[__rng3_idx] = __rng2[__rng2_idx++];
         else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -148,7 +148,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
     _Index __rng1_idx = __start1;
     _Index __rng2_idx = __start2;
 
-    using _Rng3DataType = decltype(__rng3[__start3]);
+    using _Rng3ValueType = decltype(__rng3[__start3]);
 
     for (_Index __rng3_idx = __start3; __rng3_idx < __rng3_idx_end; ++__rng3_idx)
     {
@@ -161,8 +161,8 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         __rng3[__rng3_idx] =
             ((__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])) ||
              !__rng1_idx_less_n1)
-                ? static_cast<_Rng3DataType>(__rng2[__rng2_idx++])
-                : static_cast<_Rng3DataType>(__rng1[__rng1_idx++]);
+                ? static_cast<_Rng3ValueType>(__rng2[__rng2_idx++])
+                : static_cast<_Rng3ValueType>(__rng1[__rng1_idx++]);
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -148,6 +148,8 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
     _Index __rng1_idx = __start1;
     _Index __rng2_idx = __start2;
 
+    using _Rng3DataType = decltype(__rng3[__start3]);
+
     for (_Index __rng3_idx = __start3; __rng3_idx < __rng3_idx_end; ++__rng3_idx)
     {
         const bool __rng1_idx_less_n1 = __rng1_idx < __rng1_idx_end;
@@ -159,8 +161,8 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         __rng3[__rng3_idx] =
             ((__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])) ||
              !__rng1_idx_less_n1)
-                ? __rng2[__rng2_idx++]
-                : __rng1[__rng1_idx++];
+                ? static_cast<_Rng3DataType>(__rng2[__rng2_idx++])
+                : static_cast<_Rng3DataType>(__rng1[__rng1_idx++]);
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -150,10 +150,13 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
 
     using _Rng3ValueType = std::decay_t<decltype(__rng3[__start3])>;
 
+    bool __rng1_idx_less_n1 = false;
+    bool __rng1_idx_less_n2 = false;
+
     for (_Index __rng3_idx = __start3; __rng3_idx < __rng3_idx_end; ++__rng3_idx)
     {
-        const bool __rng1_idx_less_n1 = __rng1_idx < __rng1_idx_end;
-        const bool __rng2_idx_less_n2 = __rng2_idx < __rng2_idx_end;
+        __rng1_idx_less_n1 = __rng1_idx < __rng1_idx_end;
+        __rng2_idx_less_n2 = __rng2_idx < __rng2_idx_end;
 
         // One of __rng1_idx_less_n1 and __rng2_idx_less_n2 should be true here
         // because 1) we should fill output data with elements from one of the input ranges

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -151,7 +151,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
     using _Rng3ValueType = std::decay_t<decltype(__rng3[__start3])>;
 
     bool __rng1_idx_less_n1 = false;
-    bool __rng1_idx_less_n2 = false;
+    bool __rng2_idx_less_n2 = false;
 
     for (_Index __rng3_idx = __start3; __rng3_idx < __rng3_idx_end; ++__rng3_idx)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -148,13 +148,10 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
     _Index __rng1_idx = __start1;
     _Index __rng2_idx = __start2;
 
-    bool __rng1_idx_less_n1 = false;
-    bool __rng2_idx_less_n2 = false;
-
     for (_Index __rng3_idx = __start3; __rng3_idx < __rng3_idx_end; ++__rng3_idx)
     {
-        __rng1_idx_less_n1 = __rng1_idx < __rng1_idx_end;
-        __rng2_idx_less_n2 = __rng2_idx < __rng2_idx_end;
+        const bool __rng1_idx_less_n1 = __rng1_idx < __rng1_idx_end;
+        const bool __rng2_idx_less_n2 = __rng2_idx < __rng2_idx_end;
 
         // One of __rng1_idx_less_n1 and __rng2_idx_less_n2 should be true here
         // because 1) we should fill output data with elements from one of the input ranges


### PR DESCRIPTION
In this PR we fix compile errors in `__serial_merge` function for case when the types of `__rng2` and `__rng1` aren't the same:
```C++
/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h:162:17: error: conditional expression is ambiguous; '__return_t' (aka 'const oneapi::dpl::__internal::tuple<unsigned long, unsigned long>') can be converted to 'decltype(this->make_reference(::std::declval<_tuple_ranges_t>(), __i, ::std::make_index_sequence<__num_ranges>()))' (aka 'tuple<const unsigned long &, const unsigned long &>') and vice versa
  162 |                 ? __rng2[__rng2_idx++]
      |                 ^ ~~~~~~~~~~~~~~~~~~~~
  163 |                 : __rng1[__rng1_idx++];
      |                   ~~~~~~~~~~~~~~~~~~~~
/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h:198:21: note: in instantiation of function template specialization 'oneapi::dpl::__par_backend_hetero::__serial_merge<oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::all_view<unsigned long, sycl::access::mode::read>, oneapi::dpl::__ranges::all_view<unsigned long, sycl::access::mode::read>>, oneapi::dpl::__ranges::all_view<oneapi::dpl::__internal::tuple<unsigned long, unsigned long>, sycl::access::mode::read>, const oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::all_view<unsigned long, sycl::access::mode::write>, oneapi::dpl::__ranges::all_view<unsigned long, sycl::access::mode::write>>, unsigned int, dpct::internal::compare_key_fun<>>' requested here
  198 |                     __serial_merge(__rng1, __rng2, __rng3, __start.first, __start.second, __i_elem, __chunk, __n1, __n2,
      |                     ^
/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h:1821:37: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__pattern_merge<oneapi::dpl::__internal::__device_backend_tag, oneapi::dpl::execution::device_policy<oneapi::dpl::__internal::__set_union_copy_case_2<SetUnionByKey>>, oneapi::dpl::zip_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>, oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>>, oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, oneapi::dpl::__internal::tuple<unsigned long, unsigned long>>, oneapi::dpl::zip_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>, oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>>, dpct::internal::compare_key_fun<>>' requested here
 1821 |     return oneapi::dpl::__internal::__pattern_merge(
      |                                     ^
/include/oneapi/dpl/pstl/glue_algorithm_impl.h:1007:37: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__pattern_set_union<oneapi::dpl::__internal::__device_backend_tag, oneapi::dpl::execution::device_policy<SetUnionByKey> &, oneapi::dpl::zip_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>, oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>>, oneapi::dpl::zip_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>, oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>>, oneapi::dpl::zip_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>, oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>>, dpct::internal::compare_key_fun<>>' requested here
 1007 |     return oneapi::dpl::__internal::__pattern_set_union(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),                                                                |                                     ^
/include/dpct/dpl_extras/algorithm.h:840:23: note: in instantiation of function template specialization 'oneapi::dpl::set_union<oneapi::dpl::execution::device_policy<SetUnionByKey> &, oneapi::dpl::zip_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>, oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>>, oneapi::dpl::zip_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>, oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>>, oneapi::dpl::zip_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>, oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, unsigned long>>, dpct::internal::compare_key_fun<>>' requested here
  840 |   auto ret_val = std::set_union(                                                               
```

This compile error has been introduced in the PR https://github.com/uxlfoundation/oneDPL/pull/1970
