### PR TITLE
Update version number for the coming release

### DIFF
--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -12,8 +12,8 @@
 
 // The library version
 #define ONEDPL_VERSION_MAJOR 2022
-#define ONEDPL_VERSION_MINOR 7
-#define ONEDPL_VERSION_PATCH 1
+#define ONEDPL_VERSION_MINOR 8
+#define ONEDPL_VERSION_PATCH 0
 
 #if _ONEDPL___cplusplus >= 202002L && __has_include(<version>)
 #    include <version> // The standard C++20 header

--- a/test/general/version.pass.cpp
+++ b/test/general/version.pass.cpp
@@ -25,8 +25,8 @@ static_assert(_PSTL_VERSION_PATCH == 0);
 #endif
 
 static_assert(ONEDPL_VERSION_MAJOR == 2022);
-static_assert(ONEDPL_VERSION_MINOR == 7);
-static_assert(ONEDPL_VERSION_PATCH == 1);
+static_assert(ONEDPL_VERSION_MINOR == 8);
+static_assert(ONEDPL_VERSION_PATCH == 0);
 
 #include "support/utils.h"
 


### PR DESCRIPTION
The PR updates the oneDPL version macro and test verifying it.  This PR should not be merged until code freeze for the coming release.