### PR TITLE
Fix performance issue in `__serial_merge`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -146,6 +146,7 @@ __can_use_ternary_op(...) -> std::false_type
     return {};
 }
 
+// This implementation of __assing_impl is required for performance optimisation
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
 std::enable_if_t<__can_use_ternary_op<_Rng1, _Rng2>().value, void>
 __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
@@ -154,6 +155,7 @@ __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& _
     __rng3[__rng3_idx] = __use_rng2_val ? __rng2[__rng2_idx++] : __rng1[__rng1_idx++];
 }
 
+// TODO required to understand why the usual if-else is slower then ternary operator
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
 std::enable_if_t<!__can_use_ternary_op<_Rng1, _Rng2>().value, void>
 __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -141,13 +141,13 @@ __can_use_ternary_op(int) -> decltype(true ? std::declval<_value_t_rng1>() : std
 
 template <typename _Rng1, typename _Rng2>
 constexpr auto
-__can_use_ternary_op(...) -> std::false_type
+__can_use_ternary_op(long) -> std::false_type
 {
     return {};
 }
 
 template <typename _Rng1, typename _Rng2>
-constexpr static bool __can_use_ternary_op_v = decltype(__can_use_ternary_op<_Rng1, _Rng2>(0))::value;
+constexpr static bool __can_use_ternary_op_v = decltype(__can_use_ternary_op<_Rng1, _Rng2>(int{0}))::value;
 
 // Do serial merge of the data from rng1 (starting from start1) and rng2 (starting from start2) and writing
 // to rng3 (starting from start3) in 'chunk' steps, but do not exceed the total size of the sequences (n1 and n2)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -130,19 +130,28 @@ __find_start_point(const _Rng1& __rng1, const _Index __rng1_from, _Index __rng1_
     return _split_point_t<_Index>{*__res, __index_sum - *__res + 1};
 }
 
-template <typename _Rng1, typename _Rng2,
+template <typename _Rng1, typename _Rng2, typename _Rng3,
           typename _value_t_rng1 = oneapi::dpl::__internal::__value_t<_Rng1>,
-          typename _value_t_rng2 = oneapi::dpl::__internal::__value_t<_Rng2>>
-using __may_use_ternary_op = 
-    typename std::disjunction<
-        typename std::is_same<_value_t_rng1, _value_t_rng2>::type,
-        typename std::conjunction<
-            typename std::is_arithmetic<_value_t_rng1>::type,
-            typename std::is_arithmetic<_value_t_rng2>::type>::type
-    >::type;
+          typename _value_t_rng2 = oneapi::dpl::__internal::__value_t<_Rng2>,
+          typename _value_t_rng3 = oneapi::dpl::__internal::__value_t<_Rng3>>
+constexpr auto
+__can_use_ternary_op(int)
+    -> decltype(std::declval<std::reference_wrapper<_value_t_rng3>>() ? std::declval<_value_t_rng1>()
+                                                                      : std::declval<_value_t_rng2>(),
+                std::true_type{})
+{
+    return {};
+}
+
+template <typename _T1, typename _T2>
+constexpr auto
+__can_use_ternary_op(...) -> std::false_type
+{
+    return {};
+}
 
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
-std::enable_if_t<__may_use_ternary_op<_Rng1, _Rng2>::value, void>
+std::enable_if_t<__can_use_ternary_op<_Rng1, _Rng2>().value, void>
 __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
               const _Index __rng3_idx, const bool __use_rng2_val)
 {
@@ -150,7 +159,7 @@ __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& _
 }
 
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
-std::enable_if_t<!__may_use_ternary_op<_Rng1, _Rng2>::value, void>
+std::enable_if_t<!__can_use_ternary_op<_Rng1, _Rng2>().value, void>
 __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
               const _Index __rng3_idx, const bool __use_rng2_val)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -132,12 +132,17 @@ __find_start_point(const _Rng1& __rng1, const _Index __rng1_from, _Index __rng1_
 }
 
 template <typename _Rng1, typename _Rng2, typename = void>
-struct __can_use_ternary_op : std::false_type {};
+struct __can_use_ternary_op : std::false_type
+{
+};
 
 template <typename _Rng1, typename _Rng2>
-struct __can_use_ternary_op<_Rng1, _Rng2, std::void_t<
-    decltype(true ? std::declval<oneapi::dpl::__internal::__value_t<_Rng1>>() :
-                    std::declval<oneapi::dpl::__internal::__value_t<_Rng2>>())>> : std::true_type {};
+struct __can_use_ternary_op<_Rng1, _Rng2,
+                            std::void_t<decltype(true ? std::declval<oneapi::dpl::__internal::__value_t<_Rng1>>()
+                                                      : std::declval<oneapi::dpl::__internal::__value_t<_Rng2>>())>>
+    : std::true_type
+{
+};
 
 template <typename _Rng1, typename _Rng2>
 constexpr static bool __can_use_ternary_op_v = __can_use_ternary_op<_Rng1, _Rng2>::value;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -133,8 +133,8 @@ __find_start_point(const _Rng1& __rng1, const _Index __rng1_from, _Index __rng1_
 template <typename _Rng1, typename _Rng2, typename _value_t_rng1 = oneapi::dpl::__internal::__value_t<_Rng1>,
           typename _value_t_rng2 = oneapi::dpl::__internal::__value_t<_Rng2>>
 constexpr auto
-__can_use_ternary_op(int)
-    -> decltype(true ? std::declval<_value_t_rng1>() : std::declval<_value_t_rng2>(), std::true_type{})
+__can_use_ternary_op(int) -> decltype(true ? std::declval<_value_t_rng1>() : std::declval<_value_t_rng2>(),
+                                      std::true_type{})
 {
     return {};
 }
@@ -175,11 +175,10 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         if constexpr (__can_use_ternary_op<_Rng1, _Rng2>(0).value)
         {
             // This implementation is required for performance optimisation
-            __rng3[__rng3_idx] =
-                (!__rng1_idx_less_n1 ||
-                __rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
-                    ? __rng2[__rng2_idx++]
-                    : __rng1[__rng1_idx++];
+            __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || __rng1_idx_less_n1 && __rng2_idx_less_n2 &&
+                                                             __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
+                                     ? __rng2[__rng2_idx++]
+                                     : __rng1[__rng1_idx++];
         }
         else
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -131,15 +131,15 @@ __find_start_point(const _Rng1& __rng1, const _Index __rng1_from, _Index __rng1_
     return _split_point_t<_Index>{*__res, __index_sum - *__res + 1};
 }
 
-template <typename _Rng1, typename _Rng2, typename = void>
+template <typename _Rng1DataType, typename _Rng2DataType, typename = void>
 struct __can_use_ternary_op : std::false_type
 {
 };
 
-template <typename _Rng1, typename _Rng2>
-struct __can_use_ternary_op<_Rng1, _Rng2,
-                            std::void_t<decltype(true ? std::declval<oneapi::dpl::__internal::__value_t<_Rng1>>()
-                                                      : std::declval<oneapi::dpl::__internal::__value_t<_Rng2>>())>>
+template <typename _Rng1DataType, typename _Rng2DataType>
+struct __can_use_ternary_op<_Rng1DataType, _Rng2DataType,
+                            std::void_t<decltype(true ? std::declval<_Rng1DataType>()
+                                                      : std::declval<_Rng2DataType>())>>
     : std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -173,7 +173,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         // One of __rng1_idx_less_n1 and __rng2_idx_less_n2 should be true here
         // because 1) we should fill output data with elements from one of the input ranges
         // 2) we calculate __rng3_idx_end as std::min<_Index>(__rng1_size + __rng2_size, __chunk).
-        if constexpr (__can_use_ternary_op_v<_Rng1, _Rng2>)
+        if constexpr (__can_use_ternary_op_v<decltype(__rng1[__rng1_idx]), decltype(__rng2[__rng2_idx])>)
         {
             // This implementation is required for performance optimization
             __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || __rng1_idx_less_n1 && __rng2_idx_less_n2 &&

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -138,8 +138,7 @@ struct __can_use_ternary_op : std::false_type
 
 template <typename _Rng1DataType, typename _Rng2DataType>
 struct __can_use_ternary_op<_Rng1DataType, _Rng2DataType,
-                            std::void_t<decltype(true ? std::declval<_Rng1DataType>()
-                                                      : std::declval<_Rng2DataType>())>>
+                            std::void_t<decltype(true ? std::declval<_Rng1DataType>() : std::declval<_Rng2DataType>())>>
     : std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -175,15 +175,15 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         if constexpr (__can_use_ternary_op<_Rng1, _Rng2>().value)
         {
             __rng3[__rng3_idx] =
-                (__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]) ||
-                 !__rng1_idx_less_n1)
+                (!__rng1_idx_less_n1 ||
+                __rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
                     ? __rng2[__rng2_idx++]
                     : __rng1[__rng1_idx++];
         }
         else
         {
-            if (__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]) ||
-                !__rng1_idx_less_n1)
+            if (!__rng1_idx_less_n1 ||
+                __rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
                 __rng3[__rng3_idx] = __rng2[__rng2_idx++];
             else
                 __rng3[__rng3_idx] = __rng1[__rng1_idx++];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -174,7 +174,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         // 2) we calculate __rng3_idx_end as std::min<_Index>(__rng1_size + __rng2_size, __chunk).
         if constexpr (__can_use_ternary_op<_Rng1, _Rng2>(0).value)
         {
-            // This implementation is required for performance optimisation
+            // This implementation is required for performance optimization
             __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || __rng1_idx_less_n1 && __rng2_idx_less_n2 &&
                                                              __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
                                      ? __rng2[__rng2_idx++]

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -139,12 +139,15 @@ __can_use_ternary_op(int) -> decltype(true ? std::declval<_value_t_rng1>() : std
     return {};
 }
 
-template <typename _T1, typename _T2>
+template <typename _Rng1, typename _Rng2>
 constexpr auto
 __can_use_ternary_op(...) -> std::false_type
 {
     return {};
 }
+
+template <typename _Rng1, typename _Rng2>
+constexpr static bool __can_use_ternary_op_v = decltype(__can_use_ternary_op<_Rng1, _Rng2>(0))::value;
 
 // Do serial merge of the data from rng1 (starting from start1) and rng2 (starting from start2) and writing
 // to rng3 (starting from start3) in 'chunk' steps, but do not exceed the total size of the sequences (n1 and n2)
@@ -172,7 +175,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         // One of __rng1_idx_less_n1 and __rng2_idx_less_n2 should be true here
         // because 1) we should fill output data with elements from one of the input ranges
         // 2) we calculate __rng3_idx_end as std::min<_Index>(__rng1_size + __rng2_size, __chunk).
-        if constexpr (__can_use_ternary_op<_Rng1, _Rng2>(0).value)
+        if constexpr (__can_use_ternary_op_v<_Rng1, _Rng2>)
         {
             // This implementation is required for performance optimization
             __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || __rng1_idx_less_n1 && __rng2_idx_less_n2 &&

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -130,15 +130,11 @@ __find_start_point(const _Rng1& __rng1, const _Index __rng1_from, _Index __rng1_
     return _split_point_t<_Index>{*__res, __index_sum - *__res + 1};
 }
 
-template <typename _Rng1, typename _Rng2, typename _Rng3,
-          typename _value_t_rng1 = oneapi::dpl::__internal::__value_t<_Rng1>,
-          typename _value_t_rng2 = oneapi::dpl::__internal::__value_t<_Rng2>,
-          typename _value_t_rng3 = oneapi::dpl::__internal::__value_t<_Rng3>>
+template <typename _Rng1, typename _Rng2, typename _value_t_rng1 = oneapi::dpl::__internal::__value_t<_Rng1>,
+          typename _value_t_rng2 = oneapi::dpl::__internal::__value_t<_Rng2>>
 constexpr auto
 __can_use_ternary_op(int)
-    -> decltype(std::declval<std::reference_wrapper<_value_t_rng3>>() ? std::declval<_value_t_rng1>()
-                                                                      : std::declval<_value_t_rng2>(),
-                std::true_type{})
+    -> decltype(true ? std::declval<_value_t_rng1>() : std::declval<_value_t_rng2>(), std::true_type{})
 {
     return {};
 }
@@ -151,7 +147,7 @@ __can_use_ternary_op(...) -> std::false_type
 }
 
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
-std::enable_if_t<__can_use_ternary_op<_Rng1, _Rng2, _Rng3>().value, void>
+std::enable_if_t<__can_use_ternary_op<_Rng1, _Rng2>().value, void>
 __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
               const _Index __rng3_idx, const bool __use_rng2_val)
 {
@@ -159,7 +155,7 @@ __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& _
 }
 
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
-std::enable_if_t<!__can_use_ternary_op<_Rng1, _Rng2, _Rng3>().value, void>
+std::enable_if_t<!__can_use_ternary_op<_Rng1, _Rng2>().value, void>
 __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
               const _Index __rng3_idx, const bool __use_rng2_val)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -151,7 +151,7 @@ __can_use_ternary_op(...) -> std::false_type
 }
 
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
-std::enable_if_t<__can_use_ternary_op<_Rng1, _Rng2>().value, void>
+std::enable_if_t<__can_use_ternary_op<_Rng1, _Rng2, _Rng3>().value, void>
 __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
               const _Index __rng3_idx, const bool __use_rng2_val)
 {
@@ -159,7 +159,7 @@ __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& _
 }
 
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
-std::enable_if_t<!__can_use_ternary_op<_Rng1, _Rng2>().value, void>
+std::enable_if_t<!__can_use_ternary_op<_Rng1, _Rng2, _Rng3>().value, void>
 __assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
               const _Index __rng3_idx, const bool __use_rng2_val)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -144,8 +144,8 @@ struct __can_use_ternary_op<_Rng1DataType, _Rng2DataType,
 {
 };
 
-template <typename _Rng1, typename _Rng2>
-constexpr static bool __can_use_ternary_op_v = __can_use_ternary_op<_Rng1, _Rng2>::value;
+template <typename _Rng1DataType, typename _Rng2DataType>
+constexpr static bool __can_use_ternary_op_v = __can_use_ternary_op<_Rng1DataType, _Rng2DataType>::value;
 
 // Do serial merge of the data from rng1 (starting from start1) and rng2 (starting from start2) and writing
 // to rng3 (starting from start3) in 'chunk' steps, but do not exceed the total size of the sequences (n1 and n2)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -146,25 +146,6 @@ __can_use_ternary_op(...) -> std::false_type
     return {};
 }
 
-template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
-std::enable_if_t<__can_use_ternary_op<_Rng1, _Rng2>().value, void>
-__assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
-              const _Index __rng3_idx, const bool __use_rng2_val)
-{
-    __rng3[__rng3_idx] = __use_rng2_val ? __rng2[__rng2_idx++] : __rng1[__rng1_idx++];
-}
-
-template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
-std::enable_if_t<!__can_use_ternary_op<_Rng1, _Rng2>().value, void>
-__assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
-              const _Index __rng3_idx, const bool __use_rng2_val)
-{
-    if (__use_rng2_val)
-        __rng3[__rng3_idx] = __rng2[__rng2_idx++];
-    else
-        __rng3[__rng3_idx] = __rng1[__rng1_idx++];
-}
-
 // Do serial merge of the data from rng1 (starting from start1) and rng2 (starting from start2) and writing
 // to rng3 (starting from start3) in 'chunk' steps, but do not exceed the total size of the sequences (n1 and n2)
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index, typename _Compare>
@@ -191,8 +172,22 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         // One of __rng1_idx_less_n1 and __rng2_idx_less_n2 should be true here
         // because 1) we should fill output data with elements from one of the input ranges
         // 2) we calculate __rng3_idx_end as std::min<_Index>(__rng1_size + __rng2_size, __chunk).
-        __assing_impl(__rng1, __rng2, __rng3, __rng1_idx, __rng2_idx, __rng3_idx,
-                      !__rng1_idx_less_n1 || (__rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])));
+        if constexpr (__can_use_ternary_op<_Rng1, _Rng2>().value)
+        {
+            __rng3[__rng3_idx] =
+                (__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]) ||
+                 !__rng1_idx_less_n1)
+                    ? __rng2[__rng2_idx++]
+                    : __rng1[__rng1_idx++];
+        }
+        else
+        {
+            if (__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]) ||
+                !__rng1_idx_less_n1)
+                __rng3[__rng3_idx] = __rng2[__rng2_idx++];
+            else
+                __rng3[__rng3_idx] = __rng1[__rng1_idx++];
+        }
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -146,6 +146,25 @@ __can_use_ternary_op(...) -> std::false_type
     return {};
 }
 
+template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
+std::enable_if_t<__can_use_ternary_op<_Rng1, _Rng2>().value, void>
+__assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
+              const _Index __rng3_idx, const bool __use_rng2_val)
+{
+    __rng3[__rng3_idx] = __use_rng2_val ? __rng2[__rng2_idx++] : __rng1[__rng1_idx++];
+}
+
+template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index>
+std::enable_if_t<!__can_use_ternary_op<_Rng1, _Rng2>().value, void>
+__assing_impl(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index& __rng1_idx, _Index& __rng2_idx,
+              const _Index __rng3_idx, const bool __use_rng2_val)
+{
+    if (__use_rng2_val)
+        __rng3[__rng3_idx] = __rng2[__rng2_idx++];
+    else
+        __rng3[__rng3_idx] = __rng1[__rng1_idx++];
+}
+
 // Do serial merge of the data from rng1 (starting from start1) and rng2 (starting from start2) and writing
 // to rng3 (starting from start3) in 'chunk' steps, but do not exceed the total size of the sequences (n1 and n2)
 template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index, typename _Compare>
@@ -172,22 +191,8 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         // One of __rng1_idx_less_n1 and __rng2_idx_less_n2 should be true here
         // because 1) we should fill output data with elements from one of the input ranges
         // 2) we calculate __rng3_idx_end as std::min<_Index>(__rng1_size + __rng2_size, __chunk).
-        if constexpr (__can_use_ternary_op<_Rng1, _Rng2>().value)
-        {
-            __rng3[__rng3_idx] =
-                (!__rng1_idx_less_n1 ||
-                __rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
-                    ? __rng2[__rng2_idx++]
-                    : __rng1[__rng1_idx++];
-        }
-        else
-        {
-            if (!__rng1_idx_less_n1 ||
-                __rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
-                __rng3[__rng3_idx] = __rng2[__rng2_idx++];
-            else
-                __rng3[__rng3_idx] = __rng1[__rng1_idx++];
-        }
+        __assing_impl(__rng1, __rng2, __rng3, __rng1_idx, __rng2_idx, __rng3_idx,
+                      !__rng1_idx_less_n1 || (__rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])));
     }
 }
 


### PR DESCRIPTION
This is the second attempt of https://github.com/uxlfoundation/oneDPL/pull/2013: the source compile error has been introduced in the PR https://github.com/uxlfoundation/oneDPL/pull/1970
Example of the source compile error: https://godbolt.org/z/x6z7GMv1W

In the PR https://github.com/uxlfoundation/oneDPL/pull/2013 I detected performance issue.

The goal of this PR - to use ternary operator when it's possible.

Checks on GodBold: 
1) https://godbolt.org/z/6zPcWEMsn - implementation with `__assing_impl`
2) https://godbolt.org/z/fdsPdoPz3 - implementation without `__assing_impl`

Thanks to @MikeDvorskiy and @dmitriy-sobolev for their implementations of `__can_use_ternary_op_v` !