### PR TITLE
Fix some `TODO` in `merge` and `merge_sort` algorithms

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -273,7 +273,8 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
         const _IdType __steps = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __chunk);
         std::size_t __base_diag_count = __get_max_base_diags_count(__exec, __chunk, __n);
-        std::size_t __steps_between_two_base_diags = oneapi::dpl::__internal::__dpl_ceiling_div(__steps, __base_diag_count);
+        std::size_t __steps_between_two_base_diags =
+            oneapi::dpl::__internal::__dpl_ceiling_div(__steps, __base_diag_count);
 
         return {__base_diag_count, __steps_between_two_base_diags, __chunk, __steps};
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -331,14 +331,6 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
         }
     };
 
-    template <typename _ExecutionPolicy>
-    std::size_t
-    get_max_base_diags_count(const _ExecutionPolicy& __exec, const _IndexT __chunk, std::size_t __n) const
-    {
-        const std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
-        return oneapi::dpl::__internal::__dpl_ceiling_div(__n, __chunk * __max_wg_size);
-    }
-
     // Calculate nd-range params
     template <typename _ExecutionPolicy>
     nd_range_params
@@ -350,7 +342,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
         const _IndexT __chunk = std::min<_IndexT>(__is_cpu ? 32 : 4, __n_sorted * 2);
         const _IndexT __steps = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_size, __chunk);
 
-        _IndexT __base_diag_count = get_max_base_diags_count(__exec, __chunk, __n_sorted);
+        _IndexT __base_diag_count = __get_max_base_diags_count(__exec, __chunk, __n_sorted);
         _IndexT __steps_between_two_base_diags = oneapi::dpl::__internal::__dpl_ceiling_div(__steps, __base_diag_count);
 
         return {__base_diag_count, __steps_between_two_base_diags, __chunk, __steps};
@@ -554,7 +546,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
 
         // Max amount of base diagonals
         const std::size_t __max_base_diags_count =
-            get_max_base_diags_count(__exec, __nd_range_params.chunk, __n) + __1_final_base_diag;
+            __get_max_base_diags_count(__exec, __nd_range_params.chunk, __n) + __1_final_base_diag;
 
         for (std::int64_t __i = 0; __i < __n_iter; ++__i)
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -460,12 +460,54 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
         return __base_diagonals_sp_global_ptr[__diagonal_idx];
     }
 
-    // Process parallel merge with usage of split-points on base diagonals
-    template <typename _ExecutionPolicy, typename _Range, typename _TempBuf, typename _Compare, typename _Storage>
+    // Process parallel merge
+    template <typename _ExecutionPolicy, typename _Range, typename _TempBuf, typename _Compare>
     sycl::event
     run_parallel_merge(const sycl::event& __event_chain, const _IndexT __n_sorted, const bool __data_in_temp,
                        const _ExecutionPolicy& __exec, _Range& __rng, _TempBuf& __temp_buf, _Compare __comp,
-                       const nd_range_params& __nd_range_params, _Storage& __base_diagonals_sp_global_storage) const
+                       const nd_range_params& __nd_range_params) const
+    {
+        const _IndexT __n = __rng.size();
+
+        return __exec.queue().submit([&__event_chain, __n_sorted, __data_in_temp, &__rng, &__temp_buf, __comp,
+                                      __nd_range_params, __n](sycl::handler& __cgh) {
+            __cgh.depends_on(__event_chain);
+
+            oneapi::dpl::__ranges::__require_access(__cgh, __rng);
+            sycl::accessor __dst(__temp_buf, __cgh, sycl::read_write, sycl::no_init);
+
+            __cgh.parallel_for<_GlobalSortName1...>(
+                sycl::range</*dim=*/1>(__nd_range_params.steps), [=](sycl::item</*dim=*/1> __item_id) {
+                    const std::size_t __linear_id = __item_id.get_linear_id();
+
+                    const WorkDataArea __data_area(__n, __n_sorted, __linear_id, __nd_range_params.chunk);
+
+                    if (__data_area.is_i_elem_local_inside_merge_matrix())
+                    {
+                        if (__data_in_temp)
+                        {
+                            DropViews __views(__dst, __data_area);
+                            __serial_merge(__nd_range_params, __data_area, __views, __rng,
+                                           __find_start_point(__data_area, __views, __comp), __comp);
+                        }
+                        else
+                        {
+                            DropViews __views(__rng, __data_area);
+                            __serial_merge(__nd_range_params, __data_area, __views, __dst,
+                                           __find_start_point(__data_area, __views, __comp), __comp);
+                        }
+                    }
+                });
+        });
+    }
+
+    // Process parallel merge with usage of split-points on base diagonals
+    template <typename _ExecutionPolicy, typename _Range, typename _TempBuf, typename _Compare, typename _Storage>
+    sycl::event
+    run_parallel_merge_from_diagonals(const sycl::event& __event_chain, const _IndexT __n_sorted,
+                                      const bool __data_in_temp, const _ExecutionPolicy& __exec, _Range& __rng,
+                                      _TempBuf& __temp_buf, _Compare __comp, const nd_range_params& __nd_range_params,
+                                      _Storage& __base_diagonals_sp_global_storage) const
     {
         const _IndexT __n = __rng.size();
 
@@ -550,38 +592,49 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
 
         for (std::int64_t __i = 0; __i < __n_iter; ++__i)
         {
-            if (nullptr == __p_base_diagonals_sp_global_storage)
+            // TODO required to re-check threshold data size
+            if (2 * __n_sorted < __get_starting_size_limit_for_large_submitter<__value_type>())
             {
-                // Create storage to save split-points on each base diagonal + 1 (for the right base diagonal in the last work-group)
-                __p_base_diagonals_sp_global_storage =
-                    new __base_diagonals_sp_storage_t(__exec, 0, __max_base_diags_count);
-
-                // Save the raw pointer into a shared_ptr to return it in __future and extend the lifetime of the storage.
-                __p_result_and_scratch_storage_base.reset(
-                    static_cast<__result_and_scratch_storage_base*>(__p_base_diagonals_sp_global_storage));
+                // Process parallel merge
+                __event_chain = run_parallel_merge(__event_chain, __n_sorted, __data_in_temp, __exec, __rng, __temp_buf,
+                                                   __comp, __nd_range_params);
             }
+            else
+            {
+                if (nullptr == __p_base_diagonals_sp_global_storage)
+                {
+                    // Create storage to save split-points on each base diagonal + 1 (for the right base diagonal in the last work-group)
+                    __p_base_diagonals_sp_global_storage =
+                        new __base_diagonals_sp_storage_t(__exec, 0, __max_base_diags_count);
 
-            nd_range_params __nd_range_params_this =
-                eval_nd_range_params(__exec, std::size_t(2 * __n_sorted), __n_sorted);
+                    // Save the raw pointer into a shared_ptr to return it in __future and extend the lifetime of the storage.
+                    __p_result_and_scratch_storage_base.reset(
+                        static_cast<__result_and_scratch_storage_base*>(__p_base_diagonals_sp_global_storage));
+                }
 
-            // Check that each base diagonal started from beginning of merge matrix
-            assert(0 == (2 * __n_sorted) %
-                            (__nd_range_params_this.steps_between_two_base_diags * __nd_range_params_this.chunk));
+                nd_range_params __nd_range_params_this =
+                    eval_nd_range_params(__exec, std::size_t(2 * __n_sorted), __n_sorted);
 
-            const auto __portions = oneapi::dpl::__internal::__dpl_ceiling_div(__n, 2 * __n_sorted);
-            __nd_range_params_this.base_diag_count =
-                __nd_range_params_this.base_diag_count * __portions + __1_final_base_diag;
-            __nd_range_params_this.steps *= __portions;
-            assert(__nd_range_params_this.base_diag_count <= __max_base_diags_count);
+                // Check that each base diagonal started from beginning of merge matrix
+                assert(0 == (2 * __n_sorted) %
+                                (__nd_range_params_this.steps_between_two_base_diags * __nd_range_params_this.chunk));
 
-            // Calculation of split-points on each base diagonal
-            __event_chain =
-                eval_split_points_for_groups(__event_chain, __n_sorted, __data_in_temp, __exec, __rng, __temp_buf,
-                                             __comp, __nd_range_params_this, *__p_base_diagonals_sp_global_storage);
+                const auto __portions = oneapi::dpl::__internal::__dpl_ceiling_div(__n, 2 * __n_sorted);
+                __nd_range_params_this.base_diag_count =
+                    __nd_range_params_this.base_diag_count * __portions + __1_final_base_diag;
+                __nd_range_params_this.steps *= __portions;
+                assert(__nd_range_params_this.base_diag_count <= __max_base_diags_count);
 
-            // Process parallel merge with usage of split-points on base diagonals
-            __event_chain = run_parallel_merge(__event_chain, __n_sorted, __data_in_temp, __exec, __rng, __temp_buf,
-                                               __comp, __nd_range_params_this, *__p_base_diagonals_sp_global_storage);
+                // Calculation of split-points on each base diagonal
+                __event_chain =
+                    eval_split_points_for_groups(__event_chain, __n_sorted, __data_in_temp, __exec, __rng, __temp_buf,
+                                                 __comp, __nd_range_params_this, *__p_base_diagonals_sp_global_storage);
+
+                // Process parallel merge with usage of split-points on base diagonals
+                __event_chain = run_parallel_merge_from_diagonals(__event_chain, __n_sorted, __data_in_temp, __exec,
+                                                                  __rng, __temp_buf, __comp, __nd_range_params_this,
+                                                                  *__p_base_diagonals_sp_global_storage);
+            }
 
             __n_sorted *= 2;
             __data_in_temp = !__data_in_temp;


### PR DESCRIPTION
In this PR we fix some TODO's in `merge` and `merge_sort` algorithms:
- remove hard-coded amount of base diagonals from `merge` algorithm implementation.

These TODO has been introduced in the PR https://github.com/uxlfoundation/oneDPL/pull/1933