### PR TITLE
[Docs] Explicit python 3.12 for sphinx and imghdr

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install prerequisites
         run: |
           echo GITHUB_SHA_SHORT=${GITHUB_SHA::8} >> $GITHUB_ENV

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
+          # Set the python version to 3.12 to keep imghdr for sphinx. Could upgrade sphinx to 6.2 to use 3.x version.
           python-version: '3.12'
       - name: Install prerequisites
         run: |


### PR DESCRIPTION
Python 3.13 deprecates `imghdr`, which is still used until Sphinx 6.2. https://github.com/python/cpython/issues/104818

We could upgrade Sphinx from 4.4->6.2 but it seems like we have limited Sphinx at 4.4 it there for some other reason.  For now, lets just limit python to a version (3.12) which works.