### PR TITLE
Improve usage Pattern for result_and_scratch_storage

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -315,8 +315,8 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_wg);
         // Storage for the results of scan for each workgroup
 
-        using __result_and_scratch_storage_t = __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _Type>;
-        __result_and_scratch_storage_t __result_and_scratch{__exec, 1, __n_groups + 1};
+        using __result_scratch_t = __result_and_scratch_storage_t<_ExecutionPolicy, _Type>;
+        __result_scratch_t __result_and_scratch{__exec, 1, __n_groups + 1};
 
         _PRINT_INFO_IN_DEBUG_MODE(__exec, __wgroup_size, __max_cu);
 
@@ -334,7 +334,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
                 __kernel_1,
 #endif
                 sycl::nd_range<1>(__n_groups * __wgroup_size, __wgroup_size), [=](sycl::nd_item<1> __item) {
-                    auto __temp_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                    auto __temp_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                     __local_scan(__item, __n, __local_acc, __rng1, __rng2, __temp_ptr, __size_per_wg, __wgroup_size,
                                  __iters_per_witem, __init);
                 });
@@ -356,7 +356,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
 #endif
                     // TODO: try to balance work between several workgroups instead of one
                     sycl::nd_range<1>(__wgroup_size, __wgroup_size), [=](sycl::nd_item<1> __item) {
-                        auto __temp_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                        auto __temp_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                         __group_scan(__item, __n_groups, __local_acc, __temp_ptr, __temp_ptr,
                                      /*dummy*/ __temp_ptr, __n_groups, __wgroup_size, __iters_per_single_wg);
                     });
@@ -371,9 +371,9 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
             auto __res_acc = __result_and_scratch.template __get_result_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
             __cgh.parallel_for<_PropagateScanName...>(sycl::range<1>(__n_groups * __size_per_wg), [=](auto __item) {
-                auto __temp_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                auto __temp_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 auto __res_ptr =
-                    __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc, __n_groups + 1);
+                    __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__res_acc, __n_groups + 1);
                 __global_scan(__item, __rng2, __rng1, __temp_ptr, __res_ptr, __n, __size_per_wg);
             });
         });
@@ -539,8 +539,8 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
                                                                  std::decay_t<decltype(__out_rng[0])>>::__type;
 
         constexpr ::std::uint32_t __elems_per_wg = _ElemsPerItem * _WGSize;
-        using __result_and_scratch_storage_t = __result_and_scratch_storage<std::decay_t<_Policy>, _Size>;
-        __result_and_scratch_storage_t __result{__policy, 1, 0};
+        using __result_scratch_t = __result_and_scratch_storage_t<_Policy, _Size>;
+        __result_scratch_t __result{__policy, 1, 0};
 
         auto __event = __policy.queue().submit([&](sycl::handler& __hdl) {
             oneapi::dpl::__ranges::__require_access(__hdl, __in_rng, __out_rng);
@@ -554,7 +554,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
 
             __hdl.parallel_for<_ScanKernelName...>(
                 sycl::nd_range<1>(_WGSize, _WGSize), [=](sycl::nd_item<1> __self_item) {
-                    auto __res_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc);
+                    auto __res_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__res_acc);
                     const auto& __group = __self_item.get_group();
                     // This kernel is only launched for sizes less than 2^16
                     const ::std::uint16_t __item_id = __self_item.get_local_linear_id();
@@ -615,8 +615,7 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
 
     // Although we do not actually need result storage in this case, we need to construct
     // a placeholder here to match the return type of the non-single-work-group implementation
-    using __result_and_scratch_storage_t = __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _ValueType>;
-    __result_and_scratch_storage_t __dummy_result_and_scratch{__exec, 0, 0};
+    __result_and_scratch_storage_t<_ExecutionPolicy, _ValueType> __dummy_result_and_scratch{__exec, 0, 0};
 
     if (__max_wg_size >= __targeted_wg_size)
     {
@@ -1826,9 +1825,8 @@ struct __parallel_find_or_impl_one_wg<__or_tag_check, __internal::__optional_ker
                const std::size_t __rng_n, const std::size_t __wgroup_size, const __FoundStateType __init_value,
                _Predicate __pred, _Ranges&&... __rngs)
     {
-        using __result_and_scratch_storage_t =
-            __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, __FoundStateType>;
-        __result_and_scratch_storage_t __result_storage{__exec, 1, 0};
+        using __result_scratch_t = __result_and_scratch_storage_t<_ExecutionPolicy, __FoundStateType>;
+        __result_scratch_t __result_storage{__exec, 1, 0};
 
         // Calculate the number of elements to be processed by each work-item.
         const auto __iters_per_work_item = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
@@ -1867,7 +1865,7 @@ struct __parallel_find_or_impl_one_wg<__or_tag_check, __internal::__optional_ker
                     // Set local found state value value to global state to have correct result
                     if (__local_idx == 0)
                     {
-                        __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__result_acc)[0] =
+                        __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__result_acc)[0] =
                             __found_local;
                     }
                 });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -371,7 +371,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
         // Create storage to save split-points on each base diagonal + 1 (for the right base diagonal in the last work-group)
         auto __p_base_diagonals_sp_global_storage =
-            new __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _split_point_t<_IdType>>(
+            new __result_and_scratch_storage_t<_ExecutionPolicy, _split_point_t<_IdType>>(
                 __exec, 0, __nd_range_params.base_diag_count + 1);
 
         // Save the raw pointer into a shared_ptr to return it in __future and extend the lifetime of the storage.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -371,7 +371,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
         // Create storage to save split-points on each base diagonal + 1 (for the right base diagonal in the last work-group)
         auto __p_base_diagonals_sp_global_storage =
-            new __result_and_scratch_storage_t<_ExecutionPolicy, _split_point_t<_IdType>>(
+            new __result_and_scratch_storage<_ExecutionPolicy, _split_point_t<_IdType>>(
                 __exec, 0, __nd_range_params.base_diag_count + 1);
 
         // Save the raw pointer into a shared_ptr to return it in __future and extend the lifetime of the storage.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -581,8 +581,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
         // Calculate nd-range params
         const nd_range_params __nd_range_params = eval_nd_range_params(__exec, __n, __n_sorted);
 
-        using __base_diagonals_sp_storage_t =
-            __result_and_scratch_storage<_ExecutionPolicy, _merge_split_point_t>;
+        using __base_diagonals_sp_storage_t = __result_and_scratch_storage<_ExecutionPolicy, _merge_split_point_t>;
 
         const std::size_t __n_power2 = oneapi::dpl::__internal::__dpl_bit_ceil(__n);
         // ctz precisely calculates log2 of an integral value which is a power of 2, while

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -582,7 +582,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
         const nd_range_params __nd_range_params = eval_nd_range_params(__exec, __n, __n_sorted);
 
         using __base_diagonals_sp_storage_t =
-            __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _merge_split_point_t>;
+            __result_and_scratch_storage_t<_ExecutionPolicy, _merge_split_point_t>;
 
         const std::size_t __n_power2 = oneapi::dpl::__internal::__dpl_bit_ceil(__n);
         // ctz precisely calculates log2 of an integral value which is a power of 2, while

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -582,7 +582,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
         const nd_range_params __nd_range_params = eval_nd_range_params(__exec, __n, __n_sorted);
 
         using __base_diagonals_sp_storage_t =
-            __result_and_scratch_storage_t<_ExecutionPolicy, _merge_split_point_t>;
+            __result_and_scratch_storage<_ExecutionPolicy, _merge_split_point_t>;
 
         const std::size_t __n_power2 = oneapi::dpl::__internal::__dpl_bit_ceil(__n);
         // ctz precisely calculates log2 of an integral value which is a power of 2, while

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -136,8 +136,8 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
-        using __result_scratch_t = __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>;
-        __result_scratch_t __scratch_container{__exec, 1, 0};
+        using __result_and_scratch_storage_t = __result_and_scratch_storage<_ExecutionPolicy, _Tp>;
+        __result_and_scratch_storage_t __scratch_container{__exec, 1, 0};
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
@@ -148,7 +148,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__res_acc);
+                    auto __res_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc);
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __iters_per_work_item, __is_full,
                                                     __transform_pattern, __reduce_pattern, __init, __temp_local,
                                                     __res_ptr, __rngs...);
@@ -191,7 +191,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
     operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, const _Size __n,
                const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _TransformOp __transform_op,
-               const __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>& __scratch_container,
+               const __result_and_scratch_storage<_ExecutionPolicy, _Tp>& __scratch_container,
                _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
@@ -213,7 +213,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __temp_ptr = __result_and_scratch_storage_t<_ExecutionPolicy,
+                    auto __temp_ptr = __result_and_scratch_storage<_ExecutionPolicy,
                                                                    _Tp>::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                     __device_reduce_kernel<_Tp>(__item_id, __n, __iters_per_work_item, __is_full, __n_groups,
                                                 __transform_pattern, __reduce_pattern, __temp_local, __temp_ptr,
@@ -238,7 +238,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
     operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, sycl::event& __reduce_event,
                const _Size __n, const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _InitType __init,
-               const __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>& __scratch_container) const
+               const __result_and_scratch_storage<_ExecutionPolicy, _Tp>& __scratch_container) const
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
@@ -248,7 +248,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
 
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
-        using __result_scratch_t = __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>;
+        using __result_and_scratch_storage_t = __result_and_scratch_storage<_ExecutionPolicy, _Tp>;
 
         __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
@@ -261,8 +261,8 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __temp_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                    auto __res_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__res_acc, __n);
+                    auto __temp_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                    auto __res_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc, __n);
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __iters_per_work_item, __is_full,
                                                     __transform_pattern, __reduce_pattern, __init, __temp_local,
                                                     __res_ptr, __temp_ptr);
@@ -291,7 +291,7 @@ __parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_t
     // number of buffer elements processed within workgroup
     const _Size __size_per_work_group = __iters_per_work_item_device_kernel * __work_group_size;
     const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
-    __result_and_scratch_storage_t<_ExecutionPolicy, _Tp> __scratch_container{__exec, 1, __n_groups};
+    __result_and_scratch_storage<_ExecutionPolicy, _Tp> __scratch_container{__exec, 1, __n_groups};
 
     sycl::event __reduce_event =
         __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _VecSize, _ReduceDeviceKernel>()(
@@ -341,8 +341,8 @@ struct __parallel_transform_reduce_impl
 
         // Create temporary global buffers to store temporary values
         const std::size_t __n_scratch = 2 * __n_groups;
-        using __result_scratch_t = __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>;
-        __result_scratch_t __scratch_container{__exec, 1, __n_scratch};
+        using __result_and_scratch_storage_t = __result_and_scratch_storage<_ExecutionPolicy, _Tp>;
+        __result_and_scratch_storage_t __scratch_container{__exec, 1, __n_scratch};
 
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
@@ -378,9 +378,9 @@ struct __parallel_transform_reduce_impl
                     sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                       sycl::range<1>(__work_group_size)),
                     [=](sycl::nd_item<1> __item_id) {
-                        auto __temp_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                        auto __temp_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                         auto __res_ptr =
-                            __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__res_acc, 2 * __n_groups);
+                            __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc, 2 * __n_groups);
                         auto __local_idx = __item_id.get_local_id(0);
                         auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -213,8 +213,9 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __temp_ptr = __result_and_scratch_storage<_ExecutionPolicy,
-                                                                   _Tp>::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                    auto __temp_ptr =
+                        __result_and_scratch_storage<_ExecutionPolicy, _Tp>::__get_usm_or_buffer_accessor_ptr(
+                            __temp_acc);
                     __device_reduce_kernel<_Tp>(__item_id, __n, __iters_per_work_item, __is_full, __n_groups,
                                                 __transform_pattern, __reduce_pattern, __temp_local, __temp_ptr,
                                                 __rngs...);
@@ -237,8 +238,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
     auto
     operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, sycl::event& __reduce_event,
                const _Size __n, const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
-               _InitType __init,
-               const __result_and_scratch_storage<_ExecutionPolicy, _Tp>& __scratch_container) const
+               _InitType __init, const __result_and_scratch_storage<_ExecutionPolicy, _Tp>& __scratch_container) const
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -136,8 +136,8 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
-        using __result_and_scratch_storage_t = __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _Tp>;
-        __result_and_scratch_storage_t __scratch_container{__exec, 1, 0};
+        using __result_scratch_t = __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>;
+        __result_scratch_t __scratch_container{__exec, 1, 0};
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
@@ -148,7 +148,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc);
+                    auto __res_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__res_acc);
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __iters_per_work_item, __is_full,
                                                     __transform_pattern, __reduce_pattern, __init, __temp_local,
                                                     __res_ptr, __rngs...);
@@ -191,7 +191,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
     operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, const _Size __n,
                const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _TransformOp __transform_op,
-               const __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _Tp>& __scratch_container,
+               const __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>& __scratch_container,
                _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
@@ -213,7 +213,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __temp_ptr = __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>,
+                    auto __temp_ptr = __result_and_scratch_storage_t<_ExecutionPolicy,
                                                                    _Tp>::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                     __device_reduce_kernel<_Tp>(__item_id, __n, __iters_per_work_item, __is_full, __n_groups,
                                                 __transform_pattern, __reduce_pattern, __temp_local, __temp_ptr,
@@ -238,7 +238,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
     operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, sycl::event& __reduce_event,
                const _Size __n, const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _InitType __init,
-               const __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _Tp>& __scratch_container) const
+               const __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>& __scratch_container) const
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
@@ -248,7 +248,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
 
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
-        using __result_and_scratch_storage_t = __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _Tp>;
+        using __result_scratch_t = __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>;
 
         __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
@@ -261,8 +261,8 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __temp_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                    auto __res_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc, __n);
+                    auto __temp_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                    auto __res_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__res_acc, __n);
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __iters_per_work_item, __is_full,
                                                     __transform_pattern, __reduce_pattern, __init, __temp_local,
                                                     __res_ptr, __temp_ptr);
@@ -291,7 +291,7 @@ __parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_t
     // number of buffer elements processed within workgroup
     const _Size __size_per_work_group = __iters_per_work_item_device_kernel * __work_group_size;
     const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
-    __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _Tp> __scratch_container{__exec, 1, __n_groups};
+    __result_and_scratch_storage_t<_ExecutionPolicy, _Tp> __scratch_container{__exec, 1, __n_groups};
 
     sycl::event __reduce_event =
         __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _VecSize, _ReduceDeviceKernel>()(
@@ -341,8 +341,8 @@ struct __parallel_transform_reduce_impl
 
         // Create temporary global buffers to store temporary values
         const std::size_t __n_scratch = 2 * __n_groups;
-        using __result_and_scratch_storage_t = __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _Tp>;
-        __result_and_scratch_storage_t __scratch_container{__exec, 1, __n_scratch};
+        using __result_scratch_t = __result_and_scratch_storage_t<_ExecutionPolicy, _Tp>;
+        __result_scratch_t __scratch_container{__exec, 1, __n_scratch};
 
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
@@ -378,9 +378,9 @@ struct __parallel_transform_reduce_impl
                     sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                       sycl::range<1>(__work_group_size)),
                     [=](sycl::nd_item<1> __item_id) {
-                        auto __temp_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                        auto __temp_ptr = __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                         auto __res_ptr =
-                            __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc, 2 * __n_groups);
+                            __result_scratch_t::__get_usm_or_buffer_accessor_ptr(__res_acc, 2 * __n_groups);
                         auto __local_idx = __item_id.get_local_id(0);
                         auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -813,7 +813,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     // We need temporary storage for reductions of each sub-group (__num_sub_groups_global).
     // Additionally, we need two elements for the block carry-out to prevent a race condition
     // between reading and writing the block carry-out within a single kernel.
-    __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _ValueType> __result_and_scratch{
+    __result_and_scratch_storage_t<_ExecutionPolicy, _ValueType> __result_and_scratch{
         __exec, 1, __num_sub_groups_global + 2};
 
     // Reduce and scan step implementations

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -813,7 +813,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     // We need temporary storage for reductions of each sub-group (__num_sub_groups_global).
     // Additionally, we need two elements for the block carry-out to prevent a race condition
     // between reading and writing the block carry-out within a single kernel.
-    __result_and_scratch_storage_t<_ExecutionPolicy, _ValueType> __result_and_scratch{
+    __result_and_scratch_storage<_ExecutionPolicy, _ValueType> __result_and_scratch{
         __exec, 1, __num_sub_groups_global + 2};
 
     // Reduce and scan step implementations

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -813,8 +813,8 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     // We need temporary storage for reductions of each sub-group (__num_sub_groups_global).
     // Additionally, we need two elements for the block carry-out to prevent a race condition
     // between reading and writing the block carry-out within a single kernel.
-    __result_and_scratch_storage<_ExecutionPolicy, _ValueType> __result_and_scratch{
-        __exec, 1, __num_sub_groups_global + 2};
+    __result_and_scratch_storage<_ExecutionPolicy, _ValueType> __result_and_scratch{__exec, 1,
+                                                                                    __num_sub_groups_global + 2};
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -578,8 +578,8 @@ struct __result_and_scratch_storage_impl : __result_and_scratch_storage_base
   public:
     __result_and_scratch_storage_impl(const _ExecutionPolicy& __exec_, std::size_t __result_n, std::size_t __scratch_n)
         : __exec{__exec_}, __result_n{__result_n}, __scratch_n{__scratch_n},
-          __use_USM_host{__use_USM_host_allocations(__exec.queue())}, __supports_USM_device{
-                                                                          __use_USM_allocations(__exec.queue())}
+          __use_USM_host{__use_USM_host_allocations(__exec.queue())},
+          __supports_USM_device{__use_USM_allocations(__exec.queue())}
     {
         const std::size_t __total_n = __scratch_n + __result_n;
         // Skip in case this is a dummy container
@@ -697,7 +697,7 @@ struct __result_and_scratch_storage_impl : __result_and_scratch_storage_base
 };
 
 template <typename _ExecutionPolicy, typename _T>
-using __result_and_scratch_storage = __result_and_scratch_storage_impl<std::decay_t<_ExecutionPolicy>, _T>; 
+using __result_and_scratch_storage = __result_and_scratch_storage_impl<std::decay_t<_ExecutionPolicy>, _T>;
 
 // Tag __async_mode describe a pattern call mode which should be executed asynchronously
 struct __async_mode
@@ -728,7 +728,7 @@ class __future : private std::tuple<_Args...>
         return __buf.get_host_access(sycl::read_only)[0];
     }
 
-    // Here we use __result_and_scratch_storage_impl rather than __result_and_scratch_storage because we need to 
+    // Here we use __result_and_scratch_storage_impl rather than __result_and_scratch_storage because we need to
     // match the type with the overload and are deducing the policy type. If we used __result_and_scratch_storage,
     // it would cause issues in type deduction due to decay of the policy in that using statement.
     template <typename _DecayedExecutionPolicy, typename _T>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -528,7 +528,7 @@ struct __result_and_scratch_storage_base
 };
 
 template <typename _ExecutionPolicy, typename _T>
-struct __result_and_scratch_storage : __result_and_scratch_storage_base
+struct __result_and_scratch_storage_impl : __result_and_scratch_storage_base
 {
   private:
     using __sycl_buffer_t = sycl::buffer<_T, 1>;
@@ -576,7 +576,7 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
     }
 
   public:
-    __result_and_scratch_storage(const _ExecutionPolicy& __exec_, std::size_t __result_n, std::size_t __scratch_n)
+    __result_and_scratch_storage_impl(const _ExecutionPolicy& __exec_, std::size_t __result_n, std::size_t __scratch_n)
         : __exec{__exec_}, __result_n{__result_n}, __scratch_n{__scratch_n},
           __use_USM_host{__use_USM_host_allocations(__exec.queue())}, __supports_USM_device{
                                                                           __use_USM_allocations(__exec.queue())}

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -697,7 +697,7 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
 };
 
 template <typename _ExecutionPolicy, typename _T>
-using __result_and_scratch_storage_t = __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _T>; 
+using __result_and_scratch_storage = __result_and_scratch_storage_impl<std::decay_t<_ExecutionPolicy>, _T>; 
 
 // Tag __async_mode describe a pattern call mode which should be executed asynchronously
 struct __async_mode
@@ -730,7 +730,7 @@ class __future : private std::tuple<_Args...>
 
     template <typename _DecayedExecutionPolicy, typename _T>
     constexpr auto
-    __wait_and_get_value(const __result_and_scratch_storage<_DecayedExecutionPolicy, _T>& __storage)
+    __wait_and_get_value(const __result_and_scratch_storage_impl<_DecayedExecutionPolicy, _T>& __storage)
     {
         return __storage.__wait_and_get_value(__my_event);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -696,6 +696,9 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
     }
 };
 
+template <typename _ExecutionPolicy, typename _T>
+using __result_and_scratch_storage_t = __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _T>; 
+
 // Tag __async_mode describe a pattern call mode which should be executed asynchronously
 struct __async_mode
 {
@@ -725,9 +728,9 @@ class __future : private std::tuple<_Args...>
         return __buf.get_host_access(sycl::read_only)[0];
     }
 
-    template <typename _ExecutionPolicy, typename _T>
+    template <typename _DecayedExecutionPolicy, typename _T>
     constexpr auto
-    __wait_and_get_value(const __result_and_scratch_storage<_ExecutionPolicy, _T>& __storage)
+    __wait_and_get_value(const __result_and_scratch_storage<_DecayedExecutionPolicy, _T>& __storage)
     {
         return __storage.__wait_and_get_value(__my_event);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -728,6 +728,9 @@ class __future : private std::tuple<_Args...>
         return __buf.get_host_access(sycl::read_only)[0];
     }
 
+    // Here we use __result_and_scratch_storage_impl rather than __result_and_scratch_storage because we need to 
+    // match the type with the overload and are deducing the policy type. If we used __result_and_scratch_storage,
+    // it would cause issues in type deduction due to decay of the policy in that using statement.
     template <typename _DecayedExecutionPolicy, typename _T>
     constexpr auto
     __wait_and_get_value(const __result_and_scratch_storage_impl<_DecayedExecutionPolicy, _T>& __storage)


### PR DESCRIPTION
This adds a using statement to define `__result_and_scratch_storage`   which does the decay of the execution policy for the caller, and makes the actual type `__result_and_scratch_storage_impl`.

I'm not sure I like this, because it "hides" the decay of the policy.  It certainly makes usage easier, but also obfuscates what is really happening here. 

What do you guys think?