### PR TITLE
Bugfix to avoid `__out` for MSVC

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2954,10 +2954,10 @@ __pattern_remove_if(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, 
 // the identical elements from the 2nd sequence are merged first.
 template <typename _Iterator1, typename _Iterator2, typename _Iterator3, typename _Comp>
 std::pair<_Iterator1, _Iterator2>
-__serial_merge_out_lim(_Iterator1 __x, _Iterator1 __x_e, _Iterator2 __y, _Iterator2 __y_e, _Iterator3 __out,
+__serial_merge_out_lim(_Iterator1 __x, _Iterator1 __x_e, _Iterator2 __y, _Iterator2 __y_e, _Iterator3 __out_b,
                        _Iterator3 __out_e, _Comp __comp)
 {
-    for (_Iterator3 __k = __out; __k != __out_e; ++__k)
+    for (_Iterator3 __k = __out_b; __k != __out_e; ++__k)
     {
         if (__x == __x_e)
         {


### PR DESCRIPTION
__out is a macro in Microsoft C++ SAL (Source Annotation Language).
We cant use it as a variable name.  Causes compiler errors for microsoft platforms.
