### PR TITLE
Bugfix: define NOMINMAX in a limited way around TBB less than 2021.12

### DIFF
--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -48,14 +48,14 @@
 #include <tbb/tbb_allocator.h>
 #include <tbb/enumerable_thread_specific.h>
 
+#if TBB_INTERFACE_VERSION > 12000
+#    include <tbb/task.h>
+#endif
+
 #if __ONEDPL_DEFINED_NOMINMAX
 // Avoid affecting outside code with NOMINMAX
 #    undef NOMINMAX
 #    undef __ONEDPL_DEFINED_NOMINMAX
-#endif
-
-#if TBB_INTERFACE_VERSION > 12000
-#    include <tbb/task.h>
 #endif
 
 #if TBB_INTERFACE_VERSION < 10000

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -36,23 +36,23 @@
 #include <tbb/tbb_allocator.h>
 
 #if _WIN32 || _WIN64
-    // For windows, TBB prior to version 2021.12 requires NOMINMAX to be defined before including
-    // tbb/enumerable_thread_specific.h, which includes windows.h. This is not required for TBB 2021.12 and later due
-    // to an TBB fix.
-    #if TBB_VERSION_MAJOR < 2021 || (TBB_VERSION_MAJOR == 2021 && TBB_VERSION_MINOR < 12)
-        #ifndef NOMINMAX
-            #define NOMINMAX
-            #define __ONEDPL_DEFINED_NOMINMAX 1
-        #endif
-    #endif
+// For windows, TBB prior to version 2021.12 requires NOMINMAX to be defined before including
+// tbb/enumerable_thread_specific.h, which includes windows.h. This is not required for TBB 2021.12 and later due
+// to an TBB fix.
+#    if TBB_VERSION_MAJOR < 2021 || (TBB_VERSION_MAJOR == 2021 && TBB_VERSION_MINOR < 12)
+#        ifndef NOMINMAX
+#            define NOMINMAX
+#            define __ONEDPL_DEFINED_NOMINMAX 1
+#        endif
+#    endif
 #endif
 
 #include <tbb/enumerable_thread_specific.h>
 
 #if __ONEDPL_DEFINED_NOMINMAX
-    // Avoid affecting outside code with NOMINMAX
-    #undef NOMINMAX
-    #undef __ONEDPL_DEFINED_NOMINMAX
+// Avoid affecting outside code with NOMINMAX
+#    undef NOMINMAX
+#    undef __ONEDPL_DEFINED_NOMINMAX
 #endif
 
 #if TBB_INTERFACE_VERSION > 12000

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -25,6 +25,18 @@
 #include "parallel_backend_utils.h"
 #include "execution_impl.h"
 
+#if _WIN32 || _WIN64
+// For windows, TBB prior to version 2021.12 requires NOMINMAX to be defined before including
+// tbb/enumerable_thread_specific.h, which includes windows.h. This is not required for TBB 2021.12 and later due
+// to an TBB fix.
+#    if TBB_INTERFACE_VERSION < 12120
+#        ifndef NOMINMAX
+#            define NOMINMAX
+#            define __ONEDPL_DEFINED_NOMINMAX 1
+#        endif
+#    endif
+#endif
+
 // Bring in minimal required subset of Intel(R) Threading Building Blocks (Intel(R) TBB)
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
@@ -34,19 +46,6 @@
 #include <tbb/parallel_invoke.h>
 #include <tbb/task_arena.h>
 #include <tbb/tbb_allocator.h>
-
-#if _WIN32 || _WIN64
-// For windows, TBB prior to version 2021.12 requires NOMINMAX to be defined before including
-// tbb/enumerable_thread_specific.h, which includes windows.h. This is not required for TBB 2021.12 and later due
-// to an TBB fix.
-#    if TBB_VERSION_MAJOR < 2021 || (TBB_VERSION_MAJOR == 2021 && TBB_VERSION_MINOR < 12)
-#        ifndef NOMINMAX
-#            define NOMINMAX
-#            define __ONEDPL_DEFINED_NOMINMAX 1
-#        endif
-#    endif
-#endif
-
 #include <tbb/enumerable_thread_specific.h>
 
 #if __ONEDPL_DEFINED_NOMINMAX

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -34,7 +34,27 @@
 #include <tbb/parallel_invoke.h>
 #include <tbb/task_arena.h>
 #include <tbb/tbb_allocator.h>
+
+#if _WIN32 || _WIN64
+    // For windows, TBB prior to version 2021.12 requires NOMINMAX to be defined before including
+    // tbb/enumerable_thread_specific.h, which includes windows.h. This is not required for TBB 2021.12 and later due
+    // to an TBB fix.
+    #if TBB_VERSION_MAJOR < 2021 || (TBB_VERSION_MAJOR == 2021 && TBB_VERSION_MINOR < 12)
+        #ifndef NOMINMAX
+            #define NOMINMAX
+            #define __ONEDPL_DEFINED_NOMINMAX 1
+        #endif
+    #endif
+#endif
+
 #include <tbb/enumerable_thread_specific.h>
+
+#if __ONEDPL_DEFINED_NOMINMAX
+    // Avoid affecting outside code with NOMINMAX
+    #undef NOMINMAX
+    #undef __ONEDPL_DEFINED_NOMINMAX
+#endif
+
 #if TBB_INTERFACE_VERSION > 12000
 #    include <tbb/task.h>
 #endif

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -26,9 +26,9 @@
 #include "execution_impl.h"
 
 #if _WIN32 || _WIN64
-// For windows, TBB prior to version 2021.12 requires NOMINMAX to be defined before including
-// tbb/enumerable_thread_specific.h, which includes windows.h. This is not required for TBB 2021.12 and later due
-// to an TBB fix.
+// Prior to version 2021.12, TBB requires NOMINMAX to be defined before including
+// tbb/enumerable_thread_specific.h, which includes windows.h.
+// This is no more required since TBB 2021.12 due to a TBB fix.
 #    if TBB_INTERFACE_VERSION < 12120
 #        ifndef NOMINMAX
 #            define NOMINMAX


### PR DESCRIPTION
In 2021.12, TBB fixed an issue with `tbb/enumerable_thread_specific.h` which includes `windows.h` by wrapping it in a `NOMINMAX` define.  
https://github.com/uxlfoundation/oneTBB/pull/1291

To work with versions of TBB prior to 2021.12, we need to do the same prior to including `tbb/enumerable_thread_specific.h` on windows.