### PR TITLE
Stop using std::is_trivial

### DIFF
--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -263,15 +263,15 @@ template <class _ExecutionPolicy, class _ForwardIterator>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
-    if constexpr (!::std::is_trivial_v<_ValueType>)
+    if constexpr (!std::is_trivially_default_constructible_v<_ValueType>)
     {
         const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
         oneapi::dpl::__internal::__pattern_walk1(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{});
     }
 }
@@ -280,10 +280,10 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 {
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
-    if constexpr (::std::is_trivial_v<_ValueType>)
+    if constexpr (std::is_trivially_default_constructible_v<_ValueType>)
     {
         return oneapi::dpl::__internal::__pstl_next(__first, __n);
     }
@@ -292,7 +292,7 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __
         const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
         return oneapi::dpl::__internal::__pattern_walk1_n(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{});
     }
 }

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -141,22 +141,22 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    if constexpr (::std::is_arithmetic_v<_ValueType>)
+    if constexpr (std::is_trivially_default_constructible_v<_ValueType> && std::is_trivially_copyable_v<_ValueType>)
     {
         oneapi::dpl::__internal::__pattern_walk_brick(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__brick_fill<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
                 _ValueType(__value)});
     }
     else
     {
         oneapi::dpl::__internal::__pattern_walk1(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value});
     }
 }
@@ -165,22 +165,22 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, const _Tp& __value)
 {
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    if constexpr (::std::is_arithmetic_v<_ValueType>)
+    if constexpr (std::is_trivially_default_constructible_v<_ValueType> && std::is_trivially_copyable_v<_ValueType>)
     {
         return oneapi::dpl::__internal::__pattern_walk_brick_n(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__brick_fill_n<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
                 _ValueType(__value)});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk1_n(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value});
     }
 }
@@ -303,22 +303,22 @@ template <class _ExecutionPolicy, class _ForwardIterator>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    if constexpr (::std::is_trivial_v<_ValueType>)
+    if constexpr (std::is_trivially_default_constructible_v<_ValueType> && std::is_trivially_copyable_v<_ValueType>)
     {
         oneapi::dpl::__internal::__pattern_walk_brick(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__brick_fill<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
                 _ValueType()});
     }
     else
     {
         oneapi::dpl::__internal::__pattern_walk1(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{});
     }
 }
@@ -327,22 +327,22 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 {
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    if constexpr (::std::is_trivial_v<_ValueType>)
+    if constexpr (std::is_trivially_default_constructible_v<_ValueType> && std::is_trivially_copyable_v<_ValueType>)
     {
         return oneapi::dpl::__internal::__pattern_walk_brick_n(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__brick_fill_n<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
                 _ValueType()});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk1_n(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{});
     }
 }

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -41,22 +41,22 @@ template <class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result)
 {
-    typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    if constexpr (std::is_trivially_default_constructible_v<_ValueType> &&
+                  std::is_trivially_assignable_v<_ValueType, std::iterator_traits<_InputIterator>::reference>)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
             oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
             oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{});
     }
 }
@@ -65,22 +65,22 @@ template <class _ExecutionPolicy, class _InputIterator, class _Size, class _Forw
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result)
 {
-    typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    if constexpr (std::is_trivially_default_constructible_v<_ValueType> &&
+                  std::is_trivially_assignable_v<_ValueType, std::iterator_traits<_InputIterator>::reference>)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick_n(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
             oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2_n(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
             oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{});
     }
 }
@@ -91,22 +91,22 @@ template <class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result)
 {
-    typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    if constexpr (std::is_trivially_default_constructible_v<_ValueType> &&
+                  std::is_trivially_assignable_v<_ValueType, std::iterator_traits<_InputIterator>::reference>)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
             oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
             oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{});
     }
 }
@@ -115,22 +115,22 @@ template <class _ExecutionPolicy, class _InputIterator, class _Size, class _Forw
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result)
 {
-    typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    if constexpr (std::is_trivially_default_constructible_v<_ValueType> &&
+                  std::is_trivially_assignable_v<_ValueType, std::iterator_traits<_InputIterator>::reference>)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick_n(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
             oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2_n(
-            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
             oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{});
     }
 }

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -214,10 +214,10 @@ template <class _ExecutionPolicy, class _ForwardIterator>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
 
-    if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
+    if constexpr (!std::is_trivially_destructible_v<_ValueType>)
     {
         const auto __dispatch_tag =
 #if (_PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN || _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN)
@@ -226,7 +226,7 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
             oneapi::dpl::__internal::__select_backend(__exec, __first);
 #endif
 
-        oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
+        oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first,
                                                  __last, [](_ReferenceType __val) { __val.~_ValueType(); });
     }
 }
@@ -235,10 +235,10 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 {
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
 
-    if constexpr (::std::is_trivially_destructible_v<_ValueType>)
+    if constexpr (std::is_trivially_destructible_v<_ValueType>)
     {
         return oneapi::dpl::__internal::__pstl_next(__first, __n);
     }
@@ -251,7 +251,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
             oneapi::dpl::__internal::__select_backend(__exec, __first);
 #endif
 
-        return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+        return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
                                                           __first, __n,
                                                           [](_ReferenceType __val) { __val.~_ValueType(); });
     }

--- a/include/oneapi/dpl/type_traits
+++ b/include/oneapi/dpl/type_traits
@@ -84,7 +84,7 @@ using ::std::is_same;
 using ::std::is_scalar;
 using ::std::is_signed;
 using ::std::is_standard_layout;
-using ::std::is_trivial;
+using ::std::is_trivial; // Deprecated in C++26
 using ::std::is_trivially_assignable;
 using ::std::is_trivially_constructible;
 using ::std::is_trivially_copy_assignable;
@@ -191,7 +191,7 @@ using ::std::is_same_v;
 using ::std::is_scalar_v;
 using ::std::is_signed_v;
 using ::std::is_standard_layout_v;
-using ::std::is_trivial_v;
+using ::std::is_trivial_v; // Deprecated in C++26
 using ::std::is_trivially_assignable_v;
 using ::std::is_trivially_constructible_v;
 using ::std::is_trivially_copy_assignable_v;


### PR DESCRIPTION
Since `std::is_trivial` is deprecated in C++ 26, it makes sense to get rid of it in our code in advance. This is requested in the issue #1961.

In `type_traits`, we simply inject names into the oneDPL namespace, so the only change there so far is to add a comment.

In `glue_memory_impl,h`, `is_trivial` is checked to "optimize" the implementation for trivial types (it is worth checking if that really brings any performance improvement, but let's keep that for later). There we have a few cases:

- In `uninitialized_copy/move`, the in-place construction is changed to the "copy" brick, which essentially does an assignment like `*result = *input`. Therefore, here the check is for the result value type to be trivially default-constructible and trivially assignable from the input reference type.
- In `uninitialized_value_construct`, the "optimization" uses the "fill" brick which assigns a given value of the output value type. Therefore the new check is for trivially default-constructible and trivially copyable. The same logic applies to `uninitialized_fill`, which currently (before the patch) checks for `std::is_arithmetic` :)
- In `uninitialized_default_construct`, construction is fully skipped - so the check should be for trivially default-constructible only.

Each of the described cases is fixed  (and can be reviewed) in a separate commit.