### PR TITLE
Fix duplicate kernel naming in reduce-then-scan kernels

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -763,11 +763,11 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     // necessary to obtain a unique kernel name. However, if these compile time variables are adjusted in the
     // future, then we need to be careful here to ensure unique kernel naming.
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        __reduce_then_scan_reduce_kernel, _CustomName, _InRng, _OutRng, _GenReduceInput, _ReduceOp, _InitType,
-        _Inclusive, _IsUniquePattern>;
+        __reduce_then_scan_reduce_kernel, _CustomName, _ExecutionPolicy, _InRng, _OutRng, _GenReduceInput, _ReduceOp,
+        _InitType, _Inclusive, _IsUniquePattern>;
     using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        __reduce_then_scan_scan_kernel, _CustomName, _InRng, _OutRng, _GenScanInput, _ReduceOp, _ScanInputTransform,
-        _WriteOp, _InitType, _Inclusive, _IsUniquePattern>;
+        __reduce_then_scan_scan_kernel, _CustomName, _ExecutionPolicy, _InRng, _OutRng, _GenScanInput, _ReduceOp,
+        _ScanInputTransform, _WriteOp, _InitType, _Inclusive, _IsUniquePattern>;
     static auto __kernels = __internal::__kernel_compiler<_ReduceKernel, _ScanKernel>::__compile(__exec);
     const sycl::kernel& __reduce_kernel = __kernels[0];
     const sycl::kernel& __scan_kernel = __kernels[1];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -282,15 +282,15 @@ struct __parallel_reduce_then_scan_reduce_submitter
 {
     // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
     // input buffer
-    template <typename _ExecutionPolicy, typename _InRng, typename _TmpStorageAcc>
+    template <typename _InRng, typename _TmpStorageAcc>
     sycl::event
-    operator()(_ExecutionPolicy&& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
+    operator()(sycl::queue __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
                const std::size_t __block_num, const sycl::kernel& __reduce_kernel) const
     {
         using _InitValueType = typename _InitType::__value_type;
-        return __exec.queue().submit([&, this](sycl::handler& __cgh) {
+        return __q.submit([&, this](sycl::handler& __cgh) {
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__num_sub_groups_local, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
@@ -432,9 +432,9 @@ struct __parallel_reduce_then_scan_scan_submitter
         __tmp_ptr[__num_sub_groups_global + 1 - (__block_num % 2)] = __block_carry_out;
     }
 
-    template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _TmpStorageAcc>
+    template <typename _InRng, typename _OutRng, typename _TmpStorageAcc>
     sycl::event
-    operator()(_ExecutionPolicy&& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
+    operator()(sycl::queue __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
                const std::size_t __block_num, const sycl::kernel& __scan_kernel) const
@@ -442,7 +442,7 @@ struct __parallel_reduce_then_scan_scan_submitter
         std::uint32_t __inputs_in_block = std::min(__n - __block_num * __max_block_size, std::size_t{__max_block_size});
         std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
             __inputs_in_block, __inputs_per_sub_group * __num_sub_groups_local);
-        return __exec.queue().submit([&, this](sycl::handler& __cgh) {
+        return __q.submit([&, this](sycl::handler& __cgh) {
             // We need __num_sub_groups_local + 1 temporary SLM locations to store intermediate results:
             //   __num_sub_groups_local for each sub-group partial from the reduce kernel +
             //   1 element for the accumulated block-local carry-in from previous groups in the block
@@ -845,6 +845,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
                                     __write_op,
                                     __init};
     sycl::event __event;
+    sycl::queue __q = __exec.queue();
     // Data is processed in 2-kernel blocks to allow contiguous input segment to persist in LLC between the first and second kernel for accelerators
     // with sufficiently large L2 / L3 caches.
     for (std::size_t __b = 0; __b < __num_blocks; ++__b)
@@ -857,10 +858,10 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         auto __local_range = sycl::range<1>(__work_group_size);
         auto __kernel_nd_range = sycl::nd_range<1>(__global_range, __local_range);
         // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
-        __event = __reduce_submitter(__exec, __kernel_nd_range, __in_rng, __result_and_scratch, __event,
+        __event = __reduce_submitter(__q, __kernel_nd_range, __in_rng, __result_and_scratch, __event,
                                      __inputs_per_sub_group, __inputs_per_item, __b, __reduce_kernel);
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.
-        __event = __scan_submitter(__exec, __kernel_nd_range, __in_rng, __out_rng, __result_and_scratch, __event,
+        __event = __scan_submitter(__q, __kernel_nd_range, __in_rng, __out_rng, __result_and_scratch, __event,
                                    __inputs_per_sub_group, __inputs_per_item, __b, __scan_kernel);
         __inputs_remaining -= std::min(__inputs_remaining, __block_size);
         // We only need to resize these parameters prior to the last block as it is the only non-full case.


### PR DESCRIPTION
## Description
https://github.com/uxlfoundation/oneDPL/pull/2031 reverted the change in https://github.com/uxlfoundation/oneDPL/pull/1997 which always passed execution policies through reduce-then-scan as const l-value references. After this, we began to see duplicate kernel name compilation errors in `scan_2.pass`.

This observed bug is caused by the fact that the execution policy is passed to the submitter function objects as a forwarding reference in the reduce-then-scan submitters. This means that even though the kernel names have been properly generated to be "unique", different cv / ref qualifiers of the execution policy will lead to separate function template instantiations and will be submitting separate kernels as a result. This subtle issue results in duplicate kernel names even if the kernels themselves are logically the same as the same name is used throughout.

To fix this, I have switched the function call operators of the submitters to accept a `sycl::queue` as this is all that is needed at this level.

## Further Details
Here is a minimal reproducer of the underlying issue to go alongside the explanation:
```cpp
#include <sycl/sycl.hpp>
#include <utility>

template <typename KernelName, typename Dummy>
void foo(Dummy&&, sycl::queue q)
{
    q.submit([](sycl::handler& cgh){
        cgh.single_task<KernelName>([] {
            sycl::ext::oneapi::experimental::printf("hello world\n");
        });
    }).wait();
}

struct dummy
{
};

class kernel;

int main()
{
    sycl::queue q;
    dummy d;
    
    // We will see a compiler error due to duplicate kernel names.
    foo<kernel>(d, q);
    foo<kernel>(std::move(d), q);
}
```