### PR TITLE
NOMINMAX Adding cmake, documentation and header define for windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ endif()
 
 if (WIN32)
     # oneDPL is incompatible with min/max macros defined in windows.h, NOMINMAX must be defined to avoid them
+    message(STATUS "Defining NOMINMAX to avoid collisions with windows macros")
     target_compile_options(oneDPL INTERFACE -DNOMINMAX)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ else()
 endif()
 
 if (MSVC)
-    target_compile_options(oneDPL INTERFACE /Zc:__cplusplus /EHsc)
+    target_compile_options(oneDPL INTERFACE /Zc:__cplusplus /EHsc /DNOMINMAX)
 else()
     set(CMAKE_CXX_FLAGS_DEBUG "-O0 ${CMAKE_CXX_FLAGS_DEBUG}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,8 +128,13 @@ else()
     message(STATUS "Build type is not set")
 endif()
 
+if (WIN32)
+    # oneDPL is incompatible with min/max macros defined in windows.h, NOMINMAX must be defined to avoid them
+    target_compile_options(oneDPL INTERFACE -DNOMINMAX)
+endif()
+
 if (MSVC)
-    target_compile_options(oneDPL INTERFACE /Zc:__cplusplus /EHsc /DNOMINMAX)
+    target_compile_options(oneDPL INTERFACE /Zc:__cplusplus /EHsc)
 else()
     set(CMAKE_CXX_FLAGS_DEBUG "-O0 ${CMAKE_CXX_FLAGS_DEBUG}")
 endif()

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -126,7 +126,7 @@ add_subdirectory(/path/to/oneDPL build_oneDPL)
 The supported generator in the Windows environment is Ninja, we recommend using `-GNinja` in your cmake configuration.
 
 To avoid definition of macros for min and max if and when windows.h is included, oneDPL's cmake defines `NOMINMAX`.
-These macros conflict with standard library functions and oneDPL internal functions, and cause compiler problems.
+These macros conflict with standard library functions and oneDPL internal functions, and cause compilation errors.
 
 ### oneDPLConfig files generation
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -123,7 +123,10 @@ set(ONEDPL_BACKEND tbb)
 add_subdirectory(/path/to/oneDPL build_oneDPL)
 ```
 
-Finally, the supported generator in the Windows environment is Ninja, we recommend using `-GNinja` in your cmake configuration.
+The supported generator in the Windows environment is Ninja, we recommend using `-GNinja` in your cmake configuration.
+
+To avoid definition of macros for min and max if and when windows.h is included, oneDPL's cmake defines `NOMINMAX`.
+These macros conflict with standard library functions and oneDPL internal functions, and cause compiler problems.
 
 ### oneDPLConfig files generation
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -125,7 +125,7 @@ add_subdirectory(/path/to/oneDPL build_oneDPL)
 
 The supported generator in the Windows environment is Ninja, we recommend using `-GNinja` in your cmake configuration.
 
-To avoid definition of macros for min and max if and when windows.h is included, oneDPL's cmake defines `NOMINMAX`.
+To avoid definition of macros for `min` and `max` if and when windows.h is included, oneDPL's cmake defines `NOMINMAX`.
 These macros conflict with standard library functions and oneDPL internal functions, and cause compilation errors.
 
 ### oneDPLConfig files generation

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -49,6 +49,11 @@ if (EXISTS "${_onedpl_headers}")
         include(CheckCXXCompilerFlag)
         include(CheckIncludeFileCXX)
 
+        if (CMAKE_HOST_WIN32)
+            # oneDPL is incompatible with min/max macros defined in windows.h, NOMINMAX must be defined to avoid them
+            set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_OPTIONS /DNOMINMAX)
+        endif()
+
         add_library(oneDPL INTERFACE IMPORTED)
         set_target_properties(oneDPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_onedpl_headers}")
 

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -49,7 +49,6 @@ if (EXISTS "${_onedpl_headers}")
         include(CheckCXXCompilerFlag)
         include(CheckIncludeFileCXX)
 
-
         add_library(oneDPL INTERFACE IMPORTED)
         set_target_properties(oneDPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_onedpl_headers}")
 

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -49,13 +49,14 @@ if (EXISTS "${_onedpl_headers}")
         include(CheckCXXCompilerFlag)
         include(CheckIncludeFileCXX)
 
+
+        add_library(oneDPL INTERFACE IMPORTED)
+        set_target_properties(oneDPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_onedpl_headers}")
+
         if (CMAKE_HOST_WIN32)
             # oneDPL is incompatible with min/max macros defined in windows.h, NOMINMAX must be defined to avoid them
             set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_OPTIONS /DNOMINMAX)
         endif()
-
-        add_library(oneDPL INTERFACE IMPORTED)
-        set_target_properties(oneDPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_onedpl_headers}")
 
         target_compile_features(oneDPL INTERFACE cxx_std_17)
 

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -54,6 +54,7 @@ if (EXISTS "${_onedpl_headers}")
 
         if (WIN32)
             # oneDPL is incompatible with min/max macros defined in windows.h, NOMINMAX must be defined to avoid them
+            message(STATUS "oneDPL: Defining NOMINMAX to avoid collisions with windows macros")
             set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_OPTIONS -DNOMINMAX)
         endif()
 

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -52,9 +52,9 @@ if (EXISTS "${_onedpl_headers}")
         add_library(oneDPL INTERFACE IMPORTED)
         set_target_properties(oneDPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_onedpl_headers}")
 
-        if (CMAKE_HOST_WIN32)
+        if (WIN32)
             # oneDPL is incompatible with min/max macros defined in windows.h, NOMINMAX must be defined to avoid them
-            set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_OPTIONS /DNOMINMAX)
+            set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_OPTIONS -DNOMINMAX)
         endif()
 
         target_compile_features(oneDPL INTERFACE cxx_std_17)

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -162,4 +162,9 @@ Known Limitations
 * For ``remove``, ``remove_if``, ``unique`` the dereferenced value type of the provided
   iterators should be ``MoveConstructible``.
 
+Windows Specific Information
+****************************
+* When compiling on windows, add /DNOMINMAX to the compilation command to avoid conflicts with the min and max macros
+  defined in the Windows.h header file.
+
 .. _`SYCL Specification`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -82,6 +82,12 @@
 #    define _ONEDPL_PRAGMA(x) _Pragma(#    x)
 #endif
 
+// For Windows, define NOMINMAX to avoid definition of min and max macros inside of windows.h which clash with STL
+#ifdef _MSC_VER && !defined(NOMINMAX)
+#    define NOMINMAX
+#    define _ONEDPL_DEFINED_NOMINMAX 1
+#endif
+
 #define _ONEDPL_STRING_AUX(x) #x
 #define _ONEDPL_STRING(x) _ONEDPL_STRING_AUX(x)
 #define _ONEDPL_STRING_CONCAT(x, y) x #y


### PR DESCRIPTION
Defining NOMINMAX in cmake, describing its requirement in docs, adding it to be defined by onedpl_config.h all to avoid collisions with macros `min` and `max` defined when including windows.h.