### PR TITLE
[Draft] Protecting min and max usages from macro collisions

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -44,7 +44,7 @@ __one_wg_kernel(sycl::nd_item<1> __idx, ::std::uint32_t __n, _RngPack1&& __rng_p
 
     // max SLM is 256 * 4 * 64 + 256 * 2 * 64 + 257*2, 97KB, when  __data_per_work_item = 256, __bin_count = 256
     // to support 512 processing size, we can use all SLM as reorder buffer with cost of more barrier
-    __dpl_esimd::__ns::slm_init<::std::max(__reorder_slm_size, __bin_hist_slm_size + __incoming_offset_slm_size)>();
+    __dpl_esimd::__ns::slm_init<(std::max)(__reorder_slm_size, __bin_hist_slm_size + __incoming_offset_slm_size)>();
 
     const ::std::uint32_t __local_tid = __idx.get_local_linear_id();
 
@@ -401,7 +401,7 @@ struct __radix_sort_onesweep_kernel
             __work_item_all_hists_size + __group_hist_size + __global_hist_size;
         constexpr ::std::uint32_t __reorder_substage_slm = __reorder_size + __global_hist_size;
 
-        constexpr ::std::uint32_t __slm_size = ::std::max(__offset_calc_substage_slm, __reorder_substage_slm);
+        constexpr ::std::uint32_t __slm_size = (std::max)(__offset_calc_substage_slm, __reorder_substage_slm);
         // Workaround: Align SLM allocation at 2048 byte border to avoid internal compiler error.
         // The error happens when allocating 65 * 1024 bytes, when e.g. T=int, DataPerWorkItem=256, WorkGroupSize=64
         // TODO: use __slm_size once the issue with SLM allocation has been fixed

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -152,7 +152,7 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Int, _N> __src)
     using _UInt = ::std::make_unsigned_t<_Int>;
     // __mask: 100..0 for ascending, 011..1 for descending
     constexpr _UInt __mask =
-        (__is_ascending) ? _UInt(1) << (std::numeric_limits<_Int>::digits : ::std::numeric_limits<_UInt>::max)() >> 1;
+        (__is_ascending) ? _UInt(1) << std::numeric_limits<_Int>::digits : (std::numeric_limits<_UInt>::max)() >> 1;
     return __src.template bit_cast_view<_UInt>() ^ __mask;
 }
 

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -92,7 +92,7 @@ constexpr _T
 __sort_identity()
 {
     if constexpr (__is_ascending)
-        return ::std::numeric_limits<_T>::max();
+        return (std::numeric_limits<_T>::max)();
     else
         return ::std::numeric_limits<_T>::lowest();
 }
@@ -152,7 +152,7 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Int, _N> __src)
     using _UInt = ::std::make_unsigned_t<_Int>;
     // __mask: 100..0 for ascending, 011..1 for descending
     constexpr _UInt __mask =
-        (__is_ascending) ? _UInt(1) << ::std::numeric_limits<_Int>::digits : ::std::numeric_limits<_UInt>::max() >> 1;
+        (__is_ascending) ? _UInt(1) << (std::numeric_limits<_Int>::digits : ::std::numeric_limits<_UInt>::max)() >> 1;
     return __src.template bit_cast_view<_UInt>() ^ __mask;
 }
 

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -164,7 +164,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
+    const bool use_32bit_indexing = size <= (std::numeric_limits<std::uint32_t>::max)();
     __bknd::__parallel_for(
         _BackendTag{}, ::std::forward<decltype(policy)>(policy),
         __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::lower_bound>{
@@ -197,7 +197,7 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
+    const bool use_32bit_indexing = size <= (std::numeric_limits<std::uint32_t>::max)();
     __bknd::__parallel_for(
         _BackendTag{}, std::forward<decltype(policy)>(policy),
         __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::upper_bound>{
@@ -230,7 +230,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
+    const bool use_32bit_indexing = size <= (std::numeric_limits<std::uint32_t>::max)();
     __bknd::__parallel_for(
         _BackendTag{}, std::forward<decltype(policy)>(policy),
         __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::binary_search>{

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -73,7 +73,7 @@ class auto_tune_policy
 
         report_clock_type::time_point t0_;
 
-        timing_t best_timing_ = std::numeric_limits<timing_t>::max();
+        timing_t best_timing_ = (std::numeric_limits<timing_t>::max)();
         resource_with_index_t best_resource_;
 
         const size_type max_resource_to_profile_;
@@ -130,7 +130,7 @@ class auto_tune_policy
             std::lock_guard<std::mutex> l(m_);
 
             // ignore the 1st timing to cover for JIT compilation
-            auto emplace_res = time_by_index_.try_emplace(index, time_data_t{0, std::numeric_limits<timing_t>::max()});
+            auto emplace_res = time_by_index_.try_emplace(index, time_data_t{0, (std::numeric_limits<timing_t>::max)()});
 
             // emplace_res is std::pair<time_by_index_t::iterator, bool> where
             //  - emplace_res.first iterate inserted or existing element;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -130,7 +130,7 @@ class auto_tune_policy
             std::lock_guard<std::mutex> l(m_);
 
             // ignore the 1st timing to cover for JIT compilation
-            auto emplace_res = 
+            auto emplace_res =
                 time_by_index_.try_emplace(index, time_data_t{0, (std::numeric_limits<timing_t>::max)()});
 
             // emplace_res is std::pair<time_by_index_t::iterator, bool> where

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -130,7 +130,8 @@ class auto_tune_policy
             std::lock_guard<std::mutex> l(m_);
 
             // ignore the 1st timing to cover for JIT compilation
-            auto emplace_res = time_by_index_.try_emplace(index, time_data_t{0, (std::numeric_limits<timing_t>::max)()});
+            auto emplace_res = 
+                time_by_index_.try_emplace(index, time_data_t{0, (std::numeric_limits<timing_t>::max)()});
 
             // emplace_res is std::pair<time_by_index_t::iterator, bool> where
             //  - emplace_res.first iterate inserted or existing element;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -158,7 +158,7 @@ struct dynamic_load_policy
         if (state_)
         {
             std::shared_ptr<resource_t> least_loaded;
-            int least_load = std::numeric_limits<load_t>::max();
+            int least_load = (std::numeric_limits<load_t>::max)();
 
             std::lock_guard<std::mutex> l(state_->m_);
             for (auto r : state_->resources_)

--- a/include/oneapi/dpl/internal/gcd_impl.h
+++ b/include/oneapi/dpl/internal/gcd_impl.h
@@ -33,7 +33,7 @@ __abs_impl(_Source __t, ::std::true_type)
 {
     if (__t >= 0)
         return __t;
-    if (__t == ::std::numeric_limits<_Source>::min())
+    if (__t == (std::numeric_limits<_Source>::min)())
         return -static_cast<_Result>(__t);
     return -__t;
 };

--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -88,13 +88,13 @@ class bernoulli_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return false;
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return true;
     }

--- a/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
@@ -101,15 +101,15 @@ class cauchy_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return std::numeric_limits<scalar_type>::lowest();
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
-        return std::numeric_limits<scalar_type>::max();
+        return (std::numeric_limits<scalar_type>::max)();
     }
 
     // Generate functions

--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -58,14 +58,14 @@ class discard_block_engine
     static constexpr ::std::size_t block_size = _P;
     static constexpr ::std::size_t used_block = _R;
     static constexpr scalar_type
-    min()
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION ()
     {
-        return _Engine::min();
+        return (_Engine::min)();
     }
     static constexpr scalar_type
-    max()
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION ()
     {
-        return _Engine::max();
+        return (_Engine::max)();
     }
 
     // Constructors

--- a/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
@@ -88,13 +88,13 @@ class exponential_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return scalar_type{};
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return ::std::numeric_limits<scalar_type>::infinity();
     }

--- a/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
@@ -101,15 +101,15 @@ class extreme_value_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return std::numeric_limits<scalar_type>::lowest();
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
-        return std::numeric_limits<scalar_type>::max();
+        return (std::numeric_limits<scalar_type>::max)();
     }
 
     // Generate functions

--- a/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
@@ -88,15 +88,15 @@ class geometric_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return scalar_type{};
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
-        return std::numeric_limits<scalar_type>::max();
+        return (std::numeric_limits<scalar_type>::max)();
     }
 
     // Generate functions

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -58,13 +58,13 @@ class linear_congruential_engine
     static constexpr scalar_type increment = _C;
     static constexpr scalar_type modulus = _M;
     static constexpr scalar_type
-    min()
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION ()
     {
         return (increment == static_cast<scalar_type>(0u)) ? static_cast<scalar_type>(1u)
                                                            : static_cast<scalar_type>(0u);
     }
     static constexpr scalar_type
-    max()
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION ()
     {
         return modulus - static_cast<scalar_type>(1u);
     }
@@ -94,8 +94,8 @@ class linear_congruential_engine
         // Skipping sequence
         if (__num_to_skip == 0)
             return;
-        constexpr bool __flag = (increment == 0) && (modulus < ::std::numeric_limits<::std::uint32_t>::max()) &&
-                                (multiplier < ::std::numeric_limits<::std::uint32_t>::max());
+        constexpr bool __flag = (increment == 0) && (modulus < (std::numeric_limits<::std::uint32_t>::max)()) &&
+                                (multiplier < (std::numeric_limits<::std::uint32_t>::max)());
         skip_seq<internal::type_traits_t<result_type>::num_elems, __flag>(__num_to_skip);
     }
 

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -103,15 +103,15 @@ class lognormal_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return scalar_type{};
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
-        return std::numeric_limits<scalar_type>::max();
+        return (std::numeric_limits<scalar_type>::max)();
     }
 
     // Generate functions

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -120,13 +120,13 @@ class normal_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return -(::std::numeric_limits<scalar_type>::infinity());
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return ::std::numeric_limits<scalar_type>::infinity();
     }

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -99,13 +99,13 @@ class philox_engine
         get_odd_element_array(std::array{_consts...}, std::make_index_sequence<__array_size>{});
 
     static constexpr scalar_type
-    min()
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION ()
     {
         return 0;
     }
 
     static constexpr scalar_type
-    max()
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION ()
     {
         // equals to 2^w - 1
         return in_mask;

--- a/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
@@ -53,12 +53,12 @@ class subtract_with_carry_engine
     static constexpr size_t short_lag = _S;
     static constexpr size_t long_lag = _R;
     static constexpr scalar_type
-    min()
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION ()
     {
         return 0u;
     }
     static constexpr scalar_type
-    max()
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION ()
     {
         return (static_cast<scalar_type>(1u) << word_size) - static_cast<scalar_type>(1u);
     }
@@ -118,7 +118,7 @@ class subtract_with_carry_engine
             return std::equal(__x.x_, __x.x_ + _R, __y.x_);
         if (__x.i_ == 0 || __y.i_ == 0)
         {
-            size_t __j = std::min(_R - __x.i_, _R - __y.i_);
+            size_t __j = (std::min)(_R - __x.i_, _R - __y.i_);
             if (!std::equal(__x.x_ + __x.i_, __x.x_ + __x.i_ + __j, __y.x_ + __y.i_))
                 return false;
             if (__x.i_ == 0)
@@ -174,7 +174,7 @@ class subtract_with_carry_engine
 
         for (size_t __i = 0; __i < long_lag; ++__i)
         {
-            x_[__i] = static_cast<scalar_type>(__engine() & max());
+            x_[__i] = static_cast<scalar_type>(__engine() & (max)());
 
             if (word_size > 32)
             {
@@ -182,7 +182,7 @@ class subtract_with_carry_engine
                 x_[__i] = x_[__i] + __tmp;
             }
 
-            x_[__i] &= max();
+            x_[__i] &= (max)();
         }
         c_ = x_[long_lag - 1] == 0;
     }
@@ -194,7 +194,7 @@ class subtract_with_carry_engine
         const scalar_type& __xs = x_[(i_ + (long_lag - short_lag)) % long_lag];
         scalar_type& __xr = x_[i_];
         scalar_type __new_c = c_ == 0 ? __xs < __xr : __xs != 0 ? __xs <= __xr : 1;
-        x_[i_] = __xr = (__xs - __xr - c_) & max();
+        x_[i_] = __xr = (__xs - __xr - c_) & (max)();
         c_ = __new_c;
         i_ = (i_ + 1) % long_lag;
         return __xr;

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -37,7 +37,7 @@ class uniform_int_distribution
       public:
         using distribution_type = uniform_int_distribution<result_type>;
         param_type() : param_type(scalar_type{0}) {}
-        explicit param_type(scalar_type a, scalar_type b = ::std::numeric_limits<scalar_type>::max()) : a_(a), b_(b) {}
+        explicit param_type(scalar_type a, scalar_type b = (std::numeric_limits<scalar_type>::max)()) : a_(a), b_(b) {}
         scalar_type
         a() const
         {
@@ -66,7 +66,7 @@ class uniform_int_distribution
 
     // Constructors
     uniform_int_distribution() : uniform_int_distribution(scalar_type{0}) {}
-    explicit uniform_int_distribution(scalar_type __a, scalar_type __b = ::std::numeric_limits<scalar_type>::max())
+    explicit uniform_int_distribution(scalar_type __a, scalar_type __b = (std::numeric_limits<scalar_type>::max)())
         : a_(__a), b_(__b)
     {
     }
@@ -105,13 +105,13 @@ class uniform_int_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return a();
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return b();
     }

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -102,13 +102,13 @@ class uniform_real_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return a();
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return b();
     }
@@ -209,8 +209,8 @@ class uniform_real_distribution
     make_real_uniform(_IntegerT __int_val, _Engine& __engine, const param_type& __params)
     {
         return static_cast<scalar_type>(
-            ((__int_val - __engine.min()) /
-             (static_cast<scalar_type>(1) + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+            ((__int_val - (__engine.min)()) /
+             (static_cast<scalar_type>(1) + static_cast<scalar_type>((__engine.max)() - (__engine.min)()))) *
                 (__params.b() - __params.a()) +
             __params.a());
     }

--- a/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
@@ -101,15 +101,15 @@ class weibull_distribution
     }
 
     scalar_type
-    min() const
+    min _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
         return scalar_type{};
     }
 
     scalar_type
-    max() const
+    max _ONEDPL_PREVENT_MACRO_SUBSTITUTION () const
     {
-        return std::numeric_limits<scalar_type>::max();
+        return (std::numeric_limits<scalar_type>::max)();
     }
 
     // Generate functions

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -142,7 +142,7 @@ struct __sycl_scan_by_segment_impl
         auto __seg_scan_prefix_kernel =
             __par_backend_hetero::__internal::__kernel_compiler<_SegScanPrefixKernel>::__compile(__exec);
         __wgroup_size =
-            ::std::min({__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_scan_wg_kernel),
+            (std::min)({__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_scan_wg_kernel),
                         oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_scan_prefix_kernel)});
 #endif
 
@@ -223,7 +223,7 @@ struct __sycl_scan_by_segment_impl
                     bool __group_has_segment_break = (__closest_seg_id != __no_segment_break);
 
                     //get rid of no segment end found flag
-                    __closest_seg_id = ::std::max(::std::int32_t(0), __closest_seg_id);
+                    __closest_seg_id = (std::max)(::std::int32_t(0), __closest_seg_id);
                     __val_type __carry_in =
                         __wg_segmented_scan(__item, __loc_acc, __local_id, __local_id - __closest_seg_id, __accumulator,
                                             __identity, __binary_op, __wgroup_size); // need to use exclusive scan delta

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1469,10 +1469,10 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 {
                     return __local_min;
                 }
-                return ::std::min(__local_min, _DifferenceType(__result - __mask));
+                return (std::min)(__local_min, _DifferenceType(__result - __mask));
             },
             [](_DifferenceType __local_min1, _DifferenceType __local_min2) -> _DifferenceType {
-                return ::std::min(__local_min1, __local_min2);
+                return (std::min)(__local_min1, __local_min2);
             });
 
         // No elements to remove - exit
@@ -3615,7 +3615,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
         return __internal::__except_handler([&]() {
             return __internal::__parallel_set_op(
                 __tag, ::std::forward<_ExecutionPolicy>(__exec), __left_bound_seq_1, __last1, __first2, __last2,
-                __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return ::std::min(__n, __m); },
+                __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return (std::min)(__n, __m); },
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
                     return oneapi::dpl::__utils::__set_intersection_construct(
@@ -3633,7 +3633,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
         return __internal::__except_handler([&]() {
             __result = __internal::__parallel_set_op(
                 __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __left_bound_seq_2, __last2,
-                __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return ::std::min(__n, __m); },
+                __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return (std::min)(__n, __m); },
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
                     return oneapi::dpl::__utils::__set_intersection_construct(
@@ -4102,7 +4102,7 @@ template <class _RandomAccessIterator1, class _RandomAccessIterator2, class _Pre
 __brick_mismatch(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                  _RandomAccessIterator2 __last2, _Predicate __pred, /* __is_vector = */ ::std::true_type) noexcept
 {
-    auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
+    auto __n = (std::min)(__last1 - __first1, __last2 - __first2);
     return __unseq_backend::__simd_first(__first1, __n, __first2, __not_pred<_Predicate&>(__pred));
 }
 
@@ -4124,7 +4124,7 @@ __pattern_mismatch(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
                    _Predicate __pred)
 {
     return __internal::__except_handler([&]() {
-        auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
+        auto __n = (std::min)(__last1 - __first1, __last2 - __first2);
         auto __result = __internal::__parallel_find(
             __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
             [__first1, __first2, __pred](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
@@ -4170,7 +4170,7 @@ __brick_lexicographical_compare(_RandomAccessIterator1 __first1, _RandomAccessIt
         typedef typename ::std::iterator_traits<_RandomAccessIterator2>::reference ref_type2;
         --__last1;
         --__last2;
-        auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
+        auto __n = (std::min)(__last1 - __first1, __last2 - __first2);
         ::std::pair<_RandomAccessIterator1, _RandomAccessIterator2> __result = __unseq_backend::__simd_first(
             __first1, __n, __first2, [__comp](const ref_type1 __x, const ref_type2 __y) mutable {
                 return __comp(__x, __y) || __comp(__y, __x);
@@ -4222,7 +4222,7 @@ __pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, _ExecutionPol
         return __internal::__except_handler([&]() {
             --__last1;
             --__last2;
-            auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
+            auto __n = (std::min)(__last1 - __first1, __last2 - __first2);
             auto __result = __internal::__parallel_find(
                 __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
                 [__first1, __first2, &__comp](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
@@ -4321,7 +4321,7 @@ __brick_shift_left(_ForwardIterator __first, _ForwardIterator __last,
     {
         for (auto __k = __n; __k < __size; __k += __n)
         {
-            auto __end = ::std::min(__k + __n, __size);
+            auto __end = (std::min)(__k + __n, __size);
             __unseq_backend::__simd_walk_2(__first + __k, __end - __k, __first + __k - __n,
                                            [](_ReferenceType __x, _ReferenceType __y) { __y = ::std::move(__x); });
         }
@@ -4375,7 +4375,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
             //TODO: to consider parallel processing by the 'internal' loop (but we may probably get cache locality issues)
             for (auto __k = __n; __k < __size; __k += __n)
             {
-                auto __end = ::std::min(__k + __n, __size);
+                auto __end = (std::min)(__k + __n, __size);
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __k, __end,
                                               [__first, __n](_DiffType __i, _DiffType __j) {
                                                   __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -91,7 +91,7 @@ struct __transform_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutRange>>;
-        const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
+        const _Size __size = (std::ranges::min)((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
 
         oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
             std::ranges::take_view(__r, __size), std::ranges::take_view(__out_r, __size), __op, __proj);
@@ -119,9 +119,9 @@ struct __transform_fn
             oneapi::dpl::__internal::__range_size_t<_R2>, std::ranges::range_size_t<_OutRange>>;
         _Size __size = std::ranges::size(__out_r);
         if constexpr(std::ranges::sized_range<_R1>)
-            __size = std::ranges::min(__size, (_Size)std::ranges::size(__r1));
+            __size = (std::ranges::min)(__size, (_Size)std::ranges::size(__r1));
         if constexpr(std::ranges::sized_range<_R2>)
-            __size = std::ranges::min(__size, (_Size)std::ranges::size(__r2));
+            __size = (std::ranges::min)(__size, (_Size)std::ranges::size(__r2));
 
         //take_view doesn't make unsized range sized, so subrange is used below
         oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -508,7 +508,7 @@ struct __copy_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_InRange>, std::ranges::range_size_t<_OutRange>>;
-        const _Size __size = std::ranges::min((_Size)std::ranges::size(__in_r), (_Size)std::ranges::size(__out_r));
+        const _Size __size = (std::ranges::min)((_Size)std::ranges::size(__in_r), (_Size)std::ranges::size(__out_r));
 
         oneapi::dpl::__internal::__ranges::__pattern_copy(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
             std::ranges::take_view(__in_r, __size), std::ranges::take_view(__out_r, __size));

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -913,7 +913,7 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, 
 __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __last1,
                    _Iterator2 __first2, _Iterator2 __last2, _Pred __pred)
 {
-    auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
+    auto __n = (std::min)(__last1 - __first1, __last2 - __first2);
     if (__n <= 0)
         return ::std::make_pair(__first1, __first2);
 
@@ -1407,7 +1407,7 @@ __pattern_lexicographical_compare(__hetero_tag<_BackendTag>, _ExecutionPolicy&& 
         return _ReduceValueType{1 * __is_s1_val_less - 1 * __is_s1_val_greater};
     };
 
-    auto __shared_size = ::std::min(__last1 - __first1, (_Iterator1DifferenceType)(__last2 - __first2));
+    auto __shared_size = (std::min)(__last1 - __first1, (_Iterator1DifferenceType)(__last2 - __first2));
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first1, __first1 + __shared_size);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -55,7 +55,7 @@ auto /* see _Size inside the function */
 __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function __f, _Ranges&&... __rngs)
 {
     using _Size = std::make_unsigned_t<std::common_type_t<oneapi::dpl::__internal::__difference_t<_Ranges>...>>;
-    const _Size __n = std::min({_Size(__rngs.size())...});
+    const _Size __n = (std::min)({_Size(__rngs.size())...});
     if (__n > 0)
     {
         constexpr std::size_t __num_ranges = sizeof...(_Ranges);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -252,7 +252,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         ::std::size_t __wgroup_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_Type));
         // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
         // This value matches the current practical limit for GPUs, but may need to be re-evaluated in the future.
-        __wgroup_size = std::min(__wgroup_size, (std::size_t)1024);
+        __wgroup_size = (std::min)(__wgroup_size, (std::size_t)1024);
 
 #if _ONEDPL_COMPILE_KERNEL
         //Actually there is one kernel_bundle for the all kernels of the pattern.
@@ -261,7 +261,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         auto __kernel_2 = __kernels[1];
         auto __wgroup_size_kernel_1 = oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel_1);
         auto __wgroup_size_kernel_2 = oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel_2);
-        __wgroup_size = ::std::min({__wgroup_size, __wgroup_size_kernel_1, __wgroup_size_kernel_2});
+        __wgroup_size = (std::min)({__wgroup_size, __wgroup_size_kernel_1, __wgroup_size_kernel_2});
 #endif
 
         // Practically this is the better value that was found
@@ -576,7 +576,7 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
     {
         auto __single_group_scan_f = [&](auto __size_constant) {
             constexpr ::std::uint16_t __size = decltype(__size_constant)::value;
-            constexpr ::std::uint16_t __wg_size = ::std::min(__size, __targeted_wg_size);
+            constexpr ::std::uint16_t __wg_size = (std::min)(__size, __targeted_wg_size);
             constexpr ::std::uint16_t __num_elems_per_item =
                 oneapi::dpl::__internal::__dpl_ceiling_div(__size, __wg_size);
             const bool __is_full_group = __n == __wg_size;
@@ -1141,7 +1141,7 @@ struct __invoke_single_group_copy_if
     operator()(_ExecutionPolicy&& __exec, std::size_t __n, _InRng&& __in_rng, _OutRng&& __out_rng, _Pred __pred,
                _Assign __assign)
     {
-        constexpr ::std::uint16_t __wg_size = ::std::min(_Size, __targeted_wg_size);
+        constexpr ::std::uint16_t __wg_size = (std::min)(_Size, __targeted_wg_size);
         constexpr ::std::uint16_t __num_elems_per_item = ::oneapi::dpl::__internal::__dpl_ceiling_div(_Size, __wg_size);
         const bool __is_full_group = __n == __wg_size;
 
@@ -1553,7 +1553,7 @@ struct __parallel_find_forward_tag
     static void
     __save_state_to(_TFoundState& __found, _AtomicType __new_state)
     {
-        __found = std::min(__found, __new_state);
+        __found = (std::min)(__found, __new_state);
     }
 };
 
@@ -1591,7 +1591,7 @@ struct __parallel_find_backward_tag
     static void
     __save_state_to(_TFoundState& __found, _AtomicType __new_state)
     {
-        __found = std::max(__found, __new_state);
+        __found = (std::max)(__found, __new_state);
     }
 };
 
@@ -1746,7 +1746,7 @@ struct __parallel_find_or_nd_range_tuner<oneapi::dpl::__internal::__device_backe
                 // Empirically found formula for GPU devices.
                 // TODO : need to re-evaluate this formula.
                 const float __rng_x = (float)__rng_n / 4096.f;
-                const float __desired_iters_per_work_item = std::max(std::sqrt(__rng_x), 1.f);
+                const float __desired_iters_per_work_item = (std::max)(std::sqrt(__rng_x), 1.f);
 
                 if (__iters_per_work_item < __desired_iters_per_work_item)
                 {
@@ -2085,8 +2085,8 @@ struct __partial_merge_kernel
     operator()(_Idx __global_idx, const _Acc1& __in_acc1, _Size1 __start_1, _Size1 __end_1, const _Acc2& __in_acc2,
                _Size2 __start_2, _Size2 __end_2, const _Acc3& __out_acc, _Size3 __out_shift, _Compare __comp) const
     {
-        const auto __part_end_1 = sycl::min(__start_1 + __k, __end_1);
-        const auto __part_end_2 = sycl::min(__start_2 + __k, __end_2);
+        const auto __part_end_1 = (sycl::min)(__start_1 + __k, __end_1);
+        const auto __part_end_2 = (sycl::min)(__start_2 + __k, __end_2);
 
         // Handle elements from p1
         if (__global_idx >= __start_1 && __global_idx < __part_end_1)
@@ -2165,8 +2165,8 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
                         auto __global_idx = __item_id.get_linear_id();
 
                         _Size __start = 2 * __k * (__global_idx / (2 * __k));
-                        _Size __end_1 = sycl::min(__start + __k, __n);
-                        _Size __end_2 = sycl::min(__start + 2 * __k, __n);
+                        _Size __end_1 = (sycl::min)(__start + __k, __n);
+                        _Size __end_2 = (sycl::min)(__start + 2 * __k, __n);
 
                         if (!__data_in_temp)
                         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -420,7 +420,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
 
         auto __global_mem_size = __exec.queue().get_device().template get_info<sycl::info::device::global_mem_size>();
         const ::std::size_t __max_segments =
-            ::std::min(__global_mem_size / (__num_bins * sizeof(_bin_type)),
+            (std::min)(__global_mem_size / (__num_bins * sizeof(_bin_type)),
                        oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __min_iters_per_work_item));
         const ::std::size_t __iters_per_work_item =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __max_segments * __work_group_size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -491,7 +491,7 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
     {
         using _WiIndex = std::uint32_t;
         static_assert(__get_starting_size_limit_for_large_submitter<__value_type>() <=
-                      std::numeric_limits<_WiIndex>::max());
+                      (std::numeric_limits<_WiIndex>::max)());
         using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __merge_kernel_name<_CustomName, _WiIndex>>;
         return __parallel_merge_submitter<_OutSizeLimit, _WiIndex, _MergeKernelName>()(
@@ -500,7 +500,7 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
     }
     else
     {
-        if (__n <= std::numeric_limits<std::uint32_t>::max())
+        if (__n <= (std::numeric_limits<std::uint32_t>::max)())
         {
             using _WiIndex = std::uint32_t;
             using _DiagonalsKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -79,10 +79,10 @@ struct __group_merge_path_sorter
         {
             const std::uint32_t __id_local = __id % __next_sorted;
             // Borders of the ranges to be merged
-            const std::uint32_t __start1 = std::min(__id - __id_local, __end);
-            const std::uint32_t __end1 = std::min(__start1 + __sorted, __end);
+            const std::uint32_t __start1 = (std::min)(__id - __id_local, __end);
+            const std::uint32_t __end1 = (std::min)(__start1 + __sorted, __end);
             const std::uint32_t __start2 = __end1;
-            const std::uint32_t __end2 = std::min(__start2 + __sorted, __end);
+            const std::uint32_t __end2 = (std::min)(__start2 + __sorted, __end);
             const std::uint32_t __n1 = __end1 - __start1;
             const std::uint32_t __n2 = __end2 - __start2;
 
@@ -171,8 +171,8 @@ struct __leaf_sorter
         // TODO: set a threshold for bubble sorter (likely 4 items)
         std::uint32_t __item_start = __sg_start + __sg_local_id * __data_per_workitem;
         std::uint32_t __item_end = __item_start + __data_per_workitem;
-        __item_start = std::min(__item_start, __adjusted_process_size);
-        __item_end = std::min(__item_end, __adjusted_process_size);
+        __item_start = (std::min)(__item_start, __adjusted_process_size);
+        __item_end = (std::min)(__item_end, __adjusted_process_size);
         __sub_group_sorter.sort(__storage_acc, __comp, __item_start, __item_end);
         __dpl_sycl::__group_barrier(__item);
 
@@ -791,7 +791,7 @@ auto
 __parallel_sort_impl(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range&& __rng,
                      _Compare __comp)
 {
-    if (__rng.size() <= std::numeric_limits<std::uint32_t>::max())
+    if (__rng.size() <= (std::numeric_limits<std::uint32_t>::max)())
     {
         return __submit_selecting_leaf<std::uint32_t>(std::forward<_ExecutionPolicy>(__exec),
                                                       std::forward<_Range>(__rng), __comp);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -72,7 +72,7 @@ __order_preserving_cast(_Int __val)
     using _UInt = ::std::make_unsigned_t<_Int>;
     // mask: 100..0 for ascending, 011..1 for descending
     constexpr _UInt __mask =
-        (__is_ascending) ? _UInt(1) << (std::numeric_limits<_Int>::digits : ::std::numeric_limits<_UInt>::max)() >> 1;
+        (__is_ascending) ? _UInt(1) << std::numeric_limits<_Int>::digits : (std::numeric_limits<_UInt>::max)() >> 1;
     return __val ^ __mask;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -72,7 +72,7 @@ __order_preserving_cast(_Int __val)
     using _UInt = ::std::make_unsigned_t<_Int>;
     // mask: 100..0 for ascending, 011..1 for descending
     constexpr _UInt __mask =
-        (__is_ascending) ? _UInt(1) << ::std::numeric_limits<_Int>::digits : ::std::numeric_limits<_UInt>::max() >> 1;
+        (__is_ascending) ? _UInt(1) << (std::numeric_limits<_Int>::digits : ::std::numeric_limits<_UInt>::max)() >> 1;
     return __val ^ __mask;
 }
 
@@ -214,7 +214,7 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
                 // 1.1. count per witem: create a private array for storing count values
                 _CountT __count_arr[__radix_states] = {0};
                 // 1.2. count per witem: count values and write result to private count array
-                const ::std::size_t __seg_end = sycl::min(__seg_start + __elem_per_segment, __n);
+                const ::std::size_t __seg_end = (sycl::min)(__seg_start + __elem_per_segment, __n);
                 for (::std::size_t __val_idx = __seg_start + __self_lidx; __val_idx < __seg_end;
                      __val_idx += __wg_size)
                 {
@@ -289,7 +289,7 @@ __radix_sort_scan_submit(_ExecutionPolicy&& __exec, ::std::size_t __scan_wg_size
     // There are no local offsets for the first segment, but the rest segments should be scanned
     // with respect to the count value in the first segment what requires n + 1 positions
     const ::std::size_t __scan_size = __segments + 1;
-    __scan_wg_size = ::std::min(__scan_size, __scan_wg_size);
+    __scan_wg_size = (std::min)(__scan_size, __scan_wg_size);
 
     const ::std::uint32_t __radix_states = 1 << __radix_bits;
 
@@ -481,7 +481,7 @@ __copy_kernel_for_radix_sort(::std::size_t __segments, const ::std::size_t __ele
     const ::std::size_t __seg_start = __elem_per_segment * __wgroup_idx;
     const ::std::size_t __n = __output_rng.size();
 
-    ::std::size_t __seg_end = sycl::min(__seg_start + __elem_per_segment, __n);
+    ::std::size_t __seg_end = (sycl::min)(__seg_start + __elem_per_segment, __n);
     // ensure that each work item in a subgroup does the same number of loop iterations
     const ::std::uint16_t __residual = (__seg_end - __seg_start) % __sg_size;
     __seg_end -= __residual;
@@ -587,8 +587,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                     __offset_arr[__radix_state_idx] = __scanned_bin + __offset_rng[__local_offset_idx];
                 }
 
-                ::std::size_t __seg_end =
-                    sycl::min(__seg_start + __elem_per_segment, __n);
+                std::size_t __seg_end = (sycl::min)(__seg_start + __elem_per_segment, __n);
                 // ensure that each work item in a subgroup does the same number of loop iterations
                 const ::std::uint16_t __residual = (__seg_end - __seg_start) % __sg_size;
                 __seg_end -= __residual;
@@ -687,8 +686,8 @@ struct __parallel_radix_sort_iteration
         ::std::size_t __count_sg_size = oneapi::dpl::__internal::__kernel_sub_group_size(__exec, __count_kernel);
         __reorder_sg_size = oneapi::dpl::__internal::__kernel_sub_group_size(__exec, __reorder_kernel);
         __scan_wg_size =
-            sycl::min(__scan_wg_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __local_scan_kernel));
-        __count_wg_size = sycl::max(__count_sg_size, __reorder_sg_size);
+            (sycl::min)(__scan_wg_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __local_scan_kernel));
+        __count_wg_size = (sycl::max)(__count_sg_size, __reorder_sg_size);
 #endif
         const ::std::uint32_t __radix_states = 1 << __radix_bits;
 
@@ -701,7 +700,7 @@ struct __parallel_radix_sort_iteration
         // work-group size must be a power of 2 and not less than the number of states.
         // TODO: Check how to get rid of that restriction.
         __count_wg_size =
-            sycl::max(oneapi::dpl::__internal::__dpl_bit_floor(__count_wg_size), ::std::size_t(__radix_states));
+            (sycl::max)(oneapi::dpl::__internal::__dpl_bit_floor(__count_wg_size), ::std::size_t(__radix_states));
 
         // Compute the radix position for the given iteration
         ::std::uint32_t __radix_offset = __radix_iter * __radix_bits;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -332,7 +332,7 @@ struct __parallel_transform_reduce_impl
 #if _ONEDPL_COMPILE_KERNEL
         auto __kernel = __internal::__kernel_compiler<_ReduceKernel>::__compile(__exec);
         _Size __adjusted_work_group_size = oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel);
-        __work_group_size = std::min(__work_group_size, __adjusted_work_group_size);
+        __work_group_size = (std::min)(__work_group_size, __adjusted_work_group_size);
 #endif
 
         const _Size __size_per_work_group =
@@ -450,7 +450,7 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __back
     // Empirically found tuning parameters for typical devices.
     constexpr _Size __max_iters_per_work_item = 32;
     constexpr std::size_t __max_work_group_size = 256;
-    static_assert(__max_work_group_size * __max_iters_per_work_item <= std::numeric_limits<std::uint16_t>::max(),
+    static_assert(__max_work_group_size * __max_iters_per_work_item <= (std::numeric_limits<std::uint16_t>::max)(),
                   "Out of 16-bit addressing range");
     constexpr std::uint8_t __vector_size = 4;
     constexpr std::uint32_t __oversubscription = 2;
@@ -462,7 +462,7 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __back
         oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, static_cast<std::size_t>(sizeof(_Tp) * 2));
 
     // Limit work-group size to __max_work_group_size for performance on GPUs. Empirically tested.
-    __work_group_size = std::min(__work_group_size, __max_work_group_size);
+    __work_group_size = (std::min)(__work_group_size, __max_work_group_size);
     const _Size __max_elements_per_wg = __work_group_size * __max_iters_per_work_item;
 
     // Use single work group implementation if less than __max_iters_per_work_item elements per work-group.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -139,9 +139,9 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
         __par_backend_hetero::__internal::__kernel_compiler<_SegReducePrefixKernel>::__compile(__exec);
     __wgroup_size =
         (std::min)({__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_count_kernel),
-                  oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_offset_kernel),
-                  oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_wg_kernel),
-                  oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_prefix_kernel)});
+                    oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_offset_kernel),
+                    oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_wg_kernel),
+                    oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_prefix_kernel)});
 #endif
 
     std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -138,7 +138,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     auto __seg_reduce_prefix_kernel =
         __par_backend_hetero::__internal::__kernel_compiler<_SegReducePrefixKernel>::__compile(__exec);
     __wgroup_size =
-        std::min({__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_count_kernel),
+        (std::min)({__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_count_kernel),
                   oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_offset_kernel),
                   oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_wg_kernel),
                   oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_prefix_kernel)});

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -319,7 +319,7 @@ struct __parallel_reduce_then_scan_reduce_submitter
                     __group_start_id += 1;
                 }
                 std::size_t __max_inputs_in_group = __inputs_per_sub_group * __num_sub_groups_local;
-                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                std::uint32_t __inputs_in_group = (std::min)(__n - __group_start_id, __max_inputs_in_group);
                 std::uint32_t __active_subgroups =
                     oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __inputs_per_sub_group);
                 std::size_t __subgroup_start_id = __group_start_id + (__sub_group_id * __inputs_per_sub_group);
@@ -354,7 +354,8 @@ struct __parallel_reduce_then_scan_reduce_submitter
                     if (__iters == 1)
                     {
                         // fill with unused dummy values to avoid overruning input
-                        std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
+                        std::uint32_t __load_id = (std::min)(std::uint32_t{__sub_group_local_id},
+                                                             __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
                             __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups);
@@ -383,7 +384,7 @@ struct __parallel_reduce_then_scan_reduce_submitter
                         // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
 
                         // fill with unused dummy values to avoid overruning input
-                        std::uint32_t __load_id = std::min(__reduction_scan_id, __num_sub_groups_local - 1);
+                        std::uint32_t __load_id = (std::min)(__reduction_scan_id, __num_sub_groups_local - 1);
 
                         __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
@@ -439,7 +440,8 @@ struct __parallel_reduce_then_scan_scan_submitter
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
                const std::size_t __block_num, const sycl::kernel& __scan_kernel) const
     {
-        std::uint32_t __inputs_in_block = std::min(__n - __block_num * __max_block_size, std::size_t{__max_block_size});
+        std::uint32_t __inputs_in_block = (std::min)(__n - __block_num * __max_block_size,
+                                                     std::size_t{__max_block_size});
         std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
             __inputs_in_block, __inputs_per_sub_group * __num_sub_groups_local);
         return __exec.queue().submit([&, this](sycl::handler& __cgh) {
@@ -477,7 +479,7 @@ struct __parallel_reduce_then_scan_scan_submitter
                 }
 
                 std::size_t __max_inputs_in_group = __inputs_per_sub_group * __num_sub_groups_local;
-                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                std::uint32_t __inputs_in_group = (std::min)(__n - __group_start_id, __max_inputs_in_group);
                 std::uint32_t __active_subgroups =
                     oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __inputs_per_sub_group);
                 oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
@@ -567,7 +569,7 @@ struct __parallel_reduce_then_scan_scan_submitter
                                 __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
                             // fill with unused dummy values to avoid overruning input
                             std::size_t __final_reduction_id =
-                                std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
+                                (std::min)(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
                             __value = __tmp_ptr[__final_reduction_id];
                             __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                      /*__init_present=*/true>(__sub_group, __value, __reduce_op,
@@ -609,7 +611,7 @@ struct __parallel_reduce_then_scan_scan_submitter
                     if (__sub_group_id > 0)
                     {
                         _InitValueType __value =
-                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                            __sub_group_partials[(std::min)(__sub_group_id - 1, __active_subgroups - 1)];
                         oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
                         __sub_group_carry.__setup(__value);
                     }
@@ -648,7 +650,7 @@ struct __parallel_reduce_then_scan_scan_submitter
                     if (__sub_group_id > 0)
                     {
                         _InitValueType __value =
-                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                            __sub_group_partials[(std::min)(__sub_group_id - 1, __active_subgroups - 1)];
                         __sub_group_carry.__setup(__reduce_op(__get_block_carry_in(__block_num, __tmp_ptr), __value));
                     }
                     else if (__group_id > 0)
@@ -773,7 +775,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     const sycl::kernel& __scan_kernel = __kernels[1];
 
     constexpr std::uint8_t __sub_group_size = 32;
-    constexpr std::uint8_t __block_size_scale = std::max(std::size_t{1}, sizeof(double) / sizeof(_ValueType));
+    constexpr std::uint8_t __block_size_scale = (std::max)(std::size_t{1}, sizeof(double) / sizeof(_ValueType));
     // Empirically determined maximum. May be less for non-full blocks.
     constexpr std::uint16_t __max_inputs_per_item = 64 * __block_size_scale;
     constexpr bool __inclusive = _Inclusive::value;
@@ -802,12 +804,12 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     assert(__inputs_remaining > 0);
     const std::uint32_t __max_inputs_per_subgroup = __max_inputs_per_block / __num_sub_groups_global;
     std::uint32_t __evenly_divided_remaining_inputs =
-        std::max(std::size_t{__sub_group_size},
+        (std::max)(std::size_t{__sub_group_size},
                  oneapi::dpl::__internal::__dpl_bit_ceil(__inputs_remaining) / __num_sub_groups_global);
     std::uint32_t __inputs_per_sub_group =
         __inputs_remaining >= __max_inputs_per_block ? __max_inputs_per_subgroup : __evenly_divided_remaining_inputs;
     std::uint32_t __inputs_per_item = __inputs_per_sub_group / __sub_group_size;
-    const std::size_t __block_size = std::min(__inputs_remaining, std::size_t{__max_inputs_per_block});
+    const std::size_t __block_size = (std::min)(__inputs_remaining, std::size_t{__max_inputs_per_block});
     const std::size_t __num_blocks = __inputs_remaining / __block_size + (__inputs_remaining % __block_size != 0);
 
     // We need temporary storage for reductions of each sub-group (__num_sub_groups_global).
@@ -850,7 +852,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     for (std::size_t __b = 0; __b < __num_blocks; ++__b)
     {
         std::uint32_t __workitems_in_block = oneapi::dpl::__internal::__dpl_ceiling_div(
-            std::min(__inputs_remaining, std::size_t{__max_inputs_per_block}), __inputs_per_item);
+            (std::min)(__inputs_remaining, std::size_t{__max_inputs_per_block}), __inputs_per_item);
         std::uint32_t __workitems_in_block_round_up_workgroup =
             oneapi::dpl::__internal::__dpl_ceiling_div(__workitems_in_block, __work_group_size) * __work_group_size;
         auto __global_range = sycl::range<1>(__workitems_in_block_round_up_workgroup);
@@ -862,12 +864,12 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.
         __event = __scan_submitter(__exec, __kernel_nd_range, __in_rng, __out_rng, __result_and_scratch, __event,
                                    __inputs_per_sub_group, __inputs_per_item, __b, __scan_kernel);
-        __inputs_remaining -= std::min(__inputs_remaining, __block_size);
+        __inputs_remaining -= (std::min)(__inputs_remaining, __block_size);
         // We only need to resize these parameters prior to the last block as it is the only non-full case.
         if (__b + 2 == __num_blocks)
         {
             __evenly_divided_remaining_inputs =
-                std::max(std::size_t{__sub_group_size},
+                (std::max)(std::size_t{__sub_group_size},
                          oneapi::dpl::__internal::__dpl_bit_ceil(__inputs_remaining) / __num_sub_groups_global);
             __inputs_per_sub_group = __inputs_remaining >= __max_inputs_per_block ? __max_inputs_per_subgroup
                                                                                   : __evenly_divided_remaining_inputs;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -440,7 +440,7 @@ struct __parallel_reduce_then_scan_scan_submitter
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
                const std::size_t __block_num, const sycl::kernel& __scan_kernel) const
     {
-        std::uint32_t __inputs_in_block = 
+        std::uint32_t __inputs_in_block =
             (std::min)(__n - __block_num * __max_block_size, std::size_t{__max_block_size});
         std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
             __inputs_in_block, __inputs_per_sub_group * __num_sub_groups_local);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -354,8 +354,8 @@ struct __parallel_reduce_then_scan_reduce_submitter
                     if (__iters == 1)
                     {
                         // fill with unused dummy values to avoid overruning input
-                        std::uint32_t __load_id = (std::min)(std::uint32_t{__sub_group_local_id},
-                                                             __active_subgroups - 1);
+                        std::uint32_t __load_id =
+                            (std::min)(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
                             __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups);
@@ -440,8 +440,8 @@ struct __parallel_reduce_then_scan_scan_submitter
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
                const std::size_t __block_num, const sycl::kernel& __scan_kernel) const
     {
-        std::uint32_t __inputs_in_block = (std::min)(__n - __block_num * __max_block_size,
-                                                     std::size_t{__max_block_size});
+        std::uint32_t __inputs_in_block = 
+            (std::min)(__n - __block_num * __max_block_size, std::size_t{__max_block_size});
         std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
             __inputs_in_block, __inputs_per_sub_group * __num_sub_groups_local);
         return __exec.queue().submit([&, this](sycl::handler& __cgh) {
@@ -805,7 +805,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     const std::uint32_t __max_inputs_per_subgroup = __max_inputs_per_block / __num_sub_groups_global;
     std::uint32_t __evenly_divided_remaining_inputs =
         (std::max)(std::size_t{__sub_group_size},
-                 oneapi::dpl::__internal::__dpl_bit_ceil(__inputs_remaining) / __num_sub_groups_global);
+                   oneapi::dpl::__internal::__dpl_bit_ceil(__inputs_remaining) / __num_sub_groups_global);
     std::uint32_t __inputs_per_sub_group =
         __inputs_remaining >= __max_inputs_per_block ? __max_inputs_per_subgroup : __evenly_divided_remaining_inputs;
     std::uint32_t __inputs_per_item = __inputs_per_sub_group / __sub_group_size;
@@ -870,7 +870,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         {
             __evenly_divided_remaining_inputs =
                 (std::max)(std::size_t{__sub_group_size},
-                         oneapi::dpl::__internal::__dpl_bit_ceil(__inputs_remaining) / __num_sub_groups_global);
+                           oneapi::dpl::__internal::__dpl_bit_ceil(__inputs_remaining) / __num_sub_groups_global);
             __inputs_per_sub_group = __inputs_remaining >= __max_inputs_per_block ? __max_inputs_per_subgroup
                                                                                   : __evenly_divided_remaining_inputs;
             __inputs_per_item = __inputs_per_sub_group / __sub_group_size;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -65,7 +65,7 @@ __max_work_group_size(const _ExecutionPolicy& __policy, std::size_t __wg_size_li
     // Limit the maximum work-group size supported by the device to optimize the throughput or minimize communication
     // costs. This is limited to 8192 which is the highest current limit of the tested hardware (opencl:cpu devices) to
     // prevent huge work-group sizes returned on some devices (e.g., FPGU emulation).
-    return std::min(__wg_size, __wg_size_limit);
+    return (std::min)(__wg_size, __wg_size_limit);
 }
 
 template <typename _ExecutionPolicy, typename _Size>
@@ -863,7 +863,7 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
     using _Head = typename ::std::conditional_t<
         sizeof...(_Vals) != 0,
         ::std::tuple_element<0, ::std::tuple<::std::integral_constant<::std::uint32_t, _Vals>...>>,
-        ::std::integral_constant<::std::uint32_t, ::std::numeric_limits<::std::uint32_t>::max()>>::type;
+        ::std::integral_constant<::std::uint32_t, (std::numeric_limits<::std::uint32_t>::max)()>>::type;
 
     static_assert(_X < _Head<_Xs...>::value, "Sequence must be monotonically increasing");
 
@@ -936,7 +936,7 @@ struct __vector_load
     void
     operator()(/*__is_full*/ std::false_type, _IdxType __start_idx, _LoadOp __load_op, _Rngs&&... __rngs) const
     {
-        std::uint8_t __elements = std::min(std::size_t{__vec_size}, std::size_t{__full_range_size - __start_idx});
+        std::uint8_t __elements = (std::min)(std::size_t{__vec_size}, std::size_t{__full_range_size - __start_idx});
         for (std::uint8_t __i = 0; __i < __elements; ++__i)
             __load_op(__start_idx + __i, __i, __rngs...);
     }
@@ -987,7 +987,7 @@ struct __vector_walk
     void
     operator()(std::false_type, _IdxType __idx, _WalkFunction __f, _Rngs&&... __rngs) const
     {
-        std::uint8_t __elements = std::min(std::size_t{__vec_size}, std::size_t{__full_range_size - __idx});
+        std::uint8_t __elements = (std::min)(std::size_t{__vec_size}, std::size_t{__full_range_size - __idx});
         for (std::uint8_t __i = 0; __i < __elements; ++__i)
         {
             __f(__rngs[__idx + __i]...);
@@ -1013,7 +1013,7 @@ struct __vector_store
     void
     operator()(std::false_type, _IdxType __start_idx, _StoreOp __store_op, _Rngs&&... __rngs) const
     {
-        std::uint8_t __elements = std::min(std::size_t{__vec_size}, std::size_t{__full_range_size - __start_idx});
+        std::uint8_t __elements = (std::min)(std::size_t{__vec_size}, std::size_t{__full_range_size - __start_idx});
         for (std::uint8_t __i = 0; __i < __elements; ++__i)
             __store_op(__i, __start_idx + __i, __rngs...);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -559,7 +559,7 @@ struct transform_reduce
             _Size __last_wg_remainder = __n % __items_per_work_group;
             // Adjust remainder and wg size for vector size
             _Size __last_wg_vec = oneapi::dpl::__internal::__dpl_ceiling_div(__last_wg_remainder, _VecSize);
-            _Size __last_wg_contrib = std::min(__last_wg_vec, __work_group_size);
+            _Size __last_wg_contrib = (std::min)(__last_wg_vec, __work_group_size);
             return __full_group_contrib + __last_wg_contrib;
         }
         // else (if not commutative)
@@ -1239,7 +1239,7 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
         const std::size_t __n = __size;
         const std::size_t __remaining_elements = __n - __idx;
         const std::uint8_t __elements_to_process =
-            std::min(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
+            (std::min)(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
         const std::size_t __output_start = __size - __idx - __elements_to_process;
         // 1. Load vector to reverse
         _ValueType __rng1_vector[__base_t::__preferred_vector_size];
@@ -1312,10 +1312,10 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             // the first before the wraparound point and the second after.
             const std::size_t __remaining_elements = __n - __idx;
             const std::uint8_t __elements_to_process =
-                std::min(std::size_t{__base_t::__preferred_vector_size}, __remaining_elements);
+                (std::min)(std::size_t{__base_t::__preferred_vector_size}, __remaining_elements);
             // __n - __wrapped_idx can safely fit into a uint8_t due to the condition check above.
             const std::uint8_t __loop1_elements =
-                std::min(__elements_to_process, static_cast<std::uint8_t>(__n - __wrapped_idx));
+                (std::min)(__elements_to_process, static_cast<std::uint8_t>(__n - __wrapped_idx));
             const std::uint8_t __loop2_elements = __elements_to_process - __loop1_elements;
             std::uint8_t __i = 0;
             for (__i = 0; __i < __loop1_elements; ++__i)
@@ -1473,7 +1473,7 @@ struct __brick_shift_left
                 // in branch divergence and masked execution of both vectorized and serial paths for all items in the
                 // sub-group which may worsen performance. Instead, have each item in the sub-group process its work
                 // serially.
-                for (_DiffType __j = 0; __j < std::min(std::size_t{__preferred_vector_size}, __n - __idx); ++__j)
+                for (_DiffType __j = 0; __j < (std::min)(std::size_t{__preferred_vector_size}, __n - __idx); ++__j)
                     if (__read_offset + __j < __size)
                         __rng[__write_offset + __j] = __rng[__read_offset + __j];
             }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -631,7 +631,7 @@ struct __get_sycl_range
         //   buffer and use those to create the range.
         const auto __offset = __first.get_idx();
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
-        const auto __n = ::std::min(decltype(__size)(__last - __first), __size);
+        const auto __n = (std::min)(decltype(__size)(__last - __first), __size);
         assert(__offset + __n <= __size);
 
         return __range_holder<oneapi::dpl::__ranges::all_view<value_type, _LocalAccMode>>{

--- a/include/oneapi/dpl/pstl/histogram_binhash_utils.h
+++ b/include/oneapi/dpl/pstl/histogram_binhash_utils.h
@@ -42,7 +42,7 @@ struct __evenly_divided_binhash<_T1, ::std::enable_if_t<::std::is_floating_point
     __evenly_divided_binhash(const _T1& __min, const _T1& __max, ::std::size_t __num_bins)
         : __minimum(__min), __maximum(__max), __scale(_T1(__num_bins) / (__max - __min))
     {
-        assert(__num_bins < ::std::numeric_limits<::std::int32_t>::max());
+        assert(__num_bins < (std::numeric_limits<::std::int32_t>::max)());
     }
 
     template <typename _T2>
@@ -67,7 +67,7 @@ struct __evenly_divided_binhash<_T1, ::std::enable_if_t<!::std::is_floating_poin
     __evenly_divided_binhash(const _T1& __min, const _T1& __max, ::std::size_t __num_bins_)
         : __minimum(__min), __num_bins(__num_bins_), __range_size(__max - __min)
     {
-        assert(__num_bins < ::std::numeric_limits<::std::int32_t>::max());
+        assert(__num_bins < (std::numeric_limits<::std::int32_t>::max)());
     }
 
     template <typename _T2>
@@ -105,7 +105,7 @@ struct __custom_boundary_binhash
     __custom_boundary_binhash(_RandomAccessIterator __boundary_first_, _RandomAccessIterator __boundary_last_)
         : __boundary_first(__boundary_first_), __boundary_last(__boundary_last_)
     {
-        assert(std::distance(__boundary_first, __boundary_last) < std::numeric_limits<std::int32_t>::max());
+        assert(std::distance(__boundary_first, __boundary_last) < (std::numeric_limits<std::int32_t>::max)());
     }
 
     template <typename _T2>

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -337,4 +337,11 @@
 #    define _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT __has_builtin(__builtin_sycl_unique_stable_name)
 #endif // _ONEDPL_BACKEND_SYCL
 
+// _ONEDPL_PREVENT_MACRO_SUBSTITUTION is provided to avoid substitution of min and max macros in the code on windows.
+// When defining a function
+// ret_type max();
+// to avoid macro substitution, insert this macro in function definition as follows
+// ret_type max _ONEDPL_PREVENT_MACRO_SUBSTITUTION ();
+#define _ONEDPL_PREVENT_MACRO_SUBSTITUTION
+
 #endif // _ONEDPL_CONFIG_H

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -865,8 +865,8 @@ class __merge_func
         assert(__nx > 0 && __ny > 0);
         assert(_M_nsort > 0);
 
-        auto __kx = ::std::min(_M_nsort, __nx);
-        auto __ky = ::std::min(_M_nsort, __ny);
+        auto __kx = (std::min)(_M_nsort, __nx);
+        auto __ky = (std::min)(_M_nsort, __ny);
 
         assert(_x_orig == _y_orig);
 
@@ -1136,7 +1136,7 @@ __stable_sort_func<_RandomAccessIterator1, _RandomAccessIterator2, _Compare, _Le
     assert(_M_nsort > 0);
 
     const _SizeType __n = _M_xe - _M_xs;
-    const _SizeType __nmerge = ::std::min(_M_nsort, __n);
+    const _SizeType __nmerge = (std::min)(_M_nsort, __n);
     const _SizeType __sort_cut_off = _ONEDPL_STABLE_SORT_CUT_OFF;
     if (__n <= __sort_cut_off)
     {

--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -8821,7 +8821,7 @@ struct inplace_merge_fn
             ++dist2;
         }
 
-        const auto sz = nano::min(dist1, dist2);
+        const auto sz = (nano::min)(dist1, dist2);
         auto buf = detail::temporary_vector<iter_value_t<I>>(sz);
 
         if (buf.capacity() >= static_cast<::std::size_t>(sz))
@@ -12467,8 +12467,8 @@ struct uniform_random_bit_generator_concept
 
     template <typename G>
     auto
-    requires_() -> decltype(requires_expr<same_as<decltype(G::min()), invoke_result_t<G&>>>{},
-                            requires_expr<same_as<decltype(G::max()), invoke_result_t<G&>>>{});
+    requires_() -> decltype(requires_expr<same_as<decltype((G::min)()), invoke_result_t<G&>>>{},
+                            requires_expr<same_as<decltype((G::max)()), invoke_result_t<G&>>>{});
 };
 
 } // namespace detail
@@ -12502,7 +12502,7 @@ struct sample_fn
 
         auto unsampled_size = nano::distance(first, last);
 
-        for (n = nano::min(n, unsampled_size); n != 0; ++first)
+        for (n = (nano::min)(n, unsampled_size); n != 0; ++first)
         {
             if (D(g, param_t(0, --unsampled_size)) < n)
             {
@@ -12539,7 +12539,7 @@ struct sample_fn
             }
         }
 
-        return out + nano::min(n, k);
+        return out + (nano::min)(n, k);
     }
 
     template <typename I, typename S, typename O, typename Gen>
@@ -13705,7 +13705,7 @@ struct stable_sort_fn
                     .out;
             first += two_step;
         }
-        step_size = nano::min(iter_difference_t<I>(last - first), step_size);
+        step_size = (nano::min)(iter_difference_t<I>(last - first), step_size);
         nano::merge(nano::make_move_iterator(first), nano::make_move_iterator(first + step_size),
                     nano::make_move_iterator(first + step_size), nano::make_move_iterator(last), result,
                     ::std::ref(comp), ::std::ref(proj), ::std::ref(proj));
@@ -18711,7 +18711,7 @@ struct take_view : view_interface<take_view<V>>
     size()
     {
         auto n = ranges::size(base_);
-        return ranges::min(n, static_cast<decltype(n)>(count_));
+        return (ranges::min)(n, static_cast<decltype(n)>(count_));
     }
 
     template <typename VV = V, ::std::enable_if_t<sized_range<const VV>, int> = 0>
@@ -18719,7 +18719,7 @@ struct take_view : view_interface<take_view<V>>
     size() const
     {
         auto n = ranges::size(base_);
-        return ranges::min(n, static_cast<decltype(n)>(count_));
+        return (ranges::min)(n, static_cast<decltype(n)>(count_));
     }
 };
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -805,13 +805,13 @@ struct __min_nested_type_size
 template <typename... _Ts>
 struct __min_nested_type_size<std::tuple<_Ts...>>
 {
-    constexpr static std::size_t value = std::min({__min_nested_type_size<_Ts>::value...});
+    constexpr static std::size_t value = (std::min)({__min_nested_type_size<_Ts>::value...});
 };
 
 template <typename... _Ts>
 struct __min_nested_type_size<oneapi::dpl::__internal::tuple<_Ts...>>
 {
-    constexpr static std::size_t value = std::min({__min_nested_type_size<_Ts>::value...});
+    constexpr static std::size_t value = (std::min)({__min_nested_type_size<_Ts>::value...});
 };
 
 } // namespace __internal

--- a/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
@@ -471,7 +471,7 @@ DEFINE_TEST(test_search_n)
 
             // Search for sequence of lesser size
             res = ::std::search_n(make_new_policy<new_kernel_name<Policy, 2>>(exec), first, last,
-                                ::std::max(end - start - 1, (size_t)1), T(22));
+                                (std::max)(end - start - 1, (size_t)1), T(22));
             wait_and_throw(exec);
 
             EXPECT_TRUE(res - first == start, "wrong effect from search_21");
@@ -533,7 +533,7 @@ DEFINE_TEST(test_search_n)
             host_keys.update_data();
 
             auto res = ::std::search_n(make_new_policy<new_kernel_name<Policy, 8>>(exec), first, last,
-                                     ::std::min(end1 - start1, end2 - start2), T(66));
+                                     (std::min)(end1 - start1, end2 - start2), T(66));
             wait_and_throw(exec);
 
             EXPECT_TRUE(res - first == start1, "wrong effect from search_7");

--- a/test/general/sycl_iterator/sycl_iterator_scan.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_scan.pass.cpp
@@ -140,7 +140,7 @@ DEFINE_TEST(test_unique)
 
         host_keys.retrieve_data();
         auto host_first1 = host_keys.get();
-        for (int i = 0; i < ::std::min(result_size, expected_size) && is_correct; ++i)
+        for (int i = 0; i < (std::min)(result_size, expected_size) && is_correct; ++i)
         {
             if (*(host_first1 + i) != i + 1)
             {
@@ -389,7 +389,7 @@ DEFINE_TEST(test_unique_copy)
 
         host_vals.retrieve_data();
         auto host_first2 = host_vals.get();
-        for (int i = 0; i < ::std::min(result_size, expected_size) && is_correct; ++i)
+        for (int i = 0; i < (std::min)(result_size, expected_size) && is_correct; ++i)
         {
             if (*(host_first2 + i) != i + 1)
             {
@@ -452,7 +452,7 @@ DEFINE_TEST(test_partition_copy)
                       << exp.first - exp_true_first << "," << exp.second - exp_false_first << "}" << ::std::endl;
 #endif // _ONEDPL_DEBUG_SYCL
 
-        for (int i = 0; i < ::std::min(exp.first - exp_true_first, res.first - first2) && is_correct; ++i)
+        for (int i = 0; i < (std::min)(exp.first - exp_true_first, res.first - first2) && is_correct; ++i)
         {
             if (*(exp_true_first + i) != *(host_vals.get() + i))
             {
@@ -464,7 +464,7 @@ DEFINE_TEST(test_partition_copy)
             }
         }
 
-        for (int i = 0; i < ::std::min(exp.second - exp_false_first, res.second - first3) && is_correct; ++i)
+        for (int i = 0; i < (std::min)(exp.second - exp_false_first, res.second - first3) && is_correct; ++i)
         {
             if (*(exp_false_first + i) != *(host_res.get() + i))
             {

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -227,7 +227,7 @@ main()
     // Due to small problem sizes in this test, runtime explodes on CPUs with large core counts due to
     // small grain sizes per thread and cross-socket traffic.
     const int max_threads = omp_get_max_threads();
-    const int threads_to_use = std::min(max_threads, int(32));
+    const int threads_to_use = (std::min)(max_threads, int(32));
     omp_set_num_threads(threads_to_use);
 #endif
     using ValueType = ::std::int32_t;

--- a/test/parallel_api/algorithm/alg.nonmodifying/transform_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/transform_if.pass.cpp
@@ -166,7 +166,7 @@ test()
     for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         {
-            Sequence<_Type> in1(n, [=](size_t k) { return (3 * k) % std::numeric_limits<_Type>::max(); });
+            Sequence<_Type> in1(n, [=](size_t k) { return (3 * k) % (std::numeric_limits<_Type>::max)(); });
             Sequence<_Type> in2(n, [=](size_t k) { return k % 2 == 0 ? 1 : 0; });
 
             Sequence<_Type> out(n, [=](size_t) { return init_val; });
@@ -179,7 +179,7 @@ test()
 #endif
         }
         {
-            Sequence<_Type> in1(n, [=](size_t k) { return k % std::numeric_limits<_Type>::max(); });
+            Sequence<_Type> in1(n, [=](size_t k) { return k % (std::numeric_limits<_Type>::max)(); });
             Sequence<_Type> out(n, [=](size_t) { return init_val; });
 
             invoke_on_all_policies<2>()(test_transform_if_unary<_Type>(), in1.begin(), in1.end(), out.begin(),
@@ -201,7 +201,7 @@ test_inplace()
     for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         {
-            Sequence<_Type> in1(n, [=](size_t k) { return k % std::numeric_limits<_Type>::max(); });
+            Sequence<_Type> in1(n, [=](size_t k) { return k % (std::numeric_limits<_Type>::max)(); });
             Sequence<_Type> out(n, [=](size_t) { return 0; });
 
             invoke_on_all_policies<4>()(test_transform_if_unary_inplace<_Type>(), in1.begin(), in1.end(), out.begin(),

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max.pass.cpp
@@ -29,7 +29,7 @@ template <class T>
 void
 test(const T& a, const T& b, const T& x)
 {
-    assert(&dpl::max(a, b) == &x);
+    assert(&(dpl::max)(a, b) == &x);
 }
 
 ONEDPL_TEST_NUM_MAIN
@@ -56,8 +56,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::max(x, y) == x);
-    static_assert(dpl::max(y, x) == x);
+    static_assert((dpl::max)(x, y) == x);
+    static_assert((dpl::max)(y, x) == x);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_comp.pass.cpp
@@ -31,7 +31,7 @@ template <class T, class C>
 void
 test(const T& a, const T& b, C c, const T& x)
 {
-    assert(&dpl::max(a, b, c) == &x);
+    assert(&(dpl::max)(a, b, c) == &x);
 }
 
 ONEDPL_TEST_NUM_MAIN
@@ -58,8 +58,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::max(x, y, dpl::greater<int>()) == y);
-    static_assert(dpl::max(y, x, dpl::greater<int>()) == y);
+    static_assert((dpl::max)(x, y, dpl::greater<int>()) == y);
+    static_assert((dpl::max)(y, x, dpl::greater<int>()) == y);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
@@ -34,23 +34,23 @@
 
 ONEDPL_TEST_NUM_MAIN
 {
-    int i = dpl::max({2, 3, 1});
+    int i = (dpl::max)({2, 3, 1});
     assert(i == 3);
-    i = dpl::max({2, 1, 3});
+    i = (dpl::max)({2, 1, 3});
     assert(i == 3);
-    i = dpl::max({3, 1, 2});
+    i = (dpl::max)({3, 1, 2});
     assert(i == 3);
-    i = dpl::max({3, 2, 1});
+    i = (dpl::max)({3, 2, 1});
     assert(i == 3);
-    i = dpl::max({1, 2, 3});
+    i = (dpl::max)({1, 2, 3});
     assert(i == 3);
-    i = dpl::max({1, 3, 2});
+    i = (dpl::max)({1, 3, 2});
     assert(i == 3);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::max({1, 3, 2}) == 3);
-    static_assert(dpl::max({2, 1, 3}) == 3);
-    static_assert(dpl::max({3, 2, 1}) == 3);
+    static_assert((dpl::max)({1, 3, 2}) == 3);
+    static_assert((dpl::max)({2, 1, 3}) == 3);
+    static_assert((dpl::max)({3, 2, 1}) == 3);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list_comp.pass.cpp
@@ -30,23 +30,23 @@
 
 ONEDPL_TEST_NUM_MAIN
 {
-    int i = dpl::max({2, 3, 1}, dpl::greater<int>());
+    int i = (dpl::max)({2, 3, 1}, dpl::greater<int>());
     assert(i == 1);
-    i = dpl::max({2, 1, 3}, dpl::greater<int>());
+    i = (dpl::max)({2, 1, 3}, dpl::greater<int>());
     assert(i == 1);
-    i = dpl::max({3, 1, 2}, dpl::greater<int>());
+    i = (dpl::max)({3, 1, 2}, dpl::greater<int>());
     assert(i == 1);
-    i = dpl::max({3, 2, 1}, dpl::greater<int>());
+    i = (dpl::max)({3, 2, 1}, dpl::greater<int>());
     assert(i == 1);
-    i = dpl::max({1, 2, 3}, dpl::greater<int>());
+    i = (dpl::max)({1, 2, 3}, dpl::greater<int>());
     assert(i == 1);
-    i = dpl::max({1, 3, 2}, dpl::greater<int>());
+    i = (dpl::max)({1, 3, 2}, dpl::greater<int>());
     assert(i == 1);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::max({1, 3, 2}, dpl::greater<int>()) == 1);
-    static_assert(dpl::max({2, 1, 3}, dpl::greater<int>()) == 1);
-    static_assert(dpl::max({3, 2, 1}, dpl::greater<int>()) == 1);
+    static_assert((dpl::max)({1, 3, 2}, dpl::greater<int>()) == 1);
+    static_assert((dpl::max)({2, 1, 3}, dpl::greater<int>()) == 1);
+    static_assert((dpl::max)({3, 2, 1}, dpl::greater<int>()) == 1);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min.pass.cpp
@@ -29,7 +29,7 @@ template <class T>
 void
 test(const T& a, const T& b, const T& x)
 {
-    assert(&dpl::min(a, b) == &x);
+    assert(&(dpl::min)(a, b) == &x);
 }
 
 ONEDPL_TEST_NUM_MAIN
@@ -56,8 +56,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::min(x, y) == y);
-    static_assert(dpl::min(y, x) == y);
+    static_assert((dpl::min)(x, y) == y);
+    static_assert((dpl::min)(y, x) == y);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_comp.pass.cpp
@@ -31,7 +31,7 @@ template <class T, class C>
 void
 test(const T& a, const T& b, C c, const T& x)
 {
-    assert(&dpl::min(a, b, c) == &x);
+    assert(&(dpl::min)(a, b, c) == &x);
 }
 
 ONEDPL_TEST_NUM_MAIN
@@ -58,8 +58,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::min(x, y, dpl::greater<int>()) == x);
-    static_assert(dpl::min(y, x, dpl::greater<int>()) == x);
+    static_assert((dpl::min)(x, y, dpl::greater<int>()) == x);
+    static_assert((dpl::min)(y, x, dpl::greater<int>()) == x);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
@@ -34,23 +34,23 @@
 
 ONEDPL_TEST_NUM_MAIN
 {
-    int i = dpl::min({2, 3, 1});
+    int i = (dpl::min)({2, 3, 1});
     assert(i == 1);
-    i = dpl::min({2, 1, 3});
+    i = (dpl::min)({2, 1, 3});
     assert(i == 1);
-    i = dpl::min({3, 1, 2});
+    i = (dpl::min)({3, 1, 2});
     assert(i == 1);
-    i = dpl::min({3, 2, 1});
+    i = (dpl::min)({3, 2, 1});
     assert(i == 1);
-    i = dpl::min({1, 2, 3});
+    i = (dpl::min)({1, 2, 3});
     assert(i == 1);
-    i = dpl::min({1, 3, 2});
+    i = (dpl::min)({1, 3, 2});
     assert(i == 1);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::min({1, 3, 2}) == 1);
-    static_assert(dpl::min({2, 1, 3}) == 1);
-    static_assert(dpl::min({3, 2, 1}) == 1);
+    static_assert((dpl::min)({1, 3, 2}) == 1);
+    static_assert((dpl::min)({2, 1, 3}) == 1);
+    static_assert((dpl::min)({3, 2, 1}) == 1);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list_comp.pass.cpp
@@ -30,23 +30,23 @@
 
 ONEDPL_TEST_NUM_MAIN
 {
-    int i = dpl::min({2, 3, 1}, dpl::greater<int>());
+    int i = (dpl::min)({2, 3, 1}, dpl::greater<int>());
     assert(i == 3);
-    i = dpl::min({2, 1, 3}, dpl::greater<int>());
+    i = (dpl::min)({2, 1, 3}, dpl::greater<int>());
     assert(i == 3);
-    i = dpl::min({3, 1, 2}, dpl::greater<int>());
+    i = (dpl::min)({3, 1, 2}, dpl::greater<int>());
     assert(i == 3);
-    i = dpl::min({3, 2, 1}, dpl::greater<int>());
+    i = (dpl::min)({3, 2, 1}, dpl::greater<int>());
     assert(i == 3);
-    i = dpl::min({1, 2, 3}, dpl::greater<int>());
+    i = (dpl::min)({1, 2, 3}, dpl::greater<int>());
     assert(i == 3);
-    i = dpl::min({1, 3, 2}, dpl::greater<int>());
+    i = (dpl::min)({1, 3, 2}, dpl::greater<int>());
     assert(i == 3);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::min({1, 3, 2}, dpl::greater<int>()) == 3);
-    static_assert(dpl::min({2, 1, 3}, dpl::greater<int>()) == 3);
-    static_assert(dpl::min({3, 2, 1}, dpl::greater<int>()) == 3);
+    static_assert((dpl::min)({1, 3, 2}, dpl::greater<int>()) == 3);
+    static_assert((dpl::min)({2, 1, 3}, dpl::greater<int>()) == 3);
+    static_assert((dpl::min)({3, 2, 1}, dpl::greater<int>()) == 3);
     }
 #endif
 

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -241,12 +241,12 @@ test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last *
 
     // Test negative stride value with non-forward iterators on range (first - 1, first)
     auto new_first = first;
-    ::std::advance(new_first, ::std::max(Ssize(0), Ssize(n) - 1));
+    ::std::advance(new_first, (std::max)(Ssize(0), Ssize(n) - 1));
 
     auto new_last = first;
 
     auto new_expected_first = expected_first;
-    ::std::advance(new_expected_first, ::std::max(Ssize(0), Ssize(n) - 1));
+    ::std::advance(new_expected_first, (std::max)(Ssize(0), Ssize(n) - 1));
 
     auto new_expected_last = expected_first;
 

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -43,7 +43,7 @@ test_body_reduction(Policy&& exec, Iterator first, Iterator last, Iterator /* ex
                                 ::std::experimental::reduction(var2, T(var2_init), oneapi::dpl::__internal::__pstl_min{}),
                                 [](Iterator iter, T& acc1, T& acc2) {
                                     acc1 += *iter;
-                                    acc2 = ::std::min(acc2, *iter);
+                                    acc2 = (std::min)(acc2, *iter);
                                 });
 
     T var1_exp = var1_init;
@@ -52,7 +52,7 @@ test_body_reduction(Policy&& exec, Iterator first, Iterator last, Iterator /* ex
     for (auto iter = first; iter != last; ++iter)
     {
         var1_exp += *iter;
-        var2_exp = ::std::min(var2_exp, *iter);
+        var2_exp = (std::min)(var2_exp, *iter);
     }
 
     EXPECT_TRUE(var1 == var1_exp, "wrong result of reduction 1");
@@ -107,16 +107,16 @@ struct test_body_predefined
             [](Iterator iter, T& plus_acc, T& mult_acc, T& min_acc, T& max_acc) {
                 plus_acc += *iter;
                 mult_acc *= *iter;
-                min_acc = ::std::min(min_acc, *iter);
-                max_acc = ::std::max(max_acc, *iter);
+                min_acc = (std::min)(min_acc, *iter);
+                max_acc = (std::max)(max_acc, *iter);
             });
 
         for (auto iter = first; iter != last; ++iter)
         {
             plus_exp += *iter;
             mult_exp *= *iter;
-            min_exp = ::std::min(min_exp, *iter);
-            max_exp = ::std::max(max_exp, *iter);
+            min_exp = (std::min)(min_exp, *iter);
+            max_exp = (std::max)(max_exp, *iter);
         }
 
         EXPECT_TRUE(plus_var == plus_exp, "wrong result of reduction_plus");

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -298,7 +298,7 @@ struct test_permutation_iterator
     void
     operator()(::std::vector<T1>& in1, ::std::vector<T2>& in2)
     {
-        T1 iota_max = ::std::numeric_limits<T1>::max() < in1.size() ? ::std::numeric_limits<T1>::max() : in1.size();
+        T1 iota_max = ((std::numeric_limits<T1>::max)() < in1.size() ? ::std::numeric_limits<T1>::max)() : in1.size();
         ::std::iota(in1.begin(), in1.begin() + iota_max, T1(0));
         ::std::reverse_copy(in1.begin(), in1.begin() + iota_max, in2.begin());
 

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -298,7 +298,7 @@ struct test_permutation_iterator
     void
     operator()(::std::vector<T1>& in1, ::std::vector<T2>& in2)
     {
-        T1 iota_max = ((std::numeric_limits<T1>::max)() < in1.size() ? ::std::numeric_limits<T1>::max)() : in1.size();
+        T1 iota_max = (std::numeric_limits<T1>::max)() < in1.size() ? (std::numeric_limits<T1>::max)() : in1.size();
         ::std::iota(in1.begin(), in1.begin() + iota_max, T1(0));
         ::std::reverse_copy(in1.begin(), in1.begin() + iota_max, in2.begin());
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -56,7 +56,7 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
                 {
                     const auto testing_n = permItEnd - permItBegin;
                     // run at most 3 iters per n, 0 elements should be noop / cheap
-                    const auto partial_sorting_step = std::max(testing_n / 2, decltype(testing_n){1});
+                    const auto partial_sorting_step = (std::max)(testing_n / 2, decltype(testing_n){1});
                     for (::std::size_t p = 0; p <= testing_n; p += partial_sorting_step)
                     {
                         dpl::partial_sort(exec, permItBegin, permItBegin + p, permItEnd);

--- a/test/parallel_api/iterator/zip_iterator_merge.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator_merge.pass.cpp
@@ -98,7 +98,7 @@ DEFINE_TEST(test_merge)
         auto host_first1 = host_keys.get();
         auto host_first3 = host_res_merge.get();
 
-        for (size_t i = 0; i < std::min(res_size, exp_size) && is_correct; ++i)
+        for (size_t i = 0; i < (std::min)(res_size, exp_size) && is_correct; ++i)
             if ((i < size2 * 2 && *(host_first3 + i) != i) ||
                 (i >= size2 * 2 && *(host_first3 + i) != *(host_first1 + i - size2)))
                 is_correct = false;

--- a/test/parallel_api/iterator/zip_iterator_scan.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator_scan.pass.cpp
@@ -107,7 +107,7 @@ DEFINE_TEST(test_unique)
 
         bool is_correct = (tuple_lastnew - tuple_first1) == expected_size;
         host_keys.retrieve_data();
-        for (int i = 0; i < std::min(tuple_lastnew - tuple_first1, expected_size) && is_correct; ++i)
+        for (int i = 0; i < (std::min)(tuple_lastnew - tuple_first1, expected_size) && is_correct; ++i)
             if ((*host_keys.get() + i) != i + 1)
                 is_correct = false;
 
@@ -156,7 +156,7 @@ DEFINE_TEST(test_unique_copy)
 
         bool is_correct = (tuple_last2 - tuple_first2) == expected_size;
         host_vals.retrieve_data();
-        for (int i = 0; i < std::min(tuple_last2 - tuple_first2, expected_size) && is_correct; ++i)
+        for (int i = 0; i < (std::min)(tuple_last2 - tuple_first2, expected_size) && is_correct; ++i)
             if ((*host_vals.get() + i) != i + 1)
                 is_correct = false;
 

--- a/test/parallel_api/ranges/guard_view.pass.cpp
+++ b/test/parallel_api/ranges/guard_view.pass.cpp
@@ -32,7 +32,7 @@ main()
     using CountItr = oneapi::dpl::counting_iterator<uint64_t>;
     CountItr count_itr(0UL);
 
-    const size_t max_int32p2 = (size_t)::std::numeric_limits<int32_t>::max() + 2UL;
+    const size_t max_int32p2 = (size_t)(std::numeric_limits<int32_t>::max)() + 2UL;
 
     oneapi::dpl::__ranges::guard_view<CountItr> gview{count_itr, max_int32p2};
 

--- a/test/parallel_api/ranges/std_ranges_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_copy.pass.cpp
@@ -25,7 +25,7 @@ main()
     auto copy_checker = [](std::ranges::random_access_range auto&& r_in,
                            std::ranges::random_access_range auto&& r_out)
     {
-        const auto size = std::ranges::min(std::ranges::size(r_in), std::ranges::size(r_out));
+        const auto size = (std::ranges::min)(std::ranges::size(r_in), std::ranges::size(r_out));
 
         auto res = std::ranges::copy(std::ranges::take_view(r_in, size), std::ranges::take_view(r_out, size).begin());
 

--- a/test/parallel_api/ranges/std_ranges_transform.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_transform.pass.cpp
@@ -28,7 +28,7 @@ main()
     {
         using Size = std::common_type_t<std::ranges::range_size_t<decltype(r_in)>,
             std::ranges::range_size_t<decltype(r_out)>>;
-        Size size = std::ranges::min((Size)std::ranges::size(r_out), (Size)std::ranges::size(r_in));
+        Size size = (std::ranges::min)((Size)std::ranges::size(r_out), (Size)std::ranges::size(r_in));
 
         auto res = std::ranges::transform(std::ranges::take_view(r_in, size),
             std::ranges::take_view(r_out, size).begin(), std::forward<decltype(args)>(args)...);
@@ -52,9 +52,9 @@ main()
             std::ranges::range_size_t<decltype(r_out)>>;
         Size size = std::ranges::size(r_out);
         if constexpr(std::ranges::sized_range<decltype(r_1)>)
-            size = std::ranges::min(size, (Size)std::ranges::size(r_1));
+            size = (std::ranges::min)(size, (Size)std::ranges::size(r_1));
         if constexpr(std::ranges::sized_range<decltype(r_2)>)
-            size = std::ranges::min(size, (Size)std::ranges::size(r_2));
+            size = (std::ranges::min)(size, (Size)std::ranges::size(r_2));
 
         auto res = std::ranges::transform(std::ranges::subrange(std::ranges::begin(r_1), std::ranges::begin(r_1) + size),
             std::ranges::subrange(std::ranges::begin(r_2), std::ranges::begin(r_2) + size),

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -42,7 +42,7 @@ main()
     //check access
     EXPECT_TRUE(::std::get<0>(z[2]) == 'g', "wrong effect with zip_view");
 
-    int64_t max_int32p2 = (size_t)::std::numeric_limits<int32_t>::max() + 2L;
+    int64_t max_int32p2 = (size_t)(std::numeric_limits<int32_t>::max)() + 2L;
 
     auto base_view = views::iota(::std::int64_t(0), max_int32p2);
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -41,6 +41,11 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
+#if defined(_MSC_VER)
+// Include windows.h to check that our code and tests are resiliant to min and max macros defined in windows.h
+#    include <Windows.h>
+#endif
+
 #define _PSTL_TEST_STRING(X) _PSTL_TEST_STRING_AUX(oneapi/dpl/X)
 #define _PSTL_TEST_STRING_AUX(X) #X
 //to support the optional including: <algorithm>, <memory>, <numeric> or <pstl/algorithm>, <pstl/memory>, <pstl/numeric>

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -41,11 +41,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-#if defined(_MSC_VER)
-// Include windows.h to check that our code and tests are resiliant to min and max macros defined in windows.h
-#    include <Windows.h>
-#endif
-
 #define _PSTL_TEST_STRING(X) _PSTL_TEST_STRING_AUX(oneapi/dpl/X)
 #define _PSTL_TEST_STRING_AUX(X) #X
 //to support the optional including: <algorithm>, <memory>, <numeric> or <pstl/algorithm>, <pstl/memory>, <pstl/numeric>

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -990,7 +990,7 @@ generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
     {
         // no uniform_int_distribution for chars
         using GenT = std::conditional_t<sizeof(T) < sizeof(short), int, T>;
-        std::uniform_int_distribution<GenT> dist(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
+        std::uniform_int_distribution<GenT> dist(std::numeric_limits<T>::lowest(), (std::numeric_limits<T>::max)());
         std::generate(input, input + unique_threshold, [&] { return T(dist(gen)); });
     }
     else
@@ -998,7 +998,7 @@ generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
         // log2 - exp2 transformation allows generating floating point values,
         // which distribution resembles uniform distribution of their bit representation
         // This is useful for checking different cases of radix sort
-        std::uniform_real_distribution<T> dist_real(std::numeric_limits<T>::min(), log2(std::numeric_limits<T>::max()));
+        std::uniform_real_distribution<T> dist_real((std::numeric_limits<T>::min)(), log2((std::numeric_limits<T>::max)()));
         std::uniform_int_distribution<int> dist_binary(0, 1);
         auto randomly_signed_real = [&dist_real, &dist_binary, &gen]()
         {
@@ -1029,7 +1029,7 @@ get_pattern_for_max_n()
     constexpr std::size_t max_work_group_size = 512;
     std::size_t __max_n = multiplier * max_iters_per_item * max_work_group_size *
                           d.get_info<sycl::info::device::max_compute_units>();
-    __max_n = std::min(std::size_t{10000000}, __max_n);
+    __max_n = (std::min)(std::size_t{10000000}, __max_n);
     return __max_n;
 #else
     return TestUtils::max_n;

--- a/test/support/utils_sequence.h
+++ b/test/support/utils_sequence.h
@@ -200,7 +200,7 @@ Sequence<T>::print() const
 #if PRINT_FULL_SEQUENCE_CONTENT
     ::std::copy(begin(), end(), ::std::ostream_iterator<T>(::std::cout, " "));
 #else
-    const auto printable_size = ::std::min(max_print_count, size());
+    const auto printable_size = (std::min)(max_print_count, size());
     ::std::copy(begin(), begin() + printable_size, ::std::ostream_iterator<T>(::std::cout, " "));
 #endif // PRINT_FULL_SEQUENCE_CONTENT
     ::std::cout << " } " << ::std::endl;

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range1_g.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range1_g.pass.cpp
@@ -56,9 +56,9 @@ kernel_test1()
                             for (int j = 6; j < 12; ++j)
                             {
                                 ret &= (equal_range(&access[0] + i, &access[0] + j, 1).first ==
-                                        &access[0] + std::max(i, 4));
+                                        &access[0] + (std::max)(i, 4));
                                 ret &= (equal_range(&access[0] + i, &access[0] + j, 1).second ==
-                                        &access[0] + std::min(j, 8));
+                                        &access[0] + (std::min)(j, 8));
                             }
                         }
                         ret_access[0] = ret;

--- a/test/xpu_api/language.support/support.limits/limits/max1.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/max1.pass.cpp
@@ -33,13 +33,13 @@ template <class T>
 void
 test(T expected)
 {
-    assert(dpl::numeric_limits<T>::max() == expected);
+    assert((dpl::numeric_limits<T>::max)() == expected);
     assert(dpl::numeric_limits<T>::is_bounded);
-    assert(dpl::numeric_limits<const T>::max() == expected);
+    assert((dpl::numeric_limits<const T>::max)() == expected);
     assert(dpl::numeric_limits<const T>::is_bounded);
-    assert(dpl::numeric_limits<volatile T>::max() == expected);
+    assert((dpl::numeric_limits<volatile T>::max)() == expected);
     assert(dpl::numeric_limits<volatile T>::is_bounded);
-    assert(dpl::numeric_limits<const volatile T>::max() == expected);
+    assert((dpl::numeric_limits<const volatile T>::max)() == expected);
     assert(dpl::numeric_limits<const volatile T>::is_bounded);
 }
 

--- a/test/xpu_api/numerics/c.math/abs1.pass.cpp
+++ b/test/xpu_api/numerics/c.math/abs1.pass.cpp
@@ -36,7 +36,7 @@ void test_abs()
 
 void test_big()
 {
-    long long int big_value = std::numeric_limits<long long int>::max(); // a value too big for ints to store
+    long long int big_value = (std::numeric_limits<long long int>::max)(); // a value too big for ints to store
     long long int negative_big_value = -big_value;
     assert(dpl::abs(negative_big_value) == big_value); // make sure it doesn't get casted to a smaller type
 }

--- a/test/xpu_api/numerics/c.math/cmath.pass.cpp
+++ b/test/xpu_api/numerics/c.math/cmath.pass.cpp
@@ -260,8 +260,8 @@ void test_isinf()
     assert(dpl::isinf(0) == false);
     assert(dpl::isinf(1) == false);
     assert(dpl::isinf(-1) == false);
-    assert(dpl::isinf(std::numeric_limits<int>::max()) == false);
-    assert(dpl::isinf(std::numeric_limits<int>::min()) == false);
+    assert(dpl::isinf((std::numeric_limits<int>::max)()) == false);
+    assert(dpl::isinf((std::numeric_limits<int>::min)()) == false);
 #endif // !_PSTL_ICC_TEST_COMPLEX_ISINF_BROKEN
 
 #ifdef __clang__
@@ -347,8 +347,8 @@ void test_isnan()
     assert(dpl::isnan(0) == false);
     assert(dpl::isnan(1) == false);
     assert(dpl::isnan(-1) == false);
-    assert(dpl::isnan(std::numeric_limits<int>::max()) == false);
-    assert(dpl::isnan(std::numeric_limits<int>::min()) == false);
+    assert(dpl::isnan((std::numeric_limits<int>::max)()) == false);
+    assert(dpl::isnan((std::numeric_limits<int>::min)()) == false);
 #endif // !_PSTL_ICC_TEST_COMPLEX_ISNAN_BROKEN
 
 #ifdef __clang__

--- a/test/xpu_api/random/interface_tests/common_for_distrs_methods.hpp
+++ b/test/xpu_api/random/interface_tests/common_for_distrs_methods.hpp
@@ -27,8 +27,8 @@ std::int32_t
 check_params(oneapi::dpl::uniform_int_distribution<T>& distr)
 {
     Element_type<T> a = Element_type<T>{0};
-    Element_type<T> b = std::numeric_limits<Element_type<T>>::max();
-    return ((distr.a() != a) || (distr.b() != b) || (distr.min() != a) || (distr.max() != b) ||
+    Element_type<T> b = (std::numeric_limits<Element_type<T>>::max)();
+    return ((distr.a() != a) || (distr.b() != b) || ((distr.min)() != a) || ((distr.max)() != b) ||
             (distr.param().a() != a) || (distr.param().b() != b));
 }
 
@@ -38,7 +38,7 @@ check_params(oneapi::dpl::uniform_real_distribution<T>& distr)
 {
     Element_type<T> a = Element_type<T>{0.0};
     Element_type<T> b = Element_type<T>{1.0};
-    return ((distr.a() != a) || (distr.b() != b) || (distr.min() != a) || (distr.max() != b) ||
+    return ((distr.a() != a) || (distr.b() != b) || ((distr.min)() != a) || ((distr.max)() != b) ||
             (distr.param().a() != a) || (distr.param().b() != b));
 }
 
@@ -49,8 +49,8 @@ check_params(oneapi::dpl::normal_distribution<T>& distr)
     Element_type<T> mean = Element_type<T>{0.0};
     Element_type<T> stddev = Element_type<T>{1.0};
     return ((distr.mean() != mean) || (distr.stddev() != stddev) ||
-            (distr.min() > -std::numeric_limits<Element_type<T>>::max()) ||
-            (distr.max() < std::numeric_limits<Element_type<T>>::max()) || (distr.param().mean() != mean) ||
+            ((distr.min)() > -(std::numeric_limits<Element_type<T>>::max)()) ||
+            ((distr.max)() < (std::numeric_limits<Element_type<T>>::max)()) || (distr.param().mean() != mean) ||
             (distr.param().stddev() != stddev));
 }
 
@@ -59,8 +59,8 @@ std::int32_t
 check_params(oneapi::dpl::exponential_distribution<T>& distr)
 {
     Element_type<T> lambda = Element_type<T>{1.0};
-    return ((distr.lambda() != lambda) || (distr.min() != 0) ||
-            (distr.max() < std::numeric_limits<Element_type<T>>::max()) || 
+    return ((distr.lambda() != lambda) || ((distr.min)() != 0) ||
+            ((distr.max)() < (std::numeric_limits<Element_type<T>>::max)()) || 
             (distr.param().lambda() != lambda));
 }
 
@@ -69,8 +69,8 @@ std::int32_t
 check_params(oneapi::dpl::bernoulli_distribution<T>& distr)
 {
     double p = 0.5;
-    return ((distr.p() != p) || (distr.min() != false) ||
-            (distr.max() != true) || (distr.param().p() != p));
+    return ((distr.p() != p) || ((distr.min)() != false) ||
+            ((distr.max)() != true) || (distr.param().p() != p));
 }
 
 template <class T>
@@ -78,8 +78,8 @@ std::int32_t
 check_params(oneapi::dpl::geometric_distribution<T>& distr)
 {
     double p = 0.5;
-    return ((distr.p() != p) || (distr.min() != 0) ||
-            (distr.max()  < std::numeric_limits<Element_type<T>>::max()) || 
+    return ((distr.p() != p) || ((distr.min)() != 0) ||
+            ((distr.max)()  < (std::numeric_limits<Element_type<T>>::max)()) || 
             (distr.param().p() != p));
 }
 
@@ -89,8 +89,8 @@ check_params(oneapi::dpl::weibull_distribution<T>& distr)
 {
     Element_type<T> a = Element_type<T>{1.0};
     Element_type<T> b = Element_type<T>{1.0};
-    return ((distr.a() != a) || (distr.b() != b) || (distr.min() != 0) || 
-            (distr.max() < std::numeric_limits<Element_type<T>>::max()) ||
+    return ((distr.a() != a) || (distr.b() != b) || ((distr.min)() != 0) || 
+            ((distr.max)() < (std::numeric_limits<Element_type<T>>::max)()) ||
             (distr.param().a() != a) || (distr.param().b() != b));
 }
 
@@ -101,7 +101,7 @@ check_params(oneapi::dpl::lognormal_distribution<T>& distr)
     Element_type<T> m = Element_type<T>{0.0};
     Element_type<T> s = Element_type<T>{1.0};
     return ((distr.m() != m) || (distr.s() != s) ||
-            (distr.min() != 0) || (distr.max() < std::numeric_limits<Element_type<T>>::max()) || 
+            ((distr.min)() != 0) || ((distr.max)() < (std::numeric_limits<Element_type<T>>::max)()) || 
             (distr.param().m() != m) || (distr.param().s() != s));
 }
 
@@ -112,8 +112,8 @@ check_params(oneapi::dpl::cauchy_distribution<T>& distr)
     Element_type<T> a = Element_type<T>{0.0};
     Element_type<T> b = Element_type<T>{1.0};
     return ((distr.a() != a) || (distr.b() != b) ||
-            (distr.min() > std::numeric_limits<Element_type<T>>::lowest()) || 
-            (distr.max() < std::numeric_limits<Element_type<T>>::max()) || 
+            ((distr.min)() > std::numeric_limits<Element_type<T>>::lowest()) || 
+            ((distr.max)() < (std::numeric_limits<Element_type<T>>::max)()) || 
             (distr.param().a() != a) || (distr.param().b() != b));
 }
 
@@ -124,8 +124,8 @@ check_params(oneapi::dpl::extreme_value_distribution<T>& distr)
     Element_type<T> a = Element_type<T>{0.0};
     Element_type<T> b = Element_type<T>{1.0};
     return ((distr.a() != a) || (distr.b() != b) ||
-            (distr.min() > std::numeric_limits<Element_type<T>>::lowest()) || 
-            (distr.max() < std::numeric_limits<Element_type<T>>::max()) || 
+            ((distr.min)() > std::numeric_limits<Element_type<T>>::lowest()) || 
+            ((distr.max)() < (std::numeric_limits<Element_type<T>>::max)()) || 
             (distr.param().a() != a) || (distr.param().b() != b));
 }
 
@@ -303,7 +303,7 @@ check_input_output(Distr& distr)
     }
     else if constexpr (std::is_same_v<Distr, oneapi::dpl::uniform_int_distribution<result_type>>) {
         params_type a{0};
-        params_type b = std::numeric_limits<params_type>::max();
+        params_type b = (std::numeric_limits<params_type>::max)();
 
         std::stringstream s;
         s << a << ' ' << b;

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -52,8 +52,8 @@ std::int32_t
 check_params(oneapi::dpl::minstd_rand& engine)
 {
     return ((oneapi::dpl::minstd_rand::multiplier != MINSTD_A) || (oneapi::dpl::minstd_rand::increment != MINSTD_C) ||
-            (oneapi::dpl::minstd_rand::modulus != MINSTD_M) || (engine.min() != MINSTD_MIN) ||
-            (engine.max() != MINSTD_MAX));
+            (oneapi::dpl::minstd_rand::modulus != MINSTD_M) || ((engine.min)() != MINSTD_MIN) ||
+            ((engine.max)() != MINSTD_MAX));
 }
 
 template <int N>
@@ -62,8 +62,8 @@ check_params(oneapi::dpl::minstd_rand_vec<N>& engine)
 {
     return ((oneapi::dpl::minstd_rand_vec<N>::multiplier != MINSTD_A) ||
             (oneapi::dpl::minstd_rand_vec<N>::increment != MINSTD_C) ||
-            (oneapi::dpl::minstd_rand_vec<N>::modulus != MINSTD_M) || (engine.min() != MINSTD_MIN) ||
-            (engine.max() != MINSTD_MAX));
+            (oneapi::dpl::minstd_rand_vec<N>::modulus != MINSTD_M) || ((engine.min)() != MINSTD_MIN) ||
+            ((engine.max)() != MINSTD_MAX));
 }
 
 std::int32_t
@@ -71,8 +71,8 @@ check_params(oneapi::dpl::ranlux24_base& engine)
 {
     return ((oneapi::dpl::ranlux24_base::word_size != RANLUX24_BASE_W) ||
             (oneapi::dpl::ranlux24_base::short_lag != RANLUX24_BASE_S) ||
-            (oneapi::dpl::ranlux24_base::long_lag != RANLUX24_BASE_R) || (engine.min() != RANLUX24_BASE_MIN) ||
-            (engine.max() != RANLUX24_BASE_MAX));
+            (oneapi::dpl::ranlux24_base::long_lag != RANLUX24_BASE_R) || ((engine.min)() != RANLUX24_BASE_MIN) ||
+            ((engine.max)() != RANLUX24_BASE_MAX));
 }
 
 template <int N>
@@ -81,15 +81,15 @@ check_params(oneapi::dpl::ranlux24_base_vec<N>& engine)
 {
     return ((oneapi::dpl::ranlux24_base_vec<N>::word_size != RANLUX24_BASE_W) ||
             (oneapi::dpl::ranlux24_base_vec<N>::short_lag != RANLUX24_BASE_S) ||
-            (oneapi::dpl::ranlux24_base_vec<N>::long_lag != RANLUX24_BASE_R) || (engine.min() != RANLUX24_BASE_MIN) ||
-            (engine.max() != RANLUX24_BASE_MAX));
+            (oneapi::dpl::ranlux24_base_vec<N>::long_lag != RANLUX24_BASE_R) || ((engine.min)() != RANLUX24_BASE_MIN) ||
+            ((engine.max)() != RANLUX24_BASE_MAX));
 }
 
 std::int32_t
 check_params(oneapi::dpl::ranlux24& engine)
 {
     return ((oneapi::dpl::ranlux24::block_size != RANLUX24_P) || (oneapi::dpl::ranlux24::used_block != RANLUX24_R) ||
-            (engine.min() != RANLUX24_BASE_MIN) || (engine.max() != RANLUX24_BASE_MAX));
+            ((engine.min)() != RANLUX24_BASE_MIN) || ((engine.max)() != RANLUX24_BASE_MAX));
 }
 
 template <int N>
@@ -97,8 +97,8 @@ std::int32_t
 check_params(oneapi::dpl::ranlux24_vec<N>& engine)
 {
     return ((oneapi::dpl::ranlux24_vec<N>::block_size != RANLUX24_P) ||
-            (oneapi::dpl::ranlux24_vec<N>::used_block != RANLUX24_R) || (engine.min() != RANLUX24_BASE_MIN) ||
-            (engine.max() != RANLUX24_BASE_MAX));
+            (oneapi::dpl::ranlux24_vec<N>::used_block != RANLUX24_R) || ((engine.min)() != RANLUX24_BASE_MIN) ||
+            ((engine.max)() != RANLUX24_BASE_MAX));
 }
 
 std::int32_t
@@ -108,7 +108,7 @@ check_params(ex::philox4x32& engine)
             (ex::philox4x32::word_count   != PHILOX4x32_N) ||
             (ex::philox4x32::round_count  != PHILOX4x32_R) ||
             (ex::philox4x32::default_seed != PHILOX_SEED)  ||
-            (engine.min() != PHILOX4x32_MIN) || (engine.max() != PHILOX4x32_MAX));
+            ((engine.min)() != PHILOX4x32_MIN) || ((engine.max)() != PHILOX4x32_MAX));
 }
 template <int N>
 std::int32_t
@@ -118,7 +118,7 @@ check_params(ex::philox4x32_vec<N>& engine)
             (ex::philox4x32_vec<N>::word_count   != PHILOX4x32_N) ||
             (ex::philox4x32_vec<N>::round_count  != PHILOX4x32_R) ||
             (ex::philox4x32_vec<N>::default_seed != PHILOX_SEED)  ||
-            (engine.min() != PHILOX4x32_MIN) || (engine.max() != PHILOX4x32_MAX));
+            ((engine.min)() != PHILOX4x32_MIN) || ((engine.max)() != PHILOX4x32_MAX));
 }
 
 std::int32_t
@@ -128,7 +128,7 @@ check_params(ex::philox4x64& engine)
             (ex::philox4x64::word_count   != PHILOX4x64_N) ||
             (ex::philox4x64::round_count  != PHILOX4x64_R) ||
             (ex::philox4x64::default_seed != PHILOX_SEED)  ||
-            (engine.min() != PHILOX4x64_MIN) || (engine.max() != PHILOX4x64_MAX));
+            ((engine.min)() != PHILOX4x64_MIN) || ((engine.max)() != PHILOX4x64_MAX));
 }
 template <int N>
 std::int32_t
@@ -138,7 +138,7 @@ check_params(ex::philox4x64_vec<N>& engine)
             (ex::philox4x64_vec<N>::word_count   != PHILOX4x64_N) ||
             (ex::philox4x64_vec<N>::round_count  != PHILOX4x64_R) ||
             (ex::philox4x64_vec<N>::default_seed != PHILOX_SEED)  ||
-            (engine.min() != PHILOX4x64_MIN) || (engine.max() != PHILOX4x64_MAX));
+            ((engine.min)() != PHILOX4x64_MIN) || ((engine.max)() != PHILOX4x64_MAX));
 }
 
 template <class Engine>
@@ -251,7 +251,7 @@ public:
                         engine1.discard(offset);
                         typename oneapi::dpl::ranlux24_vec<N>::result_type res0;
                         oneapi::dpl::ranlux24_vec<N> engine(engine1);
-                        auto eng = engine.base().min();
+                        auto eng = (engine.base().min)();
                         res0 = engine() + eng;
                         typename oneapi::dpl::ranlux24_vec<N>::result_type res1 = engine1();
                         std::int32_t is_inequal = 0;
@@ -461,7 +461,7 @@ public:
                         }
                         result_type res0;
                         oneapi::dpl::ranlux24 engine(engine1);
-                        auto eng = engine.base().min();
+                        auto eng = (engine.base().min)();
                         res0 = engine() + eng;
                         result_type res1 = engine1();
                         if (res0 != res1 + eng)

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -443,7 +443,7 @@ counter_overflow_test()
     std::array<T, Engine::word_count> counter;
     for (int i = 0; i < Engine::word_count; i++)
     {
-        counter[i] = std::numeric_limits<T>::max();
+        counter[i] = (std::numeric_limits<T>::max)();
     }
 
     engine1.set_counter(counter);
@@ -496,7 +496,7 @@ discard_overflow_test()
         std::array<T, Engine::word_count> counter2 = {0};
         for (int i = Engine::word_count - overflown_position - 1; i < Engine::word_count - 1; ++i)
         {
-            counter2[i] = std::numeric_limits<T>::max();
+            counter2[i] = (std::numeric_limits<T>::max)();
         }
 
         engine2.set_counter(counter2);
@@ -508,7 +508,7 @@ discard_overflow_test()
 
         for (int i = 0; i < Engine::word_count; i++)
         {
-            engine2.discard(engine2.max());
+            engine2.discard((engine2.max)());
         }
 
         if (engine1() == engine2())
@@ -543,7 +543,7 @@ counter_management_test()
     Engine referenceEngine;
 
     // set the counter which value is 2-chunk bitsize
-    unsigned long long increment = ((unsigned long long)testedEngine.max() << Engine::word_size) | testedEngine.max();
+    unsigned long long increment = ((unsigned long long)(testedEngine.max)() << Engine::word_size) | (testedEngine.max)();
     unsigned long long counter_increment = increment / Engine::word_count;
 
     std::array<T, Engine::word_count> expected_counter = {0};


### PR DESCRIPTION
Another option for resolving NOMINMAX issue.  
Similar to MSVC STL, we can protect usages of min and max against colliding with the macros defined in windows.h. 

The upside for this is that there is no need for /DNOMINMAX with this option.  The downside is cluttering the code, and maintenance in the future where we must continue to protect such instances similarly.

Perhaps we can include windows.h in our tests from windows to define these macros and detect these errors in our per commit CI going forward.