### PR TITLE
[Draft] Undefine and redefine min and max macros

### DIFF
--- a/include/oneapi/dpl/algorithm
+++ b/include/oneapi/dpl/algorithm
@@ -163,4 +163,6 @@ using ::std::upper_bound;
 } // namespace oneapi
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_ALGORITHM

--- a/include/oneapi/dpl/array
+++ b/include/oneapi/dpl/array
@@ -33,4 +33,6 @@ using ::std::tuple_size;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_ARRAY

--- a/include/oneapi/dpl/async
+++ b/include/oneapi/dpl/async
@@ -35,4 +35,6 @@
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_ASYNC

--- a/include/oneapi/dpl/cmath
+++ b/include/oneapi/dpl/cmath
@@ -92,4 +92,6 @@ using ::std::truncf;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_CMATH

--- a/include/oneapi/dpl/complex
+++ b/include/oneapi/dpl/complex
@@ -56,4 +56,6 @@ using ::std::tanh;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_COMPLEX

--- a/include/oneapi/dpl/cstddef
+++ b/include/oneapi/dpl/cstddef
@@ -32,4 +32,6 @@ using ::std::size_t;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_CSTDDEF

--- a/include/oneapi/dpl/cstring
+++ b/include/oneapi/dpl/cstring
@@ -31,4 +31,6 @@ using ::std::memset;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_CSTRING

--- a/include/oneapi/dpl/dynamic_selection
+++ b/include/oneapi/dpl/dynamic_selection
@@ -25,4 +25,7 @@
 #include "oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy.h"
 #include "oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h"
 #include "oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h"
+
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif /* ONEDPL_DYNAMIC_SELECTION */

--- a/include/oneapi/dpl/execution
+++ b/include/oneapi/dpl/execution
@@ -75,4 +75,6 @@ _PSTL_PRAGMA_MESSAGE_POLICIES(
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_EXECUTION

--- a/include/oneapi/dpl/experimental/kernel_templates
+++ b/include/oneapi/dpl/experimental/kernel_templates
@@ -20,4 +20,6 @@
 
 #include "kt/single_pass_scan.h"
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_KERNEL_TEMPLATES

--- a/include/oneapi/dpl/functional
+++ b/include/oneapi/dpl/functional
@@ -91,4 +91,6 @@ struct minimum
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_FUNCTIONAL

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -68,4 +68,6 @@
 #    endif
 #endif // __cplusplus >= 201703L
 
+#include "oneapi/dpl/internal/undefine_windows_minmax.h"
+
 #endif // _ONEDPL_COMMON_CONFIG_H

--- a/include/oneapi/dpl/internal/redefine_windows_minmax.h
+++ b/include/oneapi/dpl/internal/redefine_windows_minmax.h
@@ -22,15 +22,15 @@
 // This header must be included last by public headers.
 
 #if (_MSC_VER)
-#if defined(_ONEDPL_UNDEFINED_MIN)
-#undef _ONEDPL_UNDEFINED_MIN
-#define min(a,b)            (((a) < (b)) ? (a) : (b))
-#endif // defined(_ONEDPL_UNDEFINED_MIN)
+#    if defined(_ONEDPL_UNDEFINED_MIN)
+#        undef _ONEDPL_UNDEFINED_MIN
+#        define min(a, b) (((a) < (b)) ? (a) : (b))
+#    endif // defined(_ONEDPL_UNDEFINED_MIN)
 
-#if defined(max)
-#undef _ONEDPL_UNDEFINED_MAX
-#define max(a,b)            (((a) > (b)) ? (a) : (b))
-#endif // defined(_ONEDPL_UNDEFINED_MAX)
+#    if defined(max)
+#        undef _ONEDPL_UNDEFINED_MAX
+#        define max(a, b) (((a) > (b)) ? (a) : (b))
+#    endif // defined(_ONEDPL_UNDEFINED_MAX)
 #endif
 
 #endif // _ONEDPL_REDEFINE_WINDOWS_MINMAX_H

--- a/include/oneapi/dpl/internal/redefine_windows_minmax.h
+++ b/include/oneapi/dpl/internal/redefine_windows_minmax.h
@@ -1,0 +1,36 @@
+// -*- C++ -*-
+//===-- redefine_windows_minmax.h -----------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _ONEDPL_REDEFINE_WINDOWS_MINMAX_H
+#define _ONEDPL_REDEFINE_WINDOWS_MINMAX_H
+
+// Windows.h defines min and max macros, which can conflict with std::min and std::max and other APIs
+// in oneapi/dpl/internal/undefine_windows_minmax.h we undefine these macros to protect from conflicts.
+// Here we redefine these macros if we previously undefined them.
+// This header must be included last by public headers.
+
+#if (_MSC_VER)
+#if defined(_ONEDPL_UNDEFINED_MIN)
+#undef _ONEDPL_UNDEFINED_MIN
+#define min(a,b)            (((a) < (b)) ? (a) : (b))
+#endif // defined(_ONEDPL_UNDEFINED_MIN)
+
+#if defined(max)
+#undef _ONEDPL_UNDEFINED_MAX
+#define max(a,b)            (((a) > (b)) ? (a) : (b))
+#endif // defined(_ONEDPL_UNDEFINED_MAX)
+#endif
+
+#endif // _ONEDPL_REDEFINE_WINDOWS_MINMAX_H

--- a/include/oneapi/dpl/internal/undefine_windows_minmax.h
+++ b/include/oneapi/dpl/internal/undefine_windows_minmax.h
@@ -22,15 +22,15 @@
 // This header must be included first by public headers, or after windows.h inclusion.
 
 #if (_MSC_VER)
-#if defined(min)
-#define _ONEDPL_UNDEFINED_MIN 1
-#undef min
-#endif // defined(min)
+#    if defined(min)
+#        define _ONEDPL_UNDEFINED_MIN 1
+#        undef min
+#    endif // defined(min)
 
-#if defined(max)
-#define _ONEDPL_UNDEFINED_MAX 1
-#undef max
-#endif // defined(max)
+#    if defined(max)
+#        define _ONEDPL_UNDEFINED_MAX 1
+#        undef max
+#    endif // defined(max)
 
 #endif
 

--- a/include/oneapi/dpl/internal/undefine_windows_minmax.h
+++ b/include/oneapi/dpl/internal/undefine_windows_minmax.h
@@ -1,0 +1,37 @@
+// -*- C++ -*-
+//===-- undefine_windows_minmax.h -----------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _ONEDPL_UNDEFINE_WINDOWS_MINMAX_H
+#define _ONEDPL_UNDEFINE_WINDOWS_MINMAX_H
+
+// Windows.h defines min and max macros, which can conflict with std::min and std::max and other APIs.
+// Here we undefine them to protect from conflicts. In oneapi/dpl/internal/redefine_windows_minmax.h we
+// redefine them if they are undefined here.
+// This header must be included first by public headers, or after windows.h inclusion.
+
+#if (_MSC_VER)
+#if defined(min)
+#define _ONEDPL_UNDEFINED_MIN 1
+#undef min
+#endif // defined(min)
+
+#if defined(max)
+#define _ONEDPL_UNDEFINED_MAX 1
+#undef max
+#endif // defined(max)
+
+#endif
+
+#endif // _ONEDPL_UNDEFINE_WINDOWS_MINMAX_H

--- a/include/oneapi/dpl/iterator
+++ b/include/oneapi/dpl/iterator
@@ -60,4 +60,6 @@ using ::std::size;
 } // namespace oneapi
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_ITERATOR

--- a/include/oneapi/dpl/limits
+++ b/include/oneapi/dpl/limits
@@ -30,4 +30,6 @@ using numeric_limits = ::std::numeric_limits<T>;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_LIMITS

--- a/include/oneapi/dpl/memory
+++ b/include/oneapi/dpl/memory
@@ -59,4 +59,6 @@ using oneapi::dpl::uninitialized_value_construct;
 using oneapi::dpl::uninitialized_value_construct_n;
 } // namespace std
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_MEMORY

--- a/include/oneapi/dpl/numeric
+++ b/include/oneapi/dpl/numeric
@@ -59,4 +59,6 @@ using oneapi::dpl::transform_inclusive_scan;
 using oneapi::dpl::transform_reduce;
 } // namespace std
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_NUMERIC

--- a/include/oneapi/dpl/optional
+++ b/include/oneapi/dpl/optional
@@ -32,4 +32,6 @@ using ::std::optional;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_OPTIONAL

--- a/include/oneapi/dpl/pstl/experimental/algorithm
+++ b/include/oneapi/dpl/pstl/experimental/algorithm
@@ -50,4 +50,6 @@ using oneapi::dpl::experimental::reduction_plus;
 } // namespace experimental
 } // namespace std
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_EXPERIMENTAL_ALGORITHM

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -46,7 +46,6 @@
 //tbb headers may have included windows.h, which defines min and max macros
 #include "oneapi/dpl/internal/undefine_windows_minmax.h"
 
-
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -43,6 +43,10 @@
 #    error Intel(R) Threading Building Blocks 2018 is required; older versions are not supported.
 #endif
 
+//tbb headers may have included windows.h, which defines min and max macros
+#include "oneapi/dpl/internal/undefine_windows_minmax.h"
+
+
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/random
+++ b/include/oneapi/dpl/random
@@ -92,4 +92,6 @@ using philox4x64_vec = philox_engine<sycl::vec<uint_fast64_t, _N>, 64, 4, 10, 0x
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_RANDOM

--- a/include/oneapi/dpl/ranges
+++ b/include/oneapi/dpl/ranges
@@ -52,4 +52,6 @@ static_assert(_ONEDPL_CXX_STANDARD_LIBRARY_CHECK,
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_RANGES

--- a/include/oneapi/dpl/ratio
+++ b/include/oneapi/dpl/ratio
@@ -39,4 +39,6 @@ using ::std::ratio_subtract;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_RATIO

--- a/include/oneapi/dpl/tuple
+++ b/include/oneapi/dpl/tuple
@@ -39,4 +39,6 @@ using ::std::tuple_size;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_TUPLE

--- a/include/oneapi/dpl/type_traits
+++ b/include/oneapi/dpl/type_traits
@@ -220,4 +220,6 @@ using ::std::result_of_t;       // Deprecated in C++17, removed in C++20
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_TYPE_TRAITS

--- a/include/oneapi/dpl/utility
+++ b/include/oneapi/dpl/utility
@@ -42,4 +42,6 @@ using ::std::tuple_size;
 
 namespace dpl = oneapi::dpl;
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_UTILITY

--- a/include/oneapi/dpl/version
+++ b/include/oneapi/dpl/version
@@ -13,4 +13,6 @@
 #include "internal/common_config.h"
 #include "internal/version_impl.h"
 
+#include "oneapi/dpl/internal/redefine_windows_minmax.h"
+
 #endif // _ONEDPL_VERSION

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -50,6 +50,10 @@
 #define _SCL_SECURE_NO_WARNINGS //to prevent the compilation warning. Microsoft STL implementation has specific checking of an iterator range in DEBUG mode for the containers from the standard library.
 #endif
 
+#if defined(_MSC_VER)
+#define NOMINMAX // to prevent windows.h defined min and max macro substitutions in test code
+#endif
+
 // ICC 18 (Windows) has encountered an unexpected problem on some tests
 #define _PSTL_ICC_18_VC141_TEST_SIMD_LAMBDA_RELEASE_BROKEN                                                            \
     (!_DEBUG && __INTEL_COMPILER >= 1800 && __INTEL_COMPILER < 1900 && _MSC_VER == 1910)


### PR DESCRIPTION
Undefine and later redefine windows.h `min` and `max` macros in public headers and after TBB inclusion to protect against conflicts with `std` and other APIs.

Requires defining NOMINMAX in test_config.h (or some similar solution) to prevent similar conflict issues in test code.
