### PR TITLE
Implement unified ETLS without TBB and use it for all host backends

### DIFF
--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -153,13 +153,14 @@ __process_chunk(const __chunk_metrics& __metrics, _Iterator __base, _Index __chu
 namespace __detail
 {
 
-template <typename _ValueType, typename... Args>
+template <typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage
-    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
-          _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>
+    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
+                                                                                    _ValueType, _Args...>
 {
-    using base_type = oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
-        _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>;
+    using base_type =
+        oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
+                                                                               _ValueType, _Args...>;
 
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage(_LocalArgs&&... __args) : base_type(std::forward<_LocalArgs>(__args)...)
@@ -182,12 +183,12 @@ struct __enumerable_thread_local_storage
 } // namespace __detail
 
 // enumerable thread local storage should only be created from make function
-template <typename _ValueType, typename... Args>
-oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>
-__make_enumerable_tls(Args&&... __args)
+template <typename _ValueType, typename... _Args>
+oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>
+__make_enumerable_tls(_Args&&... __args)
 {
-    return oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>(
-        std::forward<Args>(__args)...);
+    return oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>(
+        std::forward<_Args>(__args)...);
 }
 } // namespace __omp_backend
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -158,7 +158,7 @@ __process_chunk(const __chunk_metrics& __metrics, _Iterator __base, _Index __chu
 struct __get_num_threads
 {
     std::size_t
-    operator()()
+    operator()() const
     {
         return omp_in_parallel() ? omp_get_num_threads() : omp_get_max_threads();
     }
@@ -167,7 +167,7 @@ struct __get_num_threads
 struct __get_thread_num
 {
     std::size_t
-    operator()()
+    operator()() const
     {
         return omp_get_thread_num();
     }

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -31,7 +31,7 @@
 #ifdef _MSC_VER
 #    define _PSTL_PRAGMA(x) __pragma(x)
 #else
-#    define _PSTL_PRAGMA(x) _Pragma(#    x)
+#    define _PSTL_PRAGMA(x) _Pragma(#x)
 #endif
 
 namespace oneapi
@@ -152,19 +152,28 @@ __process_chunk(const __chunk_metrics& __metrics, _Iterator __base, _Index __chu
 
 namespace __detail
 {
-struct __get_num_threads
+
+template <typename _ValueType, typename... Args>
+struct __enumerable_thread_local_storage
+    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
+          _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>
 {
-    std::size_t
-    operator()() const
+    using base_type = oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
+        _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>;
+
+    template <typename... _LocalArgs>
+    __enumerable_thread_local_storage(_LocalArgs&&... __args) : base_type(std::forward<_LocalArgs>(__args)...)
+    {
+    }
+
+    static std::size_t
+    get_num_threads()
     {
         return omp_in_parallel() ? omp_get_num_threads() : omp_get_max_threads();
     }
-};
 
-struct __get_thread_num
-{
-    std::size_t
-    operator()() const
+    static std::size_t
+    get_thread_num()
     {
         return omp_get_thread_num();
     }
@@ -174,14 +183,11 @@ struct __get_thread_num
 
 // enumerable thread local storage should only be created from make function
 template <typename _ValueType, typename... Args>
-oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage<
-    _ValueType, oneapi::dpl::__omp_backend::__detail::__get_num_threads,
-    oneapi::dpl::__omp_backend::__detail::__get_thread_num, Args...>
+oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>
 __make_enumerable_tls(Args&&... __args)
 {
-    return oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage<
-        _ValueType, oneapi::dpl::__omp_backend::__detail::__get_num_threads,
-        oneapi::dpl::__omp_backend::__detail::__get_thread_num, Args...>(std::forward<Args>(__args)...);
+    return oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>(
+        std::forward<Args>(__args)...);
 }
 } // namespace __omp_backend
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -16,11 +16,11 @@
 #ifndef _ONEDPL_INTERNAL_OMP_UTIL_H
 #define _ONEDPL_INTERNAL_OMP_UTIL_H
 
-#include <iterator> //std::iterator_traits, std::distance
-#include <cstddef> //std::size_t
-#include <memory> //std::allocator
+#include <iterator>    //std::iterator_traits, std::distance
+#include <cstddef>     //std::size_t
+#include <memory>      //std::allocator
 #include <type_traits> // std::decay, is_integral_v, enable_if_t
-#include <utility> // std::forward
+#include <utility>     // std::forward
 #include <omp.h>
 
 #include "../parallel_backend_utils.h"
@@ -150,6 +150,8 @@ __process_chunk(const __chunk_metrics& __metrics, _Iterator __base, _Index __chu
     __f(__first, __last);
 }
 
+namespace __detail
+{
 struct __get_num_threads
 {
     std::size_t
@@ -167,15 +169,19 @@ struct __get_thread_num
         return omp_get_thread_num();
     }
 };
+
+} // namespace __detail
+
 // enumerable thread local storage should only be created from make function
 template <typename _ValueType, typename... Args>
-oneapi::dpl::__utils::__enumerable_thread_local_storage<_ValueType, oneapi::dpl::__omp_backend::__get_num_threads,
-                                                        oneapi::dpl::__omp_backend::__get_thread_num, Args...>
+oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage<
+    _ValueType, oneapi::dpl::__omp_backend::__detail::__get_num_threads,
+    oneapi::dpl::__omp_backend::__detail::__get_thread_num, Args...>
 __make_enumerable_tls(Args&&... __args)
 {
-    return oneapi::dpl::__utils::__enumerable_thread_local_storage<
-        _ValueType, oneapi::dpl::__omp_backend::__get_num_threads, oneapi::dpl::__omp_backend::__get_thread_num,
-        Args...>(std::forward<Args>(__args)...);
+    return oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage<
+        _ValueType, oneapi::dpl::__omp_backend::__detail::__get_num_threads,
+        oneapi::dpl::__omp_backend::__detail::__get_thread_num, Args...>(std::forward<Args>(__args)...);
 }
 } // namespace __omp_backend
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -155,87 +155,33 @@ __process_chunk(const __chunk_metrics& __metrics, _Iterator __base, _Index __chu
     __f(__first, __last);
 }
 
-namespace __detail
+struct __get_num_threads
 {
-
-template <typename _ValueType, typename... _Args>
-struct __enumerable_thread_local_storage
-{
-    template <typename... _LocalArgs>
-    __enumerable_thread_local_storage(_LocalArgs&&... __args)
-        : __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
-    {
-        std::size_t __num_threads = omp_in_parallel() ? omp_get_num_threads() : omp_get_max_threads();
-        __thread_specific_storage.resize(__num_threads);
-    }
-
-    // Note: size should not be used concurrently with parallel loops which may instantiate storage objects, as it may
-    // not return an accurate count of instantiated storage objects in lockstep with the number allocated and stored.
-    // This is because the count is not atomic with the allocation and storage of the storage objects.
     std::size_t
-    size() const
+    operator()()
     {
-        // only count storage which has been instantiated
-        return __num_elements.load();
+        return omp_in_parallel() ? omp_get_num_threads() : omp_get_max_threads();
     }
-
-    // Note: get_with_id should not be used concurrently with parallel loops which may instantiate storage objects,
-    // as its operation may provide an out of date view of the stored objects based on the timing new object creation
-    // and incrementing of the size.
-    // TODO: Consider replacing this access with a visitor pattern.
-    _ValueType&
-    get_with_id(std::size_t __i)
-    {
-        assert(__i < size());
-
-        std::size_t __j = 0;
-
-        if (size() == __thread_specific_storage.size())
-        {
-            return *__thread_specific_storage[__i];
-        }
-
-        for (std::size_t __count = 0; __j < __thread_specific_storage.size() && __count <= __i; ++__j)
-        {
-            // Only include storage from threads which have instantiated a storage object
-            if (__thread_specific_storage[__j])
-            {
-                ++__count;
-            }
-        }
-        // Need to back up one once we have found a valid storage object
-        return *__thread_specific_storage[__j - 1];
-    }
-
-    _ValueType&
-    get_for_current_thread()
-    {
-        std::size_t __i = omp_get_thread_num();
-        if (!__thread_specific_storage[__i])
-        {
-            // create temporary storage on first usage to avoid extra parallel region and unnecessary instantiation
-            __thread_specific_storage[__i] =
-                std::apply([](_Args... __arg_pack) { return std::make_unique<_ValueType>(__arg_pack...); }, __args);
-            __num_elements.fetch_add(1);
-        }
-        return *__thread_specific_storage[__i];
-    }
-
-    std::vector<std::unique_ptr<_ValueType>> __thread_specific_storage;
-    std::atomic_size_t __num_elements;
-    std::tuple<_Args...> __args;
 };
 
-} // namespace __detail
-
+struct __get_thread_num
+{
+    std::size_t
+    operator()()
+    {
+        return omp_get_thread_num();
+    }
+};
 // enumerable thread local storage should only be created from make function
 template <typename _ValueType, typename... Args>
-__detail::__enumerable_thread_local_storage<_ValueType, Args...>
+oneapi::dpl::__utils::__enumerable_thread_local_storage<_ValueType, oneapi::dpl::__omp_backend::__get_num_threads,
+                                                        oneapi::dpl::__omp_backend::__get_thread_num, Args...>
 __make_enumerable_tls(Args&&... __args)
 {
-    return __detail::__enumerable_thread_local_storage<_ValueType, Args...>(std::forward<Args>(__args)...);
+    return oneapi::dpl::__utils::__enumerable_thread_local_storage<
+        _ValueType, oneapi::dpl::__omp_backend::__get_num_threads, oneapi::dpl::__omp_backend::__get_thread_num,
+        Args...>(std::forward<Args>(__args)...);
 }
-
 } // namespace __omp_backend
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -16,17 +16,12 @@
 #ifndef _ONEDPL_INTERNAL_OMP_UTIL_H
 #define _ONEDPL_INTERNAL_OMP_UTIL_H
 
-#include <algorithm>
-#include <atomic>
-#include <iterator>
-#include <cstddef>
-#include <cstdint>
-#include <cstdio>
-#include <memory>
-#include <vector>
-#include <type_traits>
+#include <iterator> //std::iterator_traits, std::distance
+#include <cstddef> //std::size_t
+#include <memory> //std::allocator
+#include <type_traits> // std::decay, is_integral_v, enable_if_t
+#include <utility> // std::forward
 #include <omp.h>
-#include <tuple>
 
 #include "../parallel_backend_utils.h"
 #include "../unseq_backend_simd.h"

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -31,7 +31,7 @@
 #ifdef _MSC_VER
 #    define _PSTL_PRAGMA(x) __pragma(x)
 #else
-# define _PSTL_PRAGMA(x) _Pragma(# x)
+#    define _PSTL_PRAGMA(x) _Pragma(#    x)
 #endif
 
 namespace oneapi

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -31,7 +31,7 @@
 #ifdef _MSC_VER
 #    define _PSTL_PRAGMA(x) __pragma(x)
 #else
-#    define _PSTL_PRAGMA(x) _Pragma(#x)
+# define _PSTL_PRAGMA(x) _Pragma(# x)
 #endif
 
 namespace oneapi

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -34,48 +34,6 @@ namespace dpl
 namespace __serial_backend
 {
 
-namespace __detail
-{
-
-template <typename _ValueType>
-struct __enumerable_thread_local_storage
-{
-    template <typename... _LocalArgs>
-    __enumerable_thread_local_storage(_LocalArgs&&... __args) : __storage(std::forward<_LocalArgs>(__args)...)
-    {
-    }
-
-    std::size_t
-    size() const
-    {
-        return std::size_t{1};
-    }
-
-    _ValueType&
-    get_for_current_thread()
-    {
-        return __storage;
-    }
-
-    _ValueType&
-    get_with_id(std::size_t /*__i*/)
-    {
-        return get_for_current_thread();
-    }
-
-    _ValueType __storage;
-};
-
-} //namespace __detail
-
-// enumerable thread local storage should only be created from make function
-template <typename _ValueType, typename... Args>
-__detail::__enumerable_thread_local_storage<_ValueType>
-__make_enumerable_tls(Args&&... __args)
-{
-    return __detail::__enumerable_thread_local_storage<_ValueType>(std::forward<Args>(__args)...);
-}
-
 template <typename _ExecutionPolicy, typename _Tp>
 using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
@@ -169,6 +127,35 @@ __parallel_for_each(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPol
 {
     for (auto __iter = __begin; __iter != __end; ++__iter)
         __f(*__iter);
+}
+
+struct __get_num_threads
+{
+    std::size_t
+    operator()()
+    {
+        return 1;
+    }
+};
+
+struct __get_thread_num
+{
+    std::size_t
+    operator()()
+    {
+        return 0;
+    }
+};
+
+// enumerable thread local storage should only be created from make function
+template <typename _ValueType, typename... Args>
+oneapi::dpl::__utils::__enumerable_thread_local_storage<_ValueType, oneapi::dpl::__serial_backend::__get_num_threads,
+                                                        oneapi::dpl::__serial_backend::__get_thread_num, Args...>
+__make_enumerable_tls(Args&&... __args)
+{
+    return oneapi::dpl::__utils::__enumerable_thread_local_storage<
+        _ValueType, oneapi::dpl::__serial_backend::__get_num_threads, oneapi::dpl::__serial_backend::__get_thread_num,
+        Args...>(std::forward<Args>(__args)...);
 }
 
 } // namespace __serial_backend

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -171,24 +171,6 @@ __parallel_for_each(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPol
         __f(*__iter);
 }
 
-struct __get_num_threads
-{
-    std::size_t
-    operator()() const
-    {
-        return 1;
-    }
-};
-
-struct __get_thread_num
-{
-    std::size_t
-    operator()() const
-    {
-        return 0;
-    }
-};
-
 } // namespace __serial_backend
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -46,7 +46,7 @@ struct __enumerable_thread_local_storage
     }
 
     std::size_t
-    size() const
+    size() const noexcept
     {
         return std::size_t{1};
     }

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -132,7 +132,7 @@ __parallel_for_each(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPol
 struct __get_num_threads
 {
     std::size_t
-    operator()()
+    operator()() const
     {
         return 1;
     }
@@ -141,7 +141,7 @@ struct __get_num_threads
 struct __get_thread_num
 {
     std::size_t
-    operator()()
+    operator()() const
     {
         return 0;
     }

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -46,7 +46,7 @@ struct __enumerable_thread_local_storage
     }
 
     std::size_t
-    size() const noexcept
+    size() const
     {
         return std::size_t{1};
     }

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -504,7 +504,7 @@ class __root_task
   public:
     template <typename... Args>
     __root_task(Args&&... args)
-        : _M_task{new(tbb::task::allocate_root()) __func_task<_Func>{_Func(::std::forward<Args>(args)...)}}
+        : _M_task{new (tbb::task::allocate_root()) __func_task<_Func>{_Func(::std::forward<Args>(args)...)}}
     {
     }
 
@@ -1053,8 +1053,8 @@ class __merge_func
 template <typename _RandomAccessIterator1, typename _RandomAccessIterator2, typename __M_Compare, typename _Cleanup,
           typename _LeafMerge>
 __task*
-__merge_func<_RandomAccessIterator1, _RandomAccessIterator2, __M_Compare, _Cleanup, _LeafMerge>::operator()(
-    __task* __self)
+__merge_func<_RandomAccessIterator1, _RandomAccessIterator2, __M_Compare, _Cleanup, _LeafMerge>::
+operator()(__task* __self)
 {
     //a. split merge task into 2 of the same level; the special logic,
     //without processing(process_ranges) adjacent sub-ranges x and y
@@ -1217,8 +1217,8 @@ class __merge_func_static
 template <typename _RandomAccessIterator1, typename _RandomAccessIterator2, typename _RandomAccessIterator3,
           typename __M_Compare, typename _LeafMerge>
 __task*
-__merge_func_static<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3, __M_Compare,
-                    _LeafMerge>::operator()(__task* __self)
+__merge_func_static<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3, __M_Compare, _LeafMerge>::
+operator()(__task* __self)
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType1;
     typedef typename ::std::iterator_traits<_RandomAccessIterator2>::difference_type _DifferenceType2;

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1309,7 +1309,7 @@ __parallel_for_each(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy
 struct __get_num_threads
 {
     std::size_t
-    operator()()
+    operator()() const
     {
         return tbb::this_task_arena::max_concurrency();
     }
@@ -1318,7 +1318,7 @@ struct __get_num_threads
 struct __get_thread_num
 {
     std::size_t
-    operator()()
+    operator()() const
     {
         return tbb::this_task_arena::current_thread_index();
     }

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1309,13 +1309,14 @@ __parallel_for_each(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy
 namespace __detail
 {
 
-template <typename _ValueType, typename... Args>
+template <typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage
-    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
-          _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>
+    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
+                                                                                    _ValueType, _Args...>
 {
-    using base_type = oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
-        _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>;
+    using base_type =
+        oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
+                                                                               _ValueType, _Args...>;
 
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage(_LocalArgs&&... __args) : base_type(std::forward<_LocalArgs>(__args)...)
@@ -1338,12 +1339,12 @@ struct __enumerable_thread_local_storage
 } // namespace __detail
 
 // enumerable thread local storage should only be created from make function
-template <typename _ValueType, typename... Args>
-oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>
-__make_enumerable_tls(Args&&... __args)
+template <typename _ValueType, typename... _Args>
+oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>
+__make_enumerable_tls(_Args&&... __args)
 {
-    return oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>(
-        std::forward<Args>(__args)...);
+    return oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>(
+        std::forward<_Args>(__args)...);
 }
 
 } // namespace __tbb_backend

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1308,43 +1308,35 @@ __parallel_for_each(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy
 
 namespace __detail
 {
-
-template <typename _ValueType, typename... _Args>
-struct __enumerable_thread_local_storage
-    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
-                                                                                    _ValueType, _Args...>
+struct __get_num_threads
 {
-    using base_type =
-        oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
-                                                                               _ValueType, _Args...>;
-
-    template <typename... _LocalArgs>
-    __enumerable_thread_local_storage(_LocalArgs&&... __args) : base_type(std::forward<_LocalArgs>(__args)...)
-    {
-    }
-
-    static std::size_t
-    get_num_threads()
+    std::size_t
+    operator()() const
     {
         return tbb::this_task_arena::max_concurrency();
     }
+};
 
-    static std::size_t
-    get_thread_num()
+struct __get_thread_num
+{
+    std::size_t
+    operator()() const
     {
         return tbb::this_task_arena::current_thread_index();
     }
 };
-
-} // namespace __detail
+} //namespace __detail
 
 // enumerable thread local storage should only be created from make function
-template <typename _ValueType, typename... _Args>
-oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>
-__make_enumerable_tls(_Args&&... __args)
+template <typename _ValueType, typename... Args>
+oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage<
+    _ValueType, oneapi::dpl::__tbb_backend::__detail::__get_num_threads,
+    oneapi::dpl::__tbb_backend::__detail::__get_thread_num, Args...>
+__make_enumerable_tls(Args&&... __args)
 {
-    return oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>(
-        std::forward<_Args>(__args)...);
+    return oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage<
+        _ValueType, oneapi::dpl::__tbb_backend::__detail::__get_num_threads,
+        oneapi::dpl::__tbb_backend::__detail::__get_thread_num, Args...>(std::forward<Args>(__args)...);
 }
 
 } // namespace __tbb_backend

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1306,6 +1306,8 @@ __parallel_for_each(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy
     tbb::this_task_arena::isolate([&]() { tbb::parallel_for_each(__begin, __end, __f); });
 }
 
+namespace __detail
+{
 struct __get_num_threads
 {
     std::size_t
@@ -1323,16 +1325,18 @@ struct __get_thread_num
         return tbb::this_task_arena::current_thread_index();
     }
 };
+} //namespace __detail
 
 // enumerable thread local storage should only be created from make function
 template <typename _ValueType, typename... Args>
-oneapi::dpl::__utils::__enumerable_thread_local_storage<_ValueType, oneapi::dpl::__tbb_backend::__get_num_threads,
-                                                        oneapi::dpl::__tbb_backend::__get_thread_num, Args...>
+oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage<
+    _ValueType, oneapi::dpl::__tbb_backend::__detail::__get_num_threads,
+    oneapi::dpl::__tbb_backend::__detail::__get_thread_num, Args...>
 __make_enumerable_tls(Args&&... __args)
 {
-    return oneapi::dpl::__utils::__enumerable_thread_local_storage<
-        _ValueType, oneapi::dpl::__tbb_backend::__get_num_threads, oneapi::dpl::__tbb_backend::__get_thread_num,
-        Args...>(std::forward<Args>(__args)...);
+    return oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage<
+        _ValueType, oneapi::dpl::__tbb_backend::__detail::__get_num_threads,
+        oneapi::dpl::__tbb_backend::__detail::__get_thread_num, Args...>(std::forward<Args>(__args)...);
 }
 
 } // namespace __tbb_backend

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -34,7 +34,6 @@
 #include <tbb/parallel_invoke.h>
 #include <tbb/task_arena.h>
 #include <tbb/tbb_allocator.h>
-#include <tbb/enumerable_thread_specific.h>
 #if TBB_INTERFACE_VERSION > 12000
 #    include <tbb/task.h>
 #endif
@@ -1307,47 +1306,33 @@ __parallel_for_each(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy
     tbb::this_task_arena::isolate([&]() { tbb::parallel_for_each(__begin, __end, __f); });
 }
 
-namespace __detail
+struct __get_num_threads
 {
-
-template <typename _ValueType>
-struct __enumerable_thread_local_storage
-{
-    template <typename... _LocalArgs>
-    __enumerable_thread_local_storage(_LocalArgs&&... __args)
-        : __thread_specific_storage(std::forward<_LocalArgs>(__args)...)
-    {
-    }
-
     std::size_t
-    size() const
+    operator()()
     {
-        return __thread_specific_storage.size();
+        return tbb::this_task_arena::max_concurrency();
     }
-
-    _ValueType&
-    get_for_current_thread()
-    {
-        return __thread_specific_storage.local();
-    }
-
-    _ValueType&
-    get_with_id(std::size_t __i)
-    {
-        return __thread_specific_storage.begin()[__i];
-    }
-
-    tbb::enumerable_thread_specific<_ValueType> __thread_specific_storage;
 };
 
-} // namespace __detail
+struct __get_thread_num
+{
+    std::size_t
+    operator()()
+    {
+        return tbb::this_task_arena::current_thread_index();
+    }
+};
 
 // enumerable thread local storage should only be created from make function
 template <typename _ValueType, typename... Args>
-__detail::__enumerable_thread_local_storage<_ValueType>
+oneapi::dpl::__utils::__enumerable_thread_local_storage<_ValueType, oneapi::dpl::__tbb_backend::__get_num_threads,
+                                                        oneapi::dpl::__tbb_backend::__get_thread_num, Args...>
 __make_enumerable_tls(Args&&... __args)
 {
-    return __detail::__enumerable_thread_local_storage<_ValueType>(std::forward<Args>(__args)...);
+    return oneapi::dpl::__utils::__enumerable_thread_local_storage<
+        _ValueType, oneapi::dpl::__tbb_backend::__get_num_threads, oneapi::dpl::__tbb_backend::__get_thread_num,
+        Args...>(std::forward<Args>(__args)...);
 }
 
 } // namespace __tbb_backend

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -313,7 +313,7 @@ struct __enumerable_thread_local_storage
     __enumerable_thread_local_storage(_LocalArgs&&... __args)
         : __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
     {
-        std::size_t __num_threads = _GetNumThreads{}();
+        const std::size_t __num_threads = _GetNumThreads{}();
         __thread_specific_storage.resize(__num_threads);
     }
 
@@ -358,7 +358,7 @@ struct __enumerable_thread_local_storage
     _ValueType&
     get_for_current_thread()
     {
-        std::size_t __i = _GetThreadNum{}();
+        const std::size_t __i = _GetThreadNum{}();
         if (!__thread_specific_storage[__i])
         {
             // create temporary storage on first usage to avoid extra parallel region and unnecessary instantiation

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -309,12 +309,14 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 namespace __detail
 {
 
-template <typename _ValueType, typename _Concrete, typename... _Args>
+template <template <typename...> typename _Concrete, typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage_base
 {
+    using derived_type = _Concrete<_ValueType, _Args...>;
+
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage_base(_LocalArgs&&... __args)
-        : __thread_specific_storage(_Concrete::get_num_threads()), __num_elements(0),
+        : __thread_specific_storage(derived_type::get_num_threads()), __num_elements(0),
           __args(std::forward<_LocalArgs>(__args)...)
     {
     }
@@ -359,7 +361,7 @@ struct __enumerable_thread_local_storage_base
     _ValueType&
     get_for_current_thread()
     {
-        const std::size_t __i = _Concrete::get_thread_num();
+        const std::size_t __i = derived_type::get_thread_num();
         std::unique_ptr<_ValueType>& __thread_local_storage = __thread_specific_storage[__i];
         if (!__thread_local_storage)
         {

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -16,8 +16,13 @@
 #ifndef _ONEDPL_PARALLEL_BACKEND_UTILS_H
 #define _ONEDPL_PARALLEL_BACKEND_UTILS_H
 
+#include <atomic>
+#include <cstddef>
 #include <iterator>
+#include <memory>
+#include <tuple>
 #include <utility>
+#include <vector>
 #include <cassert>
 #include "utils.h"
 #include "memory_fwd.h"
@@ -300,6 +305,74 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
     }
     return __cc_range(__first2, __last2, __result);
 }
+
+template <typename _ValueType, typename _GetNumThreads, typename _GetThreadNum, typename... _Args>
+struct __enumerable_thread_local_storage
+{
+    template <typename... _LocalArgs>
+    __enumerable_thread_local_storage(_LocalArgs&&... __args)
+        : __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
+    {
+        std::size_t __num_threads = _GetNumThreads{}();
+        __thread_specific_storage.resize(__num_threads);
+    }
+
+    // Note: size should not be used concurrently with parallel loops which may instantiate storage objects, as it may
+    // not return an accurate count of instantiated storage objects in lockstep with the number allocated and stored.
+    // This is because the count is not atomic with the allocation and storage of the storage objects.
+    std::size_t
+    size() const
+    {
+        // only count storage which has been instantiated
+        return __num_elements.load();
+    }
+
+    // Note: get_with_id should not be used concurrently with parallel loops which may instantiate storage objects,
+    // as its operation may provide an out of date view of the stored objects based on the timing new object creation
+    // and incrementing of the size.
+    // TODO: Consider replacing this access with a visitor pattern.
+    _ValueType&
+    get_with_id(std::size_t __i)
+    {
+        assert(__i < size());
+
+        std::size_t __j = 0;
+
+        if (size() == __thread_specific_storage.size())
+        {
+            return *__thread_specific_storage[__i];
+        }
+
+        for (std::size_t __count = 0; __j < __thread_specific_storage.size() && __count <= __i; ++__j)
+        {
+            // Only include storage from threads which have instantiated a storage object
+            if (__thread_specific_storage[__j])
+            {
+                ++__count;
+            }
+        }
+        // Need to back up one once we have found a valid storage object
+        return *__thread_specific_storage[__j - 1];
+    }
+
+    _ValueType&
+    get_for_current_thread()
+    {
+        std::size_t __i = _GetThreadNum{}();
+        if (!__thread_specific_storage[__i])
+        {
+            // create temporary storage on first usage to avoid extra parallel region and unnecessary instantiation
+            __thread_specific_storage[__i] =
+                std::apply([](_Args... __arg_pack) { return std::make_unique<_ValueType>(__arg_pack...); }, __args);
+            __num_elements.fetch_add(1);
+        }
+        return *__thread_specific_storage[__i];
+    }
+
+    std::vector<std::unique_ptr<_ValueType>> __thread_specific_storage;
+    std::atomic_size_t __num_elements;
+    std::tuple<_Args...> __args;
+};
 
 } // namespace __utils
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -309,15 +309,13 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 namespace __detail
 {
 
-template <template <typename, typename...> typename _Concrete, typename _ValueType, typename... _Args>
-struct __enumerable_thread_local_storage_base
+template <typename _ValueType, typename _GetNumThreads, typename _GetThreadNum, typename... _Args>
+struct __enumerable_thread_local_storage
 {
-    using derived_type = _Concrete<_ValueType, _Args...>;
 
     template <typename... _LocalArgs>
-    __enumerable_thread_local_storage_base(_LocalArgs&&... __args)
-        : __thread_specific_storage(derived_type::get_num_threads()), __num_elements(0),
-          __args(std::forward<_LocalArgs>(__args)...)
+    __enumerable_thread_local_storage(_LocalArgs&&... __args)
+        : __thread_specific_storage(_GetNumThreads{}()), __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
     {
     }
 
@@ -361,7 +359,7 @@ struct __enumerable_thread_local_storage_base
     _ValueType&
     get_for_current_thread()
     {
-        const std::size_t __i = derived_type::get_thread_num();
+        const std::size_t __i = _GetThreadNum{}();
         std::unique_ptr<_ValueType>& __thread_local_storage = __thread_specific_storage[__i];
         if (!__thread_local_storage)
         {

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -306,6 +306,9 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
     return __cc_range(__first2, __last2, __result);
 }
 
+namespace __detail
+{
+
 template <typename _ValueType, typename _GetNumThreads, typename _GetThreadNum, typename... _Args>
 struct __enumerable_thread_local_storage
 {
@@ -372,6 +375,7 @@ struct __enumerable_thread_local_storage
     std::tuple<_Args...> __args;
 };
 
+} // namespace __detail
 } // namespace __utils
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -323,7 +323,7 @@ struct __enumerable_thread_local_storage_base
     // not return an accurate count of instantiated storage objects in lockstep with the number allocated and stored.
     // This is because the count is not atomic with the allocation and storage of the storage objects.
     std::size_t
-    size() const noexcept
+    size() const
     {
         // only count storage which has been instantiated
         return __num_elements.load(std::memory_order_relaxed);

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -314,7 +314,8 @@ struct __enumerable_thread_local_storage_base
 {
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage_base(_LocalArgs&&... __args)
-        : __thread_specific_storage(_Concrete::get_num_threads()), __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
+        : __thread_specific_storage(_Concrete::get_num_threads()), __num_elements(0),
+          __args(std::forward<_LocalArgs>(__args)...)
     {
     }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -311,10 +311,8 @@ struct __enumerable_thread_local_storage
 {
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage(_LocalArgs&&... __args)
-        : __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
+        : __num_elements(0), __args(std::forward<_LocalArgs>(__args)...), __thread_specific_storage(_GetNumThreads{}())
     {
-        const std::size_t __num_threads = _GetNumThreads{}();
-        __thread_specific_storage.resize(__num_threads);
     }
 
     // Note: size should not be used concurrently with parallel loops which may instantiate storage objects, as it may

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -309,7 +309,7 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 namespace __detail
 {
 
-template <template <typename...> typename _Concrete, typename _ValueType, typename... _Args>
+template <template <typename, typename...> typename _Concrete, typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage_base
 {
     using derived_type = _Concrete<_ValueType, _Args...>;

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -311,7 +311,7 @@ struct __enumerable_thread_local_storage
 {
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage(_LocalArgs&&... __args)
-        : __num_elements(0), __args(std::forward<_LocalArgs>(__args)...), __thread_specific_storage(_GetNumThreads{}())
+        : __thread_specific_storage(_GetNumThreads{}()), __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
     {
     }
 


### PR DESCRIPTION
`tbb/enumerable_thread_specific.h` includes an indirect inclusion of windows.h on windows.  
This is undesirable, and therefore we would like to avoid it.  Without enumerable_thread_specific to depend upon in TBB, we can instead unify all implementations into a shared one which uses a pair of helpers: 
`__get_thread_num()`
and  
`__get_num_threads()` 
which are passed to the shared implementation from the parallel backends as template arguments during creation in the make function.  

We implement a make function for each backend to properly pass in the appropriate helper functions for the parallel backend. We no longer need to bury the __enumerable_thread_local_storage in a `__details` namespace, since all backends could in theory directly use the constructor if they fill out all the appropriate template arguments.  Variadic `Args...` are present in the type itself for all backends including TBB now.  However, make functions are beneficial to keep verbosity out of the local usage of `__enumerable_thread_local_storage`. 


---
Sadly, I don't see a way to automatically pick up the appropriate helper routines from the parallel backend from within `include/oneapi/dpl/pstl/parallel_backend_utils.h` because of a circular dependency without adding another utils header.  

We could consider adding another header `include/oneapi/dpl/pstl/parallel_unified_utils.h` which depends on the parallel backend rather than vice-versa.  This could allow us to depend upon a generic `__par_backend::` call for the two helpers. We could also unify all make functions into this header. The downside to this would be that we sacrifice the ability to use ETLS from the backends themselves, which we dont do now, but we may want to do in the future.