### PR TITLE
Improve the implementation of __enumerable_thread_local_storage

### DIFF
--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -31,7 +31,7 @@
 #ifdef _MSC_VER
 #    define _PSTL_PRAGMA(x) __pragma(x)
 #else
-# define _PSTL_PRAGMA(x) _Pragma(# x)
+#    define _PSTL_PRAGMA(x) _Pragma(#    x)
 #endif
 
 namespace oneapi

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -157,7 +157,7 @@ namespace __detail
 template <typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage;
 
-template<typename... _Ts>
+template <typename... _Ts>
 using __etls_base = __utils::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage, _Ts...>;
 
 template <typename _ValueType, typename... _Args>
@@ -166,7 +166,7 @@ struct __enumerable_thread_local_storage : public __etls_base<_ValueType, _Args.
 
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage(_LocalArgs&&... __args)
-    : __etls_base<_ValueType, _Args...>({std::forward<_LocalArgs>(__args)...})
+        : __etls_base<_ValueType, _Args...>({std::forward<_LocalArgs>(__args)...})
     {
     }
 

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -31,7 +31,7 @@
 #ifdef _MSC_VER
 #    define _PSTL_PRAGMA(x) __pragma(x)
 #else
-#    define _PSTL_PRAGMA(x) _Pragma(#x)
+# define _PSTL_PRAGMA(x) _Pragma(# x)
 #endif
 
 namespace oneapi

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -153,13 +153,14 @@ __process_chunk(const __chunk_metrics& __metrics, _Iterator __base, _Index __chu
 namespace __detail
 {
 
-template <typename _ValueType, typename... Args>
+template <typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage
-    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
-          _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>
+    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
+                                                                                    _ValueType, _Args...>
 {
-    using base_type = oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
-        _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>;
+    using base_type =
+        oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
+                                                                               _ValueType, _Args...>;
 
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage(_LocalArgs&&... __args) : base_type(std::forward<_LocalArgs>(__args)...)
@@ -182,12 +183,12 @@ struct __enumerable_thread_local_storage
 } // namespace __detail
 
 // enumerable thread local storage should only be created from make function
-template <typename _ValueType, typename... Args>
-oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>
-__make_enumerable_tls(Args&&... __args)
+template <typename _ValueType, typename... _Args>
+oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>
+__make_enumerable_tls(_Args&&... __args)
 {
-    return oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>(
-        std::forward<Args>(__args)...);
+    return oneapi::dpl::__omp_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>(
+        std::forward<_Args>(__args)...);
 }
 
 } // namespace __omp_backend

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1309,17 +1309,20 @@ __parallel_for_each(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy
 namespace __detail
 {
 
+// Workaround for VS 2017: declare an alias to the CRTP base template
 template <typename _ValueType, typename... _Args>
-struct __enumerable_thread_local_storage
-    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
-                                                                                    _ValueType, _Args...>
+struct __enumerable_thread_local_storage;
+
+template<typename... _Ts>
+using __etls_base = __utils::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage, _Ts...>;
+
+template <typename _ValueType, typename... _Args>
+struct __enumerable_thread_local_storage : public __etls_base<_ValueType, _Args...>
 {
-    using base_type =
-        oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
-                                                                               _ValueType, _Args...>;
 
     template <typename... _LocalArgs>
-    __enumerable_thread_local_storage(_LocalArgs&&... __args) : base_type(std::forward<_LocalArgs>(__args)...)
+    __enumerable_thread_local_storage(_LocalArgs&&... __args)
+    : __etls_base<_ValueType, _Args...>({std::forward<_LocalArgs>(__args)...})
     {
     }
 
@@ -1338,12 +1341,12 @@ struct __enumerable_thread_local_storage
 
 } // namespace __detail
 
-// enumerable thread local storage should only be created from make function
+// enumerable thread local storage should only be created with this make function
 template <typename _ValueType, typename... _Args>
-oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>
+__detail::__enumerable_thread_local_storage<_ValueType, std::remove_reference_t<_Args>...>
 __make_enumerable_tls(_Args&&... __args)
 {
-    return oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>(
+    return __detail::__enumerable_thread_local_storage<_ValueType, std::remove_reference_t<_Args>...>(
         std::forward<_Args>(__args)...);
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1313,7 +1313,7 @@ namespace __detail
 template <typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage;
 
-template<typename... _Ts>
+template <typename... _Ts>
 using __etls_base = __utils::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage, _Ts...>;
 
 template <typename _ValueType, typename... _Args>
@@ -1322,7 +1322,7 @@ struct __enumerable_thread_local_storage : public __etls_base<_ValueType, _Args.
 
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage(_LocalArgs&&... __args)
-    : __etls_base<_ValueType, _Args...>({std::forward<_LocalArgs>(__args)...})
+        : __etls_base<_ValueType, _Args...>({std::forward<_LocalArgs>(__args)...})
     {
     }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -504,7 +504,7 @@ class __root_task
   public:
     template <typename... Args>
     __root_task(Args&&... args)
-        : _M_task{new(tbb::task::allocate_root()) __func_task<_Func>{_Func(::std::forward<Args>(args)...)}}
+        : _M_task{new (tbb::task::allocate_root()) __func_task<_Func>{_Func(::std::forward<Args>(args)...)}}
     {
     }
 
@@ -1053,8 +1053,8 @@ class __merge_func
 template <typename _RandomAccessIterator1, typename _RandomAccessIterator2, typename __M_Compare, typename _Cleanup,
           typename _LeafMerge>
 __task*
-__merge_func<_RandomAccessIterator1, _RandomAccessIterator2, __M_Compare, _Cleanup, _LeafMerge>::operator()(
-    __task* __self)
+__merge_func<_RandomAccessIterator1, _RandomAccessIterator2, __M_Compare, _Cleanup, _LeafMerge>::
+operator()(__task* __self)
 {
     //a. split merge task into 2 of the same level; the special logic,
     //without processing(process_ranges) adjacent sub-ranges x and y
@@ -1217,8 +1217,8 @@ class __merge_func_static
 template <typename _RandomAccessIterator1, typename _RandomAccessIterator2, typename _RandomAccessIterator3,
           typename __M_Compare, typename _LeafMerge>
 __task*
-__merge_func_static<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3, __M_Compare,
-                    _LeafMerge>::operator()(__task* __self)
+__merge_func_static<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3, __M_Compare, _LeafMerge>::
+operator()(__task* __self)
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType1;
     typedef typename ::std::iterator_traits<_RandomAccessIterator2>::difference_type _DifferenceType2;

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1309,13 +1309,14 @@ __parallel_for_each(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy
 namespace __detail
 {
 
-template <typename _ValueType, typename... Args>
+template <typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage
-    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
-          _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>
+    : public oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
+                                                                                    _ValueType, _Args...>
 {
-    using base_type = oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<
-        _ValueType, __enumerable_thread_local_storage<_ValueType, Args...>, Args...>;
+    using base_type =
+        oneapi::dpl::__utils::__detail::__enumerable_thread_local_storage_base<__enumerable_thread_local_storage,
+                                                                               _ValueType, _Args...>;
 
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage(_LocalArgs&&... __args) : base_type(std::forward<_LocalArgs>(__args)...)
@@ -1338,12 +1339,12 @@ struct __enumerable_thread_local_storage
 } // namespace __detail
 
 // enumerable thread local storage should only be created from make function
-template <typename _ValueType, typename... Args>
-oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>
-__make_enumerable_tls(Args&&... __args)
+template <typename _ValueType, typename... _Args>
+oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>
+__make_enumerable_tls(_Args&&... __args)
 {
-    return oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, Args...>(
-        std::forward<Args>(__args)...);
+    return oneapi::dpl::__tbb_backend::__detail::__enumerable_thread_local_storage<_ValueType, _Args...>(
+        std::forward<_Args>(__args)...);
 }
 
 } // namespace __tbb_backend

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -309,13 +309,14 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 namespace __detail
 {
 
-template <typename _ValueType, typename _Concrete, typename... _Args>
+template <template <typename...> typename _Concrete, typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage_base
 {
+    using derived_type = _Concrete<_ValueType, _Args...>;
 
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage_base(_LocalArgs&&... __args)
-        : __thread_specific_storage(_Concrete::get_num_threads()), __num_elements(0),
+        : __thread_specific_storage(derived_type::get_num_threads()), __num_elements(0),
           __args(std::forward<_LocalArgs>(__args)...)
     {
     }
@@ -360,7 +361,7 @@ struct __enumerable_thread_local_storage_base
     _ValueType&
     get_for_current_thread()
     {
-        const std::size_t __i = _Concrete::get_thread_num();
+        const std::size_t __i = derived_type::get_thread_num();
         std::unique_ptr<_ValueType>& __thread_local_storage = __thread_specific_storage[__i];
         if (!__thread_local_storage)
         {

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -331,7 +331,7 @@ struct __enumerable_thread_local_storage_base
     // and incrementing of the size.
     // TODO: Consider replacing this access with a visitor pattern.
     _ValueType&
-    get_with_id(std::size_t __i) const
+    get_with_id(std::size_t __i)
     {
         assert(__i < size());
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -309,13 +309,13 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 namespace __detail
 {
 
-template <typename _ValueType, typename _GetNumThreads, typename _GetThreadNum, typename... _Args>
-struct __enumerable_thread_local_storage
+template <typename _ValueType, typename _Concrete, typename... _Args>
+struct __enumerable_thread_local_storage_base
 {
 
     template <typename... _LocalArgs>
-    __enumerable_thread_local_storage(_LocalArgs&&... __args)
-        : __thread_specific_storage(_GetNumThreads{}()), __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
+    __enumerable_thread_local_storage_base(_LocalArgs&&... __args)
+        : __thread_specific_storage(_Concrete::get_num_threads()), __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
     {
     }
 
@@ -359,7 +359,7 @@ struct __enumerable_thread_local_storage
     _ValueType&
     get_for_current_thread()
     {
-        const std::size_t __i = _GetThreadNum{}();
+        const std::size_t __i = _Concrete::get_thread_num();
         std::unique_ptr<_ValueType>& __thread_local_storage = __thread_specific_storage[__i];
         if (!__thread_local_storage)
         {

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -361,7 +361,7 @@ struct __enumerable_thread_local_storage_base
         if (!__local)
         {
             // create temporary storage on first usage to avoid extra parallel region and unnecessary instantiation
-            std::apply([&__local](_Args... __arg_pack){ __local.emplace(__arg_pack...); }, __args);
+            std::apply([&__local](_Args... __arg_pack) { __local.emplace(__arg_pack...); }, __args);
             __num_elements.fetch_add(1, std::memory_order_relaxed);
         }
         return *__local;

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -315,7 +315,8 @@ struct __enumerable_thread_local_storage_base
 
     template <typename... _LocalArgs>
     __enumerable_thread_local_storage_base(_LocalArgs&&... __args)
-        : __thread_specific_storage(_Concrete::get_num_threads()), __num_elements(0), __args(std::forward<_LocalArgs>(__args)...)
+        : __thread_specific_storage(_Concrete::get_num_threads()), __num_elements(0),
+          __args(std::forward<_LocalArgs>(__args)...)
     {
     }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -19,7 +19,7 @@
 #include <atomic>
 #include <cstddef>
 #include <iterator>
-#include <memory>
+#include <optional>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -306,18 +306,13 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
     return __cc_range(__first2, __last2, __result);
 }
 
-namespace __detail
-{
-
 template <template <typename, typename...> typename _Concrete, typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage_base
 {
-    using derived_type = _Concrete<_ValueType, _Args...>;
+    using _Derived = _Concrete<_ValueType, _Args...>;
 
-    template <typename... _LocalArgs>
-    __enumerable_thread_local_storage_base(_LocalArgs&&... __args)
-        : __thread_specific_storage(derived_type::get_num_threads()), __num_elements(0),
-          __args(std::forward<_LocalArgs>(__args)...)
+    __enumerable_thread_local_storage_base(std::tuple<_Args...> __tp)
+        : __thread_specific_storage(_Derived::get_num_threads()), __num_elements(0), __args(__tp)
     {
     }
 
@@ -336,7 +331,7 @@ struct __enumerable_thread_local_storage_base
     // and incrementing of the size.
     // TODO: Consider replacing this access with a visitor pattern.
     _ValueType&
-    get_with_id(std::size_t __i)
+    get_with_id(std::size_t __i) const
     {
         assert(__i < size());
 
@@ -361,24 +356,22 @@ struct __enumerable_thread_local_storage_base
     _ValueType&
     get_for_current_thread()
     {
-        const std::size_t __i = derived_type::get_thread_num();
-        std::unique_ptr<_ValueType>& __thread_local_storage = __thread_specific_storage[__i];
-        if (!__thread_local_storage)
+        const std::size_t __i = _Derived::get_thread_num();
+        std::optional<_ValueType>& __local = __thread_specific_storage[__i];
+        if (!__local)
         {
             // create temporary storage on first usage to avoid extra parallel region and unnecessary instantiation
-            __thread_local_storage =
-                std::apply([](_Args... __arg_pack) { return std::make_unique<_ValueType>(__arg_pack...); }, __args);
+            std::apply([&__local](_Args... __arg_pack){ __local.emplace(__arg_pack...); }, __args);
             __num_elements.fetch_add(1, std::memory_order_relaxed);
         }
-        return *__thread_local_storage;
+        return *__local;
     }
 
-    std::vector<std::unique_ptr<_ValueType>> __thread_specific_storage;
+    std::vector<std::optional<_ValueType>> __thread_specific_storage;
     std::atomic_size_t __num_elements;
     const std::tuple<_Args...> __args;
 };
 
-} // namespace __detail
 } // namespace __utils
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -309,7 +309,7 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 namespace __detail
 {
 
-template <template <typename...> typename _Concrete, typename _ValueType, typename... _Args>
+template <template <typename, typename...> typename _Concrete, typename _ValueType, typename... _Args>
 struct __enumerable_thread_local_storage_base
 {
     using derived_type = _Concrete<_ValueType, _Args...>;


### PR DESCRIPTION
This patch returns to the CRTP-based implementation, with a workaround applied to make the VS 2017 C++ compiler happy.
But more importantly, it addresses two other issues: stores the construction arguments as a tuple of values (by removing references from the deduced types) and replaces `unique_ptr` with `optional` to avoid memory allocations.