### PR TITLE
Fix synchronization issues in radix sort and histogram

### DIFF
--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -135,14 +135,4 @@ Macro                              Description
                                    .. Note:: Define ``ONEDPL_FPGA_DEVICE`` and ``ONEDPL_FPGA_EMULATOR`` macros in the same
                                       application to run on a FPGA emulation device.
                                       Define only the ``ONEDPL_FPGA_DEVICE`` macro to run on a FPGA hardware device.
----------------------------------- ------------------------------
-``ONEDPL_SYCL121_GROUP_BARRIER``   The macro controls which API for group barriers oneDPL uses,
-                                   which can be either defined as in SYCL 1.2.1 or as in SYCL 2020.
-                                   It affects algorithms that use device execution policies.
-
-                                   Set this macro to a non-zero value to enable SYCL 1.2.1 group barriers.
-                                   The default value is 1 when using the oneAPI DPC++ Compiler and 0 otherwise.
-
-                                   .. Note:: Depending on a GPU driver, SYCL 1.2.1 group barriers can provide better performance
-                                      on Intel GPUs. The default value may change in future releases in favor of SYCL 2020 group barriers.
-==================================== ==============================
+================================== ==============================

--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -50,89 +50,99 @@ Additional Macros
 Use these macros to control aspects of |onedpl_short| usage. You can set them in your program code
 before including |onedpl_short| headers.
 
-================================== ==============================
-Macro                              Description
-================================== ==============================
-``PSTL_USE_NONTEMPORAL_STORES``    This macro enables the use of ``#pragma vector nontemporal``
-                                   for write-only data when algorithms such as ``std::copy``, ``std::fill``, etc.,
-                                   are executed with unsequenced policies.
-                                   For further details about the pragma, see the |vector_pragma|_.
-                                   If the macro evaluates to a non-zero value,
-                                   the use of ``#pragma vector nontemporal`` is enabled.
-                                   By default, the macro is not defined.
+==================================== ==============================
+Macro                                Description
+==================================== ==============================
+``PSTL_USE_NONTEMPORAL_STORES``      This macro enables the use of ``#pragma vector nontemporal``
+                                     for write-only data when algorithms such as ``std::copy``, ``std::fill``, etc.,
+                                     are executed with unsequenced policies.
+                                     For further details about the pragma, see the |vector_pragma|_.
+                                     If the macro evaluates to a non-zero value,
+                                     the use of ``#pragma vector nontemporal`` is enabled.
+                                     By default, the macro is not defined.
 
-                                   Using this macro may have the same effect on the implementation of parallel
-                                   algorithms in the C++ standard libraries of GCC and LLVM.
----------------------------------- ------------------------------
-``PSTL_USAGE_WARNINGS``            This macro enables Parallel STL to
-                                   emit compile-time messages, such as warnings
-                                   about an algorithm not supporting a certain execution policy.
-                                   When set to 1, the macro allows the implementation to emit
-                                   usage warnings. When the macro is not defined (by default)
-                                   or evaluates to zero, usage warnings are disabled.
+                                     Using this macro may have the same effect on the implementation of parallel
+                                     algorithms in the C++ standard libraries of GCC and LLVM.
+------------------------------------ ------------------------------
+``PSTL_USAGE_WARNINGS``              This macro enables Parallel STL to
+                                     emit compile-time messages, such as warnings
+                                     about an algorithm not supporting a certain execution policy.
+                                     When set to 1, the macro allows the implementation to emit
+                                     usage warnings. When the macro is not defined (by default)
+                                     or evaluates to zero, usage warnings are disabled.
 
-                                   Using this macro may have the same effect on the implementation of parallel
-                                   algorithms in the C++ standard libraries of GCC and LLVM.
----------------------------------- ------------------------------
-``ONEDPL_USE_TBB_BACKEND``         This macro controls the use of |onetbb_long| or |tbb_long| for parallel
-                                   execution policies (``par`` and ``par_unseq``).
+                                     Using this macro may have the same effect on the implementation of parallel
+                                     algorithms in the C++ standard libraries of GCC and LLVM.
+------------------------------------ ------------------------------
+``ONEDPL_USE_TBB_BACKEND``           This macro controls the use of |onetbb_long| or |tbb_long| for parallel
+                                     execution policies (``par`` and ``par_unseq``).
 
-                                   When the macro evaluates to a non-zero value, or when it is not defined (by default)
-                                   and no other parallel backends are explicitly chosen, algorithms with parallel policies
-                                   are executed using the |onetbb_short| or |tbb_short| library.
-                                   Setting the macro to 0 disables use of TBB API for parallel execution and is recommended
-                                   for code that should not depend on the presence of the |onetbb_short| or |tbb_short| library.
+                                     When the macro evaluates to a non-zero value, or when it is not defined (by default)
+                                     and no other parallel backends are explicitly chosen, algorithms with parallel policies
+                                     are executed using the |onetbb_short| or |tbb_short| library.
+                                     Setting the macro to 0 disables use of TBB API for parallel execution and is recommended
+                                     for code that should not depend on the presence of the |onetbb_short| or |tbb_short| library.
 
-                                   If all parallel backends are disabled by setting respective macros to 0, algorithms
-                                   with parallel policies are executed sequentially by the calling thread.
----------------------------------- ------------------------------
-``ONEDPL_USE_OPENMP_BACKEND``      This macro controls the use of OpenMP* for parallel execution policies (``par`` and ``par_unseq``).
+                                     If all parallel backends are disabled by setting respective macros to 0, algorithms
+                                     with parallel policies are executed sequentially by the calling thread.
+------------------------------------ ------------------------------
+``ONEDPL_USE_OPENMP_BACKEND``        This macro controls the use of OpenMP* for parallel execution policies (``par`` and ``par_unseq``).
 
-                                   When the macro evaluates to a non-zero value, algorithms with parallel policies are executed
-                                   using OpenMP unless the TBB backend is explicitly enabled (that is, the TBB backend takes
-                                   precedence over the OpenMP backend).
-                                   When the macro is not defined (by default) and no other parallel backends are chosen,
-                                   a dedicated compiler option to enable OpenMP (such as ``-fopenmp``) also enables its use
-                                   for algorithms with parallel policies.
-                                   Setting the macro to 0 disables use of OpenMP for parallel execution.
+                                     When the macro evaluates to a non-zero value, algorithms with parallel policies are executed
+                                     using OpenMP unless the TBB backend is explicitly enabled (that is, the TBB backend takes
+                                     precedence over the OpenMP backend).
+                                     When the macro is not defined (by default) and no other parallel backends are chosen,
+                                     a dedicated compiler option to enable OpenMP (such as ``-fopenmp``) also enables its use
+                                     for algorithms with parallel policies.
+                                     Setting the macro to 0 disables use of OpenMP for parallel execution.
 
-                                   If all parallel backends are disabled by setting respective macros to 0, algorithms
-                                   with parallel policies are executed sequentially by the calling thread.
----------------------------------- ------------------------------
-``ONEDPL_USE_DPCPP_BACKEND``       This macro enables the use of device execution policies.
+                                     If all parallel backends are disabled by setting respective macros to 0, algorithms
+                                     with parallel policies are executed sequentially by the calling thread.
+------------------------------------ ------------------------------
+``ONEDPL_USE_DPCPP_BACKEND``         This macro enables the use of device execution policies.
 
-                                   When the macro is not defined (default),
-                                   device policies are enabled only if SYCL support can be detected;
-                                   otherwise, they are disabled.
-                                   If the macro is set to a non-zero value, device policies are enabled unconditionally.
-                                   Setting the macro to 0 disables device policies.
+                                     When the macro is not defined (default),
+                                     device policies are enabled only if SYCL support can be detected;
+                                     otherwise, they are disabled.
+                                     If the macro is set to a non-zero value, device policies are enabled unconditionally.
+                                     Setting the macro to 0 disables device policies.
 
-                                   When device policies are disabled, no SYCL dependency is introduced,
-                                   and their usage will lead to compilation errors.
----------------------------------- ------------------------------
-``ONEDPL_USE_PREDEFINED_POLICIES`` This macro enables the use of predefined device policy objects,
-                                   such as ``dpcpp_default`` and ``dpcpp_fpga``. When the macro is not defined (by default)
-                                   or evaluates to non-zero, predefined policies objects can be used.
-                                   When the macro is set to 0, predefined policies objects and make functions
-                                   without arguments (``make_device_policy()`` and ``make_fpga_policy()``) are not available.
----------------------------------- ------------------------------
-``ONEDPL_ALLOW_DEFERRED_WAITING``  This macro allows waiting for completion of certain algorithms executed with
-                                   device policies to be deferred. (Disabled by default.)
+                                     When device policies are disabled, no SYCL dependency is introduced,
+                                     and their usage will lead to compilation errors.
+------------------------------------ ------------------------------
+``ONEDPL_USE_PREDEFINED_POLICIES``   This macro enables the use of predefined device policy objects,
+                                     such as ``dpcpp_default`` and ``dpcpp_fpga``. When the macro is not defined (by default)
+                                     or evaluates to non-zero, predefined policies objects can be used.
+                                     When the macro is set to 0, predefined policies objects and make functions
+                                     without arguments (``make_device_policy()`` and ``make_fpga_policy()``) are not available.
+------------------------------------ ------------------------------
+``ONEDPL_ALLOW_DEFERRED_WAITING``    This macro allows waiting for completion of certain algorithms executed with
+                                     device policies to be deferred. (Disabled by default.)
 
-                                   When the macro evaluates to non-zero, a call to a oneDPL algorithm with
-                                   a device policy might return before the computation completes on the device.
+                                     When the macro evaluates to non-zero, a call to a oneDPL algorithm with
+                                     a device policy might return before the computation completes on the device.
 
-                                   .. Warning:: Before accessing data produced or modified by the call, waiting
-                                      for completion of all tasks in the corresponding SYCL queue is required;
-                                      otherwise, the program behavior is undefined.
----------------------------------- ------------------------------
-``ONEDPL_FPGA_DEVICE``             Use this macro to build your code containing |onedpl_short| parallel
-                                   algorithms for FPGA devices. (Disabled by default.)
----------------------------------- ------------------------------
-``ONEDPL_FPGA_EMULATOR``           Use this macro to build your code containing Parallel STL
-                                   algorithms for FPGA emulation device. (Disabled by default.)
+                                     .. Warning:: Before accessing data produced or modified by the call, waiting
+                                        for completion of all tasks in the corresponding SYCL queue is required;
+                                        otherwise, the program behavior is undefined.
+------------------------------------ ------------------------------
+``ONEDPL_FPGA_DEVICE``               Use this macro to build your code containing |onedpl_short| parallel
+                                     algorithms for FPGA devices. (Disabled by default.)
+------------------------------------ ------------------------------
+``ONEDPL_FPGA_EMULATOR``             Use this macro to build your code containing Parallel STL
+                                     algorithms for FPGA emulation device. (Disabled by default.)
 
-                                   .. Note:: Define ``ONEDPL_FPGA_DEVICE`` and ``ONEDPL_FPGA_EMULATOR`` macros in the same
-                                      application to run on a FPGA emulation device.
-                                      Define only the ``ONEDPL_FPGA_DEVICE`` macro to run on a FPGA hardware device.
-================================== ==============================
+                                     .. Note:: Define ``ONEDPL_FPGA_DEVICE`` and ``ONEDPL_FPGA_EMULATOR`` macros in the same
+                                        application to run on a FPGA emulation device.
+                                        Define only the ``ONEDPL_FPGA_DEVICE`` macro to run on a FPGA hardware device.
+------------------------------------ ------------------------------
+``ONEDPL_USE_SYCL121_GROUP_BARRIER`` The macro controls which API for group barriers oneDPL uses,
+                                     which can be either as defined in SYCL 1.2.1 or as in SYCL 2020.
+                                     It affects algorithms that use device execution policies.
+
+                                     Set this macro to a non-zero value to enable SYCL 1.2.1 group barriers.
+                                     The default value is 1 when using the oneAPI DPC++ Compiler and 0 otherwise.
+
+                                     .. Note:: Depending on a GPU driver, SYCL 1.2.1 group barriers can provide better performance
+                                        on Intel GPUs. The default value may change in future releases in favor of SYCL 2020 group barriers.
+==================================== ==============================

--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -50,99 +50,99 @@ Additional Macros
 Use these macros to control aspects of |onedpl_short| usage. You can set them in your program code
 before including |onedpl_short| headers.
 
-==================================== ==============================
-Macro                                Description
-==================================== ==============================
-``PSTL_USE_NONTEMPORAL_STORES``      This macro enables the use of ``#pragma vector nontemporal``
-                                     for write-only data when algorithms such as ``std::copy``, ``std::fill``, etc.,
-                                     are executed with unsequenced policies.
-                                     For further details about the pragma, see the |vector_pragma|_.
-                                     If the macro evaluates to a non-zero value,
-                                     the use of ``#pragma vector nontemporal`` is enabled.
-                                     By default, the macro is not defined.
+================================== ==============================
+Macro                              Description
+================================== ==============================
+``PSTL_USE_NONTEMPORAL_STORES``    This macro enables the use of ``#pragma vector nontemporal``
+                                   for write-only data when algorithms such as ``std::copy``, ``std::fill``, etc.,
+                                   are executed with unsequenced policies.
+                                   For further details about the pragma, see the |vector_pragma|_.
+                                   If the macro evaluates to a non-zero value,
+                                   the use of ``#pragma vector nontemporal`` is enabled.
+                                   By default, the macro is not defined.
 
-                                     Using this macro may have the same effect on the implementation of parallel
-                                     algorithms in the C++ standard libraries of GCC and LLVM.
------------------------------------- ------------------------------
-``PSTL_USAGE_WARNINGS``              This macro enables Parallel STL to
-                                     emit compile-time messages, such as warnings
-                                     about an algorithm not supporting a certain execution policy.
-                                     When set to 1, the macro allows the implementation to emit
-                                     usage warnings. When the macro is not defined (by default)
-                                     or evaluates to zero, usage warnings are disabled.
+                                   Using this macro may have the same effect on the implementation of parallel
+                                   algorithms in the C++ standard libraries of GCC and LLVM.
+---------------------------------- ------------------------------
+``PSTL_USAGE_WARNINGS``            This macro enables Parallel STL to
+                                   emit compile-time messages, such as warnings
+                                   about an algorithm not supporting a certain execution policy.
+                                   When set to 1, the macro allows the implementation to emit
+                                   usage warnings. When the macro is not defined (by default)
+                                   or evaluates to zero, usage warnings are disabled.
 
-                                     Using this macro may have the same effect on the implementation of parallel
-                                     algorithms in the C++ standard libraries of GCC and LLVM.
------------------------------------- ------------------------------
-``ONEDPL_USE_TBB_BACKEND``           This macro controls the use of |onetbb_long| or |tbb_long| for parallel
-                                     execution policies (``par`` and ``par_unseq``).
+                                   Using this macro may have the same effect on the implementation of parallel
+                                   algorithms in the C++ standard libraries of GCC and LLVM.
+---------------------------------- ------------------------------
+``ONEDPL_USE_TBB_BACKEND``         This macro controls the use of |onetbb_long| or |tbb_long| for parallel
+                                   execution policies (``par`` and ``par_unseq``).
 
-                                     When the macro evaluates to a non-zero value, or when it is not defined (by default)
-                                     and no other parallel backends are explicitly chosen, algorithms with parallel policies
-                                     are executed using the |onetbb_short| or |tbb_short| library.
-                                     Setting the macro to 0 disables use of TBB API for parallel execution and is recommended
-                                     for code that should not depend on the presence of the |onetbb_short| or |tbb_short| library.
+                                   When the macro evaluates to a non-zero value, or when it is not defined (by default)
+                                   and no other parallel backends are explicitly chosen, algorithms with parallel policies
+                                   are executed using the |onetbb_short| or |tbb_short| library.
+                                   Setting the macro to 0 disables use of TBB API for parallel execution and is recommended
+                                   for code that should not depend on the presence of the |onetbb_short| or |tbb_short| library.
 
-                                     If all parallel backends are disabled by setting respective macros to 0, algorithms
-                                     with parallel policies are executed sequentially by the calling thread.
------------------------------------- ------------------------------
-``ONEDPL_USE_OPENMP_BACKEND``        This macro controls the use of OpenMP* for parallel execution policies (``par`` and ``par_unseq``).
+                                   If all parallel backends are disabled by setting respective macros to 0, algorithms
+                                   with parallel policies are executed sequentially by the calling thread.
+---------------------------------- ------------------------------
+``ONEDPL_USE_OPENMP_BACKEND``      This macro controls the use of OpenMP* for parallel execution policies (``par`` and ``par_unseq``).
 
-                                     When the macro evaluates to a non-zero value, algorithms with parallel policies are executed
-                                     using OpenMP unless the TBB backend is explicitly enabled (that is, the TBB backend takes
-                                     precedence over the OpenMP backend).
-                                     When the macro is not defined (by default) and no other parallel backends are chosen,
-                                     a dedicated compiler option to enable OpenMP (such as ``-fopenmp``) also enables its use
-                                     for algorithms with parallel policies.
-                                     Setting the macro to 0 disables use of OpenMP for parallel execution.
+                                   When the macro evaluates to a non-zero value, algorithms with parallel policies are executed
+                                   using OpenMP unless the TBB backend is explicitly enabled (that is, the TBB backend takes
+                                   precedence over the OpenMP backend).
+                                   When the macro is not defined (by default) and no other parallel backends are chosen,
+                                   a dedicated compiler option to enable OpenMP (such as ``-fopenmp``) also enables its use
+                                   for algorithms with parallel policies.
+                                   Setting the macro to 0 disables use of OpenMP for parallel execution.
 
-                                     If all parallel backends are disabled by setting respective macros to 0, algorithms
-                                     with parallel policies are executed sequentially by the calling thread.
------------------------------------- ------------------------------
-``ONEDPL_USE_DPCPP_BACKEND``         This macro enables the use of device execution policies.
+                                   If all parallel backends are disabled by setting respective macros to 0, algorithms
+                                   with parallel policies are executed sequentially by the calling thread.
+---------------------------------- ------------------------------
+``ONEDPL_USE_DPCPP_BACKEND``       This macro enables the use of device execution policies.
 
-                                     When the macro is not defined (default),
-                                     device policies are enabled only if SYCL support can be detected;
-                                     otherwise, they are disabled.
-                                     If the macro is set to a non-zero value, device policies are enabled unconditionally.
-                                     Setting the macro to 0 disables device policies.
+                                   When the macro is not defined (default),
+                                   device policies are enabled only if SYCL support can be detected;
+                                   otherwise, they are disabled.
+                                   If the macro is set to a non-zero value, device policies are enabled unconditionally.
+                                   Setting the macro to 0 disables device policies.
 
-                                     When device policies are disabled, no SYCL dependency is introduced,
-                                     and their usage will lead to compilation errors.
------------------------------------- ------------------------------
-``ONEDPL_USE_PREDEFINED_POLICIES``   This macro enables the use of predefined device policy objects,
-                                     such as ``dpcpp_default`` and ``dpcpp_fpga``. When the macro is not defined (by default)
-                                     or evaluates to non-zero, predefined policies objects can be used.
-                                     When the macro is set to 0, predefined policies objects and make functions
-                                     without arguments (``make_device_policy()`` and ``make_fpga_policy()``) are not available.
------------------------------------- ------------------------------
-``ONEDPL_ALLOW_DEFERRED_WAITING``    This macro allows waiting for completion of certain algorithms executed with
-                                     device policies to be deferred. (Disabled by default.)
+                                   When device policies are disabled, no SYCL dependency is introduced,
+                                   and their usage will lead to compilation errors.
+---------------------------------- ------------------------------
+``ONEDPL_USE_PREDEFINED_POLICIES`` This macro enables the use of predefined device policy objects,
+                                   such as ``dpcpp_default`` and ``dpcpp_fpga``. When the macro is not defined (by default)
+                                   or evaluates to non-zero, predefined policies objects can be used.
+                                   When the macro is set to 0, predefined policies objects and make functions
+                                   without arguments (``make_device_policy()`` and ``make_fpga_policy()``) are not available.
+---------------------------------- ------------------------------
+``ONEDPL_ALLOW_DEFERRED_WAITING``  This macro allows waiting for completion of certain algorithms executed with
+                                   device policies to be deferred. (Disabled by default.)
 
-                                     When the macro evaluates to non-zero, a call to a oneDPL algorithm with
-                                     a device policy might return before the computation completes on the device.
+                                   When the macro evaluates to non-zero, a call to a oneDPL algorithm with
+                                   a device policy might return before the computation completes on the device.
 
-                                     .. Warning:: Before accessing data produced or modified by the call, waiting
-                                        for completion of all tasks in the corresponding SYCL queue is required;
-                                        otherwise, the program behavior is undefined.
------------------------------------- ------------------------------
-``ONEDPL_FPGA_DEVICE``               Use this macro to build your code containing |onedpl_short| parallel
-                                     algorithms for FPGA devices. (Disabled by default.)
------------------------------------- ------------------------------
-``ONEDPL_FPGA_EMULATOR``             Use this macro to build your code containing Parallel STL
-                                     algorithms for FPGA emulation device. (Disabled by default.)
+                                   .. Warning:: Before accessing data produced or modified by the call, waiting
+                                      for completion of all tasks in the corresponding SYCL queue is required;
+                                      otherwise, the program behavior is undefined.
+---------------------------------- ------------------------------
+``ONEDPL_FPGA_DEVICE``             Use this macro to build your code containing |onedpl_short| parallel
+                                   algorithms for FPGA devices. (Disabled by default.)
+---------------------------------- ------------------------------
+``ONEDPL_FPGA_EMULATOR``           Use this macro to build your code containing Parallel STL
+                                   algorithms for FPGA emulation device. (Disabled by default.)
 
-                                     .. Note:: Define ``ONEDPL_FPGA_DEVICE`` and ``ONEDPL_FPGA_EMULATOR`` macros in the same
-                                        application to run on a FPGA emulation device.
-                                        Define only the ``ONEDPL_FPGA_DEVICE`` macro to run on a FPGA hardware device.
------------------------------------- ------------------------------
-``ONEDPL_USE_SYCL121_GROUP_BARRIER`` The macro controls which API for group barriers oneDPL uses,
-                                     which can be either as defined in SYCL 1.2.1 or as in SYCL 2020.
-                                     It affects algorithms that use device execution policies.
+                                   .. Note:: Define ``ONEDPL_FPGA_DEVICE`` and ``ONEDPL_FPGA_EMULATOR`` macros in the same
+                                      application to run on a FPGA emulation device.
+                                      Define only the ``ONEDPL_FPGA_DEVICE`` macro to run on a FPGA hardware device.
+---------------------------------- ------------------------------
+``ONEDPL_SYCL121_GROUP_BARRIER``   The macro controls which API for group barriers oneDPL uses,
+                                   which can be either as defined in SYCL 1.2.1 or as in SYCL 2020.
+                                   It affects algorithms that use device execution policies.
 
-                                     Set this macro to a non-zero value to enable SYCL 1.2.1 group barriers.
-                                     The default value is 1 when using the oneAPI DPC++ Compiler and 0 otherwise.
+                                   Set this macro to a non-zero value to enable SYCL 1.2.1 group barriers.
+                                   The default value is 1 when using the oneAPI DPC++ Compiler and 0 otherwise.
 
-                                     .. Note:: Depending on a GPU driver, SYCL 1.2.1 group barriers can provide better performance
-                                        on Intel GPUs. The default value may change in future releases in favor of SYCL 2020 group barriers.
+                                   .. Note:: Depending on a GPU driver, SYCL 1.2.1 group barriers can provide better performance
+                                      on Intel GPUs. The default value may change in future releases in favor of SYCL 2020 group barriers.
 ==================================== ==============================

--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -137,7 +137,7 @@ Macro                              Description
                                       Define only the ``ONEDPL_FPGA_DEVICE`` macro to run on a FPGA hardware device.
 ---------------------------------- ------------------------------
 ``ONEDPL_SYCL121_GROUP_BARRIER``   The macro controls which API for group barriers oneDPL uses,
-                                   which can be either as defined in SYCL 1.2.1 or as in SYCL 2020.
+                                   which can be either defined as in SYCL 1.2.1 or as in SYCL 2020.
                                    It affects algorithms that use device execution policies.
 
                                    Set this macro to a non-zero value to enable SYCL 1.2.1 group barriers.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -301,7 +301,7 @@ struct __subgroup_radix_sort
                             }
 
                             // __dpl_sycl::__group_barrier(__it);
-                            sycl::group_barrier(__it.get_group(), sycl::memory_scope::work_group);
+                            __dpl_sycl::__group_barrier(__it, __dpl_sycl::__fence_space_global_and_local);
 
                             _ONEDPL_PRAGMA_UNROLL
                             for (uint16_t __i = 0; __i < __block_size; ++__i)
@@ -312,7 +312,8 @@ struct __subgroup_radix_sort
                             }
 
                             // __dpl_sycl::__group_barrier(__it);
-                            sycl::group_barrier(__it.get_group(), sycl::memory_scope::work_group);
+                            __dpl_sycl::__group_barrier(__it, __dpl_sycl::__fence_space_global_and_local);
+                            // sycl::group_barrier(__it.get_group(), sycl::memory_scope::work_group);
                         }
                     }));
             });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -177,7 +177,7 @@ struct __subgroup_radix_sort
                             if constexpr (decltype(__is_slm)::value)
                                 __dpl_sycl::__group_barrier(__it);
                             else
-                                __dpl_sycl::__group_barrier(__it, __dpl_sycl::__fence_space_global{});
+                                __dpl_sycl::__group_barrier(__it, __dpl_sycl::__fence_space_global);
                         };
 
                         //copy(move) values construction

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -177,7 +177,7 @@ struct __subgroup_radix_sort
                             if constexpr (decltype(__is_slm)::value)
                                 __dpl_sycl::__group_barrier(__it);
                             else
-                                __dpl_sycl::__group_barrier(__it, __dpl_sycl::__fence_space_global_and_local{});
+                                __dpl_sycl::__group_barrier(__it, __dpl_sycl::__fence_space_global{});
                         };
 
                         //copy(move) values construction

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -187,7 +187,8 @@ struct __subgroup_radix_sort
 
                         //copy(move) values construction
                         __block_load<_ValT>(__wi, __src, __values.__v, __n);
-                        __dpl_sycl::__group_barrier(__it, decltype(__buf_val)::get_fence()); // TODO: check if the barrier can be removed
+                        // TODO: check if the barrier can be removed
+                        __dpl_sycl::__group_barrier(__it, decltype(__buf_val)::get_fence());
 
                         while (true)
                         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -188,7 +188,7 @@ struct __subgroup_radix_sort
 
                         //copy(move) values construction
                         __block_load<_ValT>(__wi, __src, __values.__v, __n);
-                        __val_mem_adjusted_barrier();
+                        __val_mem_adjusted_barrier(); // TODO: check if the barrier can be removed
 
                         while (true)
                         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -232,10 +232,14 @@ __get_accessor_size(const _Accessor& __accessor)
 // The performance gap is negligible since
 // https://github.com/intel/intel-graphics-compiler/commit/ed639f68d142bc963a7b626badc207a42fb281cb (Aug 20, 2024)
 // But the fix is not a part of the LTS GPU drivers (Linux) yet.
+//
+// This macro may also serve as a temporary workaround to strengthen the barriers
+// if there are cases where the memory ordering is not strong enough.
 #if !defined(_ONEDPL_SYCL121_GROUP_BARRIER)
 #    if _ONEDPL_LIBSYCL_VERSION
 #        define _ONEDPL_SYCL121_GROUP_BARRIER 1
 #    else
+// For safety, assume that other SYCL implementations comply with SYCL 2020, which is a oneDPL requirement.
 #        define _ONEDPL_SYCL121_GROUP_BARRIER 0
 #    endif
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -232,28 +232,28 @@ __get_accessor_size(const _Accessor& __accessor)
 // The performance gap is negligible since
 // https://github.com/intel/intel-graphics-compiler/commit/ed639f68d142bc963a7b626badc207a42fb281cb (Aug 20, 2024)
 // But the fix is not a part of the LTS GPU drivers (Linux) yet.
-#if !defined(ONEDPL_SYCL121_GROUP_BARRIER)
+#if !defined(_ONEDPL_SYCL121_GROUP_BARRIER)
 #    if _ONEDPL_LIBSYCL_VERSION
-#        define ONEDPL_SYCL121_GROUP_BARRIER 1
+#        define _ONEDPL_SYCL121_GROUP_BARRIER 1
 #    else
-#        define ONEDPL_SYCL121_GROUP_BARRIER 0
+#        define _ONEDPL_SYCL121_GROUP_BARRIER 0
 #    endif
 #endif
 
-#if ONEDPL_SYCL121_GROUP_BARRIER
+#if _ONEDPL_SYCL121_GROUP_BARRIER
 inline constexpr sycl::access::fence_space __fence_space_local = sycl::access::fence_space::local_space;
 inline constexpr sycl::access::fence_space __fence_space_global = sycl::access::fence_space::global_space;
 #else
 struct __fence_space_dummy{}; // No-op dummy type since SYCL 2020 does not specify memory fence spaces in group barriers
 inline constexpr __fence_space_dummy __fence_space_local{};
 inline constexpr __fence_space_dummy __fence_space_global{};
-#endif // ONEDPL_SYCL121_GROUP_BARRIER
+#endif // _ONEDPL_SYCL121_GROUP_BARRIER
 
 template <typename _Item, typename _Space = decltype(__fence_space_local)>
 void
 __group_barrier(_Item __item, [[maybe_unused]] _Space __space = __fence_space_local)
 {
-#if ONEDPL_SYCL121_GROUP_BARRIER
+#if _ONEDPL_SYCL121_GROUP_BARRIER
     __item.barrier(__space);
 #elif _ONEDPL_SYCL2020_GROUP_BARRIER_PRESENT
     sycl::group_barrier(__item.get_group(), sycl::memory_scope::work_group);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -256,7 +256,8 @@ struct __fence_space_global_and_local {};
 #endif // ONEDPL_SYCL121_GROUP_BARRIER
 
 template <typename _Item, typename _Space = __fence_space_local>
-void __group_barrier(_Item __item, [[maybe_unused]] _Space __space = {})
+void
+__group_barrier(_Item __item, [[maybe_unused]] _Space __space = {})
 {
 #if ONEDPL_SYCL121_GROUP_BARRIER
     __item.barrier(_Space::__value);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -245,17 +245,19 @@ __get_accessor_size(const _Accessor& __accessor)
 #endif
 
 #if _ONEDPL_SYCL121_GROUP_BARRIER
-inline constexpr sycl::access::fence_space __fence_space_local = sycl::access::fence_space::local_space;
-inline constexpr sycl::access::fence_space __fence_space_global = sycl::access::fence_space::global_space;
+using __fence_space_t = sycl::access::fence_space;
+inline constexpr __fence_space_t __fence_space_local = sycl::access::fence_space::local_space;
+inline constexpr __fence_space_t __fence_space_global = sycl::access::fence_space::global_space;
 #else
 struct __fence_space_dummy{}; // No-op dummy type since SYCL 2020 does not specify memory fence spaces in group barriers
-inline constexpr __fence_space_dummy __fence_space_local{};
-inline constexpr __fence_space_dummy __fence_space_global{};
+using __fence_space_t = __fence_space_dummy;
+inline constexpr __fence_space_t __fence_space_local{};
+inline constexpr __fence_space_t __fence_space_global{};
 #endif // _ONEDPL_SYCL121_GROUP_BARRIER
 
-template <typename _Item, typename _Space = decltype(__fence_space_local)>
+template <typename _Item>
 void
-__group_barrier(_Item __item, [[maybe_unused]] _Space __space = __fence_space_local)
+__group_barrier(_Item __item, [[maybe_unused]] __dpl_sycl::__fence_space_t __space = __fence_space_local)
 {
 #if _ONEDPL_SYCL121_GROUP_BARRIER
     __item.barrier(__space);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -245,7 +245,7 @@ inline constexpr sycl::access::fence_space __fence_space_local = sycl::access::f
 inline constexpr sycl::access::fence_space __fence_space_global = sycl::access::fence_space::global_space;
 inline constexpr sycl::access::fence_space __fence_space_global_and_local = sycl::access::fence_space::global_and_local;
 #else
-struct __fence_space_dummy{}; // No-op dummy type since SYCL 2020 does specify memory fence spaces in group barriers
+struct __fence_space_dummy{}; // No-op dummy type since SYCL 2020 does not specify memory fence spaces in group barriers
 inline constexpr __fence_space_dummy __fence_space_local{};
 inline constexpr __fence_space_dummy __fence_space_global{};
 inline constexpr __fence_space_dummy __fence_space_global_and_local{};

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -232,15 +232,15 @@ __get_accessor_size(const _Accessor& __accessor)
 // The performance gap is negligible since
 // https://github.com/intel/intel-graphics-compiler/commit/ed639f68d142bc963a7b626badc207a42fb281cb (Aug 20, 2024)
 // But the fix is not a part of the LTS GPU drivers (Linux) yet.
-#if !defined(ONEDPL_USE_SYCL121_GROUP_BARRIER)
+#if !defined(ONEDPL_SYCL121_GROUP_BARRIER)
 #    if _ONEDPL_LIBSYCL_VERSION
-#        define ONEDPL_USE_SYCL121_GROUP_BARRIER 1
+#        define ONEDPL_SYCL121_GROUP_BARRIER 1
 #    else
-#        define ONEDPL_USE_SYCL121_GROUP_BARRIER 0
+#        define ONEDPL_SYCL121_GROUP_BARRIER 0
 #    endif
 #endif
 
-#if ONEDPL_USE_SYCL121_GROUP_BARRIER
+#if ONEDPL_SYCL121_GROUP_BARRIER
 template <sycl::access::fence_space _Space>
 struct __fence_space
 {
@@ -253,12 +253,12 @@ using __fence_space_global_and_local = __fence_space<sycl::access::fence_space::
 struct __fence_space_local {};
 struct __fence_space_global {};
 struct __fence_space_global_and_local {};
-#endif // ONEDPL_USE_SYCL121_GROUP_BARRIER
+#endif // ONEDPL_SYCL121_GROUP_BARRIER
 
 template <typename _Item, typename _Space = __fence_space_local>
 void __group_barrier(_Item __item, [[maybe_unused]] _Space __space = {})
 {
-#if ONEDPL_USE_SYCL121_GROUP_BARRIER
+#if ONEDPL_SYCL121_GROUP_BARRIER
     __item.barrier(_Space::__value);
 #elif _ONEDPL_SYCL2020_GROUP_BARRIER_PRESENT
     sycl::group_barrier(__item.get_group(), sycl::memory_scope::work_group);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -227,11 +227,18 @@ __get_accessor_size(const _Accessor& __accessor)
 }
 
 // TODO: switch to SYCL 2020 with DPC++ compiler.
-// SYCL 1.2.1 version is used due to better performance on Intel GPUs.
+// SYCL 1.2.1 version is used due to having an API with a local memory fence,
+// which gives better performance on Intel GPUs.
 // The performance gap is negligible since
 // https://github.com/intel/intel-graphics-compiler/commit/ed639f68d142bc963a7b626badc207a42fb281cb (Aug 20, 2024)
 // But the fix is not a part of the LTS GPU drivers (Linux) yet.
-#define ONEDPL_USE_SYCL121_GROUP_BARRIER 1
+#if !defined(ONEDPL_USE_SYCL121_GROUP_BARRIER)
+#    if _ONEDPL_LIBSYCL_VERSION
+#        define ONEDPL_USE_SYCL121_GROUP_BARRIER 1
+#    else
+#        define ONEDPL_USE_SYCL121_GROUP_BARRIER 0
+#    endif
+#endif
 
 #if ONEDPL_USE_SYCL121_GROUP_BARRIER
 template <sycl::access::fence_space _Space>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -249,8 +249,7 @@ using __fence_space_t = sycl::access::fence_space;
 inline constexpr __fence_space_t __fence_space_local = sycl::access::fence_space::local_space;
 inline constexpr __fence_space_t __fence_space_global = sycl::access::fence_space::global_space;
 #else
-struct __fence_space_dummy{}; // No-op dummy type since SYCL 2020 does not specify memory fence spaces in group barriers
-using __fence_space_t = __fence_space_dummy;
+struct __fence_space_t{}; // No-op dummy type since SYCL 2020 does not specify memory fence spaces in group barriers
 inline constexpr __fence_space_t __fence_space_local{};
 inline constexpr __fence_space_t __fence_space_global{};
 #endif // _ONEDPL_SYCL121_GROUP_BARRIER

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -243,12 +243,10 @@ __get_accessor_size(const _Accessor& __accessor)
 #if ONEDPL_SYCL121_GROUP_BARRIER
 inline constexpr sycl::access::fence_space __fence_space_local = sycl::access::fence_space::local_space;
 inline constexpr sycl::access::fence_space __fence_space_global = sycl::access::fence_space::global_space;
-inline constexpr sycl::access::fence_space __fence_space_global_and_local = sycl::access::fence_space::global_and_local;
 #else
 struct __fence_space_dummy{}; // No-op dummy type since SYCL 2020 does not specify memory fence spaces in group barriers
 inline constexpr __fence_space_dummy __fence_space_local{};
 inline constexpr __fence_space_dummy __fence_space_global{};
-inline constexpr __fence_space_dummy __fence_space_global_and_local{};
 #endif // ONEDPL_SYCL121_GROUP_BARRIER
 
 template <typename _Item, typename _Space = decltype(__fence_space_local)>


### PR DESCRIPTION
Value (`__buf_val`) and Count (`__buf_count`) buffers store data in either local or global memory. Let's use group barriers with proper fences (local or global memory fences) to avoid memory contention issues, which are observed on Xe2 architectures.

The fix changes how `__group_barrier` is defined, so the PR additionally includes what is done in #1988 to avoid conflicts and fix another issue related to the barriers: we use SYCL 1.2.1 barriers, but oneDPL claims to be SYCL 2020 compatible.