### PR TITLE
Global barrier fence histogram fix

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -127,10 +127,12 @@ class __histo_kernel_local_atomics;
 template <typename... _Name>
 class __histo_kernel_private_glocal_atomics;
 
-template <typename _HistAccessor, typename _OffsetT, typename _Size>
+template <typename _HistAccessor, typename _OffsetT, typename _Size,
+          typename _FenceSpace = decltype(__dpl_sycl::__fence_space_local)>
 void
 __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _OffsetT& __offset, _Size __num_bins,
-                           const sycl::nd_item<1>& __self_item)
+                           const sycl::nd_item<1>& __self_item,
+                           _FenceSpace __fence_space = __dpl_sycl::__fence_space_local)
 {
     using _BinUint_t =
         ::std::conditional_t<(sizeof(_Size) >= sizeof(::std::uint32_t)), ::std::uint64_t, ::std::uint32_t>;
@@ -148,7 +150,7 @@ __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _Offset
     {
         __local_histogram[__offset + __gSize * __k + __self_lidx] = 0;
     }
-    __dpl_sycl::__group_barrier(__self_item);
+    __dpl_sycl::__group_barrier(__self_item, __fence_space);
 }
 
 template <typename _BinIdxType, typename _ValueType, typename _HistReg, typename _BinFunc>
@@ -444,7 +446,8 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                     const ::std::size_t __wgroup_idx = __self_item.get_group(0);
                     const ::std::size_t __seg_start = __work_group_size * __iters_per_work_item * __wgroup_idx;
 
-                    __clear_wglocal_histograms(__hacc_private, __wgroup_idx * __num_bins, __num_bins, __self_item);
+                    __clear_wglocal_histograms(__hacc_private, __wgroup_idx * __num_bins, __num_bins, __self_item,
+                                               __dpl_sycl::__fence_space_global);
 
                     if (__seg_start + __work_group_size * __iters_per_work_item < __n)
                     {
@@ -469,7 +472,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                         }
                     }
 
-                    __dpl_sycl::__group_barrier(__self_item);
+                    __dpl_sycl::__group_barrier(__self_item, __dpl_sycl::__fence_space_global);
 
                     __reduce_out_histograms<_bin_type, ::std::uint32_t>(__hacc_private, __wgroup_idx * __num_bins,
                                                                         __bins, __num_bins, __self_item);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -128,7 +128,7 @@ template <typename... _Name>
 class __histo_kernel_private_glocal_atomics;
 
 template <typename _HistAccessor, typename _OffsetT, typename _Size,
-          typename _FenceSpace = decltype(__dpl_sycl::__fence_space_local)>
+          typename _FenceSpace = __dpl_sycl::__fence_space_t>
 void
 __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _OffsetT& __offset, _Size __num_bins,
                            const sycl::nd_item<1>& __self_item,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -127,12 +127,11 @@ class __histo_kernel_local_atomics;
 template <typename... _Name>
 class __histo_kernel_private_glocal_atomics;
 
-template <typename _HistAccessor, typename _OffsetT, typename _Size,
-          typename _FenceSpace = __dpl_sycl::__fence_space_t>
+template <typename _HistAccessor, typename _OffsetT, typename _Size>
 void
 __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _OffsetT& __offset, _Size __num_bins,
                            const sycl::nd_item<1>& __self_item,
-                           _FenceSpace __fence_space = __dpl_sycl::__fence_space_local)
+                           __dpl_sycl::__fence_space_t __fence_space = __dpl_sycl::__fence_space_local)
 {
     using _BinUint_t =
         ::std::conditional_t<(sizeof(_Size) >= sizeof(::std::uint32_t)), ::std::uint64_t, ::std::uint32_t>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -255,9 +255,9 @@ inline constexpr __fence_space_t __fence_space_local{};
 inline constexpr __fence_space_t __fence_space_global{};
 #endif // _ONEDPL_SYCL121_GROUP_BARRIER
 
-template <typename _Item, typename _Space = __dpl_sycl::__fence_space_t>
+template <typename _Item>
 void
-__group_barrier(_Item __item, [[maybe_unused]] _Space __space = __fence_space_local)
+__group_barrier(_Item __item, [[maybe_unused]] __dpl_sycl::__fence_space_t __space = __fence_space_local)
 {
 #if _ONEDPL_SYCL121_GROUP_BARRIER
     __item.barrier(__space);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -245,15 +245,17 @@ __get_accessor_size(const _Accessor& __accessor)
 #endif
 
 #if _ONEDPL_SYCL121_GROUP_BARRIER
-inline constexpr sycl::access::fence_space __fence_space_local = sycl::access::fence_space::local_space;
-inline constexpr sycl::access::fence_space __fence_space_global = sycl::access::fence_space::global_space;
+using __fence_space_t = sycl::access::fence_space;
+inline constexpr __fence_space_t __fence_space_local = sycl::access::fence_space::local_space;
+inline constexpr __fence_space_t __fence_space_global = sycl::access::fence_space::global_space;
 #else
 struct __fence_space_dummy{}; // No-op dummy type since SYCL 2020 does not specify memory fence spaces in group barriers
-inline constexpr __fence_space_dummy __fence_space_local{};
-inline constexpr __fence_space_dummy __fence_space_global{};
+using __fence_space_t = __fence_space_dummy;
+inline constexpr __fence_space_t __fence_space_local{};
+inline constexpr __fence_space_t __fence_space_global{};
 #endif // _ONEDPL_SYCL121_GROUP_BARRIER
 
-template <typename _Item, typename _Space = decltype(__fence_space_local)>
+template <typename _Item, typename _Space = __dpl_sycl::__fence_space_t>
 void
 __group_barrier(_Item __item, [[maybe_unused]] _Space __space = __fence_space_local)
 {


### PR DESCRIPTION
This changes the global barrier's fence spaces for histogram  catch all which uses global atomics and no SLM.

I'm not sure if we want to add this in right now, or take care of this after the release.  
This is only used when the number of histogram bins is very large as compared to the memory space of the device.

If we have any question marks here, lets wait on these changes.