### PR TITLE
Fix circular dependency between utils_ranges_sycl.h and ranges_defs.h

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -23,7 +23,7 @@
 #endif
 
 #include "../../utils_ranges.h"
-#include "../../ranges_defs.h" // contiguous_range and contiguous_iterator from nanorange
+#include "../../ranges/nanorange.hpp" // contiguous_range and contiguous_iterator from nanorange
 #include "../../iterator_impl.h"
 #include "sycl_iterator.h"
 #include "sycl_defs.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -23,7 +23,7 @@
 #endif
 
 #include "../../utils_ranges.h"
-#include "../../ranges/nanorange.hpp" // contiguous_range and contiguous_iterator from nanorange
+#include "../../ranges/nanorange.hpp" // contiguous_range from nanorange
 #include "../../iterator_impl.h"
 #include "sycl_iterator.h"
 #include "sycl_defs.h"


### PR DESCRIPTION
PR #1976 introduced a circular dependency between `oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h` and `oneapi/dpl/pstl/ranges_defs.h`. This shows up as an issue in kernel templates where the following produces a compiler error:

```
#include <oneapi/dpl/experimental/kernel_templates>

int main()
{
}
```
In `utils_ranges_sycl.h`, the include was added to be able to use `__nanorange::nano::ranges::contiguous_range`, so we can fix this by directly including the nanorange header. This resolves the circular dependency and the compilation issue.