### PR TITLE
Fix CTAD in merge sort

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -330,6 +330,8 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
         {
         }
     };
+    template <typename Rng>
+    DropViews(Rng&, const WorkDataArea&) -> DropViews<Rng>;
 
     template <typename _ExecutionPolicy>
     std::size_t


### PR DESCRIPTION
This fixes issue with template argument deduction of `DropViews` nested structure. The issue happens with clang 17 and earlier. icpx 2023.2, which is based on clang 17, is also prone to that issue.

Reproducer: https://godbolt.org/z/WhMb5W8on