### PR TITLE
Silence negators deprecation warnings

### DIFF
--- a/include/oneapi/dpl/functional
+++ b/include/oneapi/dpl/functional
@@ -17,7 +17,18 @@
 #define _ONEDPL_FUNCTIONAL
 
 #include "oneapi/dpl/internal/common_config.h"
+
+// Silence the deprecation warnings of the negators injected from <functional>
+// The macro definition is contained in this header to avoid redefinition errors on the user side
+#if _ONEDPL___cplusplus < 202002L && defined(_MSC_VER) && !defined(_SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING)
+#    define _SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING
+#    define _ONEDPL_SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING
+#endif
 #include <functional>
+#if defined(_ONEDPL_SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING)
+#   undef _SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING
+#   undef _ONEDPL_SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING
+#endif
 
 #include "oneapi/dpl/utility"
 


### PR DESCRIPTION
It suppresses the warning:

oneDPL\include\oneapi\dpl\pstl../functional(51): warning C4996: 'std::binary_negate': warning STL4008: std::not1(), std::not2(), std::unary_negate, and std::binary_negate are deprecated in C++17. They are superseded by std::not_fn(). You can define _SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to suppress this warning.
