### PR TITLE
add parentheses around && to silence a warning

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -179,8 +179,8 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         if constexpr (__can_use_ternary_op_v<decltype(__rng1[__rng1_idx]), decltype(__rng2[__rng2_idx])>)
         {
             // This implementation is required for performance optimization
-            __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || __rng1_idx_less_n1 && __rng2_idx_less_n2 &&
-                                                             __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
+            __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || (__rng1_idx_less_n1 && __rng2_idx_less_n2 &&
+														  __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])))
                                      ? __rng2[__rng2_idx++]
                                      : __rng1[__rng1_idx++];
         }
@@ -188,7 +188,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, const _I
         {
             // TODO required to understand why the usual if-else is slower then ternary operator
             if (!__rng1_idx_less_n1 ||
-                __rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
+                (__rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx])))
                 __rng3[__rng3_idx] = __rng2[__rng2_idx++];
             else
                 __rng3[__rng3_idx] = __rng1[__rng1_idx++];


### PR DESCRIPTION
Fixed warning
```
/home/runner/work/distributed-ranges/distributed-ranges/build/_deps/dpl-src/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h:182:99: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
  182 |             __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || __rng1_idx_less_n1 && __rng2_idx_less_n2 &&
      |                                                       ~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  183 |                                                              __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
      |                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/distributed-ranges/distributed-ranges/build/_deps/dpl-src/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h:182:99: note: place parentheses around the '&&' expression to silence this warning
  182 |             __rng3[__rng3_idx] = (!__rng1_idx_less_n1 || __rng1_idx_less_n1 && __rng2_idx_less_n2 &&
      |                                                                                                   ^
      |                                                          (
  183 |                                                              __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
      |                                                                                                            
      |                                                                                                            )
/home/runner/work/distributed-ranges/distributed-ranges/build/_deps/dpl-src/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h:191:58: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
  190 |             if (!__rng1_idx_less_n1 ||
      |                                     ~~
  191 |                 __rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/distributed-ranges/distributed-ranges/build/_deps/dpl-src/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h:191:58: note: place parentheses around the '&&' expression to silence this warning
  191 |                 __rng1_idx_less_n1 && __rng2_idx_less_n2 && __comp(__rng2[__rng2_idx], __rng1[__rng1_idx]))
      |                                                          ^                                                
      |                 (                                                                                         )
```