### PR TITLE
[Tests] Remove broken macro for MSVC array swap

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -78,13 +78,6 @@
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 // GCC7 std::get doesn't return const rvalue reference from const rvalue reference of tuple
 #define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE > 0 && _GLIBCXX_RELEASE < 8)
-// Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
-// call some internal function which is not declared as SYCL external and we have compile error
-#if defined(_MSC_VER)
-#   define TEST_XPU_ARRAY_SWAP_BROKEN (_MSC_VER <= 1937)
-#else
-#   define TEST_XPU_ARRAY_SWAP_BROKEN 0
-#endif
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/xpu_api/containers/sequences/array/array.special/swap1.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.special/swap1.pass.cpp
@@ -30,7 +30,6 @@
 int
 main()
 {
-#if !TEST_XPU_ARRAY_SWAP_BROKEN
     bool ret = true;
     {
         sycl::buffer<bool, 1> buf(&ret, sycl::range<1>{1});
@@ -67,7 +66,6 @@ main()
     }
 
     EXPECT_TRUE(ret, "Wrong result of work with dpl::swap(dpl::array, dpl::array)");
-#endif // !TEST_XPU_ARRAY_SWAP_BROKEN
 
-    return TestUtils::done(!TEST_XPU_ARRAY_SWAP_BROKEN);
+    return TestUtils::done();
 }

--- a/test/xpu_api/containers/sequences/array/array.swap/swap.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.swap/swap.pass.cpp
@@ -29,7 +29,6 @@
 
 #include "support/utils.h"
 
-#if !TEST_XPU_ARRAY_SWAP_BROKEN
 class KernelTest1;
 
 bool
@@ -96,15 +95,12 @@ kernel_test()
     }
     return ret;
 }
-#endif // !TEST_XPU_ARRAY_SWAP_BROKEN
 
 int
 main()
 {
-#if !TEST_XPU_ARRAY_SWAP_BROKEN
     auto ret = kernel_test();
     EXPECT_TRUE(ret, "Wrong result of work with dpl::swap");
-#endif // !TEST_XPU_ARRAY_SWAP_BROKEN
 
-    return TestUtils::done(!TEST_XPU_ARRAY_SWAP_BROKEN);
+    return TestUtils::done();
 }


### PR DESCRIPTION
We added a workaround for an issue with swapping with MSVC in #1560, but neglected to remove the test's "broken" macro.

This PR removes the broken macro, which allows us to resume testing on windows with the workaround.