### PR TITLE
Ranges sort tests: filter out policies to reduce execution time

### DIFF
--- a/test/parallel_api/ranges/std_ranges_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_sort.pass.cpp
@@ -24,9 +24,9 @@ main()
 
     auto sort_checker = TEST_PREPARE_CALLABLE(std::ranges::sort);
 
-    test_range_algo<0, int, data_in, SkipHostPolicies>{big_sz}(dpl_ranges::sort, sort_checker);
+    test_range_algo<0, int, data_in, DevicePolicy>{big_sz}(dpl_ranges::sort, sort_checker);
 
-    test_range_algo<1, int, data_in, ParHostPolicies>{medium_sz}(dpl_ranges::sort, sort_checker, std::ranges::less{});
+    test_range_algo<1, int, data_in, DeviceAndParPolicies>{medium_sz}(dpl_ranges::sort, sort_checker, std::ranges::less{});
 
     test_range_algo<2>{}(dpl_ranges::sort, sort_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(dpl_ranges::sort, sort_checker, std::ranges::greater{}, proj);

--- a/test/parallel_api/ranges/std_ranges_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_sort.pass.cpp
@@ -24,9 +24,8 @@ main()
 
     auto sort_checker = TEST_PREPARE_CALLABLE(std::ranges::sort);
 
-    test_range_algo<0, int, data_in, DevicePolicy>{big_sz}(dpl_ranges::sort, sort_checker);
-
-    test_range_algo<1, int, data_in, DeviceAndParPolicies>{medium_sz}(dpl_ranges::sort, sort_checker, std::ranges::less{});
+    test_range_algo<0>{}(dpl_ranges::sort, sort_checker);
+    test_range_algo<1>{}(dpl_ranges::sort, sort_checker, std::ranges::less{});
 
     test_range_algo<2>{}(dpl_ranges::sort, sort_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(dpl_ranges::sort, sort_checker, std::ranges::greater{}, proj);
@@ -36,6 +35,12 @@ main()
 
     test_range_algo<6, P2>{}(dpl_ranges::sort, sort_checker, std::ranges::less{}, &P2::proj);
     test_range_algo<7, P2>{}(dpl_ranges::sort, sort_checker, std::ranges::greater{}, &P2::proj);
+
+    // Check larger specializations, use a custom comparator for a comparison-based sort (e.g. merge-sort)
+    auto custom_less = [](const auto& a, const auto& b){ return a < b;};
+    test_range_algo<8, std::uint16_t, data_in, DevicePolicy>{big_sz}(dpl_ranges::sort, sort_checker, custom_less);
+    test_range_algo<9, int, data_in, DeviceAndParPolicies>{medium_sz}(dpl_ranges::sort, sort_checker, custom_less);
+
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_sort.pass.cpp
@@ -24,8 +24,9 @@ main()
 
     auto sort_checker = TEST_PREPARE_CALLABLE(std::ranges::sort);
 
-    test_range_algo<0>{big_sz}(dpl_ranges::sort, sort_checker);
-    test_range_algo<1>{}(dpl_ranges::sort, sort_checker, std::ranges::less{});
+    test_range_algo<0, int, data_in, SkipHostPolicies>{big_sz}(dpl_ranges::sort, sort_checker);
+
+    test_range_algo<1, int, data_in, ParHostPolicies>{medium_sz}(dpl_ranges::sort, sort_checker, std::ranges::less{});
 
     test_range_algo<2>{}(dpl_ranges::sort, sort_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(dpl_ranges::sort, sort_checker, std::ranges::greater{}, proj);

--- a/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
@@ -24,7 +24,7 @@ main()
 
     auto sort_stable_checker = TEST_PREPARE_CALLABLE(std::ranges::stable_sort);
 
-    test_range_algo<0>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
+    test_range_algo<0>{}(dpl_ranges::stable_sort, sort_stable_checker);
     test_range_algo<1>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{});
 
     test_range_algo<2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{}, proj);

--- a/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
@@ -24,10 +24,8 @@ main()
 
     auto sort_stable_checker = TEST_PREPARE_CALLABLE(std::ranges::stable_sort);
 
-    test_range_algo<0, int, data_in, DevicePolicy>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
-
-    test_range_algo<1, int, data_in, DeviceAndParPolicies>{medium_sz}(dpl_ranges::stable_sort, sort_stable_checker,
-                                                                      std::ranges::less{});
+    test_range_algo<0>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
+    test_range_algo<1>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{});
 
     test_range_algo<2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::greater{}, proj);
@@ -37,6 +35,11 @@ main()
 
     test_range_algo<6, P2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{}, &P2::proj);
     test_range_algo<7, P2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::greater{}, &P2::proj);
+
+    // Check larger specializations, use default comparator for a non-comparison-based sort (e.g. radix-sort) if exists
+    test_range_algo<8, int, data_in, DeviceAndParPolicies>{medium_sz}(dpl_ranges::stable_sort, sort_stable_checker);
+    test_range_algo<9, std::uint16_t, data_in, DevicePolicy>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
+
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
@@ -24,10 +24,10 @@ main()
 
     auto sort_stable_checker = TEST_PREPARE_CALLABLE(std::ranges::stable_sort);
 
-    test_range_algo<0, int, data_in, SkipHostPolicies>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
+    test_range_algo<0, int, data_in, DevicePolicy>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
 
-    test_range_algo<1, int, data_in, ParHostPolicies>{medium_sz}(dpl_ranges::stable_sort, sort_stable_checker,
-                                                                 std::ranges::less{});
+    test_range_algo<1, int, data_in, DeviceAndParPolicies>{medium_sz}(dpl_ranges::stable_sort, sort_stable_checker,
+                                                                      std::ranges::less{});
 
     test_range_algo<2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::greater{}, proj);

--- a/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
@@ -24,8 +24,10 @@ main()
 
     auto sort_stable_checker = TEST_PREPARE_CALLABLE(std::ranges::stable_sort);
 
-    test_range_algo<0>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
-    test_range_algo<1>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{});
+    test_range_algo<0, int, data_in, SkipHostPolicies>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
+
+    test_range_algo<1, int, data_in, ParHostPolicies>{medium_sz}(dpl_ranges::stable_sort, sort_stable_checker,
+                                                                 std::ranges::less{});
 
     test_range_algo<2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::greater{}, proj);

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -146,6 +146,12 @@ bool is_range<T, std::void_t<decltype(std::declval<T&>().begin())>> = true;
 using AllHostPolicies = std::integral_constant<int, 0>;
 using ParHostPolicies = std::integral_constant<int, 1>;
 using SkipHostPolicies = std::integral_constant<int, 2>;
+template <typename T>
+struct is_host_policy_selector: std::bool_constant<std::is_same_v<T, AllHostPolicies> ||
+                                                   std::is_same_v<T, ParHostPolicies> ||
+                                                   std::is_same_v<T, SkipHostPolicies>> {};
+template <typename T>
+inline constexpr bool is_host_policy_selector_v = is_host_policy_selector<T>::value;
 
 template<typename DataType, typename Container, TestDataMode test_mode = data_in>
 struct test
@@ -168,9 +174,7 @@ struct test
     operator()(SkipHostPolicies, auto algo, auto& checker, auto... args) {}
 
     template<typename Policy, typename Algo, typename Checker, typename TransIn, typename TransOut, TestDataMode mode = test_mode>
-    std::enable_if_t<mode == data_in && !std::is_same_v<Policy, AllHostPolicies> &&
-                                        !std::is_same_v<Policy, ParHostPolicies> &&
-                                        !std::is_same_v<Policy, SkipHostPolicies>>
+    std::enable_if_t<!is_host_policy_selector_v<Policy> && mode == data_in>
     operator()(Policy&& exec, Algo algo, Checker& checker, TransIn tr_in, TransOut, auto... args)
     {
         Container cont_in(exec, max_n, [](auto i) { return i;});
@@ -236,9 +240,7 @@ private:
 
 public:
     template<typename Policy, typename Algo, typename Checker, TestDataMode mode = test_mode>
-    std::enable_if_t<mode == data_in_out && !std::is_same_v<Policy, AllHostPolicies> &&
-                                            !std::is_same_v<Policy, ParHostPolicies> &&
-                                            !std::is_same_v<Policy, SkipHostPolicies>>
+    std::enable_if_t<!is_host_policy_selector_v<Policy> && mode == data_in_out>
     operator()(Policy&& exec, Algo algo, Checker& checker, auto... args)
     {
         const int r_size = max_n;
@@ -246,9 +248,7 @@ public:
     }
 
     template<typename Policy, typename Algo, typename Checker, TestDataMode mode = test_mode>
-    std::enable_if_t<mode == data_in_out_lim && !std::is_same_v<Policy, AllHostPolicies> &&
-                                                !std::is_same_v<Policy, ParHostPolicies> &&
-                                                !std::is_same_v<Policy, SkipHostPolicies>>
+    std::enable_if_t<!is_host_policy_selector_v<Policy> && mode == data_in_out_lim>
     operator()(Policy&& exec, Algo algo, Checker& checker, auto... args)
     {
         const int r_size = max_n;
@@ -260,9 +260,7 @@ public:
     }
 
     template<typename Policy, typename Algo, typename Checker, typename TransIn, typename TransOut, TestDataMode mode = test_mode>
-    std::enable_if_t<mode == data_in_in && !std::is_same_v<Policy, AllHostPolicies> &&
-                                           !std::is_same_v<Policy, ParHostPolicies> &&
-                                           !std::is_same_v<Policy, SkipHostPolicies>>
+    std::enable_if_t<!is_host_policy_selector_v<Policy> && mode == data_in_in>
     operator()(Policy&& exec, Algo algo, Checker& checker, TransIn tr_in, TransOut, auto... args)
     {
         Container cont_in1(exec, max_n, [](auto i) { return i;});
@@ -324,9 +322,7 @@ private:
 
 public:
     template<typename Policy, typename Algo, typename Checker, TestDataMode mode = test_mode>
-    std::enable_if_t<mode == data_in_in_out && !std::is_same_v<Policy, AllHostPolicies> &&
-                                               !std::is_same_v<Policy, ParHostPolicies> &&
-                                               !std::is_same_v<Policy, SkipHostPolicies>>
+    std::enable_if_t<!is_host_policy_selector_v<Policy> && mode == data_in_in_out>
     operator()(Policy&& exec, Algo algo, Checker& checker, auto... args)
     {
         const int r_size = max_n;

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -51,8 +51,6 @@ auto dpcpp_policy()
 }
 #endif //TEST_DPCPP_BACKEND_PRESENT
 
-auto host_policies() { return std::true_type{};}
-
 enum TestDataMode
 {
     data_in,

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -333,7 +333,7 @@ public:
     }
 
     template<typename Policy, typename Algo, typename Checker, TestDataMode mode = test_mode>
-    std::enable_if_t<!std::is_same_v<Policy, std::true_type> && mode == data_in_in_out_lim>
+    std::enable_if_t<!is_host_policy_selector_v<Policy> && mode == data_in_in_out_lim>
     operator()(Policy&& exec, Algo algo, Checker& checker, auto... args)
     {
         const int r_size = max_n;

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -532,7 +532,7 @@ using  usm_span = usm_subrange_impl<T, std::span<T>>;
 template<int call_id = 0, typename T = int, TestDataMode mode = data_in, typename PolicySelector = AllPolicies>
 struct test_range_algo
 {
-    const int max_n = 10;
+    const int max_n = 2000;
     void test_view(auto view, auto algo, auto& checker, auto... args)
     {
         test<T, host_subrange<T>, mode>{max_n}(PolicySelector{}, algo, checker, view, std::identity{}, args...);

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -38,7 +38,7 @@ static_assert(ONEDPL_HAS_RANGE_ALGORITHMS >= 202409L);
 namespace test_std_ranges
 {
 
-inline constexpr std::size_t big_sz = (1<<25) + 10; //32M
+inline constexpr std::size_t big_sz = (1<<24) + 10; //16M
 inline constexpr std::size_t medium_sz = (1<<17) + 10; //128K
 
 #if TEST_DPCPP_BACKEND_PRESENT

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -40,6 +40,7 @@ namespace test_std_ranges
 
 inline constexpr std::size_t big_sz = (1<<24) + 10; //16M
 inline constexpr std::size_t medium_sz = (1<<17) + 10; //128K
+inline constexpr std::size_t small_sz = 2025;
 
 #if TEST_DPCPP_BACKEND_PRESENT
 template<int call_id = 0>
@@ -157,7 +158,7 @@ bool is_range<T, std::void_t<decltype(std::declval<T&>().begin())>> = true;
 template<typename DataType, typename Container, TestDataMode test_mode = data_in>
 struct test
 {
-    const int max_n = 10;
+    const int max_n = small_sz;
 
     template<typename PolicySelector>
     std::enable_if_t<is_host_policy_selector_v<PolicySelector>>
@@ -532,7 +533,7 @@ using  usm_span = usm_subrange_impl<T, std::span<T>>;
 template<int call_id = 0, typename T = int, TestDataMode mode = data_in, typename PolicySelector = AllPolicies>
 struct test_range_algo
 {
-    const int max_n = 2000;
+    const int max_n = small_sz;
     void test_view(auto view, auto algo, auto& checker, auto... args)
     {
         test<T, host_subrange<T>, mode>{max_n}(PolicySelector{}, algo, checker, view, std::identity{}, args...);

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -157,7 +157,8 @@ template<typename DataType, typename Container, TestDataMode test_mode = data_in
 struct test
 {
     const int max_n = 10;
-    void operator()(AllHostPolicies, auto algo, auto& checker, auto... args)
+    void
+    operator()(AllHostPolicies, auto algo, auto& checker, auto... args)
     {
         operator()(oneapi::dpl::execution::seq, algo, checker, args...);
         operator()(oneapi::dpl::execution::unseq, algo, checker, args...);


### PR DESCRIPTION
`std_ranges_sort.pass` and `std_ranges_stable_sort.pass` tests take to much time to complete. Let's filter out cases which do not have much sense, for example testing millions elements with host policies and thousands with serial ones.
Testing 32M elements with device policies also is too much. There are no specializations for more than 16M elements.