### PR TITLE
Rely on new IGC behavior to workaround issues with -O0 compilation in reduce-then-scan

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1057,7 +1057,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
     // work-group implementation requires a fundamental type which must also be trivially copyable.
     if constexpr (std::is_trivially_copyable_v<_Type>)
     {
-        bool __use_reduce_then_scan = oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec);
+        bool __use_reduce_then_scan = oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec);
 
         // TODO: Consider re-implementing single group scan to support types without known identities. This could also
         // allow us to use single wg scan for the last block of reduce-then-scan if it is sufficiently small.
@@ -1233,7 +1233,7 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
     // can simply copy the input range to the output.
     assert(__n > 1);
 
-    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
@@ -1297,7 +1297,7 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
                           _Range1&& __rng, _Range2&& __result, _UnaryPredicate __pred)
 {
     oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng.size();
-    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
         using _WriteOp =
@@ -1349,7 +1349,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
             _SingleGroupInvoker{}, __n, std::forward<_ExecutionPolicy>(__exec), __n, std::forward<_InRng>(__in_rng),
             std::forward<_OutRng>(__out_rng), __pred, __assign);
     }
-    else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
+    else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
@@ -1463,7 +1463,7 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _
                   _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
                   _IsOpDifference __is_op_difference)
 {
-    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
                                                std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
@@ -2407,7 +2407,7 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
 #if !defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER >= 20250000
     if constexpr (std::is_trivially_copyable_v<__val_type>)
     {
-        if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
+        if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
         {
             auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan(
                 oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -733,8 +733,7 @@ template <typename _ExecutionPolicy>
 bool
 __is_gpu_with_sg_32(const _ExecutionPolicy& __exec)
 {
-    const bool __dev_supports_sg_sz = oneapi::dpl::__internal::__supports_sub_group_size(__exec, 32);
-    return (__exec.queue().get_device().is_gpu() && __dev_supports_sg_sz);
+    return __exec.queue().get_device().is_gpu() && oneapi::dpl::__internal::__supports_sub_group_size(__exec, 32);
 }
 
 // General scan-like algorithm helpers

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -157,15 +157,6 @@
 #define _ONEDPL_CPP17_EXECUTION_POLICIES_PRESENT                                                                       \
     (_ONEDPL___cplusplus >= 201703L && (_MSC_VER >= 1912 || (_GLIBCXX_RELEASE >= 9 && __GLIBCXX__ >= 20190503)))
 
-// In the SYCL backend reduce-then-scan path, we need to be able to differentiate between when a compiler enables
-// optimizations and when it does not. With GCC and clang-based compilers, we can detect this with the __OPTIMIZE__
-// flag.
-#if _ONEDPL_GCC_VERSION > 0 || defined(_ONEDPL_CLANG_VERSION)
-#    define _ONEDPL_DETECT_COMPILER_OPTIMIZATIONS_ENABLED __OPTIMIZE__
-#else
-#    define _ONEDPL_DETECT_COMPILER_OPTIMIZATIONS_ENABLED 0
-#endif
-
 #define _ONEDPL_EARLYEXIT_PRESENT (__INTEL_COMPILER >= 1800)
 #if (defined(_PSTL_PRAGMA_SIMD_EARLYEXIT) && _PSTL_EARLYEXIT_PRESENT)
 #    define _ONEDPL_PRAGMA_SIMD_EARLYEXIT _PSTL_PRAGMA_SIMD_EARLYEXIT


### PR DESCRIPTION
I recently discovered that after our discussions with the IGC team, IGC reimplemented it's software workaround for the function calling bug that affects certain integrated graphics / DG2 kernels compiled with `-O0` due to the large number of issues similar to what we have encountered and worked around in https://github.com/uxlfoundation/oneDPL/pull/2046.

The new device compiler behavior enables `-O0` to work with SIMD32 kernels (sub-group sizes of `32`) with a tradeoff of EU occupancy by disabling a hardware feature known as EU fusion. With this approach, my understanding is that EU occupancy only reaches 50% as opposed to our current SIMD16 workaround which has no such issue. The performance impact is acceptable from my perspective given that this only occurs when the kernels are compiled with `-O0` which will likely be used for debugging only. This also avoids changing the kernel SIMD width between optimization levels which may impact debuggability from the user's side.

Relying on the new IGC behavior also resolves the recently documented scenario where kernel name mismatches occur when the host and device compiler use different optimization levels which is the default behavior with the intel/llvm open-source clang++ driver when no optimization flag is specified.

GPU Driver support this patch relies on is currently limited to the `2506.18` rolling driver: https://dgpu-docs.intel.com/releases/releases.html with no current LTS driver support. Given that onedpl 2022.8.0 has already dropped with our workaround, users on LTS drivers will not see a kernel compilation crash with this release. For onedpl 2022.9.0 and beyond, we can document the minimum LTS / rolling driver with the workaround along with the following device compiler warning message users will see with AOT compilation:
```
warning: EU fusion is disabled, it does not work on the current platform if SIMD32 mode specified by intel_reqd_sub_group_size(32)
```
I have tested through internal CI and tests behave as expected.