### PR TITLE
Add RelWithAsserts cmake config for testing

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -148,19 +148,19 @@ jobs:
           - os: ubuntu-latest
             cxx_compiler: icpx
             std: 20
-            build_type: release
+            build_type: RelWithAsserts
             backend: dpcpp
             device_type: CPU
           - os: ubuntu-latest
             cxx_compiler: icpx
             std: 20
-            build_type: release
+            build_type: RelWithAsserts
             backend: tbb
             device_type: HOST
           - os: ubuntu-latest
             cxx_compiler: icpx
             std: 20
-            build_type: release
+            build_type: RelWithAsserts
             backend: omp
             device_type: HOST
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,18 @@ if (FIND_GXX_EXE)
     execute_process(COMMAND ${FIND_GXX_EXE} -dumpfullversion OUTPUT_VARIABLE _onedpl_gxx_version)
 endif()
 
+# RelWithAsserts has the same flags as Release, but removes NDEBUG.
+# This build type can be enabled via CMAKE_BUILD_TYPE=RelWithAsserts.
+# It is useful to fully cover tests relying on asserts, such as those exported from libc++, or Tested Standard C++ API tests.
+foreach(FLAGS CMAKE_CXX_FLAGS CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS
+        CMAKE_STATIC_LINKER_FLAGS)
+    if (FLAGS STREQUAL "CMAKE_CXX_FLAGS")
+        string(REGEX REPLACE "(^| )[/-]DNDEBUG( |$)" " " BORROWED_FLAGS "${${FLAGS}_RELEASE}")
+    else()
+        set(BORROWED_FLAGS "${${FLAGS}_RELEASE}")
+    endif()
+    set(${FLAGS}_RELWITHASSERTS "${BORROWED_FLAGS}" CACHE STRING "Flags used during RELWITHASSERTS builds." FORCE)
+endforeach()
 
 include(CMakePackageConfigHelpers)
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
Addresses #1945 by adding `RelWithAsserts` cmake configuration.

### Technical details 

https://cmake.org/cmake/help/v3.31/manual/cmake-buildsystem.7.html#default-and-custom-configurations

Each configuration defines a set of compiler and linker flag variables for the language in use. These variables follow the convention `CMAKE_<LANG>_FLAGS_<CONFIG>`, where `<CONFIG>` is always the uppercase configuration name. When defining a custom configuration type, make sure these variables are set appropriately, typically as cache variables.


Additionally, I've noticed more configuration specific variables: `CMAKE_EXE_LINKER_FLAGS`, `CMAKE_MODULE_LINKER_FLAGS` and `CMAKE_SHARED_LINKER_FLAGS` investigating cache after ninja run (a single-config generator). 