### PR TITLE
Fix constructors of two `__transform_if_`-functors

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -48,7 +48,7 @@ transform_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk2_async(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__transform_functor<_UnaryOperation>{::std::move(__op)});
+        oneapi::dpl::__internal::__transform_functor{__op});
     return ret_val;
 }
 
@@ -66,7 +66,7 @@ transform_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk3_async(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>(::std::move(__op)));
+        oneapi::dpl::__internal::__transform_functor{__op});
     return ret_val;
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -77,7 +77,7 @@ __pattern_transform(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _O
 
     oneapi::dpl::__internal::__pattern_walk2(__tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__in_r),
         std::ranges::begin(__in_r) + std::ranges::size(__in_r), std::ranges::begin(__out_r),
-        oneapi::dpl::__internal::__transform_functor<decltype(__unary_op)>{std::move(__unary_op)});
+        oneapi::dpl::__internal::__transform_functor{__unary_op});
 }
 
 template<typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _F, typename _Proj>
@@ -106,7 +106,7 @@ __pattern_transform(_Tag __tag, _ExecutionPolicy&& __exec, _InRange1&& __in_r1, 
 
     oneapi::dpl::__internal::__pattern_walk3(__tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__in_r1),
         std::ranges::begin(__in_r1) + std::ranges::size(__in_r1), std::ranges::begin(__in_r2),
-        std::ranges::begin(__out_r), oneapi::dpl::__internal::__transform_functor<decltype(__f)>{std::move(__f)});
+        std::ranges::begin(__out_r), oneapi::dpl::__internal::__transform_functor{__f});
 }
 
 template<typename _ExecutionPolicy, typename _InRange1, typename _InRange2, typename _OutRange, typename _F,

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -76,8 +76,9 @@ __pattern_transform(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _O
         return std::invoke(__op, std::invoke(__proj, std::forward<decltype(__val)>(__val)));};
 
     oneapi::dpl::__internal::__pattern_walk2(__tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__in_r),
-        std::ranges::begin(__in_r) + std::ranges::size(__in_r), std::ranges::begin(__out_r),
-        oneapi::dpl::__internal::__transform_functor{__unary_op});
+                                             std::ranges::begin(__in_r) + std::ranges::size(__in_r),
+                                             std::ranges::begin(__out_r),
+                                             oneapi::dpl::__internal::__transform_functor{__unary_op});
 }
 
 template<typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _F, typename _Proj>
@@ -105,8 +106,9 @@ __pattern_transform(_Tag __tag, _ExecutionPolicy&& __exec, _InRange1&& __in_r1, 
             std::invoke(__proj2, std::forward<decltype(__val2)>(__val2)));};
 
     oneapi::dpl::__internal::__pattern_walk3(__tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__in_r1),
-        std::ranges::begin(__in_r1) + std::ranges::size(__in_r1), std::ranges::begin(__in_r2),
-        std::ranges::begin(__out_r), oneapi::dpl::__internal::__transform_functor{__f});
+                                             std::ranges::begin(__in_r1) + std::ranges::size(__in_r1),
+                                             std::ranges::begin(__in_r2), std::ranges::begin(__out_r),
+                                             oneapi::dpl::__internal::__transform_functor{__f});
 }
 
 template<typename _ExecutionPolicy, typename _InRange1, typename _InRange2, typename _OutRange, typename _F,

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -329,7 +329,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator
 
     return oneapi::dpl::__internal::__pattern_walk2(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__transform_functor<_UnaryOperation>{::std::move(__op)});
+        oneapi::dpl::__internal::__transform_functor{__op});
 }
 
 // we can't use non-const __op here
@@ -343,7 +343,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
 
     return oneapi::dpl::__internal::__pattern_walk3(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>(::std::move(__op)));
+        oneapi::dpl::__internal::__transform_functor(__op));
 }
 
 // [alg.transform_if]
@@ -358,7 +358,7 @@ transform_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardItera
 
     return oneapi::dpl::__internal::__pattern_walk2_transform_if(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__transform_if_unary_functor<_UnaryOperation, _UnaryPredicate>(__op, __pred));
+        oneapi::dpl::__internal::__transform_if_unary_functor(__op, __pred));
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3,
@@ -371,7 +371,7 @@ transform_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIter
 
     return oneapi::dpl::__internal::__pattern_walk3_transform_if(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_if_binary_functor<_BinaryOperation, _BinaryPredicate>(__op, __pred));
+        oneapi::dpl::__internal::__transform_if_binary_functor(__op, __pred));
 }
 
 // [alg.replace]

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -358,8 +358,7 @@ transform_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardItera
 
     return oneapi::dpl::__internal::__pattern_walk2_transform_if(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__transform_if_unary_functor<_UnaryOperation, _UnaryPredicate>(::std::move(__op),
-                                                                                                ::std::move(__pred)));
+        oneapi::dpl::__internal::__transform_if_unary_functor<_UnaryOperation, _UnaryPredicate>(__op, __pred));
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3,
@@ -372,8 +371,7 @@ transform_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIter
 
     return oneapi::dpl::__internal::__pattern_walk3_transform_if(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_if_binary_functor<_BinaryOperation, _BinaryPredicate>(
-            ::std::move(__op), ::std::move(__pred)));
+        oneapi::dpl::__internal::__transform_if_binary_functor<_BinaryOperation, _BinaryPredicate>(__op, __pred));
 }
 
 // [alg.replace]

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -327,9 +327,9 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    return oneapi::dpl::__internal::__pattern_walk2(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__transform_functor{__op});
+    return oneapi::dpl::__internal::__pattern_walk2(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
+                                                    __last, __result,
+                                                    oneapi::dpl::__internal::__transform_functor{__op});
 }
 
 // we can't use non-const __op here
@@ -341,9 +341,9 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __result);
 
-    return oneapi::dpl::__internal::__pattern_walk3(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_functor{__op});
+    return oneapi::dpl::__internal::__pattern_walk3(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1,
+                                                    __last1, __first2, __result,
+                                                    oneapi::dpl::__internal::__transform_functor{__op});
 }
 
 // [alg.transform_if]

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -343,7 +343,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
 
     return oneapi::dpl::__internal::__pattern_walk3(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_functor(__op));
+        oneapi::dpl::__internal::__transform_functor{__op});
 }
 
 // [alg.transform_if]
@@ -358,7 +358,7 @@ transform_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardItera
 
     return oneapi::dpl::__internal::__pattern_walk2_transform_if(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__transform_if_unary_functor(__op, __pred));
+        oneapi::dpl::__internal::__transform_if_unary_functor{__op, __pred});
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3,
@@ -371,7 +371,7 @@ transform_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIter
 
     return oneapi::dpl::__internal::__pattern_walk3_transform_if(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_if_binary_functor(__op, __pred));
+        oneapi::dpl::__internal::__transform_if_binary_functor{__op, __pred});
 }
 
 // [alg.replace]

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -103,7 +103,7 @@ __pattern_for_each(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
         [__f, __proj](auto&& __val) { std::invoke(__f, std::invoke(__proj, std::forward<decltype(__val)>(__val)));};
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(__tag, std::forward<_ExecutionPolicy>(__exec), __f_1,
-                                                            oneapi::dpl::__ranges::views::all(std::forward<_R>(__r)));
+                                                        oneapi::dpl::__ranges::views::all(std::forward<_R>(__r)));
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -119,10 +119,10 @@ __pattern_transform(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
     auto __unary_op = [__op, __proj](auto&& __val)
         { return std::invoke(__op, std::invoke(__proj, std::forward<decltype(__val)>(__val)));};
 
-    oneapi::dpl::__internal::__ranges::__pattern_walk_n(__tag, std::forward<_ExecutionPolicy>(__exec),
-            oneapi::dpl::__internal::__transform_functor{__unary_op},
-            oneapi::dpl::__ranges::views::all_read(std::forward<_InRange>(__in_r)),
-            oneapi::dpl::__ranges::views::all_write(std::forward<_OutRange>(__out_r)));
+    oneapi::dpl::__internal::__ranges::__pattern_walk_n(
+        __tag, std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__internal::__transform_functor{__unary_op},
+        oneapi::dpl::__ranges::views::all_read(std::forward<_InRange>(__in_r)),
+        oneapi::dpl::__ranges::views::all_write(std::forward<_OutRange>(__out_r)));
 }
 
 template<typename _BackendTag, typename _ExecutionPolicy, typename _InRange1, typename _InRange2, typename _OutRange, typename _F,
@@ -135,11 +135,11 @@ __pattern_transform(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
         return std::invoke(__binary_op, std::invoke(__proj1, std::forward<decltype(__val1)>(__val1)),
             std::invoke(__proj2, std::forward<decltype(__val2)>(__val2)));};
 
-    oneapi::dpl::__internal::__ranges::__pattern_walk_n(__tag, std::forward<_ExecutionPolicy>(__exec),
-            oneapi::dpl::__internal::__transform_functor{__f},
-            oneapi::dpl::__ranges::views::all_read(std::forward<_InRange1>(__in_r1)),
-            oneapi::dpl::__ranges::views::all_read(std::forward<_InRange2>(__in_r2)),
-            oneapi::dpl::__ranges::views::all_write(std::forward<_OutRange>(__out_r)));
+    oneapi::dpl::__internal::__ranges::__pattern_walk_n(
+        __tag, std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__internal::__transform_functor{__f},
+        oneapi::dpl::__ranges::views::all_read(std::forward<_InRange1>(__in_r1)),
+        oneapi::dpl::__ranges::views::all_read(std::forward<_InRange2>(__in_r2)),
+        oneapi::dpl::__ranges::views::all_write(std::forward<_OutRange>(__out_r)));
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _InRange, typename _OutRange>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -120,7 +120,7 @@ __pattern_transform(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
         { return std::invoke(__op, std::invoke(__proj, std::forward<decltype(__val)>(__val)));};
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(__tag, std::forward<_ExecutionPolicy>(__exec),
-            oneapi::dpl::__internal::__transform_functor<decltype(__unary_op)>{std::move(__unary_op)},
+            oneapi::dpl::__internal::__transform_functor{__unary_op},
             oneapi::dpl::__ranges::views::all_read(std::forward<_InRange>(__in_r)),
             oneapi::dpl::__ranges::views::all_write(std::forward<_OutRange>(__out_r)));
 }
@@ -136,7 +136,7 @@ __pattern_transform(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
             std::invoke(__proj2, std::forward<decltype(__val2)>(__val2)));};
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(__tag, std::forward<_ExecutionPolicy>(__exec),
-            oneapi::dpl::__internal::__transform_functor<decltype(__f)>{std::move(__f)},
+            oneapi::dpl::__internal::__transform_functor{__f},
             oneapi::dpl::__ranges::views::all_read(std::forward<_InRange1>(__in_r1)),
             oneapi::dpl::__ranges::views::all_read(std::forward<_InRange2>(__in_r2)),
             oneapi::dpl::__ranges::views::all_write(std::forward<_OutRange>(__out_r)));

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -303,7 +303,7 @@ class __transform_if_unary_functor
 
   public:
     explicit __transform_if_unary_functor(_UnaryOper __op, _UnaryPred __pred)
-        : _M_oper(std::move<_UnaryOper>(__op)), _M_pred(std::move(__pred))
+        : _M_oper(std::move(__op)), _M_pred(std::move(__pred))
     {
     }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -302,8 +302,8 @@ class __transform_if_unary_functor
     mutable _UnaryPred _M_pred;
 
   public:
-    explicit __transform_if_unary_functor(_UnaryOper&& __op, _UnaryPred&& __pred)
-        : _M_oper(::std::forward<_UnaryOper>(__op)), _M_pred(::std::forward<_UnaryPred>(__pred))
+    explicit __transform_if_unary_functor(_UnaryOper __op, _UnaryPred __pred)
+        : _M_oper(std::move<_UnaryOper>(__op)), _M_pred(std::move(__pred))
     {
     }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -323,8 +323,8 @@ class __transform_if_binary_functor
     mutable _BinaryPred _M_pred;
 
   public:
-    explicit __transform_if_binary_functor(_BinaryOper&& __op, _BinaryPred&& __pred)
-        : _M_oper(::std::forward<_BinaryOper>(__op)), _M_pred(::std::forward<_BinaryPred>(__pred))
+    explicit __transform_if_binary_functor(_BinaryOper __op, _BinaryPred __pred)
+        : _M_oper(std::move(__op)), _M_pred(std::move(__pred))
     {
     }
 


### PR DESCRIPTION
In this PR we fix two functors: `__transform_if_unary_functor` and `__transform_if_binary_functor` :
1) remove `&&` params qualifiers in constructor;
2) using `std::move` instead of `std::forward`.