### PR TITLE
Avoid specializations of the same submitters with the some policy type but with different type qualifiers (`l-value`, `r-value`)

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -32,7 +32,7 @@ namespace __internal
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
 auto
-__pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator __first,
+__pattern_walk1_async(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator __first,
                       _ForwardIterator __last, _Function __f)
 {
     auto __n = __last - __first;
@@ -43,7 +43,7 @@ __pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __buf = __keep(__first, __last);
 
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__buf.all_view())>{
             __f, static_cast<std::size_t>(__n)},
         __n, __buf.all_view());
@@ -55,7 +55,7 @@ template <__par_backend_hetero::access_mode __acc_mode1 = __par_backend_hetero::
           typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Function>
 auto
-__pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk2_async(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                       _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f)
 {
     auto __n = __last1 - __first1;
@@ -68,7 +68,7 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
                                                 decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view());
@@ -79,7 +79,7 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _ForwardIterator3, typename _Function>
 auto
-__pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk3_async(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                       _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f)
 {
     auto __n = __last1 - __first1;
@@ -96,7 +96,7 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __buf3 = __keep3(__first3, __first3 + __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
                                                 decltype(__buf2.all_view()), decltype(__buf3.all_view())>{
             __f, static_cast<size_t>(__n)},
@@ -108,12 +108,12 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Brick>
 auto
-__pattern_walk2_brick_async(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk2_brick_async(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                             _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Brick __brick)
 {
     return __pattern_walk2_async(
         __tag,
-        __par_backend_hetero::make_wrapped_policy<__walk2_brick_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        __par_backend_hetero::make_wrapped_policy<__walk2_brick_wrapper>(__exec),
         __first1, __last1, __first2, __brick);
 }
 
@@ -124,7 +124,7 @@ __pattern_walk2_brick_async(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _RandomAccessIterator1,
           typename _RandomAccessIterator2, typename _Tp, typename _BinaryOperation1, typename _BinaryOperation2>
 auto
-__pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_transform_reduce_async(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                                  _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _Tp __init,
                                  _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2)
 {
@@ -144,7 +144,7 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& _
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
                                                                           ::std::true_type /*is_commutative*/>(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
+        _BackendTag{}, __exec, __binary_op1, _Functor{__binary_op2},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf1.all_view(), __buf2.all_view());
 }
@@ -156,7 +156,7 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& _
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Tp,
           typename _BinaryOperation, typename _UnaryOperation>
 auto
-__pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator __first,
+__pattern_transform_reduce_async(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator __first,
                                  _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op,
                                  _UnaryOperation __unary_op)
 {
@@ -171,18 +171,18 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& _
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
                                                                           ::std::true_type /*is_commutative*/>(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
+        _BackendTag{}, __exec, __binary_op, _Functor{__unary_op},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf.all_view());
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _T>
 auto
-__pattern_fill_async(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first,
+__pattern_fill_async(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first,
                      _ForwardIterator __last, const _T& __value)
 {
     return __pattern_walk1_async(
-        __tag, ::std::forward<_ExecutionPolicy>(__exec),
+        __tag, __exec,
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__last),
         fill_functor<_T>{__value});
@@ -195,7 +195,7 @@ __pattern_fill_async(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec,
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _UnaryOperation, typename _InitType, typename _BinaryOperation, typename _Inclusive>
 auto
-__pattern_transform_scan_base_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first,
+__pattern_transform_scan_base_async(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator1 __first,
                                     _Iterator1 __last, _Iterator2 __result, _UnaryOperation __unary_op,
                                     _InitType __init, _BinaryOperation __binary_op, _Inclusive)
 {
@@ -208,7 +208,7 @@ __pattern_transform_scan_base_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&
     auto __buf2 = __keep2(__result, __result + __n);
 
     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n, __unary_op,
+        _BackendTag{}, __exec, __buf1.all_view(), __buf2.all_view(), __n, __unary_op,
         __init, __binary_op, _Inclusive{});
     return __res.__make_future(__result + __n);
 }
@@ -216,14 +216,14 @@ __pattern_transform_scan_base_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _UnaryOperation, typename _Type, typename _BinaryOperation, typename _Inclusive>
 auto
-__pattern_transform_scan_async(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first,
+__pattern_transform_scan_async(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __first,
                                _Iterator1 __last, _Iterator2 __result, _UnaryOperation __unary_op, _Type __init,
                                _BinaryOperation __binary_op, _Inclusive)
 {
     using _RepackedType = __par_backend_hetero::__repacked_tuple_t<_Type>;
     using _InitType = unseq_backend::__init_value<_RepackedType>;
 
-    return __pattern_transform_scan_base_async(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+    return __pattern_transform_scan_base_async(__tag, __exec, __first, __last,
                                                __result, __unary_op, _InitType{__init}, __binary_op, _Inclusive{});
 }
 
@@ -231,7 +231,7 @@ __pattern_transform_scan_async(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _UnaryOperation, typename _BinaryOperation, typename _Inclusive>
 auto
-__pattern_transform_scan_async(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first,
+__pattern_transform_scan_async(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __first,
                                _Iterator1 __last, _Iterator2 __result, _UnaryOperation __unary_op,
                                _BinaryOperation __binary_op, _Inclusive)
 {
@@ -239,7 +239,7 @@ __pattern_transform_scan_async(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy
     using _RepackedType = __par_backend_hetero::__repacked_tuple_t<_ValueType>;
     using _InitType = unseq_backend::__no_init_value<_RepackedType>;
 
-    return __pattern_transform_scan_base_async(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+    return __pattern_transform_scan_base_async(__tag, __exec, __first, __last,
                                                __result, __unary_op, _InitType{}, __binary_op, _Inclusive{});
 }
 

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -130,8 +130,7 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, const _ExecutionPoli
 {
     assert(__first1 < __last1);
 
-    using _Policy = _ExecutionPolicy;
-    using _Functor = unseq_backend::walk_n<_Policy, _BinaryOperation2>;
+    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _BinaryOperation2>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
 
     auto __n = __last1 - __first1;
@@ -162,8 +161,7 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, const _ExecutionPoli
 {
     assert(__first < __last);
 
-    using _Policy = _ExecutionPolicy;
-    using _Functor = unseq_backend::walk_n<_Policy, _UnaryOperation>;
+    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _UnaryOperation>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -47,7 +47,7 @@ transform_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk2_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+        __dispatch_tag, __exec, __first, __last, __result,
         oneapi::dpl::__internal::__transform_functor<_UnaryOperation>{::std::move(__op)});
     return ret_val;
 }
@@ -65,7 +65,7 @@ transform_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk3_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
+        __dispatch_tag, __exec, __first1, __last1, __first2, __result,
         oneapi::dpl::__internal::__transform_functor<_BinaryOperation>(::std::move(__op)));
     return ret_val;
 }
@@ -81,7 +81,7 @@ copy_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterato
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk2_brick_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+        __dispatch_tag, __exec, __first, __last, __result,
         oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _ExecutionPolicy>{});
     return ret_val;
 }
@@ -102,7 +102,7 @@ sort_async(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Comp
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
     using __backend_tag = typename decltype(__dispatch_tag)::__backend_tag;
 
-    return __par_backend_hetero::__parallel_stable_sort(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+    return __par_backend_hetero::__parallel_stable_sort(__backend_tag{}, __exec,
                                                         __buf.all_view(), __comp, oneapi::dpl::identity{});
 }
 
@@ -127,8 +127,7 @@ for_each_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    auto ret_val = oneapi::dpl::__internal::__pattern_walk1_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __f);
+    auto ret_val = oneapi::dpl::__internal::__pattern_walk1_async(__dispatch_tag, __exec, __first, __last, __f);
     return ret_val;
 }
 
@@ -145,7 +144,7 @@ reduce_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterat
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
+        __dispatch_tag, __exec, __first, __last, __init, __binary_op,
         oneapi::dpl::__internal::__no_op());
     return ret_val;
 }
@@ -181,8 +180,7 @@ fill_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    return oneapi::dpl::__internal::__pattern_fill_async(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                         __first, __last, __value);
+    return oneapi::dpl::__internal::__pattern_fill_async(__dispatch_tag, __exec, __first, __last, __value);
 }
 
 // [async.transform_reduce]
@@ -198,9 +196,8 @@ transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _Forward
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    return oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __init, __binary_op1,
-        __binary_op2);
+    return oneapi::dpl::__internal::__pattern_transform_reduce_async(__dispatch_tag, __exec, __first1, __last1,
+                                                                     __first2, __init, __binary_op1, __binary_op2);
 }
 
 template <class _ExecutionPolicy, class _ForwardIt, class _T, class _BinaryOp, class _UnaryOp, class... _Events,
@@ -213,8 +210,8 @@ transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIt __first, _ForwardIt
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    return oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op, __unary_op);
+    return oneapi::dpl::__internal::__pattern_transform_reduce_async(__dispatch_tag, __exec, __first, __last, __init,
+                                                                     __binary_op, __unary_op);
 }
 
 template <class _ExecutionPolicy, class _ForwardIt1, class _ForwardIt2, class _T, class... _Events,
@@ -242,7 +239,7 @@ inclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _ForwardIt
     using _ValueType = typename ::std::iterator_traits<_ForwardIt1>::value_type;
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     return oneapi::dpl::__internal::__pattern_transform_scan_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+        __dispatch_tag, __exec, __first1, __last1, __first2,
         oneapi::dpl::__internal::__no_op(), ::std::plus<_ValueType>(), /*inclusive=*/::std::true_type());
 }
 
@@ -256,9 +253,9 @@ inclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _ForwardIt
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    return oneapi::dpl::__internal::__pattern_transform_scan_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
-        oneapi::dpl::__internal::__no_op(), __binary_op, /*inclusive=*/::std::true_type());
+    return oneapi::dpl::__internal::__pattern_transform_scan_async(__dispatch_tag, __exec, __first1, __last1, __first2,
+                                                                   oneapi::dpl::__internal::__no_op(), __binary_op,
+                                                                   /*inclusive=*/::std::true_type());
 }
 
 template <class _ExecutionPolicy, class _ForwardIt1, class _ForwardIt2, class _BinaryOperation, class _T,
@@ -272,9 +269,9 @@ inclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _ForwardIt
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    return oneapi::dpl::__internal::__pattern_transform_scan_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
-        oneapi::dpl::__internal::__no_op(), __init, __binary_op, /*inclusive=*/::std::true_type());
+    return oneapi::dpl::__internal::__pattern_transform_scan_async(__dispatch_tag, __exec, __first1, __last1, __first2,
+                                                                   oneapi::dpl::__internal::__no_op(), __init,
+                                                                   __binary_op, /*inclusive=*/::std::true_type());
 }
 
 template <class _ExecutionPolicy, class _ForwardIt1, class _ForwardIt2, class _T, class... _Events,
@@ -287,8 +284,8 @@ exclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _ForwardIt
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     return oneapi::dpl::__internal::__pattern_transform_scan_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
-        oneapi::dpl::__internal::__no_op(), __init, ::std::plus<_T>(), /*exclusive=*/::std::false_type());
+        __dispatch_tag, __exec, __first1, __last1, __first2, oneapi::dpl::__internal::__no_op(), __init,
+        ::std::plus<_T>(), /*exclusive=*/::std::false_type());
 }
 
 template <class _ExecutionPolicy, class _ForwardIt1, class _ForwardIt2, class _T, class _BinaryOperation,
@@ -302,9 +299,9 @@ exclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _ForwardIt
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    return oneapi::dpl::__internal::__pattern_transform_scan_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
-        oneapi::dpl::__internal::__no_op(), __init, __binary_op, /*exclusive=*/::std::false_type());
+    return oneapi::dpl::__internal::__pattern_transform_scan_async(__dispatch_tag, __exec, __first1, __last1, __first2,
+                                                                   oneapi::dpl::__internal::__no_op(), __init,
+                                                                   __binary_op, /*exclusive=*/::std::false_type());
 }
 
 template <class _ExecutionPolicy, class _ForwardIt1, class _ForwardIt2, class _T, class _BinaryOperation,
@@ -318,9 +315,8 @@ transform_exclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, 
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    return oneapi::dpl::__internal::__pattern_transform_scan_async(__dispatch_tag,
-                                                                   ::std::forward<_ExecutionPolicy>(__exec), __first1,
-                                                                   __last1, __first2, __unary_op, __init, __binary_op,
+    return oneapi::dpl::__internal::__pattern_transform_scan_async(__dispatch_tag, __exec, __first1, __last1, __first2,
+                                                                   __unary_op, __init, __binary_op,
                                                                    /*exclusive=*/::std::false_type());
 }
 
@@ -335,9 +331,9 @@ transform_inclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, 
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    return oneapi::dpl::__internal::__pattern_transform_scan_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __unary_op, __binary_op,
-        /*inclusive=*/::std::true_type());
+    return oneapi::dpl::__internal::__pattern_transform_scan_async(__dispatch_tag, __exec, __first1, __last1, __first2,
+                                                                   __unary_op, __binary_op,
+                                                                   /*inclusive=*/::std::true_type());
 }
 
 template <class _ExecutionPolicy, class _ForwardIt1, class _ForwardIt2, class _BinaryOperation, class _UnaryOperation,
@@ -352,9 +348,8 @@ transform_inclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, 
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    return oneapi::dpl::__internal::__pattern_transform_scan_async(__dispatch_tag,
-                                                                   ::std::forward<_ExecutionPolicy>(__exec), __first1,
-                                                                   __last1, __first2, __unary_op, __init, __binary_op,
+    return oneapi::dpl::__internal::__pattern_transform_scan_async(__dispatch_tag, __exec, __first1, __last1, __first2,
+                                                                   __unary_op, __init, __binary_op,
                                                                    /*inclusive=*/::std::true_type());
 }
 

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -251,8 +251,8 @@ lower_bound(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, start, value_start, result);
 
-    return internal::lower_bound_impl(__dispatch_tag, ::std::forward<Policy>(policy), start, end, value_start,
-                                      value_end, result, oneapi::dpl::__internal::__pstl_less());
+    return internal::lower_bound_impl(__dispatch_tag, policy, start, end, value_start, value_end, result,
+                                      oneapi::dpl::__internal::__pstl_less());
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -263,8 +263,7 @@ lower_bound(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, start, value_start, result);
 
-    return internal::lower_bound_impl(__dispatch_tag, ::std::forward<Policy>(policy), start, end, value_start,
-                                      value_end, result, comp);
+    return internal::lower_bound_impl(__dispatch_tag, policy, start, end, value_start, value_end, result, comp);
 }
 //Lower Bound end
 
@@ -277,8 +276,8 @@ upper_bound(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, start, value_start, result);
 
-    return internal::upper_bound_impl(__dispatch_tag, ::std::forward<Policy>(policy), start, end, value_start,
-                                      value_end, result, oneapi::dpl::__internal::__pstl_less());
+    return internal::upper_bound_impl(__dispatch_tag, policy, start, end, value_start, value_end, result,
+                                      oneapi::dpl::__internal::__pstl_less());
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -289,8 +288,7 @@ upper_bound(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, start, value_start, result);
 
-    return internal::upper_bound_impl(__dispatch_tag, ::std::forward<Policy>(policy), start, end, value_start,
-                                      value_end, result, comp);
+    return internal::upper_bound_impl(__dispatch_tag, policy, start, end, value_start, value_end, result, comp);
 }
 
 //Upper Bound end
@@ -304,8 +302,8 @@ binary_search(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIt
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, start, value_start, result);
 
-    return internal::binary_search_impl(__dispatch_tag, ::std::forward<Policy>(policy), start, end, value_start,
-                                        value_end, result, oneapi::dpl::__internal::__pstl_less());
+    return internal::binary_search_impl(__dispatch_tag, policy, start, end, value_start, value_end, result,
+                                        oneapi::dpl::__internal::__pstl_less());
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -316,8 +314,7 @@ binary_search(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIt
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, start, value_start, result);
 
-    return internal::binary_search_impl(__dispatch_tag, ::std::forward<Policy>(policy), start, end, value_start,
-                                        value_end, result, comp);
+    return internal::binary_search_impl(__dispatch_tag, policy, start, end, value_start, value_end, result, comp);
 }
 
 //Binary search end

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -95,7 +95,7 @@ struct __custom_brick : oneapi::dpl::unseq_backend::walk_scalar_base<_Range>
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
 OutputIterator
-lower_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
+lower_bound_impl(_Tag tag, const Policy& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
@@ -103,7 +103,7 @@ lower_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
     using _ValueType = typename std::iterator_traits<InputIterator2>::value_type;
 
     return oneapi::dpl::__internal::__pattern_walk2(
-        tag, std::forward<Policy>(policy), value_start, value_end, result,
+        tag, policy, value_start, value_end, result,
         oneapi::dpl::__internal::__transform_functor{
             [start, end, comp](const _ValueType& val) { return std::lower_bound(start, end, val, comp) - start; }});
 }
@@ -111,7 +111,7 @@ lower_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
 OutputIterator
-upper_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
+upper_bound_impl(_Tag tag, const Policy& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
@@ -119,7 +119,7 @@ upper_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
     using _ValueType = typename std::iterator_traits<InputIterator2>::value_type;
 
     return oneapi::dpl::__internal::__pattern_walk2(
-        tag, std::forward<Policy>(policy), value_start, value_end, result,
+        tag, policy, value_start, value_end, result,
         oneapi::dpl::__internal::__transform_functor{
             [start, end, comp](const _ValueType& val) { return std::upper_bound(start, end, val, comp) - start; }});
 }
@@ -127,7 +127,7 @@ upper_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
 OutputIterator
-binary_search_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
+binary_search_impl(_Tag tag, const Policy& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                    InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
@@ -135,7 +135,7 @@ binary_search_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterato
     using _ValueType = typename std::iterator_traits<InputIterator2>::value_type;
 
     return oneapi::dpl::__internal::__pattern_walk2(
-        tag, std::forward<Policy>(policy), value_start, value_end, result,
+        tag, policy, value_start, value_end, result,
         oneapi::dpl::__internal::__transform_functor{
             [start, end, comp](const _ValueType& val) { return std::binary_search(start, end, val, comp); }});
 }
@@ -144,7 +144,7 @@ binary_search_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterato
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename StrictWeakOrdering>
 OutputIterator
-lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 start, InputIterator1 end,
+lower_bound_impl(__internal::__hetero_tag<_BackendTag>, const Policy& policy, InputIterator1 start, InputIterator1 end,
                  InputIterator2 value_start, InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     namespace __bknd = __par_backend_hetero;
@@ -166,7 +166,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
     __bknd::__parallel_for(
-        _BackendTag{}, ::std::forward<decltype(policy)>(policy),
+        _BackendTag{}, policy,
         __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::lower_bound>{
             comp, size, use_32bit_indexing},
         value_size, zip_vw)
@@ -177,7 +177,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename StrictWeakOrdering>
 OutputIterator
-upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 start, InputIterator1 end,
+upper_bound_impl(__internal::__hetero_tag<_BackendTag>, coonst Policy& policy, InputIterator1 start, InputIterator1 end,
                  InputIterator2 value_start, InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     namespace __bknd = __par_backend_hetero;
@@ -199,7 +199,7 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
     __bknd::__parallel_for(
-        _BackendTag{}, std::forward<decltype(policy)>(policy),
+        _BackendTag{}, policy,
         __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::upper_bound>{
             comp, size, use_32bit_indexing},
         value_size, zip_vw)
@@ -210,7 +210,7 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename StrictWeakOrdering>
 OutputIterator
-binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 start, InputIterator1 end,
+binary_search_impl(__internal::__hetero_tag<_BackendTag>, const Policy& policy, InputIterator1 start, InputIterator1 end,
                    InputIterator2 value_start, InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     namespace __bknd = __par_backend_hetero;
@@ -232,7 +232,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
     __bknd::__parallel_for(
-        _BackendTag{}, std::forward<decltype(policy)>(policy),
+        _BackendTag{}, policy,
         __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::binary_search>{
             comp, size, use_32bit_indexing},
         value_size, zip_vw)

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -189,8 +189,8 @@ exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, first1, first2, result);
 
-    return internal::pattern_exclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1, last1,
-                                                       first2, result, init, binary_pred, binary_op);
+    return internal::pattern_exclusive_scan_by_segment(__dispatch_tag, policy, first1, last1, first2, result, init,
+                                                       binary_pred, binary_op);
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -97,19 +97,19 @@ pattern_exclusive_scan_by_segment(_Tag, const Policy& policy, InputIterator1 fir
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator>
 OutputIterator
-exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
+exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, const Policy& policy, InputIterator1 first1,
                                InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
                                BinaryPredicate binary_pred, Operator binary_op,
                                ::std::true_type /* has_known_identity*/)
 {
-    return internal::__scan_by_segment_impl_common(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
+    return internal::__scan_by_segment_impl_common(__tag, policy, first1, last1, first2, result,
                                                    init, binary_pred, binary_op, ::std::false_type{});
 }
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator>
 OutputIterator
-exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
+exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, const Policy& policy, InputIterator1 first1,
                                InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
                                BinaryPredicate binary_pred, Operator binary_op,
                                ::std::false_type /* has_known_identity*/)
@@ -154,8 +154,7 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
                     ::std::negate<FlagType>(), init);
 #    endif
 
-    auto policy2 =
-        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<ExclusiveScan2>(::std::forward<Policy>(policy));
+    auto policy2 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<ExclusiveScan2>(policy);
 
     // scan key-flag tuples
     transform_inclusive_scan(::std::move(policy2), make_zip_iterator(_temp.get(), _flags.get()),

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -40,7 +40,7 @@ class ExclusiveScan2;
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename T, typename BinaryPredicate, typename Operator>
 OutputIterator
-pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, InputIterator1 last1,
+pattern_exclusive_scan_by_segment(_Tag, const Policy& policy, InputIterator1 first1, InputIterator1 last1,
                                   InputIterator2 first2, OutputIterator result, T init, BinaryPredicate binary_pred,
                                   Operator binary_op)
 {
@@ -87,7 +87,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 #endif
 
     // scan key-flag tuples
-    inclusive_scan(::std::forward<Policy>(policy), make_zip_iterator(_temp.get(), _flags.get()),
+    inclusive_scan(policy, make_zip_iterator(_temp.get(), _flags.get()),
                    make_zip_iterator(_temp.get(), _flags.get()) + n, make_zip_iterator(result, _flags.get()),
                    internal::segmented_scan_fun<ValueType, FlagType, Operator>(binary_op));
     return result + n;
@@ -169,12 +169,12 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator>
 OutputIterator
-pattern_exclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
+pattern_exclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag, const Policy& policy, InputIterator1 first1,
                                   InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
                                   BinaryPredicate binary_pred, Operator binary_op)
 {
     return internal::exclusive_scan_by_segment_impl(
-        __tag, ::std::forward<Policy>(policy), first1, last1, first2, result, init, binary_pred, binary_op,
+        __tag, policy, first1, last1, first2, result, init, binary_pred, binary_op,
         typename unseq_backend::__has_known_identity<
             Operator, typename ::std::iterator_traits<InputIterator2>::value_type>::type{});
 }

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -42,7 +42,7 @@ class InclusiveScan1;
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
 OutputIterator
-pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, InputIterator1 last1,
+pattern_inclusive_scan_by_segment(_Tag, const Policy& policy, InputIterator1 first1, InputIterator1 last1,
                                   InputIterator2 first2, OutputIterator result, BinaryPredicate binary_pred,
                                   BinaryOperator binary_op)
 {
@@ -70,7 +70,7 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     transform(policy, first1, last1 - 1, first1 + 1, _mask.get() + 1,
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
-    inclusive_scan(::std::forward<Policy>(policy), make_zip_iterator(first2, _mask.get()),
+    inclusive_scan(policy, make_zip_iterator(first2, _mask.get()),
                    make_zip_iterator(first2, _mask.get()) + n, make_zip_iterator(result, _mask.get()),
                    internal::segmented_scan_fun<ValueType, FlagType, BinaryOperator>(binary_op));
 
@@ -134,12 +134,12 @@ inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename BinaryPredicate, typename BinaryOperator>
 OutputIterator
-pattern_inclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
+pattern_inclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag, const Policy& policy, InputIterator1 first1,
                                   InputIterator1 last1, InputIterator2 first2, OutputIterator result,
                                   BinaryPredicate binary_pred, BinaryOperator binary_op)
 {
     return internal::inclusive_scan_by_segment_impl(
-        __tag, ::std::forward<Policy>(policy), first1, last1, first2, result, binary_pred, binary_op,
+        __tag, policy, first1, last1, first2, result, binary_pred, binary_op,
         typename unseq_backend::__has_known_identity<
             BinaryOperator, typename ::std::iterator_traits<InputIterator2>::value_type>::type{});
 }

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -155,8 +155,8 @@ inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, first1, first2, result);
 
-    return internal::pattern_inclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1, last1,
-                                                       first2, result, binary_pred, binary_op);
+    return internal::pattern_inclusive_scan_by_segment(__dispatch_tag, policy, first1, last1, first2, result,
+                                                       binary_pred, binary_op);
 }
 
 template <typename Policy, typename InputIter1, typename InputIter2, typename OutputIter, typename BinaryPredicate>

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -81,21 +81,21 @@ pattern_inclusive_scan_by_segment(_Tag, const Policy& policy, InputIterator1 fir
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename BinaryPredicate, typename BinaryOperator>
 OutputIterator
-inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
+inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, const Policy& policy, InputIterator1 first1,
                                InputIterator1 last1, InputIterator2 first2, OutputIterator result,
                                BinaryPredicate binary_pred, BinaryOperator binary_op,
                                ::std::true_type /* has_known_identity */)
 {
     using iter_value_t = typename ::std::iterator_traits<InputIterator2>::value_type;
     iter_value_t identity = unseq_backend::__known_identity<BinaryOperator, iter_value_t>;
-    return internal::__scan_by_segment_impl_common(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
+    return internal::__scan_by_segment_impl_common(__tag, policy, first1, last1, first2, result,
                                                    identity, binary_pred, binary_op, ::std::true_type{});
 }
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename BinaryPredicate, typename BinaryOperator>
 OutputIterator
-inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
+inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, const Policy& policy, InputIterator1 first1,
                                InputIterator1 last1, InputIterator2 first2, OutputIterator result,
                                BinaryPredicate binary_pred, BinaryOperator binary_op,
                                ::std::false_type /* has_known_identity */)
@@ -120,7 +120,7 @@ inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
         mask[0] = initial_mask;
     }
 
-    transform(::std::forward<Policy>(policy), first1, last1 - 1, first1 + 1, _mask.get() + 1,
+    transform(policy, first1, last1 - 1, first1 + 1, _mask.get() + 1,
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     auto policy1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<InclusiveScan1>(policy);

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -80,7 +80,7 @@ class Reduce4;
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
 ::std::pair<OutputIterator1, OutputIterator2>
-reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
+reduce_by_segment_impl(_Tag, const Policy& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,
                        BinaryOperator binary_op)
 {
@@ -155,7 +155,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     CountType N = scanned_tail_flags[n - 1] + 1;
 
     // scatter the keys and accumulated values
-    oneapi::dpl::for_each(::std::forward<Policy>(policy),
+    oneapi::dpl::for_each(policy,
                           make_zip_iterator(first1, scanned_tail_flags, mask, scanned_values, mask + 1),
                           make_zip_iterator(first1, scanned_tail_flags, mask, scanned_values, mask + 1) + n,
                           internal::scatter_and_accumulate_fun<OutputIterator1, OutputIterator2>(result1, result2));
@@ -171,7 +171,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator1, typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
 std::pair<OutputIterator1, OutputIterator2>
-reduce_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
+reduce_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, const Policy& policy, InputIterator1 first1,
                        InputIterator1 last1, InputIterator2 first2, OutputIterator1 result1, OutputIterator2 result2,
                        BinaryPred binary_pred, BinaryOperator binary_op)
 {
@@ -195,7 +195,7 @@ reduce_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& pol
 
     // number of unique keys
     _CountType __n = oneapi::dpl::__internal::__pattern_reduce_by_segment(
-        __tag, std::forward<Policy>(policy), first1, last1, first2, result1, result2, binary_pred, binary_op);
+        __tag, policy, first1, last1, first2, result1, result2, binary_pred, binary_op);
 
     return std::make_pair(result1 + __n, result2 + __n);
 }

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -210,8 +210,8 @@ reduce_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, 
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, first1, first2, result1, result2);
 
-    return internal::reduce_by_segment_impl(__dispatch_tag, ::std::forward<Policy>(policy), first1, last1, first2,
-                                            result1, result2, binary_pred, binary_op);
+    return internal::reduce_by_segment_impl(__dispatch_tag, policy, first1, last1, first2, result1, result2,
+                                            binary_pred, binary_op);
 }
 
 template <typename Policy, typename InputIt1, typename InputIt2, typename OutputIt1, typename OutputIt2,

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -108,8 +108,9 @@ struct __sycl_scan_by_segment_impl
     template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
               typename _BinaryPredicate, typename _BinaryOperator, typename _T>
     void
-    operator()(_BackendTag, const _ExecutionPolicy& __exec, _Range1&& __keys, _Range2&& __values, _Range3&& __out_values,
-               _BinaryPredicate __binary_pred, _BinaryOperator __binary_op, _T __init, _T __identity)
+    operator()(_BackendTag, const _ExecutionPolicy& __exec, _Range1&& __keys, _Range2&& __values,
+               _Range3&& __out_values, _BinaryPredicate __binary_pred, _BinaryOperator __binary_op, _T __init,
+               _T __identity)
     {
         using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
@@ -393,9 +394,9 @@ __scan_by_segment_impl_common(__internal::__hetero_tag<_BackendTag>, const Polic
 
     constexpr iter_value_t identity = unseq_backend::__known_identity<Operator, iter_value_t>;
 
-    __sycl_scan_by_segment_impl<Inclusive::value>()(_BackendTag{}, policy, key_buf.all_view(),
-                                                    value_buf.all_view(), value_output_buf.all_view(), binary_pred,
-                                                    binary_op, init, identity);
+    __sycl_scan_by_segment_impl<Inclusive::value>()(_BackendTag{}, policy, key_buf.all_view(), value_buf.all_view(),
+                                                    value_output_buf.all_view(), binary_pred, binary_op, init,
+                                                    identity);
     return result + n;
 }
 

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -117,7 +117,7 @@ struct __sycl_scan_by_segment_impl
         // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
         // because we always specialize this operator() calls only by _ExecutionPolicy as "const reference".
         // So, from this template param point of view, only one specialization is possible per concrete _ExecutionPolicy type.
-        // _ExecutionPolicy type information is encoded in _CustomName to distinguish between concrete policy types.
+        // _ExecutionPolicy type information is embedded in _CustomName to distinguish between concrete policy types.
         using _SegScanWgKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             _SegScanWgPhase, _CustomName, _Range1, _Range2, _Range3, _BinaryPredicate, _BinaryOperator>;
         using _SegScanPrefixKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -116,7 +116,8 @@ struct __sycl_scan_by_segment_impl
 
         // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
         // because we always specialize this operator() calls only by _ExecutionPolicy as "const reference".
-        // So, from this template param point of view, only one specialization is possible.
+        // So, from this template param point of view, only one specialization is possible per concrete _ExecutionPolicy type.
+        // _ExecutionPolicy type information is encoded in _CustomName to distinguish between concrete policy types.
         using _SegScanWgKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             _SegScanWgPhase, _CustomName, _Range1, _Range2, _Range3, _BinaryPredicate, _BinaryOperator>;
         using _SegScanPrefixKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -370,7 +370,7 @@ struct __sycl_scan_by_segment_impl
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator, typename Inclusive>
 OutputIterator
-__scan_by_segment_impl_common(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
+__scan_by_segment_impl_common(__internal::__hetero_tag<_BackendTag>, const Policy& policy, InputIterator1 first1,
                               InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
                               BinaryPredicate binary_pred, Operator binary_op, Inclusive)
 {
@@ -393,7 +393,7 @@ __scan_by_segment_impl_common(__internal::__hetero_tag<_BackendTag>, Policy&& po
 
     constexpr iter_value_t identity = unseq_backend::__known_identity<Operator, iter_value_t>;
 
-    __sycl_scan_by_segment_impl<Inclusive::value>()(_BackendTag{}, ::std::forward<Policy>(policy), key_buf.all_view(),
+    __sycl_scan_by_segment_impl<Inclusive::value>()(_BackendTag{}, policy, key_buf.all_view(),
                                                     value_buf.all_view(), value_output_buf.all_view(), binary_pred,
                                                     binary_op, init, identity);
     return result + n;

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -42,11 +42,11 @@ __brick_any_of(const _RandomAccessIterator, const _RandomAccessIterator, _Pred,
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Pred>
 bool
-__pattern_any_of(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Pred) noexcept;
+__pattern_any_of(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Pred) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Pred>
 bool
-__pattern_any_of(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Pred);
+__pattern_any_of(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, _Pred);
 
 //------------------------------------------------------------------------
 // walk1 (pseudo)
@@ -64,23 +64,23 @@ void __brick_walk1(_RandomAccessIterator, _RandomAccessIterator, _Function,
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
 void
-__pattern_walk1(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Function);
+__pattern_walk1(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Function);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
-__pattern_walk1(__parallel_forward_tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Function);
+__pattern_walk1(__parallel_forward_tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Function);
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Function>
 void
-__pattern_walk1(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Function);
+__pattern_walk1(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, _Function);
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Brick>
 void
-__pattern_walk_brick(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Brick) noexcept;
+__pattern_walk_brick(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Brick) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Brick>
 void
-__pattern_walk_brick(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_walk_brick(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                      _Brick);
 
 //------------------------------------------------------------------------
@@ -97,19 +97,19 @@ _RandomAccessIterator __brick_walk1_n(_RandomAccessIterator, _DifferenceType, _F
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function>
 _ForwardIterator
-__pattern_walk1_n(_Tag, _ExecutionPolicy&&, _ForwardIterator, _Size, _Function);
+__pattern_walk1_n(_Tag, const _ExecutionPolicy&, _ForwardIterator, _Size, _Function);
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Function>
 _RandomAccessIterator
-__pattern_walk1_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _Size, _Function);
+__pattern_walk1_n(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _Size, _Function);
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Brick>
 _ForwardIterator
-__pattern_walk_brick_n(_Tag, _ExecutionPolicy&&, _ForwardIterator, _Size, _Brick) noexcept;
+__pattern_walk_brick_n(_Tag, const _ExecutionPolicy&, _ForwardIterator, _Size, _Brick) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Brick>
 _RandomAccessIterator
-__pattern_walk_brick_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _Size, _Brick);
+__pattern_walk_brick_n(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _Size, _Brick);
 
 //------------------------------------------------------------------------
 // walk2 (pseudo)
@@ -135,55 +135,55 @@ _RandomAccessIterator2 __brick_walk2_n(_RandomAccessIterator1, _Size, _RandomAcc
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function>
 _ForwardIterator2
-__pattern_walk2(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _Function) noexcept;
+__pattern_walk2(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _Function) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Function>
 _RandomAccessIterator2
-__pattern_walk2(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_walk2(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                 _RandomAccessIterator2, _Function);
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function>
 _ForwardIterator2
-__pattern_walk2(__parallel_forward_tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_walk2(__parallel_forward_tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                 _Function);
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2,
           class _Function>
 _ForwardIterator2
-__pattern_walk2_n(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _Size, _ForwardIterator2, _Function) noexcept;
+__pattern_walk2_n(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _Size, _ForwardIterator2, _Function) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _Size,
           class _RandomAccessIterator2, class _Function>
 _RandomAccessIterator2
-__pattern_walk2_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _Size, _RandomAccessIterator2,
+__pattern_walk2_n(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _Size, _RandomAccessIterator2,
                   _Function);
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Brick>
 _ForwardIterator2
-__pattern_walk2_brick(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_walk2_brick(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                       _Brick) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Brick>
 _RandomAccessIterator2
-__pattern_walk2_brick(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_walk2_brick(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                       _RandomAccessIterator2, _Brick);
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Brick>
 _ForwardIterator2
-__pattern_walk2_brick(__parallel_forward_tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1,
+__pattern_walk2_brick(__parallel_forward_tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1,
                       _ForwardIterator2, _Brick);
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2,
           class _Brick>
 _ForwardIterator2
-__pattern_walk2_brick_n(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _Size, _ForwardIterator2, _Brick) noexcept;
+__pattern_walk2_brick_n(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _Size, _ForwardIterator2, _Brick) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _Size,
           class _RandomAccessIterator2, class _Brick>
 _RandomAccessIterator2
-__pattern_walk2_brick_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _Size,
+__pattern_walk2_brick_n(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _Size,
                         _RandomAccessIterator2, _Brick);
 
 //------------------------------------------------------------------------
@@ -204,19 +204,19 @@ _RandomAccessIterator3 __brick_walk3(_RandomAccessIterator1, _RandomAccessIterat
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3,
           class _Function>
 _ForwardIterator3
-__pattern_walk3(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator3,
+__pattern_walk3(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator3,
                 _Function) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Function>
 _RandomAccessIterator3
-__pattern_walk3(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_walk3(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                 _RandomAccessIterator2, _RandomAccessIterator3, _Function);
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3,
           class _Function>
 _ForwardIterator3
-__pattern_walk3(__parallel_forward_tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_walk3(__parallel_forward_tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                 _ForwardIterator3, _Function);
 
 //------------------------------------------------------------------------
@@ -226,13 +226,13 @@ __pattern_walk3(__parallel_forward_tag, _ExecutionPolicy&&, _ForwardIterator1, _
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Function>
 _ForwardIterator2
-__pattern_walk2_transform_if(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_walk2_transform_if(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                              _Function) noexcept;
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _ForwardIterator3, typename _Function>
 _ForwardIterator3
-__pattern_walk3_transform_if(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_walk3_transform_if(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                              _ForwardIterator3, _Function) noexcept;
 
 //------------------------------------------------------------------------
@@ -249,13 +249,13 @@ bool __brick_equal(_RandomAccessIterator1, _RandomAccessIterator1, _RandomAccess
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 bool
-__pattern_equal(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
+__pattern_equal(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
                 _BinaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 bool
-__pattern_equal(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_equal(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                 _RandomAccessIterator2, _RandomAccessIterator2, _BinaryPredicate);
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
@@ -268,13 +268,13 @@ bool __brick_equal(_RandomAccessIterator1, _RandomAccessIterator1, _RandomAccess
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 bool
-__pattern_equal(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_equal(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                 _BinaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 bool
-__pattern_equal(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_equal(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                 _RandomAccessIterator2, _BinaryPredicate);
 
 //------------------------------------------------------------------------
@@ -291,11 +291,11 @@ _RandomAccessIterator __brick_find_if(_RandomAccessIterator, _RandomAccessIterat
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
 _ForwardIterator
-__pattern_find_if(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Predicate) noexcept;
+__pattern_find_if(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Predicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Predicate>
 _RandomAccessIterator
-__pattern_find_if(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_find_if(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                   _Predicate);
 
 //------------------------------------------------------------------------
@@ -314,13 +314,13 @@ _RandomAccessIterator1 __brick_find_end(_RandomAccessIterator1, _RandomAccessIte
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 _ForwardIterator1
-__pattern_find_end(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
+__pattern_find_end(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
                    _BinaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 _RandomAccessIterator1
-__pattern_find_end(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_find_end(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                    _RandomAccessIterator2, _RandomAccessIterator2, _BinaryPredicate);
 
 //------------------------------------------------------------------------
@@ -339,13 +339,13 @@ _RandomAccessIterator1 __brick_find_first_of(_RandomAccessIterator1, _RandomAcce
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 _ForwardIterator1
-__pattern_find_first_of(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_find_first_of(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                         _ForwardIterator2, _BinaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 _RandomAccessIterator1
-__pattern_find_first_of(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_find_first_of(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                         _RandomAccessIterator2, _RandomAccessIterator2, _BinaryPredicate);
 
 //------------------------------------------------------------------------
@@ -364,13 +364,13 @@ _RandomAccessIterator1 __brick_search(_RandomAccessIterator1, _RandomAccessItera
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 _ForwardIterator1
-__pattern_search(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
+__pattern_search(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
                  _BinaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 _RandomAccessIterator1
-__pattern_search(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_search(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                  _RandomAccessIterator2, _RandomAccessIterator2, _BinaryPredicate);
 
 //------------------------------------------------------------------------
@@ -389,13 +389,13 @@ __brick_search_n(_RandomAccessIterator, _RandomAccessIterator, _Size, const _Tp&
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
 _ForwardIterator
-__pattern_search_n(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Size, const _Tp&,
+__pattern_search_n(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Size, const _Tp&,
                    _BinaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Tp,
           class _BinaryPredicate>
 _RandomAccessIterator
-__pattern_search_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Size,
+__pattern_search_n(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, _Size,
                    const _Tp&, _BinaryPredicate);
 
 //------------------------------------------------------------------------
@@ -467,13 +467,13 @@ __brick_partition_by_mask(_RandomAccessIterator, _RandomAccessIterator, _OutputI
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _UnaryPredicate>
 _OutputIterator
-__pattern_copy_if(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _OutputIterator,
+__pattern_copy_if(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _OutputIterator,
                   _UnaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _UnaryPredicate>
 _RandomAccessIterator2
-__pattern_copy_if(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_copy_if(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                   _RandomAccessIterator2, _UnaryPredicate);
 
 //------------------------------------------------------------------------
@@ -492,11 +492,11 @@ typename ::std::iterator_traits<_ForwardIterator>::difference_type
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
 typename ::std::iterator_traits<_ForwardIterator>::difference_type
-__pattern_count(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Predicate) noexcept;
+__pattern_count(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Predicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Predicate>
 typename ::std::iterator_traits<_RandomAccessIterator>::difference_type
-__pattern_count(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_count(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                 _Predicate);
 
 //------------------------------------------------------------------------
@@ -513,11 +513,11 @@ _RandomAccessIterator __brick_unique(_RandomAccessIterator, _RandomAccessIterato
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
 _ForwardIterator
-__pattern_unique(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _BinaryPredicate) noexcept;
+__pattern_unique(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _BinaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _BinaryPredicate>
 _RandomAccessIterator
-__pattern_unique(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_unique(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                  _BinaryPredicate);
 
 //------------------------------------------------------------------------
@@ -534,7 +534,7 @@ _OutputIterator __brick_unique_copy(_RandomAccessIterator, _RandomAccessIterator
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _BinaryPredicate>
 _OutputIterator
-__pattern_unique_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _OutputIterator,
+__pattern_unique_copy(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _OutputIterator,
                       _BinaryPredicate) noexcept;
 
 template <class _ExecutionPolicy, class _DifferenceType, class _RandomAccessIterator, class _BinaryPredicate>
@@ -550,7 +550,7 @@ __brick_calc_mask_2(_RandomAccessIterator, _RandomAccessIterator, bool* __restri
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 _RandomAccessIterator2
-__pattern_unique_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_unique_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                       _RandomAccessIterator2, _BinaryPredicate);
 
 //------------------------------------------------------------------------
@@ -575,11 +575,11 @@ void __brick_reverse(_RandomAccessIterator, _RandomAccessIterator, _RandomAccess
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator>
 void
-__pattern_reverse(_Tag, _ExecutionPolicy&&, _BidirectionalIterator, _BidirectionalIterator) noexcept;
+__pattern_reverse(_Tag, const _ExecutionPolicy&, _BidirectionalIterator, _BidirectionalIterator) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator>
 void
-__pattern_reverse(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator);
+__pattern_reverse(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator);
 
 //------------------------------------------------------------------------
 // reverse_copy
@@ -595,12 +595,12 @@ _OutputIterator __brick_reverse_copy(_RandomAccessIterator, _RandomAccessIterato
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator, class _OutputIterator>
 _OutputIterator
-__pattern_reverse_copy(_Tag, _ExecutionPolicy&&, _BidirectionalIterator, _BidirectionalIterator,
+__pattern_reverse_copy(_Tag, const _ExecutionPolicy&, _BidirectionalIterator, _BidirectionalIterator,
                        _OutputIterator) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2>
 _RandomAccessIterator2
-__pattern_reverse_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_reverse_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                        _RandomAccessIterator2);
 
 //------------------------------------------------------------------------
@@ -617,11 +617,11 @@ _RandomAccessIterator __brick_rotate(_RandomAccessIterator, _RandomAccessIterato
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator>
 _ForwardIterator
-__pattern_rotate(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _ForwardIterator) noexcept;
+__pattern_rotate(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _ForwardIterator) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator>
 _RandomAccessIterator
-__pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_rotate(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                  _RandomAccessIterator);
 
 //------------------------------------------------------------------------
@@ -638,12 +638,12 @@ _OutputIterator __brick_rotate_copy(__parallel_tag<_IsVector>, _RandomAccessIter
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator>
 _OutputIterator
-__pattern_rotate_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _ForwardIterator,
+__pattern_rotate_copy(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _ForwardIterator,
                       _OutputIterator) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2>
 _RandomAccessIterator2
-__pattern_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_rotate_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                       _RandomAccessIterator1, _RandomAccessIterator2);
 
 //------------------------------------------------------------------------
@@ -660,11 +660,11 @@ bool __brick_is_partitioned(_RandomAccessIterator, _RandomAccessIterator, _Unary
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
 bool
-__pattern_is_partitioned(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _UnaryPredicate) noexcept;
+__pattern_is_partitioned(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _UnaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryPredicate>
 bool
-__pattern_is_partitioned(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_is_partitioned(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                          _UnaryPredicate);
 
 //------------------------------------------------------------------------
@@ -681,11 +681,11 @@ _RandomAccessIterator __brick_partition(_RandomAccessIterator, _RandomAccessIter
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
 _ForwardIterator
-__pattern_partition(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _UnaryPredicate) noexcept;
+__pattern_partition(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _UnaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryPredicate>
 _RandomAccessIterator
-__pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_partition(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                     _UnaryPredicate);
 
 //------------------------------------------------------------------------
@@ -702,12 +702,12 @@ _RandomAccessIterator __brick_stable_partition(_RandomAccessIterator, _RandomAcc
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate>
 _BidirectionalIterator
-__pattern_stable_partition(_Tag, _ExecutionPolicy&&, _BidirectionalIterator, _BidirectionalIterator,
+__pattern_stable_partition(_Tag, const _ExecutionPolicy&, _BidirectionalIterator, _BidirectionalIterator,
                            _UnaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryPredicate>
 _RandomAccessIterator
-__pattern_stable_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_stable_partition(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                            _UnaryPredicate);
 
 //------------------------------------------------------------------------
@@ -728,13 +728,13 @@ template <class _RandomAccessIterator, class _OutputIterator1, class _OutputIter
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator1, class _OutputIterator2,
           class _UnaryPredicate>
 ::std::pair<_OutputIterator1, _OutputIterator2>
-__pattern_partition_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _OutputIterator1,
+__pattern_partition_copy(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _OutputIterator1,
                          _OutputIterator2, _UnaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _UnaryPredicate>
 ::std::pair<_RandomAccessIterator2, _RandomAccessIterator3>
-__pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_partition_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                          _RandomAccessIterator2, _RandomAccessIterator3, _UnaryPredicate);
 
 //------------------------------------------------------------------------
@@ -743,11 +743,11 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomA
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _LeafSort>
 void
-__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare, _LeafSort) noexcept;
+__pattern_sort(_Tag, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, _Compare, _LeafSort) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _LeafSort>
 void
-__pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare,
+__pattern_sort(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, _Compare,
                _LeafSort);
 
 //------------------------------------------------------------------------
@@ -757,13 +757,13 @@ __pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessItera
 template <typename _Tag, typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _Compare, typename _LeafSort>
 void
-__pattern_sort_by_key(_Tag, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1, _RandomAccessIterator2,
+__pattern_sort_by_key(_Tag, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1, _RandomAccessIterator2,
                       _Compare, _LeafSort) noexcept;
 
 template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator1,
           typename _RandomAccessIterator2, typename _Compare, typename _LeafSort>
 void
-__pattern_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_sort_by_key(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                       _RandomAccessIterator2, _Compare, _LeafSort);
 
 //------------------------------------------------------------------------
@@ -772,12 +772,12 @@ __pattern_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAcce
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_partial_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_partial_sort(_Tag, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator,
                        _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_partial_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_partial_sort(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                        _RandomAccessIterator, _Compare);
 
 //------------------------------------------------------------------------
@@ -786,13 +786,13 @@ __pattern_partial_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAcc
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
 _RandomAccessIterator
-__pattern_partial_sort_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _RandomAccessIterator,
+__pattern_partial_sort_copy(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _RandomAccessIterator,
                             _RandomAccessIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Compare>
 _RandomAccessIterator2
-__pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
+__pattern_partial_sort_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1,
                             _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2, _Compare);
 
 //------------------------------------------------------------------------
@@ -811,12 +811,12 @@ __brick_adjacent_find(_ForwardIterator, _ForwardIterator, _BinaryPredicate,
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate, class _Semantic>
 _ForwardIterator
-__pattern_adjacent_find(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _BinaryPredicate,
+__pattern_adjacent_find(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _BinaryPredicate,
                         _Semantic) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _BinaryPredicate, class _Semantic>
 _RandomAccessIterator
-__pattern_adjacent_find(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_adjacent_find(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                         _BinaryPredicate, _Semantic);
 
 //------------------------------------------------------------------------
@@ -825,12 +825,12 @@ __pattern_adjacent_find(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAc
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_nth_element(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_nth_element(_Tag, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator,
                       _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_nth_element(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_nth_element(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                       _RandomAccessIterator, _Compare);
 
 //------------------------------------------------------------------------
@@ -841,22 +841,22 @@ struct __brick_fill;
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Tp>
 void
-__pattern_fill(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, const _Tp&) noexcept;
+__pattern_fill(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, const _Tp&) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Tp>
 _RandomAccessIterator
-__pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, const _Tp&);
+__pattern_fill(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, const _Tp&);
 
 template <class _Tag, typename _ExecutionPolicy, typename _Tp, typename = void>
 struct __brick_fill_n;
 
 template <class _Tag, class _ExecutionPolicy, class _OutputIterator, class _Size, class _Tp>
 _OutputIterator
-__pattern_fill_n(_Tag, _ExecutionPolicy&&, _OutputIterator, _Size, const _Tp&) noexcept;
+__pattern_fill_n(_Tag, const _ExecutionPolicy&, _OutputIterator, _Size, const _Tp&) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Tp>
 _RandomAccessIterator
-__pattern_fill_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _Size, const _Tp&);
+__pattern_fill_n(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _Size, const _Tp&);
 
 //------------------------------------------------------------------------
 // generate, generate_n
@@ -872,11 +872,11 @@ void __brick_generate(_ForwardIterator, _ForwardIterator, _Generator,
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Generator>
 void
-__pattern_generate(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Generator) noexcept;
+__pattern_generate(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Generator) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Generator>
 _RandomAccessIterator
-__pattern_generate(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_generate(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                    _Generator);
 
 template <class _RandomAccessIterator, class Size, class _Generator>
@@ -889,11 +889,11 @@ OutputIterator __brick_generate_n(OutputIterator, Size, _Generator,
 
 template <class _Tag, class _ExecutionPolicy, class _OutputIterator, class _Size, class _Generator>
 _OutputIterator
-__pattern_generate_n(_Tag, _ExecutionPolicy&&, _OutputIterator, _Size, _Generator) noexcept;
+__pattern_generate_n(_Tag, const _ExecutionPolicy&, _OutputIterator, _Size, _Generator) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Generator>
 _RandomAccessIterator
-__pattern_generate_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _Size, _Generator);
+__pattern_generate_n(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _Size, _Generator);
 
 //------------------------------------------------------------------------
 // remove
@@ -908,11 +908,11 @@ _RandomAccessIterator __brick_remove_if(_RandomAccessIterator, _RandomAccessIter
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
 _ForwardIterator
-__pattern_remove_if(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _UnaryPredicate) noexcept;
+__pattern_remove_if(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _UnaryPredicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryPredicate>
 _RandomAccessIterator
-__pattern_remove_if(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_remove_if(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                     _UnaryPredicate);
 
 //------------------------------------------------------------------------
@@ -932,13 +932,13 @@ _OutputIterator __brick_merge(_RandomAccessIterator1, _RandomAccessIterator1, _R
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_merge(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
+__pattern_merge(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
                 _OutputIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Compare>
 _RandomAccessIterator3
-__pattern_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_merge(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                 _RandomAccessIterator2, _RandomAccessIterator2, _RandomAccessIterator3, _Compare);
 
 //------------------------------------------------------------------------
@@ -955,12 +955,12 @@ void __brick_inplace_merge(_RandomAccessIterator, _RandomAccessIterator, _Random
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
 void
-__pattern_inplace_merge(_Tag, _ExecutionPolicy&&, _BidirectionalIterator, _BidirectionalIterator,
+__pattern_inplace_merge(_Tag, const _ExecutionPolicy&, _BidirectionalIterator, _BidirectionalIterator,
                         _BidirectionalIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_inplace_merge(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                         _RandomAccessIterator, _Compare);
 
 //------------------------------------------------------------------------
@@ -969,13 +969,13 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAc
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
 bool
-__pattern_includes(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
+__pattern_includes(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
                    _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Compare>
 bool
-__pattern_includes(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_includes(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                    _RandomAccessIterator2, _RandomAccessIterator2, _Compare);
 
 //------------------------------------------------------------------------
@@ -995,13 +995,13 @@ _OutputIterator __brick_set_union(_RandomAccessIterator1, _RandomAccessIterator1
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_set_union(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_set_union(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                     _ForwardIterator2, _OutputIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _OutputIterator, class _Compare>
 _OutputIterator
-__pattern_set_union(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_set_union(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                     _RandomAccessIterator2, _RandomAccessIterator2, _OutputIterator, _Compare);
 
 //------------------------------------------------------------------------
@@ -1021,13 +1021,13 @@ _OutputIterator __brick_set_intersection(_RandomAccessIterator1, _RandomAccessIt
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_set_intersection(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_set_intersection(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                            _ForwardIterator2, _OutputIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Compare>
 _RandomAccessIterator3
-__pattern_set_intersection(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
+__pattern_set_intersection(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1,
                            _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2,
                            _RandomAccessIterator3, _Compare);
 
@@ -1048,13 +1048,13 @@ _OutputIterator __brick_set_difference(_RandomAccessIterator1, _RandomAccessIter
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_set_difference(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_set_difference(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                          _ForwardIterator2, _OutputIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Compare>
 _RandomAccessIterator3
-__pattern_set_difference(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_set_difference(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                          _RandomAccessIterator2, _RandomAccessIterator2, _RandomAccessIterator3, _Compare);
 
 //------------------------------------------------------------------------
@@ -1074,13 +1074,13 @@ _OutputIterator __brick_set_symmetric_difference(_RandomAccessIterator1, _Random
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_set_symmetric_difference(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_set_symmetric_difference(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                                    _ForwardIterator2, _OutputIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Compare>
 _RandomAccessIterator3
-__pattern_set_symmetric_difference(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
+__pattern_set_symmetric_difference(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1,
                                    _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2,
                                    _RandomAccessIterator3, _Compare);
 
@@ -1098,11 +1098,11 @@ _RandomAccessIterator __brick_is_heap_until(_RandomAccessIterator, _RandomAccess
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 _RandomAccessIterator
-__pattern_is_heap_until(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
+__pattern_is_heap_until(_Tag, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 _RandomAccessIterator
-__pattern_is_heap_until(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_is_heap_until(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                         _Compare);
 
 //------------------------------------------------------------------------
@@ -1119,11 +1119,11 @@ bool __brick_is_heap(_RandomAccessIterator, _RandomAccessIterator, _Compare,
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 bool
-__pattern_is_heap(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
+__pattern_is_heap(_Tag, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 bool
-__pattern_is_heap(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_is_heap(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                   _Compare);
 
 //------------------------------------------------------------------------
@@ -1140,11 +1140,11 @@ _RandomAccessIterator __brick_min_element(_RandomAccessIterator, _RandomAccessIt
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>
 _ForwardIterator
-__pattern_min_element(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Compare) noexcept;
+__pattern_min_element(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Compare) noexcept;
 
 template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare>
 _RandomAccessIterator
-__pattern_min_element(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_min_element(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                       _Compare);
 
 //------------------------------------------------------------------------
@@ -1162,11 +1162,11 @@ template <typename _RandomAccessIterator, typename _Compare>
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>
 ::std::pair<_ForwardIterator, _ForwardIterator>
-__pattern_minmax_element(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Compare) noexcept;
+__pattern_minmax_element(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Compare) noexcept;
 
 template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare>
 ::std::pair<_RandomAccessIterator, _RandomAccessIterator>
-__pattern_minmax_element(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_minmax_element(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                          _Compare);
 
 //------------------------------------------------------------------------
@@ -1186,13 +1186,13 @@ template <class _RandomAccessIterator1, class _RandomAccessIterator2, class _Pre
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
 ::std::pair<_ForwardIterator1, _ForwardIterator2>
-__pattern_mismatch(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
+__pattern_mismatch(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _ForwardIterator2,
                    _Predicate) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Predicate>
 ::std::pair<_RandomAccessIterator1, _RandomAccessIterator2>
-__pattern_mismatch(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+__pattern_mismatch(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1, _RandomAccessIterator1,
                    _RandomAccessIterator2, _RandomAccessIterator2, _Predicate);
 
 //------------------------------------------------------------------------
@@ -1211,19 +1211,19 @@ bool __brick_lexicographical_compare(_RandomAccessIterator1, _RandomAccessIterat
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
 bool
-__pattern_lexicographical_compare(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
+__pattern_lexicographical_compare(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                                   _ForwardIterator2, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Compare>
 bool
-__pattern_lexicographical_compare(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
+__pattern_lexicographical_compare(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1,
                                   _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2,
                                   _Compare) noexcept;
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function>
 _ForwardIterator2
-__pattern_swap(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _Function);
+__pattern_swap(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _Function);
 
 //------------------------------------------------------------------------
 // shift_left
@@ -1241,12 +1241,12 @@ _ForwardIterator __brick_shift_left(_ForwardIterator, _ForwardIterator,
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator>
 _ForwardIterator
-__pattern_shift_left(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator,
+__pattern_shift_left(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator,
                      typename ::std::iterator_traits<_ForwardIterator>::difference_type) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator>
 _RandomAccessIterator
-__pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_shift_left(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                      typename ::std::iterator_traits<_RandomAccessIterator>::difference_type);
 
 //------------------------------------------------------------------------
@@ -1255,7 +1255,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAcces
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator>
 _BidirectionalIterator
-__pattern_shift_right(_Tag, _ExecutionPolicy&&, _BidirectionalIterator, _BidirectionalIterator,
+__pattern_shift_right(_Tag, const _ExecutionPolicy&, _BidirectionalIterator, _BidirectionalIterator,
                       typename ::std::iterator_traits<_BidirectionalIterator>::difference_type);
 
 } // namespace __internal

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -68,7 +68,7 @@ __brick_any_of(const _RandomAccessIterator __first, const _RandomAccessIterator 
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Pred>
 bool
-__pattern_any_of(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Pred __pred) noexcept
+__pattern_any_of(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last, _Pred __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -77,11 +77,11 @@ __pattern_any_of(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIte
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Pred>
 bool
-__pattern_any_of(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_any_of(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                  _RandomAccessIterator __last, _Pred __pred)
 {
     return __internal::__except_handler([&]() {
-        return __internal::__parallel_or(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        return __internal::__parallel_or(__tag, __exec, __first, __last,
                                          [__pred](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                                              return __internal::__brick_any_of(__i, __j, __pred, _IsVector{});
                                          });
@@ -140,7 +140,7 @@ __brick_walk1(_DifferenceType __n, _Function __f, ::std::true_type) noexcept
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
-__pattern_walk1(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Function __f)
+__pattern_walk1(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last, _Function __f)
 {
     static_assert(__is_serial_tag_v<_Tag>);
 
@@ -149,7 +149,7 @@ __pattern_walk1(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIter
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
-__pattern_walk1(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_walk1(__parallel_forward_tag, const _ExecutionPolicy& __exec, _ForwardIterator __first, _ForwardIterator __last,
                 _Function __f)
 {
     using __backend_tag = typename __parallel_forward_tag::__backend_tag;
@@ -157,20 +157,20 @@ __pattern_walk1(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardItera
     typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
     auto __func = [&__f](_ReferenceType arg) { __f(arg); };
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_for_each(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __par_backend::__parallel_for_each(__backend_tag{}, __exec, __first, __last,
                                            __func);
     });
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Function>
 void
-__pattern_walk1(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_walk1(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                 _RandomAccessIterator __last, _Function __f)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __par_backend::__parallel_for(__backend_tag{}, __exec, __first, __last,
                                       [__f](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                                           __internal::__brick_walk1(__i, __j, __f, _IsVector{});
                                       });
@@ -179,7 +179,7 @@ __pattern_walk1(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Brick>
 void
-__pattern_walk_brick(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_walk_brick(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                      _Brick __brick) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -189,14 +189,14 @@ __pattern_walk_brick(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Forwar
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Brick>
 void
-__pattern_walk_brick(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_walk_brick(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                      _RandomAccessIterator __last, _Brick __brick)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __backend_tag{}, __exec, __first, __last,
             [__brick](_RandomAccessIterator __i, _RandomAccessIterator __j) { __brick(__i, __j, _IsVector{}); });
     });
 }
@@ -222,7 +222,7 @@ __brick_walk1_n(_RandomAccessIterator __first, _DifferenceType __n, _Function __
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function>
 _ForwardIterator
-__pattern_walk1_n(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Size __n, _Function __f)
+__pattern_walk1_n(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _Size __n, _Function __f)
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -231,17 +231,17 @@ __pattern_walk1_n(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Size __n,
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Function>
 _RandomAccessIterator
-__pattern_walk1_n(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Size __n,
+__pattern_walk1_n(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first, _Size __n,
                   _Function __f)
 {
-    oneapi::dpl::__internal::__pattern_walk1(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + __n,
+    oneapi::dpl::__internal::__pattern_walk1(__tag, __exec, __first, __first + __n,
                                              __f);
     return __first + __n;
 }
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Brick>
 _ForwardIterator
-__pattern_walk_brick_n(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Size __n, _Brick __brick) noexcept
+__pattern_walk_brick_n(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _Size __n, _Brick __brick) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -250,14 +250,14 @@ __pattern_walk_brick_n(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Size
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Brick>
 _RandomAccessIterator
-__pattern_walk_brick_n(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Size __n,
+__pattern_walk_brick_n(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first, _Size __n,
                        _Brick __brick)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + __n,
+            __backend_tag{}, __exec, __first, __first + __n,
             [__brick](_RandomAccessIterator __i, _RandomAccessIterator __j) { __brick(__i, __j - __i, _IsVector{}); });
         return __first + __n;
     });
@@ -307,7 +307,7 @@ __brick_walk2_n(_RandomAccessIterator1 __first1, _Size __n, _RandomAccessIterato
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function>
 _ForwardIterator2
-__pattern_walk2(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_walk2(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _Function __f) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag>);
@@ -318,14 +318,14 @@ __pattern_walk2(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIt
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Function>
 _RandomAccessIterator2
-__pattern_walk2(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_walk2(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                 _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _Function __f)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            __backend_tag{}, __exec, __first1, __last1,
             [__f, __first1, __first2](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 __internal::__brick_walk2(__i, __j, __first2 + (__i - __first1), __f, _IsVector{});
             });
@@ -335,7 +335,7 @@ __pattern_walk2(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function>
 _ForwardIterator2
-__pattern_walk2(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk2(__parallel_forward_tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                 _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f)
 {
     using __backend_tag = typename __parallel_forward_tag::__backend_tag;
@@ -348,7 +348,7 @@ __pattern_walk2(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardItera
         typedef typename ::std::iterator_traits<_ForwardIterator1>::reference _ReferenceType1;
         typedef typename ::std::iterator_traits<_ForwardIterator2>::reference _ReferenceType2;
 
-        __par_backend::__parallel_for_each(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __begin, __end,
+        __par_backend::__parallel_for_each(__backend_tag{}, __exec, __begin, __end,
                                            [&__f](::std::tuple<_ReferenceType1, _ReferenceType2> __val) {
                                                __f(::std::get<0>(__val), ::std::get<1>(__val));
                                            });
@@ -364,7 +364,7 @@ __pattern_walk2(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardItera
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2,
           class _Function>
 _ForwardIterator2
-__pattern_walk2_n(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2,
+__pattern_walk2_n(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2,
                   _Function __f) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -375,16 +375,16 @@ __pattern_walk2_n(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _Size __
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _Size,
           class _RandomAccessIterator2, class _Function>
 _RandomAccessIterator2
-__pattern_walk2_n(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_walk2_n(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                   _Size __n, _RandomAccessIterator2 __first2, _Function __f)
 {
-    return __internal::__pattern_walk2(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
+    return __internal::__pattern_walk2(__tag, __exec, __first1, __first1 + __n,
                                        __first2, __f);
 }
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Brick>
 _ForwardIterator2
-__pattern_walk2_brick(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_walk2_brick(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                       _ForwardIterator2 __first2, _Brick __brick) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag>);
@@ -395,14 +395,14 @@ __pattern_walk2_brick(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _For
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Brick>
 _RandomAccessIterator2
-__pattern_walk2_brick(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_walk2_brick(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                       _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _Brick __brick)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            __backend_tag{}, __exec, __first1, __last1,
             [__first1, __first2, __brick](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 __brick(__i, __j, __first2 + (__i - __first1), _IsVector{});
             });
@@ -413,7 +413,7 @@ __pattern_walk2_brick(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
 //TODO: it postponed till adding more or less effective parallel implementation
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Brick>
 _ForwardIterator2
-__pattern_walk2_brick(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk2_brick(__parallel_forward_tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                       _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Brick __brick)
 {
     using __backend_tag = typename __parallel_forward_tag::__backend_tag;
@@ -426,7 +426,7 @@ __pattern_walk2_brick(__parallel_forward_tag, _ExecutionPolicy&& __exec, _Forwar
     typedef typename ::std::iterator_traits<_ForwardIterator2>::reference _ReferenceType2;
 
     return __except_handler([&]() {
-        __par_backend::__parallel_for_each(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __begin, __end,
+        __par_backend::__parallel_for_each(__backend_tag{}, __exec, __begin, __end,
                                            [__brick](::std::tuple<_ReferenceType1, _ReferenceType2> __val) {
                                                __brick(::std::get<0>(__val),
                                                        ::std::forward<_ReferenceType2>(::std::get<1>(__val)));
@@ -443,14 +443,14 @@ __pattern_walk2_brick(__parallel_forward_tag, _ExecutionPolicy&& __exec, _Forwar
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _Size,
           class _RandomAccessIterator2, class _Brick>
 _RandomAccessIterator2
-__pattern_walk2_brick_n(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_walk2_brick_n(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                         _Size __n, _RandomAccessIterator2 __first2, _Brick __brick)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
+            __backend_tag{}, __exec, __first1, __first1 + __n,
             [__first1, __first2, __brick](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 __brick(__i, __j - __i, __first2 + (__i - __first1), _IsVector{});
             });
@@ -461,7 +461,7 @@ __pattern_walk2_brick_n(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2,
           class _Brick>
 _ForwardIterator2
-__pattern_walk2_brick_n(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _Size __n,
+__pattern_walk2_brick_n(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _Size __n,
                         _ForwardIterator2 __first2, _Brick __brick) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -495,7 +495,7 @@ __brick_walk3(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3,
           class _Function>
 _ForwardIterator3
-__pattern_walk3(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_walk3(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag>);
@@ -506,7 +506,7 @@ __pattern_walk3(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIt
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Function>
 _RandomAccessIterator3
-__pattern_walk3(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_walk3(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                 _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator3 __first3,
                 _Function __f)
 {
@@ -514,7 +514,7 @@ __pattern_walk3(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            __backend_tag{}, __exec, __first1, __last1,
             [__f, __first1, __first2, __first3](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 __internal::__brick_walk3(__i, __j, __first2 + (__i - __first1), __first3 + (__i - __first1), __f,
                                           _IsVector{});
@@ -526,7 +526,7 @@ __pattern_walk3(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3,
           class _Function>
 _ForwardIterator3
-__pattern_walk3(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk3(__parallel_forward_tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                 _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f)
 {
     using __backend_tag = typename __parallel_forward_tag::__backend_tag;
@@ -541,7 +541,7 @@ __pattern_walk3(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardItera
         typedef typename ::std::iterator_traits<_ForwardIterator2>::reference _ReferenceType2;
         typedef typename ::std::iterator_traits<_ForwardIterator3>::reference _ReferenceType3;
 
-        __par_backend::__parallel_for_each(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __begin, __end,
+        __par_backend::__parallel_for_each(__backend_tag{}, __exec, __begin, __end,
                                            [&](::std::tuple<_ReferenceType1, _ReferenceType2, _ReferenceType3> __val) {
                                                __f(::std::get<0>(__val), ::std::get<1>(__val), ::std::get<2>(__val));
                                            });
@@ -561,24 +561,24 @@ __pattern_walk3(__parallel_forward_tag, _ExecutionPolicy&& __exec, _ForwardItera
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Function>
 _ForwardIterator2
-__pattern_walk2_transform_if(_Tag __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk2_transform_if(_Tag __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                              _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __func) noexcept
 {
     static_assert(__is_host_dispatch_tag_v<_Tag>);
 
-    return __pattern_walk2(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __func);
+    return __pattern_walk2(__tag, __exec, __first1, __last1, __first2, __func);
 }
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _ForwardIterator3, typename _Function>
 _ForwardIterator3
-__pattern_walk3_transform_if(_Tag __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk3_transform_if(_Tag __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                              _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator3 __first3,
                              _Function __func) noexcept
 {
     static_assert(__is_host_dispatch_tag_v<_Tag>);
 
-    return __pattern_walk3(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __first3,
+    return __pattern_walk3(__tag, __exec, __first1, __last1, __first2, __first3,
                            __func);
 }
 
@@ -608,7 +608,7 @@ __brick_equal(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 bool
-__pattern_equal(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_equal(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _BinaryPredicate __p) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -619,7 +619,7 @@ __pattern_equal(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIt
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 bool
-__pattern_equal(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_equal(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                 _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                 _BinaryPredicate __p)
 {
@@ -628,7 +628,7 @@ __pattern_equal(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _Ran
 
     return __internal::__except_handler([&]() {
         return !__internal::__parallel_or(
-            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            __tag, __exec, __first1, __last1,
             [__first1, __first2, __p](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 return !__internal::__brick_equal(__i, __j, __first2 + (__i - __first1), __first2 + (__j - __first1),
                                                   __p, _IsVector{});
@@ -659,7 +659,7 @@ __brick_equal(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 bool
-__pattern_equal(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_equal(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _BinaryPredicate __p) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -670,12 +670,12 @@ __pattern_equal(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIt
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 bool
-__pattern_equal(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_equal(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                 _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _BinaryPredicate __p)
 {
     return __internal::__except_handler([&]() {
         return !__internal::__parallel_or(
-            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            __tag, __exec, __first1, __last1,
             [__first1, __first2, __p](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 return !__internal::__brick_equal(__i, __j, __first2 + (__i - __first1), __p, _IsVector{});
             });
@@ -706,7 +706,7 @@ __brick_find_if(_RandomAccessIterator __first, _RandomAccessIterator __last, _Pr
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
 _ForwardIterator
-__pattern_find_if(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_find_if(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                   _Predicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -716,12 +716,12 @@ __pattern_find_if(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIt
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Predicate>
 _RandomAccessIterator
-__pattern_find_if(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_find_if(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                   _RandomAccessIterator __last, _Predicate __pred)
 {
     return __except_handler([&]() {
         return __parallel_find(
-            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __tag, __exec, __first, __last,
             [__pred](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                 return __brick_find_if(__i, __j, __pred, _IsVector{});
             },
@@ -850,7 +850,7 @@ __brick_find_end(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, 
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 _ForwardIterator1
-__pattern_find_end(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first, _ForwardIterator1 __last,
+__pattern_find_end(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first, _ForwardIterator1 __last,
                    _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -861,13 +861,13 @@ __pattern_find_end(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first, _Forward
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 _RandomAccessIterator1
-__pattern_find_end(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_find_end(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                    _RandomAccessIterator1 __last, _RandomAccessIterator2 __s_first, _RandomAccessIterator2 __s_last,
                    _BinaryPredicate __pred)
 {
     if (__last - __first == __s_last - __s_first)
     {
-        const bool __res = __internal::__pattern_equal(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        const bool __res = __internal::__pattern_equal(__tag, __exec, __first, __last,
                                                        __s_first, __pred);
         return __res ? __first : __last;
     }
@@ -875,7 +875,7 @@ __pattern_find_end(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
     {
         return __internal::__except_handler([&]() {
             return __internal::__parallel_find(
-                __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                __tag, __exec, __first, __last,
                 [__last, __s_first, __s_last, __pred](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                     return __internal::__find_subrange(__i, __j, __last, __s_first, __s_last, __pred, false,
                                                        _IsVector{});
@@ -906,7 +906,7 @@ __brick_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _Forw
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 _ForwardIterator1
-__pattern_find_first_of(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first, _ForwardIterator1 __last,
+__pattern_find_first_of(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first, _ForwardIterator1 __last,
                         _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -918,13 +918,13 @@ __pattern_find_first_of(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first, _Fo
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 _RandomAccessIterator1
-__pattern_find_first_of(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_find_first_of(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                         _RandomAccessIterator1 __last, _RandomAccessIterator2 __s_first,
                         _RandomAccessIterator2 __s_last, _BinaryPredicate __pred)
 {
     return __internal::__except_handler([&]() {
         return __internal::__parallel_find(
-            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __tag, __exec, __first, __last,
             [__s_first, __s_last, &__pred](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 return __internal::__brick_find_first_of(__i, __j, __s_first, __s_last, __pred, _IsVector{});
             },
@@ -953,7 +953,7 @@ __brick_search(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIter
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 _ForwardIterator1
-__pattern_search(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first, _ForwardIterator1 __last,
+__pattern_search(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first, _ForwardIterator1 __last,
                  _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -964,13 +964,13 @@ __pattern_search(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first, _ForwardIt
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 _RandomAccessIterator1
-__pattern_search(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_search(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                  _RandomAccessIterator1 __last, _RandomAccessIterator2 __s_first, _RandomAccessIterator2 __s_last,
                  _BinaryPredicate __pred)
 {
     if (__last - __first == __s_last - __s_first)
     {
-        const bool __res = __internal::__pattern_equal(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        const bool __res = __internal::__pattern_equal(__tag, __exec, __first, __last,
                                                        __s_first, __pred);
         return __res ? __first : __last;
     }
@@ -978,7 +978,7 @@ __pattern_search(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _Ra
     {
         return __internal::__except_handler([&]() {
             return __internal::__parallel_find(
-                __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                __tag, __exec, __first, __last,
                 [__last, __s_first, __s_last, __pred](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                     return __internal::__find_subrange(__i, __j, __last, __s_first, __s_last, __pred, true,
                                                        _IsVector{});
@@ -1009,7 +1009,7 @@ __brick_search_n(_RandomAccessIterator __first, _RandomAccessIterator __last, _S
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
 _ForwardIterator
-__pattern_search_n(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Size __count,
+__pattern_search_n(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last, _Size __count,
                    const _Tp& __value, _BinaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -1020,12 +1020,12 @@ __pattern_search_n(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardI
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Tp,
           class _BinaryPredicate>
 _RandomAccessIterator
-__pattern_search_n(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_search_n(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                    _RandomAccessIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred)
 {
     if (static_cast<_Size>(__last - __first) == __count)
     {
-        const bool __result = !__internal::__pattern_any_of(__tag, std::forward<_ExecutionPolicy>(__exec), __first,
+        const bool __result = !__internal::__pattern_any_of(__tag, __exec, __first,
             __last, [&__value, __pred](auto&& __val) mutable { return !__pred(std::forward<decltype(__val)>(__val),
             __value); });
         return __result ? __first : __last;
@@ -1034,7 +1034,7 @@ __pattern_search_n(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
     {
         return __internal::__except_handler([__tag, &__exec, __first, __last, __count, &__value, __pred]() {
             return __internal::__parallel_find(
-                __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                __tag, __exec, __first, __last,
                 [__last, __count, &__value, __pred](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                     return __internal::__find_subrange(__i, __j, __last, __count, __value, __pred, _IsVector{});
                 },
@@ -1307,7 +1307,7 @@ __brick_partition_by_mask(_RandomAccessIterator1 __first, _RandomAccessIterator1
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _UnaryPredicate>
 _OutputIterator
-__pattern_copy_if(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+__pattern_copy_if(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
                   _UnaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -1318,7 +1318,7 @@ __pattern_copy_if(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIt
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _UnaryPredicate>
 _RandomAccessIterator2
-__pattern_copy_if(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_copy_if(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                   _RandomAccessIterator1 __last, _RandomAccessIterator2 __result, _UnaryPredicate __pred)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -1332,7 +1332,7 @@ __pattern_copy_if(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
             bool* __mask = __mask_buf.get();
             _DifferenceType __m{};
             __par_backend::__parallel_strict_scan(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
+                __backend_tag{}, __exec, __n, _DifferenceType(0),
                 [=](_DifferenceType __i, _DifferenceType __len) { // Reduce
                     return __internal::__brick_calc_mask_1<_DifferenceType>(__first + __i, __first + (__i + __len),
                                                                             __mask + __i, __pred, _IsVector{})
@@ -1373,7 +1373,7 @@ __brick_count(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pr
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
 typename ::std::iterator_traits<_ForwardIterator>::difference_type
-__pattern_count(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) noexcept
+__pattern_count(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -1382,7 +1382,7 @@ __pattern_count(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIter
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Predicate>
 typename ::std::iterator_traits<_RandomAccessIterator>::difference_type
-__pattern_count(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_count(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                 _RandomAccessIterator __last, _Predicate __pred)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -1395,7 +1395,7 @@ __pattern_count(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
 
     return __internal::__except_handler([&]() {
         return __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, _SizeType(0),
+            __backend_tag{}, __exec, __first, __last, _SizeType(0),
             [__pred](_RandomAccessIterator __begin, _RandomAccessIterator __end, _SizeType __value) -> _SizeType {
                 return __value + __internal::__brick_count(__begin, __end, __pred, _IsVector{});
             },
@@ -1426,7 +1426,7 @@ __brick_unique(_RandomAccessIterator __first, _RandomAccessIterator __last, _Bin
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
 _ForwardIterator
-__pattern_unique(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_unique(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                  _BinaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -1438,7 +1438,7 @@ __pattern_unique(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIte
 // So, a caller passes _CalcMask brick into remove_elements.
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _CalcMask>
 _RandomAccessIterator
-__remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__remove_elements(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                   _RandomAccessIterator __last, _CalcMask __calc_mask)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -1451,7 +1451,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     return __internal::__except_handler([&]() {
         bool* __mask = __mask_buf.get();
         _DifferenceType __min = __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), _DifferenceType(0), __n, __n,
+            __backend_tag{}, __exec, _DifferenceType(0), __n, __n,
             [__first, __mask, &__calc_mask](_DifferenceType __i, _DifferenceType __j,
                                             _DifferenceType __local_min) -> _DifferenceType {
                 // Create mask
@@ -1489,7 +1489,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         _DifferenceType __m{};
         // 2. Elements that doesn't satisfy pred are moved to result
         __par_backend::__parallel_strict_scan(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
+            __backend_tag{}, __exec, __n, _DifferenceType(0),
             [__mask](_DifferenceType __i, _DifferenceType __len) {
                 return __internal::__brick_count(
                     __mask + __i, __mask + __i + __len, [](bool __val) { return __val; }, _IsVector{});
@@ -1504,7 +1504,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
             [&__m](_DifferenceType __total) { __m = __total; });
 
         // 3. Elements from result are moved to [first, last)
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
+        __par_backend::__parallel_for(__backend_tag{}, __exec, __result,
                                       __result + __m, [__result, __first](_Tp* __i, _Tp* __j) {
                                           __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
                                               __i, __j, __first + (__i - __result), _IsVector{});
@@ -1515,7 +1515,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _BinaryPredicate>
 _RandomAccessIterator
-__pattern_unique(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_unique(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                  _RandomAccessIterator __last, _BinaryPredicate __pred)
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::reference _ReferenceType;
@@ -1530,7 +1530,7 @@ __pattern_unique(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _Ra
         return __internal::__brick_unique(__first, __last, __pred, _IsVector{});
     }
     return __internal::__remove_elements(
-        __tag, ::std::forward<_ExecutionPolicy>(__exec), ++__first, __last,
+        __tag, __exec, ++__first, __last,
         [&__pred](bool* __b, bool* __e, _RandomAccessIterator __it) {
             __internal::__brick_walk3(
                 __b, __e, __it - 1, __it,
@@ -1564,7 +1564,7 @@ __brick_unique_copy(_RandomAccessIterator1 __first, _RandomAccessIterator1 __las
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _BinaryPredicate>
 _OutputIterator
-__pattern_unique_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_unique_copy(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                       _OutputIterator __result, _BinaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -1597,7 +1597,7 @@ __brick_calc_mask_2(_RandomAccessIterator __first, _RandomAccessIterator __last,
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
 _RandomAccessIterator2
-__pattern_unique_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_unique_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                       _RandomAccessIterator1 __last, _RandomAccessIterator2 __result, _BinaryPredicate __pred)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -1613,7 +1613,7 @@ __pattern_unique_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
                 bool* __mask = __mask_buf.get();
                 _DifferenceType __m{};
                 __par_backend::__parallel_strict_scan(
-                    __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
+                    __backend_tag{}, __exec, __n, _DifferenceType(0),
                     [=](_DifferenceType __i, _DifferenceType __len) -> _DifferenceType { // Reduce
                         _DifferenceType __extra = 0;
                         if (__i == 0)
@@ -1701,7 +1701,7 @@ __brick_reverse(_RandomAccessIterator __first, _RandomAccessIterator __last, _Ra
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator>
 void
-__pattern_reverse(_Tag, _ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __last) noexcept
+__pattern_reverse(_Tag, const _ExecutionPolicy&, _BidirectionalIterator __first, _BidirectionalIterator __last) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -1710,7 +1710,7 @@ __pattern_reverse(_Tag, _ExecutionPolicy&&, _BidirectionalIterator __first, _Bid
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator>
 void
-__pattern_reverse(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_reverse(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                   _RandomAccessIterator __last)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -1720,7 +1720,7 @@ __pattern_reverse(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
     __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + (__last - __first) / 2,
+            __backend_tag{}, __exec, __first, __first + (__last - __first) / 2,
             [__first, __last](_RandomAccessIterator __inner_first, _RandomAccessIterator __inner_last) {
                 __internal::__brick_reverse(__inner_first, __inner_last, __last - (__inner_first - __first),
                                             _IsVector{});
@@ -1754,7 +1754,7 @@ __brick_reverse_copy(_RandomAccessIterator1 __first, _RandomAccessIterator1 __la
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator, class _OutputIterator>
 _OutputIterator
-__pattern_reverse_copy(_Tag, _ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __last,
+__pattern_reverse_copy(_Tag, const _ExecutionPolicy&, _BidirectionalIterator __first, _BidirectionalIterator __last,
                        _OutputIterator __d_first) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -1764,7 +1764,7 @@ __pattern_reverse_copy(_Tag, _ExecutionPolicy&&, _BidirectionalIterator __first,
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2>
 _RandomAccessIterator2
-__pattern_reverse_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_reverse_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                        _RandomAccessIterator1 __last, _RandomAccessIterator2 __d_first)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -1776,7 +1776,7 @@ __pattern_reverse_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ra
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __backend_tag{}, __exec, __first, __last,
             [__first, __len, __d_first](_RandomAccessIterator1 __inner_first, _RandomAccessIterator1 __inner_last) {
                 __internal::__brick_reverse_copy(__inner_first, __inner_last,
                                                  __d_first + (__len - (__inner_last - __first)), _IsVector{});
@@ -1839,7 +1839,7 @@ __brick_rotate(_RandomAccessIterator __first, _RandomAccessIterator __middle, _R
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator>
 _ForwardIterator
-__pattern_rotate(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __middle,
+__pattern_rotate(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __middle,
                  _ForwardIterator __last) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -1849,7 +1849,7 @@ __pattern_rotate(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIte
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator>
 _RandomAccessIterator
-__pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_rotate(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                  _RandomAccessIterator __middle, _RandomAccessIterator __last)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -1862,19 +1862,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
         __par_backend::__buffer<_Tp> __buf(__n - __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
+            __par_backend::__parallel_for(__backend_tag{}, __exec, __middle, __last,
                                           [__middle, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_uninitialized_move(
                                                   __b, __e, __result + (__b - __middle), _IsVector{});
                                           });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
+            __par_backend::__parallel_for(__backend_tag{}, __exec, __first, __middle,
                                           [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
                                                   __b, __e, __b + (__last - __middle), _IsVector{});
                                           });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
+            __par_backend::__parallel_for(__backend_tag{}, __exec, __result,
                                           __result + (__n - __m), [__first, __result](_Tp* __b, _Tp* __e) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
                                                   __b, __e, __first + (__b - __result), _IsVector{});
@@ -1888,19 +1888,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
         __par_backend::__buffer<_Tp> __buf(__m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
+            __par_backend::__parallel_for(__backend_tag{}, __exec, __first, __middle,
                                           [__first, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_uninitialized_move(
                                                   __b, __e, __result + (__b - __first), _IsVector{});
                                           });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
+            __par_backend::__parallel_for(__backend_tag{}, __exec, __middle, __last,
                                           [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
                                                   __b, __e, __first + (__b - __middle), _IsVector{});
                                           });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
+            __par_backend::__parallel_for(__backend_tag{}, __exec, __result,
                                           __result + __m, [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
                                                   __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
@@ -1917,7 +1917,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator>
 _OutputIterator
-__brick_rotate_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __middle,
+__brick_rotate_copy(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __middle,
                     _ForwardIterator __last, _OutputIterator __result) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -1927,7 +1927,7 @@ __brick_rotate_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Forward
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2>
 _RandomAccessIterator2
-__brick_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1 __first,
+__brick_rotate_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1 __first,
                     _RandomAccessIterator1 __middle, _RandomAccessIterator1 __last,
                     _RandomAccessIterator2 __result) noexcept
 {
@@ -1938,25 +1938,25 @@ __brick_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccess
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator>
 _OutputIterator
-__pattern_rotate_copy(_Tag __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __middle,
+__pattern_rotate_copy(_Tag __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first, _ForwardIterator __middle,
                       _ForwardIterator __last, _OutputIterator __result) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    return __internal::__brick_rotate_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
+    return __internal::__brick_rotate_copy(__tag, __exec, __first, __middle, __last,
                                            __result);
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2>
 _RandomAccessIterator2
-__pattern_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_rotate_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                       _RandomAccessIterator1 __middle, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __backend_tag{}, __exec, __first, __last,
             [__first, __last, __middle, __result](_RandomAccessIterator1 __b, _RandomAccessIterator1 __e) {
                 __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy> __copy{};
                 if (__b > __middle)
@@ -2022,7 +2022,7 @@ __brick_is_partitioned(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
 bool
-__pattern_is_partitioned(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_is_partitioned(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                          _UnaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2032,7 +2032,7 @@ __pattern_is_partitioned(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Fo
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryPredicate>
 bool
-__pattern_is_partitioned(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_is_partitioned(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                          _RandomAccessIterator __last, _UnaryPredicate __pred)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -2074,7 +2074,7 @@ __pattern_is_partitioned(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
         const _ReduceType __identity{__not_init, __last};
 
         _ReduceType __result = __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __identity,
+            __backend_tag{}, __exec, __first, __last, __identity,
             [&__pred, __combine](_RandomAccessIterator __i, _RandomAccessIterator __j,
                                  _ReduceType __value) -> _ReduceType {
                 if (__value.__val == __broken)
@@ -2152,7 +2152,7 @@ __brick_partition(_RandomAccessIterator __first, _RandomAccessIterator __last, _
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
 _ForwardIterator
-__pattern_partition(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_partition(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                     _UnaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2162,7 +2162,7 @@ __pattern_partition(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Forward
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryPredicate>
 _RandomAccessIterator
-__pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_partition(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                     _RandomAccessIterator __last, _UnaryPredicate __pred)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -2195,7 +2195,7 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
             else if (__size2 > __size1)
             {
                 __par_backend::__parallel_for(
-                    __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size1,
+                    __backend_tag{}, __exec, __val1.__pivot, __val1.__pivot + __size1,
                     [__val1, __val2, __size1](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, (__val2.__pivot - __size1) + (__i - __val1.__pivot),
                                                         _IsVector{});
@@ -2206,7 +2206,7 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
             else
             {
                 __par_backend::__parallel_for(
-                    __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size2,
+                    __backend_tag{}, __exec, __val1.__pivot, __val1.__pivot + __size2,
                     [__val1, __val2](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, __val2.__begin + (__i - __val1.__pivot), _IsVector{});
                     });
@@ -2215,7 +2215,7 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
         };
 
         _PartitionRange __result = __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init,
+            __backend_tag{}, __exec, __first, __last, __init,
             [__pred, __reductor](_RandomAccessIterator __i, _RandomAccessIterator __j,
                                  _PartitionRange __value) -> _PartitionRange {
                 //1. serial partition
@@ -2252,7 +2252,7 @@ __brick_stable_partition(_RandomAccessIterator __first, _RandomAccessIterator __
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate>
 _BidirectionalIterator
-__pattern_stable_partition(_Tag, _ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __last,
+__pattern_stable_partition(_Tag, const _ExecutionPolicy&, _BidirectionalIterator __first, _BidirectionalIterator __last,
                            _UnaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2262,7 +2262,7 @@ __pattern_stable_partition(_Tag, _ExecutionPolicy&&, _BidirectionalIterator __fi
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryPredicate>
 _RandomAccessIterator
-__pattern_stable_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_stable_partition(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                            _RandomAccessIterator __last, _UnaryPredicate __pred)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -2299,7 +2299,7 @@ __pattern_stable_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
         };
 
         _PartitionRange __result = __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init,
+            __backend_tag{}, __exec, __first, __last, __init,
             [&__pred, __reductor](_RandomAccessIterator __i, _RandomAccessIterator __j,
                                   _PartitionRange __value) -> _PartitionRange {
                 //1. serial stable_partition
@@ -2342,7 +2342,7 @@ __brick_partition_copy(_RandomAccessIterator1 __first, _RandomAccessIterator1 __
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator1, class _OutputIterator2,
           class _UnaryPredicate>
 ::std::pair<_OutputIterator1, _OutputIterator2>
-__pattern_partition_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_partition_copy(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                          _OutputIterator1 __out_true, _OutputIterator2 __out_false, _UnaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2354,7 +2354,7 @@ __pattern_partition_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Fo
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _UnaryPredicate>
 ::std::pair<_RandomAccessIterator2, _RandomAccessIterator3>
-__pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_partition_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                          _RandomAccessIterator1 __last, _RandomAccessIterator2 __out_true,
                          _RandomAccessIterator3 __out_false, _UnaryPredicate __pred)
 {
@@ -2370,7 +2370,7 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
             bool* __mask = __mask_buf.get();
             _ReturnType __m{};
             __par_backend::__parallel_strict_scan(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n,
+                __backend_tag{}, __exec, __n,
                 ::std::make_pair(_DifferenceType(0), _DifferenceType(0)),
                 [=](_DifferenceType __i, _DifferenceType __len) { // Reduce
                     return __internal::__brick_calc_mask_1<_DifferenceType>(__first + __i, __first + (__i + __len),
@@ -2398,7 +2398,7 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _LeafSort>
 void
-__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+__pattern_sort(_Tag, const _ExecutionPolicy&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                _LeafSort __leaf_sort) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2408,14 +2408,14 @@ __pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomA
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _LeafSort>
 void
-__pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_sort(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                _RandomAccessIterator __last, _Compare __comp, _LeafSort __leaf_sort)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     __internal::__except_handler([&]() {
         __par_backend::__parallel_stable_sort(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+            __backend_tag{}, __exec, __first, __last, __comp,
             [__leaf_sort](_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
                 __leaf_sort(__first, __last, __comp);
             },
@@ -2430,7 +2430,7 @@ __pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
 template <typename _Tag, typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _Compare, typename _LeafSort>
 void
-__pattern_sort_by_key(_Tag, _ExecutionPolicy&&, _RandomAccessIterator1 __keys_first,
+__pattern_sort_by_key(_Tag, const _ExecutionPolicy&, _RandomAccessIterator1 __keys_first,
                       _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp,
                       _LeafSort __leaf_sort) noexcept
 {
@@ -2446,7 +2446,7 @@ __pattern_sort_by_key(_Tag, _ExecutionPolicy&&, _RandomAccessIterator1 __keys_fi
 template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator1,
           typename _RandomAccessIterator2, typename _Compare, typename _LeafSort>
 void
-__pattern_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
+__pattern_sort_by_key(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __keys_first,
                       _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp,
                       _LeafSort __leaf_sort)
 {
@@ -2458,7 +2458,7 @@ __pattern_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
 
     __internal::__except_handler([&]() {
         __par_backend::__parallel_stable_sort(
-            __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __beg, __end, __cmp_f,
+            __backend_tag{}, __exec, __beg, __end, __cmp_f,
             [__leaf_sort](auto __first, auto __last, auto __cmp) { __leaf_sort(__first, __last, __cmp); },
             __end - __beg);
     });
@@ -2470,7 +2470,7 @@ __pattern_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_partial_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __middle,
+__pattern_partial_sort(_Tag, const _ExecutionPolicy&, _RandomAccessIterator __first, _RandomAccessIterator __middle,
                        _RandomAccessIterator __last, _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2480,7 +2480,7 @@ __pattern_partial_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, 
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_partial_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_partial_sort(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                        _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -2491,7 +2491,7 @@ __pattern_partial_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ra
 
     __except_handler([&]() {
         __par_backend::__parallel_stable_sort(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+            __backend_tag{}, __exec, __first, __last, __comp,
             [__n](_RandomAccessIterator __begin, _RandomAccessIterator __end, _Compare __comp) {
                 if (__n < __end - __begin)
                     ::std::partial_sort(__begin, __begin + __n, __end, __comp);
@@ -2508,7 +2508,7 @@ __pattern_partial_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ra
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
 _RandomAccessIterator
-__pattern_partial_sort_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_partial_sort_copy(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                             _RandomAccessIterator __d_first, _RandomAccessIterator __d_last, _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2519,7 +2519,7 @@ __pattern_partial_sort_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Compare>
 _RandomAccessIterator2
-__pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_partial_sort_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                             _RandomAccessIterator1 __last, _RandomAccessIterator2 __d_first,
                             _RandomAccessIterator2 __d_last, _Compare __comp)
 {
@@ -2535,7 +2535,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
         if (__n2 >= __n1)
         {
             __par_backend::__parallel_stable_sort(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __d_first, __d_first + __n1, __comp,
+                __backend_tag{}, __exec, __d_first, __d_first + __n1, __comp,
                 [__first, __d_first](_RandomAccessIterator2 __i, _RandomAccessIterator2 __j, _Compare __comp) {
                     _RandomAccessIterator1 __i1 = __first + (__i - __d_first);
                     _RandomAccessIterator1 __j1 = __first + (__j - __d_first);
@@ -2556,7 +2556,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
             _T1* __r = __buf.get();
 
             __par_backend::__parallel_stable_sort(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n1, __comp,
+                __backend_tag{}, __exec, __r, __r + __n1, __comp,
                 [__n2, __first, __r](_T1* __i, _T1* __j, _Compare __comp) {
                     _RandomAccessIterator1 __it = __first + (__i - __r);
 
@@ -2575,14 +2575,14 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                 __n2);
 
             // 3. Move elements from temporary buffer to output
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
+            __par_backend::__parallel_for(__backend_tag{}, __exec, __r, __r + __n2,
                                           [__r, __d_first](_T1* __i, _T1* __j) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
                                           });
 
             if constexpr (!::std::is_trivially_destructible_v<_T1>)
-                __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
+                __par_backend::__parallel_for(__backend_tag{}, __exec, __r + __n2,
                                               __r + __n1,
                                               [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); });
 
@@ -2612,7 +2612,7 @@ __brick_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _Binary
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate, class _Semantic>
 _ForwardIterator
-__pattern_adjacent_find(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_adjacent_find(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                         _BinaryPredicate __pred, _Semantic) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2622,7 +2622,7 @@ __pattern_adjacent_find(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _For
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _BinaryPredicate, class _Semantic>
 _RandomAccessIterator
-__pattern_adjacent_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_adjacent_find(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                         _RandomAccessIterator __last, _BinaryPredicate __pred, _Semantic __or_semantic)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -2632,7 +2632,7 @@ __pattern_adjacent_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
 
     return __internal::__except_handler([&]() {
         return __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __last,
+            __backend_tag{}, __exec, __first, __last, __last,
             [__last, __pred, __or_semantic](_RandomAccessIterator __begin, _RandomAccessIterator __end,
                                             _RandomAccessIterator __value) -> _RandomAccessIterator {
                 // TODO: investigate performance benefits from the use of shared variable for the result,
@@ -2672,7 +2672,7 @@ __pattern_adjacent_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_nth_element(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __nth,
+__pattern_nth_element(_Tag, const _ExecutionPolicy&, _RandomAccessIterator __first, _RandomAccessIterator __nth,
                       _RandomAccessIterator __last, _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2682,7 +2682,7 @@ __pattern_nth_element(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_nth_element(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_nth_element(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                       _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp)
 {
     if (__first == __last || __nth == __last)
@@ -2695,7 +2695,7 @@ __pattern_nth_element(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec
     _RandomAccessIterator __x;
     do
     {
-        __x = __internal::__pattern_partition(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first + 1, __last,
+        __x = __internal::__pattern_partition(__tag, __exec, __first + 1, __last,
                                               [&__comp, __first](const _Tp& __x) { return __comp(__x, *__first); });
         --__x;
         if (__x != __first)
@@ -2748,7 +2748,7 @@ struct __brick_fill<_Tag, _ExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_di
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Tp>
 void
-__pattern_fill(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) noexcept
+__pattern_fill(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -2757,13 +2757,13 @@ __pattern_fill(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardItera
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Tp>
 _RandomAccessIterator
-__pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_fill(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                _RandomAccessIterator __last, const _Tp& __value)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&__exec, __first, __last, &__value]() {
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __par_backend::__parallel_for(__backend_tag{}, __exec, __first, __last,
                                       [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
                                           __internal::__brick_fill<__parallel_tag<_IsVector>, _ExecutionPolicy, _Tp>{
                                               __value}(__begin, __end, _IsVector{});
@@ -2796,7 +2796,7 @@ struct __brick_fill_n<_Tag, _ExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_
 
 template <class _Tag, class _ExecutionPolicy, class _OutputIterator, class _Size, class _Tp>
 _OutputIterator
-__pattern_fill_n(_Tag, _ExecutionPolicy&&, _OutputIterator __first, _Size __count, const _Tp& __value) noexcept
+__pattern_fill_n(_Tag, const _ExecutionPolicy&, _OutputIterator __first, _Size __count, const _Tp& __value) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -2806,10 +2806,10 @@ __pattern_fill_n(_Tag, _ExecutionPolicy&&, _OutputIterator __first, _Size __coun
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Tp>
 _RandomAccessIterator
-__pattern_fill_n(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_fill_n(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                  _Size __count, const _Tp& __value)
 {
-    return __internal::__pattern_fill(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + __count,
+    return __internal::__pattern_fill(__tag, __exec, __first, __first + __count,
                                       __value);
 }
 
@@ -2834,7 +2834,7 @@ __brick_generate(_ForwardIterator __first, _ForwardIterator __last, _Generator _
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Generator>
 void
-__pattern_generate(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Generator __g) noexcept
+__pattern_generate(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last, _Generator __g) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -2843,13 +2843,13 @@ __pattern_generate(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardI
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Generator>
 _RandomAccessIterator
-__pattern_generate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_generate(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                    _RandomAccessIterator __last, _Generator __g)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     return __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __par_backend::__parallel_for(__backend_tag{}, __exec, __first, __last,
                                       [__g](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
                                           __internal::__brick_generate(__begin, __end, __g, _IsVector{});
                                       });
@@ -2874,7 +2874,7 @@ __brick_generate_n(OutputIterator __first, Size __count, _Generator __g, /* is_v
 
 template <class _Tag, class _ExecutionPolicy, class _OutputIterator, class _Size, class _Generator>
 _OutputIterator
-__pattern_generate_n(_Tag, _ExecutionPolicy&&, _OutputIterator __first, _Size __count, _Generator __g) noexcept
+__pattern_generate_n(_Tag, const _ExecutionPolicy&, _OutputIterator __first, _Size __count, _Generator __g) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -2883,12 +2883,12 @@ __pattern_generate_n(_Tag, _ExecutionPolicy&&, _OutputIterator __first, _Size __
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Generator>
 _RandomAccessIterator
-__pattern_generate_n(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_generate_n(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                      _Size __count, _Generator __g)
 {
     static_assert(__is_random_access_iterator_v<_RandomAccessIterator>,
                   "Pattern-brick error. Should be a random access iterator.");
-    return __internal::__pattern_generate(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + __count,
+    return __internal::__pattern_generate(__tag, __exec, __first, __first + __count,
                                           __g);
 }
 
@@ -2918,7 +2918,7 @@ __brick_remove_if(_RandomAccessIterator __first, _RandomAccessIterator __last, _
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
 _ForwardIterator
-__pattern_remove_if(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_remove_if(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                     _UnaryPredicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -2928,7 +2928,7 @@ __pattern_remove_if(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Forward
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryPredicate>
 _RandomAccessIterator
-__pattern_remove_if(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_remove_if(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                     _RandomAccessIterator __last, _UnaryPredicate __pred)
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::reference _ReferenceType;
@@ -2940,7 +2940,7 @@ __pattern_remove_if(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, 
     }
 
     return __internal::__remove_elements(
-        __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __tag, __exec, __first, __last,
         [&__pred](bool* __b, bool* __e, _RandomAccessIterator __it) {
             __internal::__brick_walk2(
                 __b, __e, __it, [&__pred](bool& __x, _ReferenceType __y) { __x = !__pred(__y); }, _IsVector{});
@@ -3007,7 +3007,7 @@ __brick_merge(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_merge(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_merge(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __d_first,
                 _Compare __comp) noexcept
 {
@@ -3020,7 +3020,7 @@ __pattern_merge(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIt
 template <typename _Tag, typename _ExecutionPolicy, typename _It1, typename _Index1, typename _It2, typename _Index2,
           typename _OutIt, typename _Index3, typename _Comp>
 std::pair<_It1, _It2>
-___merge_path_out_lim(_Tag, _ExecutionPolicy&&, _It1 __it_1, _Index1 __n_1, _It2 __it_2, _Index2 __n_2,
+___merge_path_out_lim(_Tag, const _ExecutionPolicy&, _It1 __it_1, _Index1 __n_1, _It2 __it_2, _Index2 __n_2,
                       _OutIt __it_out, _Index3 __n_out, _Comp __comp)
 {
     return __serial_merge_out_lim(__it_1, __it_1 + __n_1, __it_2, __it_2 + __n_2, __it_out, __it_out + __n_out, __comp);
@@ -3033,7 +3033,7 @@ inline constexpr std::size_t __merge_path_cut_off = 2000;
 template <typename _IsVector, typename _ExecutionPolicy, typename _It1, typename _Index1, typename _It2,
           typename _Index2, typename _OutIt, typename _Index3, typename _Comp>
 std::pair<_It1, _It2>
-___merge_path_out_lim(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _It1 __it_1, _Index1 __n_1, _It2 __it_2,
+___merge_path_out_lim(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _It1 __it_1, _Index1 __n_1, _It2 __it_2,
                       _Index2 __n_2, _OutIt __it_out, _Index3 __n_out, _Comp __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -3043,7 +3043,7 @@ ___merge_path_out_lim(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _It1
 
     __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), _Index3(0), __n_out,
+            __backend_tag{}, __exec, _Index3(0), __n_out,
             [=, &__it_res_1, &__it_res_2](_Index3 __i, _Index3 __j) {
                 //a start merging point on the merge path; for each thread
                 _Index1 __r = 0; //row index
@@ -3098,7 +3098,7 @@ ___merge_path_out_lim(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _It1
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Compare>
 _RandomAccessIterator3
-__pattern_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_merge(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                 _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                 _RandomAccessIterator3 __d_first, _Compare __comp)
 {
@@ -3106,7 +3106,7 @@ __pattern_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcc
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_merge(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __d_first,
+            __backend_tag{}, __exec, __first1, __last1, __first2, __last2, __d_first,
             __comp,
             [](_RandomAccessIterator1 __f1, _RandomAccessIterator1 __l1, _RandomAccessIterator2 __f2,
                _RandomAccessIterator2 __l2, _RandomAccessIterator3 __f3, _Compare __comp) {
@@ -3138,7 +3138,7 @@ __brick_inplace_merge(_RandomAccessIterator __first, _RandomAccessIterator __mid
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
 void
-__pattern_inplace_merge(_Tag, _ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __middle,
+__pattern_inplace_merge(_Tag, const _ExecutionPolicy&, _BidirectionalIterator __first, _BidirectionalIterator __middle,
                         _BidirectionalIterator __last, _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -3148,7 +3148,7 @@ __pattern_inplace_merge(_Tag, _ExecutionPolicy&&, _BidirectionalIterator __first
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_inplace_merge(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                         _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -3172,7 +3172,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
         };
 
         __par_backend::__parallel_merge(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle, __middle, __last, __r, __comp,
+            __backend_tag{}, __exec, __first, __middle, __middle, __last, __r, __comp,
             [__n, __move_values, __move_sequences](_RandomAccessIterator __f1, _RandomAccessIterator __l1,
                                                    _RandomAccessIterator __f2, _RandomAccessIterator __l2, _Tp* __f3,
                                                    _Compare __comp) {
@@ -3180,7 +3180,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
                                                     __move_sequences, __move_sequences);
                 return __f3 + (__l1 - __f1) + (__l2 - __f2);
             });
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n,
+        __par_backend::__parallel_for(__backend_tag{}, __exec, __r, __r + __n,
                                       [__r, __first](_Tp* __i, _Tp* __j) {
                                           __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
                                               __i, __j, __first + (__i - __r), _IsVector{});
@@ -3194,7 +3194,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
 bool
-__pattern_includes(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_includes(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                    _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -3205,7 +3205,7 @@ __pattern_includes(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _Forwar
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Compare>
 bool
-__pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_includes(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                    _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                    _Compare __comp)
 {
@@ -3229,7 +3229,7 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
 
     return __internal::__except_handler([&]() {
         return !__internal::__parallel_or(
-            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
+            __tag, __exec, __first2, __last2,
             [__first1, __last1, __first2, __last2, &__comp](_RandomAccessIterator2 __i, _RandomAccessIterator2 __j) {
                 assert(__j > __i);
                 //assert(__j - __i > 1);
@@ -3269,7 +3269,7 @@ inline constexpr auto __set_algo_cut_off = 1000;
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _OutputIterator, class _Compare, class _SizeFunction, class _SetOP>
 _OutputIterator
-__parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__parallel_set_op(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                   _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                   _OutputIterator __result, _Compare __comp, _SizeFunction __size_func, _SetOP __set_op)
 {
@@ -3304,7 +3304,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                     _IsVector{});
         };
         __par_backend::__parallel_strict_scan(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n1, _SetRange{0, 0, 0}, //-1, 0},
+            __backend_tag{}, __exec, __n1, _SetRange{0, 0, 0}, //-1, 0},
             [=](_DifferenceType __i, _DifferenceType __len) {                                    // Reduce
                 //[__b; __e) - a subrange of the first sequence, to reduce
                 _RandomAccessIterator1 __b = __first1 + __i, __e = __first1 + (__i + __len);
@@ -3362,7 +3362,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _OutputIterator, class _Compare, class _SetUnionOp>
 _OutputIterator
-__parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__parallel_set_union_op(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                         _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                         _OutputIterator __result, _Compare __comp, _SetUnionOp __set_union_op)
 {
@@ -3377,12 +3377,12 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // {1} {}: parallel copying just first sequence
     if (__n2 == 0)
-        return __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+        return __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
                                                  __result, __copy_range);
 
     // {} {2}: parallel copying justmake  second sequence
     if (__n1 == 0)
-        return __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
+        return __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
                                                  __result, __copy_range);
 
     // testing  whether the sequences are intersected
@@ -3392,13 +3392,13 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
     {
         //{1} < {2}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            __backend_tag{}, __exec,
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
                                                   __result, __copy_range);
             },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
                                                   __result + __n1, __copy_range);
             });
         return __result + __n1 + __n2;
@@ -3411,13 +3411,13 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
     {
         //{2} < {1}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            __backend_tag{}, __exec,
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
                                                   __result, __copy_range);
             },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
                                                   __result + __n2, __copy_range);
             });
         return __result + __n1 + __n2;
@@ -3429,15 +3429,15 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         auto __res_or = __result;
         __result += __m1; //we know proper offset due to [first1; left_bound_seq_1) < [first2; last2)
         __par_backend::__parallel_invoke(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            __backend_tag{}, __exec,
             //do parallel copying of [first1; left_bound_seq_1)
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1,
                                                   __left_bound_seq_1, __res_or, __copy_range);
             },
             [=, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, ::std::forward<_ExecutionPolicy>(__exec), __left_bound_seq_1, __last1, __first2, __last2,
+                    __tag, __exec, __left_bound_seq_1, __last1, __first2, __last2,
                     __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; },
                     __set_union_op);
             });
@@ -3451,15 +3451,15 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         auto __res_or = __result;
         __result += __m2; //we know proper offset due to [first2; left_bound_seq_2) < [first1; last1)
         __par_backend::__parallel_invoke(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            __backend_tag{}, __exec,
             //do parallel copying of [first2; left_bound_seq_2)
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first2,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2,
                                                   __left_bound_seq_2, __res_or, __copy_range);
             },
             [=, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __left_bound_seq_2, __last2,
+                    __tag, __exec, __first1, __last1, __left_bound_seq_2, __last2,
                     __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; },
                     __set_union_op);
             });
@@ -3467,7 +3467,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
     }
 
     return __internal::__parallel_set_op(
-        __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, __comp,
+        __tag, __exec, __first1, __last1, __first2, __last2, __result, __comp,
         [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; }, __set_union_op);
 }
 
@@ -3508,7 +3508,7 @@ __brick_set_union(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_set_union(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_set_union(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                     _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result,
                     _Compare __comp) noexcept
 {
@@ -3521,7 +3521,7 @@ __pattern_set_union(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _Forwa
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _OutputIterator, class _Compare>
 _OutputIterator
-__pattern_set_union(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_set_union(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                     _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                     _OutputIterator __result, _Compare __comp)
 {
@@ -3534,7 +3534,7 @@ __pattern_set_union(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, 
 
     typedef typename ::std::iterator_traits<_OutputIterator>::value_type _Tp;
     return __parallel_set_union_op(
-        __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, __comp,
+        __tag, __exec, __first1, __last1, __first2, __last2, __result, __comp,
         [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
            _RandomAccessIterator2 __last2, _Tp* __result, _Compare __comp) {
             return oneapi::dpl::__utils::__set_union_construct(__first1, __last1, __first2, __last2, __result, __comp,
@@ -3569,7 +3569,7 @@ __brick_set_intersection(_RandomAccessIterator1 __first1, _RandomAccessIterator1
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_set_intersection(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_set_intersection(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                            _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result,
                            _Compare __comp) noexcept
 {
@@ -3582,7 +3582,7 @@ __pattern_set_intersection(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1,
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Compare>
 _RandomAccessIterator3
-__pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_set_intersection(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                            _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                            _RandomAccessIterator2 __last2, _RandomAccessIterator3 __result, _Compare __comp)
 {
@@ -3614,7 +3614,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
         //we know proper offset due to [first1; left_bound_seq_1) < [first2; last2)
         return __internal::__except_handler([&]() {
             return __internal::__parallel_set_op(
-                __tag, ::std::forward<_ExecutionPolicy>(__exec), __left_bound_seq_1, __last1, __first2, __last2,
+                __tag, __exec, __left_bound_seq_1, __last1, __first2, __last2,
                 __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return ::std::min(__n, __m); },
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
@@ -3632,7 +3632,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
         //we know proper offset due to [first2; left_bound_seq_2) < [first1; last1)
         return __internal::__except_handler([&]() {
             __result = __internal::__parallel_set_op(
-                __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __left_bound_seq_2, __last2,
+                __tag, __exec, __first1, __last1, __left_bound_seq_2, __last2,
                 __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return ::std::min(__n, __m); },
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
@@ -3675,7 +3675,7 @@ __brick_set_difference(_RandomAccessIterator1 __first1, _RandomAccessIterator1 _
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_set_difference(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_set_difference(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                          _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result,
                          _Compare __comp) noexcept
 {
@@ -3688,7 +3688,7 @@ __pattern_set_difference(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Compare>
 _RandomAccessIterator3
-__pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_set_difference(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                          _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                          _RandomAccessIterator2 __last2, _RandomAccessIterator3 __result, _Compare __comp)
 {
@@ -3704,26 +3704,26 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 
     // {1} \ {}: parallel copying just first sequence
     if (__n2 == 0)
-        return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
+        return __pattern_walk2_brick(__tag, __exec, __first1, __last1, __result,
                                      __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 = ::std::lower_bound(__first1, __last1, *__first2, __comp);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
-        return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
+        return __pattern_walk2_brick(__tag, __exec, __first1, __last1, __result,
                                      __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 = ::std::lower_bound(__first2, __last2, *__first1, __comp);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)
-        return __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+        return __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
                                                  __result, __brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{});
 
     if (__n1 + __n2 > __set_algo_cut_off)
         return __parallel_set_op(
-            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, __comp,
+            __tag, __exec, __first1, __last1, __first2, __last2, __result, __comp,
             [](_DifferenceType __n, _DifferenceType) { return __n; },
             [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
@@ -3762,7 +3762,7 @@ __brick_set_symmetric_difference(_RandomAccessIterator1 __first1, _RandomAccessI
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
           class _Compare>
 _OutputIterator
-__pattern_set_symmetric_difference(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_set_symmetric_difference(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                                    _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result,
                                    _Compare __comp) noexcept
 {
@@ -3775,7 +3775,7 @@ __pattern_set_symmetric_difference(_Tag, _ExecutionPolicy&&, _ForwardIterator1 _
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _RandomAccessIterator3, class _Compare>
 _RandomAccessIterator3
-__pattern_set_symmetric_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec,
+__pattern_set_symmetric_difference(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec,
                                    _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                                    _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                                    _RandomAccessIterator3 __result, _Compare __comp)
@@ -3790,7 +3790,7 @@ __pattern_set_symmetric_difference(__parallel_tag<_IsVector> __tag, _ExecutionPo
     typedef typename ::std::iterator_traits<_RandomAccessIterator3>::value_type _T;
     return __internal::__except_handler([&]() {
         return __internal::__parallel_set_union_op(
-            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, __comp,
+            __tag, __exec, __first1, __last1, __first2, __last2, __result, __comp,
             [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
                 return oneapi::dpl::__utils::__set_symmetric_difference_construct(
@@ -3824,7 +3824,7 @@ __brick_is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __las
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 _RandomAccessIterator
-__pattern_is_heap_until(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
+__pattern_is_heap_until(_Tag, const _ExecutionPolicy&, _RandomAccessIterator __first, _RandomAccessIterator __last,
                         _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -3856,12 +3856,12 @@ __is_heap_until_local(_RandomAccessIterator __first, _DifferenceType __begin, _D
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 _RandomAccessIterator
-__pattern_is_heap_until(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_is_heap_until(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                         _RandomAccessIterator __last, _Compare __comp)
 {
     return __internal::__except_handler([&]() {
         return __parallel_find(
-            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __tag, __exec, __first, __last,
             [__first, __comp](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                 return __internal::__is_heap_until_local(__first, __i - __first, __j - __first, __comp, _IsVector{});
             },
@@ -3912,7 +3912,7 @@ __is_heap_local(_RandomAccessIterator __first, _DifferenceType __begin, _Differe
 
 template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 bool
-__pattern_is_heap(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
+__pattern_is_heap(_Tag, const _ExecutionPolicy&, _RandomAccessIterator __first, _RandomAccessIterator __last,
                   _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -3922,11 +3922,11 @@ __pattern_is_heap(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _Rand
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 bool
-__pattern_is_heap(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_is_heap(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                   _RandomAccessIterator __last, _Compare __comp)
 {
     return __internal::__except_handler([&]() {
-        return !__parallel_or(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        return !__parallel_or(__tag, __exec, __first, __last,
                               [__first, __comp](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                                   return !__internal::__is_heap_local(__first, __i - __first, __j - __first, __comp,
                                                                       _IsVector{});
@@ -3960,7 +3960,7 @@ __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last,
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>
 _ForwardIterator
-__pattern_min_element(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_min_element(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                       _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -3970,7 +3970,7 @@ __pattern_min_element(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Forwa
 
 template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare>
 _RandomAccessIterator
-__pattern_min_element(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_min_element(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                       _RandomAccessIterator __last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -3981,7 +3981,7 @@ __pattern_min_element(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
 
     return __internal::__except_handler([&]() {
         return __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, /*identity*/ __last,
+            __backend_tag{}, __exec, __first, __last, /*identity*/ __last,
             [=](_RandomAccessIterator __begin, _RandomAccessIterator __end,
                 _RandomAccessIterator __init) -> _RandomAccessIterator {
                 const _RandomAccessIterator __subresult =
@@ -4027,7 +4027,7 @@ __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>
 ::std::pair<_ForwardIterator, _ForwardIterator>
-__pattern_minmax_element(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_minmax_element(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                          _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -4037,7 +4037,7 @@ __pattern_minmax_element(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Fo
 
 template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare>
 ::std::pair<_RandomAccessIterator, _RandomAccessIterator>
-__pattern_minmax_element(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_minmax_element(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                          _RandomAccessIterator __last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -4050,7 +4050,7 @@ __pattern_minmax_element(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
         typedef ::std::pair<_RandomAccessIterator, _RandomAccessIterator> _Result;
 
         return __par_backend::__parallel_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __backend_tag{}, __exec, __first, __last,
             /*identity*/ ::std::make_pair(__last, __last),
             [=, &__comp](_RandomAccessIterator __begin, _RandomAccessIterator __end, _Result __init) -> _Result {
                 const _Result __subresult = __internal::__brick_minmax_element(__begin, __end, __comp, _IsVector{});
@@ -4108,7 +4108,7 @@ __brick_mismatch(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
 ::std::pair<_ForwardIterator1, _ForwardIterator2>
-__pattern_mismatch(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_mismatch(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                    _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Predicate __pred) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -4119,14 +4119,14 @@ __pattern_mismatch(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _Forwar
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Predicate>
 ::std::pair<_RandomAccessIterator1, _RandomAccessIterator2>
-__pattern_mismatch(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_mismatch(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                    _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                    _Predicate __pred)
 {
     return __internal::__except_handler([&]() {
         auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
         auto __result = __internal::__parallel_find(
-            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
+            __tag, __exec, __first1, __first1 + __n,
             [__first1, __first2, __pred](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                 return __internal::__brick_mismatch(__i, __j, __first2 + (__i - __first1), __first2 + (__j - __first1),
                                                     __pred, _IsVector{})
@@ -4189,7 +4189,7 @@ __brick_lexicographical_compare(_RandomAccessIterator1 __first1, _RandomAccessIt
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
 bool
-__pattern_lexicographical_compare(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_lexicographical_compare(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                                   _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -4201,7 +4201,7 @@ __pattern_lexicographical_compare(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Compare>
 bool
-__pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec,
+__pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec,
                                   _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                                   _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                                   _Compare __comp) noexcept
@@ -4224,7 +4224,7 @@ __pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, _ExecutionPol
             --__last2;
             auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
             auto __result = __internal::__parallel_find(
-                __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
+                __tag, __exec, __first1, __first1 + __n,
                 [__first1, __first2, &__comp](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
                     return __internal::__brick_mismatch(
                                __i, __j, __first2 + (__i - __first1), __first2 + (__j - __first1),
@@ -4254,12 +4254,12 @@ __pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, _ExecutionPol
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function>
 _ForwardIterator2
-__pattern_swap(_Tag __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_swap(_Tag __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                _ForwardIterator2 __first2, _Function __f)
 {
     static_assert(__is_host_dispatch_tag_v<_Tag>);
 
-    return __pattern_walk2(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __f);
+    return __pattern_walk2(__tag, __exec, __first1, __last1, __first2, __f);
 }
 
 //------------------------------------------------------------------------
@@ -4332,7 +4332,7 @@ __brick_shift_left(_ForwardIterator __first, _ForwardIterator __last,
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator>
 _ForwardIterator
-__pattern_shift_left(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_shift_left(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                      typename ::std::iterator_traits<_ForwardIterator>::difference_type __n) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -4342,7 +4342,7 @@ __pattern_shift_left(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Forwar
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator>
 _RandomAccessIterator
-__pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_shift_left(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                      _RandomAccessIterator __last,
                      typename ::std::iterator_traits<_RandomAccessIterator>::difference_type __n)
 {
@@ -4364,7 +4364,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
         //1. n >= size/2; there is enough memory to 'total' parallel copying
         if (__n >= __mid)
         {
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, __size,
+            __par_backend::__parallel_for(__backend_tag{}, __exec, __n, __size,
                                           [__first, __n](_DiffType __i, _DiffType __j) {
                                               __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
                                                   __first + __i, __first + __j, __first + __i - __n, _IsVector{});
@@ -4376,7 +4376,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
             for (auto __k = __n; __k < __size; __k += __n)
             {
                 auto __end = ::std::min(__k + __n, __size);
-                __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __k, __end,
+                __par_backend::__parallel_for(__backend_tag{}, __exec, __k, __end,
                                               [__first, __n](_DiffType __i, _DiffType __j) {
                                                   __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
                                                       __first + __i, __first + __j, __first + __i - __n, _IsVector{});
@@ -4390,7 +4390,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
 
 template <class _Tag, class _ExecutionPolicy, class _BidirectionalIterator>
 _BidirectionalIterator
-__pattern_shift_right(_Tag __tag, _ExecutionPolicy&& __exec, _BidirectionalIterator __first,
+__pattern_shift_right(_Tag __tag, const _ExecutionPolicy& __exec, _BidirectionalIterator __first,
                       _BidirectionalIterator __last,
                       typename ::std::iterator_traits<_BidirectionalIterator>::difference_type __n)
 {
@@ -4399,7 +4399,7 @@ __pattern_shift_right(_Tag __tag, _ExecutionPolicy&& __exec, _BidirectionalItera
     using _ReverseIterator = typename ::std::reverse_iterator<_BidirectionalIterator>;
 
     auto __res = oneapi::dpl::__internal::__pattern_shift_left(
-        __tag, ::std::forward<_ExecutionPolicy>(__exec), _ReverseIterator(__last), _ReverseIterator(__first), __n);
+        __tag, __exec, _ReverseIterator(__last), _ReverseIterator(__first), __n);
 
     return __res.base();
 }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2888,8 +2888,7 @@ __pattern_generate_n(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __
 {
     static_assert(__is_random_access_iterator_v<_RandomAccessIterator>,
                   "Pattern-brick error. Should be a random access iterator.");
-    return __internal::__pattern_generate(__tag, __exec, __first, __first + __count,
-                                          __g);
+    return __internal::__pattern_generate(__tag, __exec, __first, __first + __count, __g);
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -378,8 +378,7 @@ _RandomAccessIterator2
 __pattern_walk2_n(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                   _Size __n, _RandomAccessIterator2 __first2, _Function __f)
 {
-    return __internal::__pattern_walk2(__tag, __exec, __first1, __first1 + __n,
-                                       __first2, __f);
+    return __internal::__pattern_walk2(__tag, __exec, __first1, __first1 + __n, __first2, __f);
 }
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Brick>
@@ -578,8 +577,7 @@ __pattern_walk3_transform_if(_Tag __tag, const _ExecutionPolicy& __exec, _Forwar
 {
     static_assert(__is_host_dispatch_tag_v<_Tag>);
 
-    return __pattern_walk3(__tag, __exec, __first1, __last1, __first2, __first3,
-                           __func);
+    return __pattern_walk3(__tag, __exec, __first1, __last1, __first2, __first3, __func);
 }
 
 //------------------------------------------------------------------------
@@ -867,8 +865,7 @@ __pattern_find_end(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __ex
 {
     if (__last - __first == __s_last - __s_first)
     {
-        const bool __res = __internal::__pattern_equal(__tag, __exec, __first, __last,
-                                                       __s_first, __pred);
+        const bool __res = __internal::__pattern_equal(__tag, __exec, __first, __last, __s_first, __pred);
         return __res ? __first : __last;
     }
     else
@@ -970,8 +967,7 @@ __pattern_search(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec
 {
     if (__last - __first == __s_last - __s_first)
     {
-        const bool __res = __internal::__pattern_equal(__tag, __exec, __first, __last,
-                                                       __s_first, __pred);
+        const bool __res = __internal::__pattern_equal(__tag, __exec, __first, __last, __s_first, __pred);
         return __res ? __first : __last;
     }
     else
@@ -1943,8 +1939,7 @@ __pattern_rotate_copy(_Tag __tag, const _ExecutionPolicy& __exec, _ForwardIterat
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    return __internal::__brick_rotate_copy(__tag, __exec, __first, __middle, __last,
-                                           __result);
+    return __internal::__brick_rotate_copy(__tag, __exec, __first, __middle, __last, __result);
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2>
@@ -2582,8 +2577,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, const _ExecutionPolicy& _
                                           });
 
             if constexpr (!::std::is_trivially_destructible_v<_T1>)
-                __par_backend::__parallel_for(__backend_tag{}, __exec, __r + __n2,
-                                              __r + __n1,
+                __par_backend::__parallel_for(__backend_tag{}, __exec, __r + __n2, __r + __n1,
                                               [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); });
 
             return __d_first + __n2;
@@ -2809,8 +2803,7 @@ _RandomAccessIterator
 __pattern_fill_n(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                  _Size __count, const _Tp& __value)
 {
-    return __internal::__pattern_fill(__tag, __exec, __first, __first + __count,
-                                      __value);
+    return __internal::__pattern_fill(__tag, __exec, __first, __first + __count, __value);
 }
 
 //------------------------------------------------------------------------
@@ -3376,13 +3369,11 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy&
 
     // {1} {}: parallel copying just first sequence
     if (__n2 == 0)
-        return __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
-                                                 __result, __copy_range);
+        return __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result, __copy_range);
 
     // {} {2}: parallel copying justmake  second sequence
     if (__n1 == 0)
-        return __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
-                                                 __result, __copy_range);
+        return __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result, __copy_range);
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 = ::std::lower_bound(__first1, __last1, *__first2, __comp);
@@ -3392,13 +3383,9 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy&
         //{1} < {2}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
             __backend_tag{}, __exec,
+            [=] { __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result, __copy_range); },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
-                                                  __result, __copy_range);
-            },
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
-                                                  __result + __n1, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result + __n1, __copy_range);
             });
         return __result + __n1 + __n2;
     }
@@ -3411,13 +3398,9 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, const _ExecutionPolicy&
         //{2} < {1}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
             __backend_tag{}, __exec,
+            [=] { __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result, __copy_range); },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
-                                                  __result, __copy_range);
-            },
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
-                                                  __result + __n2, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result + __n2, __copy_range);
             });
         return __result + __n1 + __n2;
     }

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -474,8 +474,7 @@ __pattern_merge(_Tag __tag, const _ExecutionPolicy& __exec, _R1&& __r1, _R2&& __
     // Parallel and serial versions of ___merge_path_out_lim merge the 1st sequence and the 2nd sequence in "reverse order":
     // the identical elements from the 2nd sequence are merged first.
     // So, the call to ___merge_path_out_lim swaps the order of sequences.
-    std::pair __res = ___merge_path_out_lim(__tag, __exec, __it_2, __n_2, __it_1, __n_1,
-                                            __it_out, __n_out, __comp_2);
+    std::pair __res = ___merge_path_out_lim(__tag, __exec, __it_2, __n_2, __it_1, __n_1, __it_out, __n_out, __comp_2);
 
     return __return_type{__res.second, __res.first, __it_out + __n_out};
 }

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -42,20 +42,20 @@ namespace __ranges
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Fun>
 void
-__pattern_for_each(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Fun __f, _Proj __proj)
+__pattern_for_each(_Tag __tag, const _ExecutionPolicy& __exec, _R&& __r, _Fun __f, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
     auto __f_1 =
         [__f, __proj](auto&& __val) { std::invoke(__f, std::invoke(__proj, std::forward<decltype(__val)>(__val)));};
 
-    oneapi::dpl::__internal::__pattern_walk1(__tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__r),
+    oneapi::dpl::__internal::__pattern_walk1(__tag, __exec, std::ranges::begin(__r),
         std::ranges::begin(__r) + std::ranges::size(__r), __f_1);
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Fun>
 void
-__pattern_for_each(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R&& __r, _Fun __f, _Proj __proj)
+__pattern_for_each(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R&& __r, _Fun __f, _Proj __proj)
 {
     std::ranges::for_each(std::forward<_R>(__r), __f, __proj);
 }
@@ -66,7 +66,7 @@ __pattern_for_each(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&
 
 template<typename _Tag, typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _F, typename _Proj>
 void
-__pattern_transform(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, _F __op,
+__pattern_transform(_Tag __tag, const _ExecutionPolicy& __exec, _InRange&& __in_r, _OutRange&& __out_r, _F __op,
                     _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
@@ -75,14 +75,14 @@ __pattern_transform(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _O
     auto __unary_op = [__op, __proj](auto&& __val) {
         return std::invoke(__op, std::invoke(__proj, std::forward<decltype(__val)>(__val)));};
 
-    oneapi::dpl::__internal::__pattern_walk2(__tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__in_r),
+    oneapi::dpl::__internal::__pattern_walk2(__tag, __exec, std::ranges::begin(__in_r),
         std::ranges::begin(__in_r) + std::ranges::size(__in_r), std::ranges::begin(__out_r),
         oneapi::dpl::__internal::__transform_functor<decltype(__unary_op)>{std::move(__unary_op)});
 }
 
 template<typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _F, typename _Proj>
 void
-__pattern_transform(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _InRange&& __in_r, _OutRange&& __out_r,
+__pattern_transform(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _InRange&& __in_r, _OutRange&& __out_r,
                     _F __op, _Proj __proj)
 {
     std::ranges::transform(std::forward<_InRange>(__in_r), std::ranges::begin(__out_r), __op, __proj);
@@ -95,7 +95,7 @@ __pattern_transform(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&
 template<typename _Tag, typename _ExecutionPolicy, typename _InRange1, typename _InRange2, typename _OutRange,
          typename _F, typename _Proj1, typename _Proj2>
 void
-__pattern_transform(_Tag __tag, _ExecutionPolicy&& __exec, _InRange1&& __in_r1, _InRange2&& __in_r2,
+__pattern_transform(_Tag __tag, const _ExecutionPolicy& __exec, _InRange1&& __in_r1, _InRange2&& __in_r2,
                     _OutRange&& __out_r, _F __binary_op, _Proj1 __proj1,_Proj2 __proj2)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
@@ -104,7 +104,7 @@ __pattern_transform(_Tag __tag, _ExecutionPolicy&& __exec, _InRange1&& __in_r1, 
         return std::invoke(__binary_op, std::invoke(__proj1, std::forward<decltype(__val1)>(__val1)),
             std::invoke(__proj2, std::forward<decltype(__val2)>(__val2)));};
 
-    oneapi::dpl::__internal::__pattern_walk3(__tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__in_r1),
+    oneapi::dpl::__internal::__pattern_walk3(__tag, __exec, std::ranges::begin(__in_r1),
         std::ranges::begin(__in_r1) + std::ranges::size(__in_r1), std::ranges::begin(__in_r2),
         std::ranges::begin(__out_r), oneapi::dpl::__internal::__transform_functor<decltype(__f)>{std::move(__f)});
 }
@@ -112,7 +112,7 @@ __pattern_transform(_Tag __tag, _ExecutionPolicy&& __exec, _InRange1&& __in_r1, 
 template<typename _ExecutionPolicy, typename _InRange1, typename _InRange2, typename _OutRange, typename _F,
          typename _Proj1, typename _Proj2>
 void
-__pattern_transform(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _InRange1&& __in_r1, _InRange2&& __in_r2, _OutRange&& __out_r,
+__pattern_transform(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _InRange1&& __in_r1, _InRange2&& __in_r2, _OutRange&& __out_r,
                     _F __binary_op, _Proj1 __proj1, _Proj2 __proj2)
 {
     std::ranges::transform(std::forward<_InRange1>(__in_r1), std::forward<_InRange2>(__in_r2),
@@ -125,7 +125,7 @@ __pattern_transform(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Pred>
 auto
-__pattern_find_if(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj)
+__pattern_find_if(_Tag __tag, const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
@@ -133,13 +133,13 @@ __pattern_find_if(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pred __pred,
         return std::invoke(__pred, std::invoke(__proj, std::forward<decltype(__val)>(__val)));};
 
     return std::ranges::borrowed_iterator_t<_R>(oneapi::dpl::__internal::__pattern_find_if(__tag,
-        std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__r), std::ranges::begin(__r) +
+        __exec, std::ranges::begin(__r), std::ranges::begin(__r) +
         std::ranges::size(__r), __pred_1));
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Pred>
 auto
-__pattern_find_if(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R&& __r, _Pred __pred, _Proj __proj)
+__pattern_find_if(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R&& __r, _Pred __pred, _Proj __proj)
 {
     return std::ranges::find_if(std::forward<_R>(__r), __pred, __proj);
 }
@@ -150,19 +150,19 @@ __pattern_find_if(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&,
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Pred>
 bool
-__pattern_any_of(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj)
+__pattern_any_of(_Tag __tag, const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
     auto __pred_1 = [__pred, __proj](auto&& __val) {
         return std::invoke(__pred, std::invoke(__proj, std::forward<decltype(__val)>(__val)));};
-    return oneapi::dpl::__internal::__pattern_any_of(__tag, std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_any_of(__tag, __exec,
         std::ranges::begin(__r), std::ranges::begin(__r) + std::ranges::size(__r), __pred_1);
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Pred>
 bool
-__pattern_any_of(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R&& __r, _Pred __pred, _Proj __proj)
+__pattern_any_of(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R&& __r, _Pred __pred, _Proj __proj)
 {
     return std::ranges::any_of(std::forward<_R>(__r), __pred, __proj);
 }
@@ -173,7 +173,7 @@ __pattern_any_of(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, 
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Pred>
 auto
-__pattern_adjacent_find_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pred __pred,
+__pattern_adjacent_find_ranges(_Tag __tag, const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred,
                         _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
@@ -181,7 +181,7 @@ __pattern_adjacent_find_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, 
     auto __pred_2 = [__pred, __proj](auto&& __val, auto&& __next) { return std::invoke(__pred, std::invoke(__proj,
         std::forward<decltype(__val)>(__val)), std::invoke(__proj, std::forward<decltype(__next)>(__next)));};
 
-    auto __res = oneapi::dpl::__internal::__pattern_adjacent_find(__tag, std::forward<_ExecutionPolicy>(__exec),
+    auto __res = oneapi::dpl::__internal::__pattern_adjacent_find(__tag, __exec,
         std::ranges::begin(__r), std::ranges::begin(__r) + std::ranges::size(__r), __pred_2,
         oneapi::dpl::__internal::__first_semantic());
     return std::ranges::borrowed_iterator_t<_R>(__res);
@@ -189,7 +189,7 @@ __pattern_adjacent_find_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, 
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Pred>
 auto
-__pattern_adjacent_find_ranges(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R&& __r, _Pred __pred, _Proj __proj)
+__pattern_adjacent_find_ranges(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R&& __r, _Pred __pred, _Proj __proj)
 {
     return std::ranges::adjacent_find(std::forward<_R>(__r), __pred, __proj);
 }
@@ -201,7 +201,7 @@ __pattern_adjacent_find_ranges(__serial_tag</*IsVector*/std::false_type>, _Execu
 template<typename _Tag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Pred, typename _Proj1,
          typename _Proj2>
 auto
-__pattern_search(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred,
+__pattern_search(_Tag __tag, const _ExecutionPolicy& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred,
                  _Proj1 __proj1, _Proj2 __proj2)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
@@ -210,7 +210,7 @@ __pattern_search(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, 
         std::invoke(__proj1, std::forward<decltype(__val1)>(__val1)),
         std::invoke(__proj2, std::forward<decltype(__val2)>(__val2)));};
 
-    auto __res = oneapi::dpl::__internal::__pattern_search(__tag, std::forward<_ExecutionPolicy>(__exec),
+    auto __res = oneapi::dpl::__internal::__pattern_search(__tag, __exec,
         std::ranges::begin(__r1), std::ranges::begin(__r1) + std::ranges::size(__r1), std::ranges::begin(__r2),
         std::ranges::begin(__r2) + std::ranges::size(__r2), __pred_2);
 
@@ -221,7 +221,7 @@ __pattern_search(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, 
 template<typename _ExecutionPolicy, typename _R1, typename _R2, typename _Pred, typename _Proj1,
          typename _Proj2>
 auto
-__pattern_search(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R1&& __r1, _R2&& __r2, _Pred __pred, _Proj1 __proj1, _Proj2 __proj2)
+__pattern_search(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R1&& __r1, _R2&& __r2, _Pred __pred, _Proj1 __proj1, _Proj2 __proj2)
 {
     return std::ranges::search(std::forward<_R1>(__r1), std::forward<_R2>(__r2), __pred, __proj1, __proj2);
 }
@@ -232,7 +232,7 @@ __pattern_search(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, 
 
 template<typename _Tag, typename _ExecutionPolicy, typename _R, typename _T, typename _Pred, typename _Proj>
 auto
-__pattern_search_n(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r,
+__pattern_search_n(_Tag __tag, const _ExecutionPolicy& __exec, _R&& __r,
                    std::ranges::range_difference_t<_R> __count, const _T& __value, _Pred __pred, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
@@ -240,7 +240,7 @@ __pattern_search_n(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r,
     auto __pred_2 = [__pred, __proj](auto&& __val1, auto&& __val2) { return std::invoke(__pred,
         std::invoke(__proj, std::forward<decltype(__val1)>(__val1)), std::forward<decltype(__val2)>(__val2));};
 
-    auto __res = oneapi::dpl::__internal::__pattern_search_n(__tag, std::forward<_ExecutionPolicy>(__exec),
+    auto __res = oneapi::dpl::__internal::__pattern_search_n(__tag, __exec,
         std::ranges::begin(__r), std::ranges::begin(__r) + std::ranges::size(__r), __count, __value, __pred_2);
 
     return std::ranges::borrowed_subrange_t<_R>(__res, __res == std::ranges::end(__r) ? __res : __res + __count);
@@ -248,7 +248,7 @@ __pattern_search_n(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r,
 
 template<typename _ExecutionPolicy, typename _R, typename _T, typename _Pred, typename _Proj>
 auto
-__pattern_search_n(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R&& __r, std::ranges::range_difference_t<_R> __count, const _T& __value,
+__pattern_search_n(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R&& __r, std::ranges::range_difference_t<_R> __count, const _T& __value,
                    _Pred __pred, _Proj __proj)
 {
     return std::ranges::search_n(std::forward<_R>(__r), __count, __value, __pred, __proj);
@@ -260,19 +260,19 @@ __pattern_search_n(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Pred>
 std::ranges::range_difference_t<_R>
-__pattern_count_if(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj)
+__pattern_count_if(_Tag __tag, const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
     auto __pred_1 = [__pred, __proj](auto&& __val) { return std::invoke(__pred, std::invoke(__proj,
         std::forward<decltype(__val)>(__val)));};
-    return oneapi::dpl::__internal::__pattern_count(__tag, std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_count(__tag, __exec,
         std::ranges::begin(__r), std::ranges::begin(__r) + std::ranges::size(__r), __pred_1);
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Pred>
 std::ranges::range_difference_t<_R>
-__pattern_count_if(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R&& __r, _Pred __pred, _Proj __proj)
+__pattern_count_if(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R&& __r, _Pred __pred, _Proj __proj)
 {
     return std::ranges::count_if(std::forward<_R>(__r), __pred, __proj);
 }
@@ -283,7 +283,7 @@ __pattern_count_if(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&
 template<typename _Tag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Pred, typename _Proj1,
          typename _Proj2>
 bool
-__pattern_equal(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred,
+__pattern_equal(_Tag __tag, const _ExecutionPolicy& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred,
                 _Proj1 __proj1, _Proj2 __proj2)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
@@ -292,7 +292,7 @@ __pattern_equal(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _
         { return std::invoke(__pred, std::invoke(__proj1, std::forward<decltype(__val1)>(__val1)),
         std::invoke(__proj2, std::forward<decltype(__val2)>(__val2)));};
 
-    return oneapi::dpl::__internal::__pattern_equal(__tag, std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_equal(__tag, __exec,
         std::ranges::begin(__r1), std::ranges::begin(__r1) + std::ranges::size(__r1), std::ranges::begin(__r2),
         std::ranges::begin(__r2) + std::ranges::size(__r2), __pred_2);
 }
@@ -300,7 +300,7 @@ __pattern_equal(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _
 template<typename _ExecutionPolicy, typename _R1, typename _R2, typename _Pred, typename _Proj1,
          typename _Proj2>
 bool
-__pattern_equal(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R1&& __r1, _R2&& __r2, _Pred __pred, _Proj1 __proj1, _Proj2 __proj2)
+__pattern_equal(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R1&& __r1, _R2&& __r2, _Pred __pred, _Proj1 __proj1, _Proj2 __proj2)
 {
     return std::ranges::equal(std::forward<_R1>(__r1), std::forward<_R2>(__r2), __pred, __proj1, __proj2);
 }
@@ -311,21 +311,21 @@ __pattern_equal(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
 bool
-__pattern_is_sorted(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
+__pattern_is_sorted(_Tag __tag, const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
     auto __pred_2 = [__comp, __proj](auto&& __val1, auto&& __val2) { return std::invoke(__comp, std::invoke(__proj,
         std::forward<decltype(__val1)>(__val1)), std::invoke(__proj, std::forward<decltype(__val2)>(__val2)));};
 
-    return oneapi::dpl::__internal::__pattern_adjacent_find(__tag, std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_adjacent_find(__tag, __exec,
         std::ranges::begin(__r), std::ranges::begin(__r) + std::ranges::size(__r),
         oneapi::dpl::__internal::__reorder_pred(__pred_2), oneapi::dpl::__internal::__or_semantic()) == __r.end();
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
 bool
-__pattern_is_sorted(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R&& __r, _Comp __comp, _Proj __proj)
+__pattern_is_sorted(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R&& __r, _Comp __comp, _Proj __proj)
 {
     return std::ranges::is_sorted(std::forward<_R>(__r), __comp, __proj);
 }
@@ -336,14 +336,14 @@ __pattern_is_sorted(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp, typename _LeafSort>
 auto
-__pattern_sort_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj,
+__pattern_sort_ranges(_Tag __tag, const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp, _Proj __proj,
                       _LeafSort __leaf_sort)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
     auto __comp_2 = [__comp, __proj](auto&& __val1, auto&& __val2) { return std::invoke(__comp, std::invoke(__proj,
         std::forward<decltype(__val1)>(__val1)), std::invoke(__proj, std::forward<decltype(__val2)>(__val2)));};
-    oneapi::dpl::__internal::__pattern_sort(__tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__r),
+    oneapi::dpl::__internal::__pattern_sort(__tag, __exec, std::ranges::begin(__r),
                                             std::ranges::begin(__r) + std::ranges::size(__r), __comp_2, __leaf_sort);
 
     return std::ranges::borrowed_iterator_t<_R>(std::ranges::begin(__r) + std::ranges::size(__r));
@@ -351,7 +351,7 @@ __pattern_sort_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __c
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp, typename _LeafSort>
 auto
-__pattern_sort_ranges(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&&, _R&& __r, _Comp __comp,
+__pattern_sort_ranges(__serial_tag</*IsVector*/ std::false_type>, const _ExecutionPolicy&, _R&& __r, _Comp __comp,
                       _Proj __proj, _LeafSort __leaf_sort)
 {
     return __leaf_sort(std::forward<_R>(__r), __comp, __proj);
@@ -363,14 +363,14 @@ __pattern_sort_ranges(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPoli
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
 auto
-__pattern_min_element(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
+__pattern_min_element(_Tag __tag, const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
     auto __comp_2 = [__comp, __proj](auto&& __val1, auto&& __val2) { return std::invoke(__comp, std::invoke(__proj,
         std::forward<decltype(__val1)>(__val1)), std::invoke(__proj, std::forward<decltype(__val2)>(__val2)));};
 
-    auto __res = oneapi::dpl::__internal::__pattern_min_element(__tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__r),
+    auto __res = oneapi::dpl::__internal::__pattern_min_element(__tag, __exec, std::ranges::begin(__r),
         std::ranges::begin(__r) + std::ranges::size(__r), __comp_2);
 
     return std::ranges::borrowed_iterator_t<_R>(__res);
@@ -378,7 +378,7 @@ __pattern_min_element(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __c
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
 auto
-__pattern_min_element(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R&& __r, _Comp __comp, _Proj __proj)
+__pattern_min_element(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _R&& __r, _Comp __comp, _Proj __proj)
 {
     return std::ranges::min_element(std::forward<_R>(__r), __comp, __proj);
 }
@@ -389,20 +389,20 @@ __pattern_min_element(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolic
 
 template <typename _Tag, typename _ExecutionPolicy, typename _InRange, typename _OutRange>
 void
-__pattern_copy(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r)
+__pattern_copy(_Tag __tag, const _ExecutionPolicy& __exec, _InRange&& __in_r, _OutRange&& __out_r)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
     assert(std::ranges::size(__in_r) <= std::ranges::size(__out_r)); // for debug purposes only
 
-    oneapi::dpl::__internal::__pattern_walk2_brick(__tag, std::forward<_ExecutionPolicy>(__exec),
+    oneapi::dpl::__internal::__pattern_walk2_brick(__tag, __exec,
         std::ranges::begin(__in_r), std::ranges::begin(__in_r) + std::ranges::size(__in_r), std::ranges::begin(__out_r),
         oneapi::dpl::__internal::__brick_copy<decltype(__tag), _ExecutionPolicy>{});
 }
 
 template<typename _ExecutionPolicy, typename _InRange, typename _OutRange>
 void
-__pattern_copy(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _InRange&& __in_r, _OutRange&& __out_r)
+__pattern_copy(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _InRange&& __in_r, _OutRange&& __out_r)
 {
     std::ranges::copy(std::forward<_InRange>(__in_r), std::ranges::begin(__out_r));
 }
@@ -413,14 +413,14 @@ __pattern_copy(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _I
 template <typename _Tag, typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _Pred,
           typename _Proj>
 auto
-__pattern_copy_if_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Pred __pred, _Proj __proj)
+__pattern_copy_if_ranges(_Tag __tag, const _ExecutionPolicy& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Pred __pred, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
     auto __pred_1 = [__pred, __proj](auto&& __val) { return std::invoke(__pred, std::invoke(__proj,
         std::forward<decltype(__val)>(__val)));};
 
-    auto __res_idx = oneapi::dpl::__internal::__pattern_copy_if(__tag, std::forward<_ExecutionPolicy>(__exec),
+    auto __res_idx = oneapi::dpl::__internal::__pattern_copy_if(__tag, __exec,
         std::ranges::begin(__in_r), std::ranges::begin(__in_r) + std::ranges::size(__in_r),
         std::ranges::begin(__out_r), __pred_1) - std::ranges::begin(__out_r);
 
@@ -432,7 +432,7 @@ __pattern_copy_if_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_
 
 template<typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _Pred, typename _Proj>
 auto
-__pattern_copy_if_ranges(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _InRange&& __in_r, _OutRange&& __out_r,
+__pattern_copy_if_ranges(__serial_tag</*IsVector*/std::false_type>, const _ExecutionPolicy&, _InRange&& __in_r, _OutRange&& __out_r,
                          _Pred __pred, _Proj __proj)
 {
     return std::ranges::copy_if(std::forward<_InRange>(__in_r), std::ranges::begin(__out_r), __pred, __proj);
@@ -445,7 +445,7 @@ __pattern_copy_if_ranges(__serial_tag</*IsVector*/std::false_type>, _ExecutionPo
 template<typename _Tag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _OutRange, typename _Comp,
          typename _Proj1, typename _Proj2>
 auto
-__pattern_merge(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp,
+__pattern_merge(_Tag __tag, const _ExecutionPolicy& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp,
                 _Proj1 __proj1, _Proj2 __proj2)
 {
     using __return_type =
@@ -474,7 +474,7 @@ __pattern_merge(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _
     // Parallel and serial versions of ___merge_path_out_lim merge the 1st sequence and the 2nd sequence in "reverse order":
     // the identical elements from the 2nd sequence are merged first.
     // So, the call to ___merge_path_out_lim swaps the order of sequences.
-    std::pair __res = ___merge_path_out_lim(__tag, std::forward<_ExecutionPolicy>(__exec), __it_2, __n_2, __it_1, __n_1,
+    std::pair __res = ___merge_path_out_lim(__tag, __exec, __it_2, __n_2, __it_1, __n_1,
                                             __it_out, __n_out, __comp_2);
 
     return __return_type{__res.second, __res.first, __it_out + __n_out};

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop.h
@@ -59,7 +59,7 @@ for_loop(_ExecutionPolicy&& __exec, type_identity_t<_Ip> __start, _Ip __finish, 
     static_assert(oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
                   "for_loop is implemented for the host policies only");
 
-    oneapi::dpl::__internal::__for_loop_repack(::std::forward<_ExecutionPolicy>(__exec), __start, __finish,
+    oneapi::dpl::__internal::__for_loop_repack(__exec, __start, __finish,
                                                oneapi::dpl::__internal::__single_stride_type{},
                                                ::std::forward_as_tuple(::std::forward<_Rest>(__rest)...));
 }
@@ -71,7 +71,7 @@ for_loop_strided(_ExecutionPolicy&& __exec, type_identity_t<_Ip> __start, _Ip __
     static_assert(oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
                   "for_loop_strided is implemented for the host policies only");
 
-    oneapi::dpl::__internal::__for_loop_repack(::std::forward<_ExecutionPolicy>(__exec), __start, __finish, __stride,
+    oneapi::dpl::__internal::__for_loop_repack(__exec, __start, __finish, __stride,
                                                ::std::forward_as_tuple(::std::forward<_Rest>(__rest)...));
 }
 
@@ -82,7 +82,7 @@ for_loop_n(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Rest&&... __rest)
     static_assert(oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
                   "for_loop_n is implemented for the host policies only");
 
-    oneapi::dpl::__internal::__for_loop_repack_n(::std::forward<_ExecutionPolicy>(__exec), __start, __n,
+    oneapi::dpl::__internal::__for_loop_repack_n(__exec, __start, __n,
                                                  oneapi::dpl::__internal::__single_stride_type{},
                                                  ::std::forward_as_tuple(::std::forward<_Rest>(__rest)...));
 }
@@ -94,7 +94,7 @@ for_loop_n_strided(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Sp __stri
     static_assert(oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
                   "for_loop_n_strided is implemented for the host policies only");
 
-    oneapi::dpl::__internal::__for_loop_repack_n(::std::forward<_ExecutionPolicy>(__exec), __start, __n, __stride,
+    oneapi::dpl::__internal::__for_loop_repack_n(__exec, __start, __n, __stride,
                                                  ::std::forward_as_tuple(::std::forward<_Rest>(__rest)...));
 }
 

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -164,7 +164,7 @@ class __reduction_pack
 // Sequenced version of for_loop_n
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename... _Rest>
 void
-__pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, __single_stride_type,
+__pattern_for_loop_n(const _ExecutionPolicy&, _Ip __first, _Size __n, _Function __f, __single_stride_type,
                      /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     __reduction_pack<_Rest...> __pack{__reduction_pack_tag(), ::std::forward<_Rest>(__rest)...};
@@ -177,7 +177,7 @@ __pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, 
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename _Sp, typename... _Rest>
 void
-__pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, _Sp __stride,
+__pattern_for_loop_n(const _ExecutionPolicy&, _Ip __first, _Size __n, _Function __f, _Sp __stride,
                      /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     __reduction_pack<_Rest...> __pack{__reduction_pack_tag(), ::std::forward<_Rest>(__rest)...};
@@ -222,11 +222,11 @@ inline constexpr bool __is_random_access_or_integral_v = __is_random_access_or_i
 // Sequenced version of for_loop for RAI and integral types
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename... _Rest>
 ::std::enable_if_t<__is_random_access_or_integral_v<_Ip>>
-__pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
+__pattern_for_loop(const _ExecutionPolicy& __exec, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     oneapi::dpl::__internal::__pattern_for_loop_n(
-        ::std::forward<_ExecutionPolicy>(__exec), __first,
+        __exec, __first,
         oneapi::dpl::__internal::__calculate_input_sequence_length(__first, __last, __stride), __f, __stride,
         ::std::false_type{}, ::std::false_type{}, ::std::forward<_Rest>(__rest)...);
 }
@@ -294,7 +294,7 @@ __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pa
 // Sequenced version of for_loop for non-RAI and non-integral types
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename... _Rest>
 ::std::enable_if_t<!__is_random_access_or_integral_v<_Ip>>
-__pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, __single_stride_type,
+__pattern_for_loop(const _ExecutionPolicy&, _Ip __first, _Ip __last, _Function __f, __single_stride_type,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     __reduction_pack<_Rest...> __pack{__reduction_pack_tag(), ::std::forward<_Rest>(__rest)...};
@@ -312,7 +312,7 @@ __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename... _Rest>
 ::std::enable_if_t<!__is_random_access_or_integral_v<_Ip>>
-__pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
+__pattern_for_loop(const _ExecutionPolicy&, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     __reduction_pack<_Rest...> __pack{__reduction_pack_tag(), ::std::forward<_Rest>(__rest)...};
@@ -341,7 +341,7 @@ __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _
 // Vectorized version of for_loop_n
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename... _Rest>
 void
-__pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, __single_stride_type,
+__pattern_for_loop_n(const _ExecutionPolicy&, _Ip __first, _Size __n, _Function __f, __single_stride_type,
                      /*vector=*/::std::true_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     __reduction_pack<_Rest...> __pack{__reduction_pack_tag(), ::std::forward<_Rest>(__rest)...};
@@ -355,7 +355,7 @@ __pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, 
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename _Sp, typename... _Rest>
 void
-__pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, _Sp __stride,
+__pattern_for_loop_n(const _ExecutionPolicy&, _Ip __first, _Size __n, _Function __f, _Sp __stride,
                      /*vector=*/::std::true_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     __reduction_pack<_Rest...> __pack{__reduction_pack_tag(), ::std::forward<_Rest>(__rest)...};
@@ -371,11 +371,11 @@ __pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, 
 // Vectorized version of for_loop
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename... _Rest>
 void
-__pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
+__pattern_for_loop(const _ExecutionPolicy& __exec, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    /*vector=*/::std::true_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     oneapi::dpl::__internal::__pattern_for_loop_n(
-        ::std::forward<_ExecutionPolicy>(__exec), __first,
+        __exec, __first,
         oneapi::dpl::__internal::__calculate_input_sequence_length(__first, __last, __stride), __f, __stride,
         ::std::true_type{}, ::std::false_type{}, ::std::forward<_Rest>(__rest)...);
 }
@@ -389,7 +389,7 @@ __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename _IsVector,
           typename... _Rest>
 void
-__pattern_for_loop_n(_ExecutionPolicy&& __exec, _Ip __first, _Size __n, _Function __f, __single_stride_type,
+__pattern_for_loop_n(const _ExecutionPolicy& __exec, _Ip __first, _Size __n, _Function __f, __single_stride_type,
                      _IsVector __is_vector, /*parallel=*/::std::true_type, _Rest&&... __rest)
 {
     using __pack_type = __reduction_pack<_Rest...>;
@@ -400,7 +400,7 @@ __pattern_for_loop_n(_ExecutionPolicy&& __exec, _Ip __first, _Size __n, _Functio
     using __backend_tag = typename oneapi::dpl::__internal::__parallel_tag<_IsVector>::__backend_tag;
     oneapi::dpl::__internal::__except_handler([&]() {
         return __par_backend::__parallel_reduce(
-                   __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), _Size(0), __n, __identity,
+                   __backend_tag{}, __exec, _Size(0), __n, __identity,
                    [__is_vector, __first, __f](_Size __i, _Size __j, __pack_type __value) {
                        const auto __subseq_start = __first + __i;
                        const auto __length = __j - __i;
@@ -425,7 +425,7 @@ __pattern_for_loop_n(_ExecutionPolicy&& __exec, _Ip __first, _Size __n, _Functio
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename _Sp, typename _IsVector,
           typename... _Rest>
 void
-__pattern_for_loop_n(_ExecutionPolicy&& __exec, _Ip __first, _Size __n, _Function __f, _Sp __stride,
+__pattern_for_loop_n(const _ExecutionPolicy& __exec, _Ip __first, _Size __n, _Function __f, _Sp __stride,
                      _IsVector __is_vector, /*parallel=*/::std::true_type, _Rest&&... __rest)
 {
     using __pack_type = __reduction_pack<_Rest...>;
@@ -436,7 +436,7 @@ __pattern_for_loop_n(_ExecutionPolicy&& __exec, _Ip __first, _Size __n, _Functio
     using __backend_tag = typename oneapi::dpl::__internal::__parallel_tag<_IsVector>::__backend_tag;
     oneapi::dpl::__internal::__except_handler([&]() {
         return __par_backend::__parallel_reduce(
-                   __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), _Size(0), __n, __identity,
+                   __backend_tag{}, __exec, _Size(0), __n, __identity,
                    [__is_vector, __first, __f, __stride](_Size __i, _Size __j, __pack_type __value) {
                        const auto __subseq_start = __first + __i * __stride;
                        const auto __length = __j - __i;
@@ -461,12 +461,12 @@ __pattern_for_loop_n(_ExecutionPolicy&& __exec, _Ip __first, _Size __n, _Functio
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename _IsVector,
           typename... _Rest>
 void
-__pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
+__pattern_for_loop(const _ExecutionPolicy& __exec, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    _IsVector __is_vector,
                    /*parallel=*/::std::true_type, _Rest&&... __rest)
 {
     oneapi::dpl::__internal::__pattern_for_loop_n(
-        ::std::forward<_ExecutionPolicy>(__exec), __first,
+        __exec, __first,
         oneapi::dpl::__internal::__calculate_input_sequence_length(__first, __last, __stride), __f, __stride,
         __is_vector, ::std::true_type{}, ::std::forward<_Rest>(__rest)...);
 }
@@ -480,7 +480,7 @@ struct __use_par_vec_helper
 
     template <typename _ExecutionPolicy>
     static constexpr auto
-    __use_vector(_ExecutionPolicy&& __exec)
+    __use_vector(const _ExecutionPolicy& __exec)
     {
         using __tag_type = decltype(oneapi::dpl::__internal::__select_backend(__exec, std::declval<__it_type>()));
         return typename __tag_type::__is_vector{};
@@ -488,7 +488,7 @@ struct __use_par_vec_helper
 
     template <typename _ExecutionPolicy>
     static constexpr auto
-    __use_parallel(_ExecutionPolicy&& __exec)
+    __use_parallel(const _ExecutionPolicy& __exec)
     {
         using __tag_type = decltype(oneapi::dpl::__internal::__select_backend(__exec, std::declval<__it_type>()));
         return oneapi::dpl::__internal::__is_parallel_tag<__tag_type>{};
@@ -498,26 +498,26 @@ struct __use_par_vec_helper
 // Special versions for for_loop: handles both iterators and integral types(treated as random access iterators)
 template <typename _ExecutionPolicy, typename _Ip>
 auto
-__use_vectorization(_ExecutionPolicy&& __exec)
+__use_vectorization(const _ExecutionPolicy& __exec)
 {
-    return __use_par_vec_helper<_Ip>::__use_vector(::std::forward<_ExecutionPolicy>(__exec));
+    return __use_par_vec_helper<_Ip>::__use_vector(__exec);
 }
 
 template <typename _ExecutionPolicy, typename _Ip>
 auto
-__use_parallelization(_ExecutionPolicy&& __exec)
+__use_parallelization(const _ExecutionPolicy& __exec)
 {
-    return __use_par_vec_helper<_Ip>::__use_parallel(::std::forward<_ExecutionPolicy>(__exec));
+    return __use_par_vec_helper<_Ip>::__use_parallel(__exec);
 }
 
 // Helper functions to extract to separate a Callable object from the pack of reductions and inductions
 template <typename _ExecutionPolicy, typename _Ip, typename _Fp, typename _Sp, typename... _Rest, ::std::size_t... _Is>
 void
-__for_loop_impl(_ExecutionPolicy&& __exec, _Ip __start, _Ip __finish, _Fp&& __f, _Sp __stride,
+__for_loop_impl(const _ExecutionPolicy& __exec, _Ip __start, _Ip __finish, _Fp&& __f, _Sp __stride,
                 ::std::tuple<_Rest...>&& __t, ::std::index_sequence<_Is...>)
 {
     oneapi::dpl::__internal::__pattern_for_loop(
-        ::std::forward<_ExecutionPolicy>(__exec), __start, __finish, __f, __stride,
+        __exec, __start, __finish, __f, __stride,
         oneapi::dpl::__internal::__use_vectorization<_ExecutionPolicy, _Ip>(__exec),
         oneapi::dpl::__internal::__use_parallelization<_ExecutionPolicy, _Ip>(__exec),
         ::std::get<_Is>(::std::move(__t))...);
@@ -526,11 +526,11 @@ __for_loop_impl(_ExecutionPolicy&& __exec, _Ip __start, _Ip __finish, _Fp&& __f,
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Fp, typename _Sp, typename... _Rest,
           ::std::size_t... _Is>
 void
-__for_loop_n_impl(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Fp&& __f, _Sp __stride,
+__for_loop_n_impl(const _ExecutionPolicy& __exec, _Ip __start, _Size __n, _Fp&& __f, _Sp __stride,
                   ::std::tuple<_Rest...>&& __t, ::std::index_sequence<_Is...>)
 {
     oneapi::dpl::__internal::__pattern_for_loop_n(
-        ::std::forward<_ExecutionPolicy>(__exec), __start, __n, __f, __stride,
+        __exec, __start, __n, __f, __stride,
         oneapi::dpl::__internal::__use_vectorization<_ExecutionPolicy, _Ip>(__exec),
         oneapi::dpl::__internal::__use_parallelization<_ExecutionPolicy, _Ip>(__exec),
         ::std::get<_Is>(::std::move(__t))...);
@@ -538,20 +538,20 @@ __for_loop_n_impl(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Fp&& __f, 
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Sp, typename... _Rest>
 void
-__for_loop_repack(_ExecutionPolicy&& __exec, _Ip __start, _Ip __finish, _Sp __stride, ::std::tuple<_Rest...>&& __t)
+__for_loop_repack(const _ExecutionPolicy& __exec, _Ip __start, _Ip __finish, _Sp __stride, ::std::tuple<_Rest...>&& __t)
 {
     // Extract a callable object from the parameter pack and put it before the other elements
-    oneapi::dpl::__internal::__for_loop_impl(::std::forward<_ExecutionPolicy>(__exec), __start, __finish,
+    oneapi::dpl::__internal::__for_loop_impl(__exec, __start, __finish,
                                              ::std::get<sizeof...(_Rest) - 1>(__t), __stride, ::std::move(__t),
                                              ::std::make_index_sequence<sizeof...(_Rest) - 1>());
 }
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Sp, typename... _Rest>
 void
-__for_loop_repack_n(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Sp __stride, ::std::tuple<_Rest...>&& __t)
+__for_loop_repack_n(const _ExecutionPolicy& __exec, _Ip __start, _Size __n, _Sp __stride, ::std::tuple<_Rest...>&& __t)
 {
     // Extract a callable object from the parameter pack and put it before the other elements
-    oneapi::dpl::__internal::__for_loop_n_impl(::std::forward<_ExecutionPolicy>(__exec), __start, __n,
+    oneapi::dpl::__internal::__for_loop_n_impl(__exec, __start, __n,
                                                ::std::get<sizeof...(_Rest) - 1>(__t), __stride, ::std::move(__t),
                                                ::std::make_index_sequence<sizeof...(_Rest) - 1>());
 }

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -306,7 +306,7 @@ swap_ranges(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardItera
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     return oneapi::dpl::__internal::__pattern_swap(__dispatch_tag, __exec, __first1,
-                                                   __last1, __first2, [](_ReferenceType1 __x, _ReferenceType2 __y) {
+                                                   __last1, __first2, [](_ReferenceType1 __x, _ReferenceType2 __y) {// KSATODO move lambda
                                                        using ::std::swap;
                                                        swap(__x, __y);
                                                    });
@@ -646,7 +646,7 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, __exec, __first, __last,
-                                            __comp, [](auto... __args) { std::sort(__args...); });
+                                            __comp, [](auto... __args) { std::sort(__args...); });// KSATODO move lambda
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
@@ -666,7 +666,7 @@ stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAcc
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, __exec, __first, __last,
-                                            __comp, [](auto... __args) { std::stable_sort(__args...); });
+                                            __comp, [](auto... __args) { std::stable_sort(__args...); });// KSATODO move lambda
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
@@ -689,7 +689,7 @@ sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first, _Ran
 
     oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, __exec,
                                                    __keys_first, __keys_last, __values_first, __comp,
-                                                   [](auto... __args) { std::sort(__args...); });
+                                                   [](auto... __args) { std::sort(__args...); });// KSATODO move lambda
 }
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2>
@@ -713,7 +713,7 @@ stable_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_firs
 
     oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, __exec,
                                                    __keys_first, __keys_last, __values_first, __comp,
-                                                   [](auto... __args) { std::stable_sort(__args...); });
+                                                   [](auto... __args) { std::stable_sort(__args...); });// KSATODO move lambda
 }
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2>

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -224,8 +224,8 @@ search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __s_first);
 
-    return oneapi::dpl::__internal::__pattern_search(__dispatch_tag, __exec, __first,
-                                                     __last, __s_first, __s_last, __pred);
+    return oneapi::dpl::__internal::__pattern_search(__dispatch_tag, __exec, __first, __last, __s_first, __s_last,
+                                                     __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -991,8 +991,8 @@ includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
-    return oneapi::dpl::__internal::__pattern_includes(__dispatch_tag, __exec,
-                                                       __first1, __last1, __first2, __last2, __comp);
+    return oneapi::dpl::__internal::__pattern_includes(__dispatch_tag, __exec, __first1, __last1, __first2, __last2,
+                                                       __comp);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -1037,8 +1037,8 @@ set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Forward
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __result);
 
-    return oneapi::dpl::__internal::__pattern_set_intersection(__dispatch_tag, __exec,
-                                                               __first1, __last1, __first2, __last2, __result, __comp);
+    return oneapi::dpl::__internal::__pattern_set_intersection(__dispatch_tag, __exec, __first1, __last1, __first2,
+                                                               __last2, __result, __comp);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
@@ -1060,8 +1060,8 @@ set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIt
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __result);
 
-    return oneapi::dpl::__internal::__pattern_set_difference(__dispatch_tag, __exec,
-                                                             __first1, __last1, __first2, __last2, __result, __comp);
+    return oneapi::dpl::__internal::__pattern_set_difference(__dispatch_tag, __exec, __first1, __last1, __first2,
+                                                             __last2, __result, __comp);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -293,6 +293,20 @@ copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 
     return oneapi::dpl::__internal::__pattern_copy_if(__dispatch_tag, __exec, __first, __last, __result, __pred);
 }
 
+namespace __internal
+{
+template <typename _ReferenceType1, typename _ReferenceType2>
+struct __swap_ranges_fn
+{
+    void
+    operator()(_ReferenceType1 __x, _ReferenceType2 __y) const
+    {
+        using ::std::swap;
+        swap(__x, __y);
+    }
+};
+} // namespace __internal
+
 // [alg.swap]
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -305,11 +319,9 @@ swap_ranges(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardItera
 
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
-    return oneapi::dpl::__internal::__pattern_swap(__dispatch_tag, __exec, __first1,
-                                                   __last1, __first2, [](_ReferenceType1 __x, _ReferenceType2 __y) {// KSATODO move lambda
-                                                       using ::std::swap;
-                                                       swap(__x, __y);
-                                                   });
+    return oneapi::dpl::__internal::__pattern_swap(
+        __dispatch_tag, __exec, __first1,
+        oneapi::dpl::__internal::__swap_ranges_fn<_ReferenceType1, _ReferenceType2>{});
 }
 
 // [alg.transform]
@@ -637,6 +649,18 @@ partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
                                                              __out_false, __pred);
 }
 
+namespace __internal
+{
+struct __sort_fn
+{
+    void
+    operator()(auto... __args) const
+    {
+        std::sort(__args...);
+    }
+};
+} // namespace __internal
+
 // [alg.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
@@ -645,8 +669,8 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, __exec, __first, __last,
-                                            __comp, [](auto... __args) { std::sort(__args...); });// KSATODO move lambda
+    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, __exec, __first, __last, __comp,
+                                            oneapi::dpl::__internal::__sort_fn{});
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
@@ -657,6 +681,18 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
                       oneapi::dpl::__internal::__pstl_less());
 }
 
+namespace __internal
+{
+struct __stable_sort_fn
+{
+    void
+    operator()(auto... __args) const
+    {
+        std::stable_sort(__args...);
+    }
+};
+} // namespace __internal
+
 // [stable.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
@@ -665,8 +701,8 @@ stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAcc
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, __exec, __first, __last,
-                                            __comp, [](auto... __args) { std::stable_sort(__args...); });// KSATODO move lambda
+    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, __exec, __first, __last, __comp,
+                                            oneapi::dpl::__internal::__stable_sort_fn{});
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
@@ -687,9 +723,8 @@ sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first, _Ran
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __keys_first, __values_first);
 
-    oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, __exec,
-                                                   __keys_first, __keys_last, __values_first, __comp,
-                                                   [](auto... __args) { std::sort(__args...); });// KSATODO move lambda
+    oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, __exec, __keys_first, __keys_last, __values_first,
+                                                   __comp, oneapi::dpl::__internal::__sort_fn{});
 }
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2>
@@ -711,9 +746,8 @@ stable_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_firs
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __keys_first, __values_first);
 
-    oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, __exec,
-                                                   __keys_first, __keys_last, __values_first, __comp,
-                                                   [](auto... __args) { std::stable_sort(__args...); });// KSATODO move lambda
+    oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, __exec, __keys_first, __keys_last, __values_first,
+                                                   __comp, oneapi::dpl::__internal::__stable_sort_fn{});
 }
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2>

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -46,8 +46,7 @@ any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __l
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_any_of(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                     __last, __pred);
+    return oneapi::dpl::__internal::__pattern_any_of(__dispatch_tag, __exec, __first, __last, __pred);
 }
 
 // [alg.all_of]
@@ -78,8 +77,7 @@ for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                             __f);
+    oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, __exec, __first, __last, __f);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function>
@@ -88,8 +86,7 @@ for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, _Func
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                      __n, __f);
+    return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, __exec, __first, __n, __f);
 }
 
 // [alg.find]
@@ -100,8 +97,7 @@ find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_find_if(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                      __last, __pred);
+    return oneapi::dpl::__internal::__pattern_find_if(__dispatch_tag, __exec, __first, __last, __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
@@ -132,8 +128,8 @@ find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __s_first);
 
-    return oneapi::dpl::__internal::__pattern_find_end(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                       __first, __last, __s_first, __s_last, __pred);
+    return oneapi::dpl::__internal::__pattern_find_end(__dispatch_tag, __exec, __first, __last, __s_first, __s_last,
+                                                       __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -153,8 +149,8 @@ find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __s_first);
 
-    return oneapi::dpl::__internal::__pattern_find_first_of(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                            __first, __last, __s_first, __s_last, __pred);
+    return oneapi::dpl::__internal::__pattern_find_first_of(__dispatch_tag, __exec, __first, __last, __s_first,
+                                                            __s_last, __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -175,7 +171,7 @@ adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardItera
 
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_adjacent_find(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_adjacent_find(__dispatch_tag, __exec,
                                                             __first, __last, ::std::equal_to<_ValueType>(),
                                                             oneapi::dpl::__internal::__first_semantic());
 }
@@ -186,7 +182,7 @@ adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardItera
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_adjacent_find(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_adjacent_find(__dispatch_tag, __exec,
                                                             __first, __last, __pred,
                                                             oneapi::dpl::__internal::__first_semantic());
 }
@@ -204,7 +200,7 @@ count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __la
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     return oneapi::dpl::__internal::__pattern_count(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __dispatch_tag, __exec, __first, __last,
         oneapi::dpl::__internal::__equal_value<oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>>(
             __value));
 }
@@ -216,8 +212,7 @@ count_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_count(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                    __last, __pred);
+    return oneapi::dpl::__internal::__pattern_count(__dispatch_tag, __exec, __first, __last, __pred);
 }
 
 // [alg.search]
@@ -229,7 +224,7 @@ search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __s_first);
 
-    return oneapi::dpl::__internal::__pattern_search(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
+    return oneapi::dpl::__internal::__pattern_search(__dispatch_tag, __exec, __first,
                                                      __last, __s_first, __s_last, __pred);
 }
 
@@ -249,8 +244,8 @@ search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_search_n(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                       __first, __last, __count, __value, __pred);
+    return oneapi::dpl::__internal::__pattern_search_n(__dispatch_tag, __exec, __first, __last, __count, __value,
+                                                       __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
@@ -271,7 +266,7 @@ copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __l
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_walk2_brick(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+        __dispatch_tag, __exec, __first, __last, __result,
         oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _ExecutionPolicy>{});
 }
 
@@ -284,7 +279,7 @@ copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _Forward
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_walk2_brick_n(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+        __dispatch_tag, __exec, __first, __n, __result,
         oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
 }
 
@@ -295,8 +290,7 @@ copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    return oneapi::dpl::__internal::__pattern_copy_if(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                      __last, __result, __pred);
+    return oneapi::dpl::__internal::__pattern_copy_if(__dispatch_tag, __exec, __first, __last, __result, __pred);
 }
 
 // [alg.swap]
@@ -311,7 +305,7 @@ swap_ranges(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardItera
 
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
-    return oneapi::dpl::__internal::__pattern_swap(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1,
+    return oneapi::dpl::__internal::__pattern_swap(__dispatch_tag, __exec, __first1,
                                                    __last1, __first2, [](_ReferenceType1 __x, _ReferenceType2 __y) {
                                                        using ::std::swap;
                                                        swap(__x, __y);
@@ -328,7 +322,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_walk2(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+        __dispatch_tag, __exec, __first, __last, __result,
         oneapi::dpl::__internal::__transform_functor<_UnaryOperation>{::std::move(__op)});
 }
 
@@ -342,7 +336,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __result);
 
     return oneapi::dpl::__internal::__pattern_walk3(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
+        __dispatch_tag, __exec, __first1, __last1, __first2, __result,
         oneapi::dpl::__internal::__transform_functor<_BinaryOperation>(::std::move(__op)));
 }
 
@@ -357,7 +351,7 @@ transform_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardItera
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_walk2_transform_if(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+        __dispatch_tag, __exec, __first, __last, __result,
         oneapi::dpl::__internal::__transform_if_unary_functor<_UnaryOperation, _UnaryPredicate>(::std::move(__op),
                                                                                                 ::std::move(__pred)));
 }
@@ -371,7 +365,7 @@ transform_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIter
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __result);
 
     return oneapi::dpl::__internal::__pattern_walk3_transform_if(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
+        __dispatch_tag, __exec, __first1, __last1, __first2, __result,
         oneapi::dpl::__internal::__transform_if_binary_functor<_BinaryOperation, _BinaryPredicate>(
             ::std::move(__op), ::std::move(__pred)));
 }
@@ -386,7 +380,7 @@ replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     oneapi::dpl::__internal::__pattern_walk1(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __dispatch_tag, __exec, __first, __last,
         oneapi::dpl::__internal::__replace_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>(__new_value, __pred));
@@ -412,7 +406,7 @@ replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_walk2(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+        __dispatch_tag, __exec, __first, __last, __result,
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
             ::std::conditional_t<oneapi::dpl::__internal::__is_const_callable_object_v<_UnaryPredicate>,
@@ -441,8 +435,7 @@ fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __las
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_fill(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                            __value);
+    oneapi::dpl::__internal::__pattern_fill(__dispatch_tag, __exec, __first, __last, __value);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
@@ -454,8 +447,7 @@ fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, const
 
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_fill_n(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                     __count, __value);
+    return oneapi::dpl::__internal::__pattern_fill_n(__dispatch_tag, __exec, __first, __count, __value);
 }
 
 // [alg.generate]
@@ -465,8 +457,7 @@ generate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_generate(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                __last, __g);
+    oneapi::dpl::__internal::__pattern_generate(__dispatch_tag, __exec, __first, __last, __g);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Generator>
@@ -478,8 +469,7 @@ generate_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, _
 
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_generate_n(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                         __first, __count, __g);
+    return oneapi::dpl::__internal::__pattern_generate_n(__dispatch_tag, __exec, __first, __count, __g);
 }
 
 // [alg.remove]
@@ -512,8 +502,7 @@ remove_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator 
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_remove_if(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                        __first, __last, __pred);
+    return oneapi::dpl::__internal::__pattern_remove_if(__dispatch_tag, __exec, __first, __last, __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
@@ -534,8 +523,7 @@ unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __l
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_unique(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                     __last, __pred);
+    return oneapi::dpl::__internal::__pattern_unique(__dispatch_tag, __exec, __first, __last, __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator>
@@ -553,8 +541,7 @@ unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterat
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    return oneapi::dpl::__internal::__pattern_unique_copy(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          __first, __last, __result, __pred);
+    return oneapi::dpl::__internal::__pattern_unique_copy(__dispatch_tag, __exec, __first, __last, __result, __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -573,8 +560,7 @@ reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _Bidirectiona
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_reverse(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                               __last);
+    oneapi::dpl::__internal::__pattern_reverse(__dispatch_tag, __exec, __first, __last);
 }
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _ForwardIterator>
@@ -584,8 +570,7 @@ reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _Bidirec
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __d_first);
 
-    return oneapi::dpl::__internal::__pattern_reverse_copy(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                           __first, __last, __d_first);
+    return oneapi::dpl::__internal::__pattern_reverse_copy(__dispatch_tag, __exec, __first, __last, __d_first);
 }
 
 // [alg.rotate]
@@ -596,8 +581,7 @@ rotate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __m
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_rotate(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                     __middle, __last);
+    return oneapi::dpl::__internal::__pattern_rotate(__dispatch_tag, __exec, __first, __middle, __last);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -607,8 +591,7 @@ rotate_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterat
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    return oneapi::dpl::__internal::__pattern_rotate_copy(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          __first, __middle, __last, __result);
+    return oneapi::dpl::__internal::__pattern_rotate_copy(__dispatch_tag, __exec, __first, __middle, __last, __result);
 }
 
 // [alg.partitions]
@@ -619,8 +602,7 @@ is_partitioned(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_is_partitioned(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                             __first, __last, __pred);
+    return oneapi::dpl::__internal::__pattern_is_partitioned(__dispatch_tag, __exec, __first, __last, __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
@@ -629,8 +611,7 @@ partition(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator 
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_partition(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                        __first, __last, __pred);
+    return oneapi::dpl::__internal::__pattern_partition(__dispatch_tag, __exec, __first, __last, __pred);
 }
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate>
@@ -640,8 +621,7 @@ stable_partition(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _Bid
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_stable_partition(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                               __first, __last, __pred);
+    return oneapi::dpl::__internal::__pattern_stable_partition(__dispatch_tag, __exec, __first, __last, __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _ForwardIterator1, class _ForwardIterator2,
@@ -653,8 +633,8 @@ partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __out_true, __out_false);
 
-    return oneapi::dpl::__internal::__pattern_partition_copy(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                             __first, __last, __out_true, __out_false, __pred);
+    return oneapi::dpl::__internal::__pattern_partition_copy(__dispatch_tag, __exec, __first, __last, __out_true,
+                                                             __out_false, __pred);
 }
 
 // [alg.sort]
@@ -665,7 +645,7 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, __exec, __first, __last,
                                             __comp, [](auto... __args) { std::sort(__args...); });
 }
 
@@ -685,7 +665,7 @@ stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAcc
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, __exec, __first, __last,
                                             __comp, [](auto... __args) { std::stable_sort(__args...); });
 }
 
@@ -707,7 +687,7 @@ sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first, _Ran
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __keys_first, __values_first);
 
-    oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, __exec,
                                                    __keys_first, __keys_last, __values_first, __comp,
                                                    [](auto... __args) { std::sort(__args...); });
 }
@@ -731,7 +711,7 @@ stable_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_firs
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __keys_first, __values_first);
 
-    oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, __exec,
                                                    __keys_first, __keys_last, __values_first, __comp,
                                                    [](auto... __args) { std::stable_sort(__args...); });
 }
@@ -755,8 +735,8 @@ mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
-    return oneapi::dpl::__internal::__pattern_mismatch(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                       __first1, __last1, __first2, __last2, __pred);
+    return oneapi::dpl::__internal::__pattern_mismatch(__dispatch_tag, __exec, __first1, __last1, __first2, __last2,
+                                                       __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
@@ -799,8 +779,7 @@ equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
-    return oneapi::dpl::__internal::__pattern_equal(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1,
-                                                    __last1, __first2, __p);
+    return oneapi::dpl::__internal::__pattern_equal(__dispatch_tag, __exec, __first1, __last1, __first2, __p);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -818,8 +797,7 @@ equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
-    return oneapi::dpl::__internal::__pattern_equal(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1,
-                                                    __last1, __first2, __last2, __p);
+    return oneapi::dpl::__internal::__pattern_equal(__dispatch_tag, __exec, __first1, __last1, __first2, __last2, __p);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -841,7 +819,7 @@ move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __l
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __d_first);
 
     return oneapi::dpl::__internal::__pattern_walk2_brick(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first,
+        __dispatch_tag, __exec, __first, __last, __d_first,
         oneapi::dpl::__internal::__brick_move<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
 }
 
@@ -854,8 +832,7 @@ partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAc
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_partial_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                    __middle, __last, __comp);
+    oneapi::dpl::__internal::__pattern_partial_sort(__dispatch_tag, __exec, __first, __middle, __last, __comp);
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
@@ -877,7 +854,7 @@ partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardI
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __d_first);
 
     return oneapi::dpl::__internal::__pattern_partial_sort_copy(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first, __d_last, __comp);
+        __dispatch_tag, __exec, __first, __last, __d_first, __d_last, __comp);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator>
@@ -897,7 +874,7 @@ is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIte
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     const _ForwardIterator __res = oneapi::dpl::__internal::__pattern_adjacent_find(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __dispatch_tag, __exec, __first, __last,
         oneapi::dpl::__internal::__reorder_pred<_Compare>(__comp), oneapi::dpl::__internal::__first_semantic());
     return __res == __last ? __last : oneapi::dpl::__internal::__pstl_next(__res);
 }
@@ -916,7 +893,7 @@ is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator 
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_adjacent_find(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_adjacent_find(__dispatch_tag, __exec,
                                                             __first, __last,
                                                             oneapi::dpl::__internal::__reorder_pred<_Compare>(__comp),
                                                             oneapi::dpl::__internal::__or_semantic()) == __last;
@@ -939,7 +916,7 @@ merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __d_first);
 
-    return oneapi::dpl::__internal::__pattern_merge(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1,
+    return oneapi::dpl::__internal::__pattern_merge(__dispatch_tag, __exec, __first1,
                                                     __last1, __first2, __last2, __d_first, __comp);
 }
 
@@ -959,8 +936,7 @@ inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _Bidire
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_inplace_merge(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                     __middle, __last, __comp);
+    oneapi::dpl::__internal::__pattern_inplace_merge(__dispatch_tag, __exec, __first, __middle, __last, __comp);
 }
 
 template <class _ExecutionPolicy, class _BidirectionalIterator>
@@ -981,7 +957,7 @@ includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
-    return oneapi::dpl::__internal::__pattern_includes(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_includes(__dispatch_tag, __exec,
                                                        __first1, __last1, __first2, __last2, __comp);
 }
 
@@ -1004,8 +980,8 @@ set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __result);
 
-    return oneapi::dpl::__internal::__pattern_set_union(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                        __first1, __last1, __first2, __last2, __result, __comp);
+    return oneapi::dpl::__internal::__pattern_set_union(__dispatch_tag, __exec, __first1, __last1, __first2, __last2,
+                                                        __result, __comp);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
@@ -1027,7 +1003,7 @@ set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Forward
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __result);
 
-    return oneapi::dpl::__internal::__pattern_set_intersection(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_set_intersection(__dispatch_tag, __exec,
                                                                __first1, __last1, __first2, __last2, __result, __comp);
 }
 
@@ -1050,7 +1026,7 @@ set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIt
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __result);
 
-    return oneapi::dpl::__internal::__pattern_set_difference(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_set_difference(__dispatch_tag, __exec,
                                                              __first1, __last1, __first2, __last2, __result, __comp);
 }
 
@@ -1074,9 +1050,8 @@ set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, 
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2, __result);
 
-    return oneapi::dpl::__internal::__pattern_set_symmetric_difference(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
-        __comp);
+    return oneapi::dpl::__internal::__pattern_set_symmetric_difference(__dispatch_tag, __exec, __first1, __last1,
+                                                                       __first2, __last2, __result, __comp);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
@@ -1095,8 +1070,7 @@ is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomA
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_is_heap_until(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                            __first, __last, __comp);
+    return oneapi::dpl::__internal::__pattern_is_heap_until(__dispatch_tag, __exec, __first, __last, __comp);
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
@@ -1113,8 +1087,7 @@ is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessI
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_is_heap(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                      __last, __comp);
+    return oneapi::dpl::__internal::__pattern_is_heap(__dispatch_tag, __exec, __first, __last, __comp);
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
@@ -1133,8 +1106,7 @@ min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterato
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_min_element(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          __first, __last, __comp);
+    return oneapi::dpl::__internal::__pattern_min_element(__dispatch_tag, __exec, __first, __last, __comp);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator>
@@ -1168,8 +1140,7 @@ minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_minmax_element(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                             __first, __last, __comp);
+    return oneapi::dpl::__internal::__pattern_minmax_element(__dispatch_tag, __exec, __first, __last, __comp);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator>
@@ -1189,8 +1160,7 @@ nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAcc
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_nth_element(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                   __nth, __last, __comp);
+    oneapi::dpl::__internal::__pattern_nth_element(__dispatch_tag, __exec, __first, __nth, __last, __comp);
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
@@ -1211,8 +1181,8 @@ lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
-    return oneapi::dpl::__internal::__pattern_lexicographical_compare(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __comp);
+    return oneapi::dpl::__internal::__pattern_lexicographical_compare(__dispatch_tag, __exec, __first1, __last1,
+                                                                      __first2, __last2, __comp);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
@@ -1233,8 +1203,7 @@ shift_left(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_shift_left(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                         __first, __last, __n);
+    return oneapi::dpl::__internal::__pattern_shift_left(__dispatch_tag, __exec, __first, __last, __n);
 }
 
 // [shift.right]
@@ -1246,8 +1215,7 @@ shift_right(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _Bidirect
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_shift_right(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          __first, __last, __n);
+    return oneapi::dpl::__internal::__pattern_shift_right(__dispatch_tag, __exec, __first, __last, __n);
 }
 
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -824,7 +824,7 @@ swap_ranges(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
 
     return oneapi::dpl::__internal::__ranges::__pattern_swap(
         __dispatch_tag, __exec, views::all(::std::forward<_Range1>(__rng1)),
-        views::all(::std::forward<_Range2>(__rng2)), [](_ReferenceType1 __x, _ReferenceType2 __y) {
+        views::all(::std::forward<_Range2>(__rng2)), [](_ReferenceType1 __x, _ReferenceType2 __y) { // KSATODO need to move out
             using ::std::swap;
             swap(__x, __y);
         });
@@ -839,7 +839,7 @@ transform(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, _Unary
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng, __result);
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-        __dispatch_tag, __exec, [__op](auto x, auto& z) { z = __op(x); },
+        __dispatch_tag, __exec, [__op](auto x, auto& z) { z = __op(x); }, // KSATODO need to move out
         views::all_read(::std::forward<_Range1>(__rng)), views::all_write(::std::forward<_Range2>(__result)));
 }
 
@@ -850,7 +850,7 @@ transform(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2, __result);
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-        __dispatch_tag, __exec, [__op](auto x, auto y, auto& z) { z = __op(x, y); },
+        __dispatch_tag, __exec, [__op](auto x, auto y, auto& z) { z = __op(x, y); }, // KSATODO need to move out
         views::all_read(::std::forward<_Range1>(__rng1)), views::all_read(::std::forward<_Range2>(__rng2)),
         views::all_write(::std::forward<_Range3>(__result)));
 }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -60,11 +60,10 @@ struct __for_each_fn
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
 
     std::ranges::borrowed_iterator_t<_R>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Fun __f, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Fun __f, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        oneapi::dpl::__internal::__ranges::__pattern_for_each(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __r, __f, __proj);
+        oneapi::dpl::__internal::__ranges::__pattern_for_each(__dispatch_tag, __exec, __r, __f, __proj);
 
         return {std::ranges::begin(__r) + std::ranges::size(__r)};
     }
@@ -86,14 +85,14 @@ struct __transform_fn
                  std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
 
     std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutRange&& __out_r, _F __op, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _OutRange&& __out_r, _F __op, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutRange>>;
         const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
 
-        oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, __exec,
             std::ranges::take_view(__r, __size), std::ranges::take_view(__out_r, __size), __op, __proj);
 
         return {std::ranges::begin(__r) + __size, std::ranges::begin(__out_r) +  __size};
@@ -110,7 +109,7 @@ struct __transform_fn
 
     std::ranges::binary_transform_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
         std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _F __binary_op,
+    operator()(const _ExecutionPolicy& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _F __binary_op,
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
@@ -124,7 +123,7 @@ struct __transform_fn
             __size = std::ranges::min(__size, (_Size)std::ranges::size(__r2));
 
         //take_view doesn't make unsized range sized, so subrange is used below
-        oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, __exec,
             std::ranges::subrange(std::ranges::begin(__r1), std::ranges::begin(__r1) + __size),
             std::ranges::subrange(std::ranges::begin(__r2), std::ranges::begin(__r2) + __size),
             std::ranges::take_view(__out_r, __size), __binary_op, __proj1, __proj2);
@@ -146,11 +145,11 @@ struct __find_if_fn
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_find_if(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __pred, __proj);
+        return oneapi::dpl::__internal::__ranges::__pattern_find_if(__dispatch_tag, __exec, std::forward<_R>(__r),
+                                                                    __pred, __proj);
     }
 }; //__find_if_fn
 }  //__internal
@@ -167,9 +166,9 @@ struct __find_if_not_fn
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
-        return oneapi::dpl::ranges::find_if(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
+        return oneapi::dpl::ranges::find_if(__exec, std::forward<_R>(__r),
             oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy,
             _Pred>>(__pred), __proj);
     }
@@ -190,9 +189,9 @@ struct __find_fn
         && std::indirect_binary_predicate<std::ranges::equal_to, std::projected<std::ranges::iterator_t<_R>, _Proj>,
         const _T*>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
-        return oneapi::dpl::ranges::find_if(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
+        return oneapi::dpl::ranges::find_if(__exec, std::forward<_R>(__r),
             oneapi::dpl::__internal::__equal_value<oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy,
             const _T>>(__value), __proj);
     }
@@ -209,11 +208,11 @@ struct __any_of_fn
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
     bool
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_any_of(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __pred, __proj);
+        return oneapi::dpl::__internal::__ranges::__pattern_any_of(__dispatch_tag, __exec, std::forward<_R>(__r),
+                                                                   __pred, __proj);
     }
 }; //__any_of_fn
 }  //__internal
@@ -228,9 +227,9 @@ struct __all_of_fn
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
     bool
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
-        return !oneapi::dpl::ranges::any_of(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
+        return !oneapi::dpl::ranges::any_of(__exec, std::forward<_R>(__r),
             oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _Pred>>(__pred),
             __proj);
     }
@@ -247,10 +246,9 @@ struct __none_of_fn
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
     bool
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
-        return !oneapi::dpl::ranges::any_of(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            __pred, __proj);
+        return !oneapi::dpl::ranges::any_of(__exec, std::forward<_R>(__r), __pred, __proj);
     }
 }; //__none_of_fn
 }  //__internal
@@ -266,11 +264,11 @@ struct __adjacent_find_fn
              std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred = std::ranges::equal_to>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred = {}, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_adjacent_find_ranges(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __pred, __proj);
+            __exec, std::forward<_R>(__r), __pred, __proj);
     }
 }; //__adjacent_find_fn
 }  //__internal
@@ -287,12 +285,12 @@ struct __search_fn
         && std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2>
         && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
+    operator()(const _ExecutionPolicy& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
         _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_search(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2), __pred, __proj1,
+            __exec, std::forward<_R1>(__r1), std::forward<_R2>(__r2), __pred, __proj1,
             __proj2);
     }
 }; //__search_fn
@@ -309,12 +307,12 @@ struct __search_n_fn
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
         && std::indirectly_comparable<std::ranges::iterator_t<_R>, const _T*, _Pred, _Proj>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __count, const _T& __value,
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, std::ranges::range_difference_t<_R> __count, const _T& __value,
         _Pred __pred = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_search_n(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __count, __value, __pred, __proj);
+            __exec, std::forward<_R>(__r), __count, __value, __pred, __proj);
     }
 }; //__search_n_fn
 }  //__internal
@@ -330,11 +328,11 @@ struct __count_if_fn
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
 
     std::ranges::range_difference_t<_R>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_count_if(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __pred, __proj);
+            __exec, std::forward<_R>(__r), __pred, __proj);
     }
 }; //__count_if_fn
 }  //__internal
@@ -351,12 +349,11 @@ struct __count_fn
         && std::indirect_binary_predicate<std::ranges::equal_to, std::projected<std::ranges::iterator_t<_R>, _Proj>,
         const _T*>
     std::ranges::range_difference_t<_R>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
         auto __pred = [__value](auto&& __val) { return std::ranges::equal_to{}(
             std::forward<decltype(__val)>(__val), __value);};
-        return oneapi::dpl::ranges::count_if(std::forward<_ExecutionPolicy>(__exec),
-            std::forward<_R>(__r), __pred, __proj);
+        return oneapi::dpl::ranges::count_if(__exec, std::forward<_R>(__r), __pred, __proj);
     }
 }; //__count_fn
 }  //__internal
@@ -374,7 +371,7 @@ struct __equal_fn
            && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
            _Proj2>
     bool
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
+    operator()(const _ExecutionPolicy& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
     {
         if constexpr(!std::ranges::sized_range<_R1> || !std::ranges::sized_range<_R2>)
@@ -383,7 +380,7 @@ struct __equal_fn
         {
             const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
             return oneapi::dpl::__internal::__ranges::__pattern_equal(__dispatch_tag,
-                std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2), __pred,
+                __exec, std::forward<_R1>(__r1), std::forward<_R2>(__r2), __pred,
                 __proj1, __proj2);
         }
     }
@@ -401,11 +398,11 @@ struct __is_sorted_fn
              _Comp = std::ranges::less>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
     bool
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_is_sorted(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj);
+            __exec, std::forward<_R>(__r), __comp, __proj);
     }
 }; //__is_sorted_fn
 }  //__internal
@@ -421,11 +418,11 @@ struct __stable_sort_fn
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
            && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
+            __dispatch_tag, __exec, std::forward<_R>(__r), __comp, __proj,
             [](auto&&... __args) { return std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); });
     }
 }; //__stable_sort_fn
@@ -442,11 +439,11 @@ struct __sort_fn
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
            && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
+            __dispatch_tag, __exec, std::forward<_R>(__r), __comp, __proj,
             [](auto&&... __args) { return std::ranges::sort(std::forward<decltype(__args)>(__args)...); });
     }
 }; //__sort_fn
@@ -463,11 +460,11 @@ struct __min_element_fn
              _Comp = std::ranges::less>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_min_element(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj);
+            __exec, std::forward<_R>(__r), __comp, __proj);
     }
 }; //__min_element_fn
 }  //__internal
@@ -482,9 +479,9 @@ struct __max_element_fn
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
-        return oneapi::dpl::ranges::min_element(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
+        return oneapi::dpl::ranges::min_element(__exec, std::forward<_R>(__r),
             oneapi::dpl::__internal::__reorder_pred(__comp), __proj);
     }
 }; //__max_element_fn
@@ -503,14 +500,14 @@ struct __copy_fn
         && std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
 
     std::ranges::copy_result<std::ranges::borrowed_iterator_t<_InRange>, std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
+    operator()(const _ExecutionPolicy& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_InRange>, std::ranges::range_size_t<_OutRange>>;
         const _Size __size = std::ranges::min((_Size)std::ranges::size(__in_r), (_Size)std::ranges::size(__out_r));
 
-        oneapi::dpl::__internal::__ranges::__pattern_copy(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__internal::__ranges::__pattern_copy(__dispatch_tag, __exec,
             std::ranges::take_view(__in_r, __size), std::ranges::take_view(__out_r, __size));
 
         return {std::ranges::begin(__in_r) + __size, std::ranges::begin(__out_r) +  __size};
@@ -531,11 +528,11 @@ struct __copy_if_fn
         && std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange>
         && std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
     auto
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Pred __pred, _Proj __proj = {}) const
+    operator()(const _ExecutionPolicy& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         // No minimum common size is calculated here, because the size of the output range is unknown
-        return oneapi::dpl::__internal::__ranges::__pattern_copy_if_ranges(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
+        return oneapi::dpl::__internal::__ranges::__pattern_copy_if_ranges(__dispatch_tag, __exec,
             std::forward<_InRange>(__in_r), std::forward<_OutRange>(__out_r), __pred, __proj);
     }
 }; //__copy_if_fn
@@ -555,12 +552,12 @@ struct __merge_fn
         && std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
         std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
     auto
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {}, _Proj1 __proj1 = {},
+    operator()(const _ExecutionPolicy& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
     {
         // TODO: develop a strategy to get a common minimum size
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_merge(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
+        return oneapi::dpl::__internal::__ranges::__pattern_merge(__dispatch_tag, __exec,
             std::forward<_R1>(__r1), std::forward<_R2>(__r2), std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
     }
 }; //__merge_fn

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -267,8 +267,8 @@ struct __adjacent_find_fn
     operator()(const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_adjacent_find_ranges(__dispatch_tag,
-            __exec, std::forward<_R>(__r), __pred, __proj);
+        return oneapi::dpl::__internal::__ranges::__pattern_adjacent_find_ranges(__dispatch_tag, __exec,
+                                                                                 std::forward<_R>(__r), __pred, __proj);
     }
 }; //__adjacent_find_fn
 }  //__internal
@@ -289,9 +289,8 @@ struct __search_fn
         _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_search(__dispatch_tag,
-            __exec, std::forward<_R1>(__r1), std::forward<_R2>(__r2), __pred, __proj1,
-            __proj2);
+        return oneapi::dpl::__internal::__ranges::__pattern_search(__dispatch_tag, __exec, std::forward<_R1>(__r1),
+                                                                   std::forward<_R2>(__r2), __pred, __proj1, __proj2);
     }
 }; //__search_fn
 }  //__internal
@@ -311,8 +310,8 @@ struct __search_n_fn
         _Pred __pred = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_search_n(__dispatch_tag,
-            __exec, std::forward<_R>(__r), __count, __value, __pred, __proj);
+        return oneapi::dpl::__internal::__ranges::__pattern_search_n(__dispatch_tag, __exec, std::forward<_R>(__r),
+                                                                     __count, __value, __pred, __proj);
     }
 }; //__search_n_fn
 }  //__internal
@@ -331,8 +330,8 @@ struct __count_if_fn
     operator()(const _ExecutionPolicy& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_count_if(__dispatch_tag,
-            __exec, std::forward<_R>(__r), __pred, __proj);
+        return oneapi::dpl::__internal::__ranges::__pattern_count_if(__dispatch_tag, __exec, std::forward<_R>(__r),
+                                                                     __pred, __proj);
     }
 }; //__count_if_fn
 }  //__internal
@@ -351,8 +350,9 @@ struct __count_fn
     std::ranges::range_difference_t<_R>
     operator()(const _ExecutionPolicy& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
-        auto __pred = [__value](auto&& __val) { return std::ranges::equal_to{}(
-            std::forward<decltype(__val)>(__val), __value);};
+        auto __pred = [__value](auto&& __val) {
+            return std::ranges::equal_to{}(std::forward<decltype(__val)>(__val), __value);
+        };
         return oneapi::dpl::ranges::count_if(__exec, std::forward<_R>(__r), __pred, __proj);
     }
 }; //__count_fn
@@ -379,9 +379,8 @@ struct __equal_fn
         else
         {
             const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-            return oneapi::dpl::__internal::__ranges::__pattern_equal(__dispatch_tag,
-                __exec, std::forward<_R1>(__r1), std::forward<_R2>(__r2), __pred,
-                __proj1, __proj2);
+            return oneapi::dpl::__internal::__ranges::__pattern_equal(
+                __dispatch_tag, __exec, std::forward<_R1>(__r1), std::forward<_R2>(__r2), __pred, __proj1, __proj2);
         }
     }
 }; //__equal_fn
@@ -401,8 +400,8 @@ struct __is_sorted_fn
     operator()(const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_is_sorted(__dispatch_tag,
-            __exec, std::forward<_R>(__r), __comp, __proj);
+        return oneapi::dpl::__internal::__ranges::__pattern_is_sorted(__dispatch_tag, __exec, std::forward<_R>(__r),
+                                                                      __comp, __proj);
     }
 }; //__is_sorted_fn
 }  //__internal
@@ -463,8 +462,8 @@ struct __min_element_fn
     operator()(const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_min_element(__dispatch_tag,
-            __exec, std::forward<_R>(__r), __comp, __proj);
+        return oneapi::dpl::__internal::__ranges::__pattern_min_element(__dispatch_tag, __exec, std::forward<_R>(__r),
+                                                                        __comp, __proj);
     }
 }; //__min_element_fn
 }  //__internal
@@ -482,7 +481,7 @@ struct __max_element_fn
     operator()(const _ExecutionPolicy& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         return oneapi::dpl::ranges::min_element(__exec, std::forward<_R>(__r),
-            oneapi::dpl::__internal::__reorder_pred(__comp), __proj);
+                                                oneapi::dpl::__internal::__reorder_pred(__comp), __proj);
     }
 }; //__max_element_fn
 }  //__internal
@@ -532,8 +531,8 @@ struct __copy_if_fn
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         // No minimum common size is calculated here, because the size of the output range is unknown
-        return oneapi::dpl::__internal::__ranges::__pattern_copy_if_ranges(__dispatch_tag, __exec,
-            std::forward<_InRange>(__in_r), std::forward<_OutRange>(__out_r), __pred, __proj);
+        return oneapi::dpl::__internal::__ranges::__pattern_copy_if_ranges(
+            __dispatch_tag, __exec, std::forward<_InRange>(__in_r), std::forward<_OutRange>(__out_r), __pred, __proj);
     }
 }; //__copy_if_fn
 }  //__internal
@@ -557,8 +556,9 @@ struct __merge_fn
     {
         // TODO: develop a strategy to get a common minimum size
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_merge(__dispatch_tag, __exec,
-            std::forward<_R1>(__r1), std::forward<_R2>(__r2), std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+        return oneapi::dpl::__internal::__ranges::__pattern_merge(
+            __dispatch_tag, __exec, std::forward<_R1>(__r1), std::forward<_R2>(__r2), std::forward<_OutRange>(__out_r),
+            __comp, __proj1, __proj2);
     }
 }; //__merge_fn
 }  //__internal

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -583,7 +583,7 @@ any_of(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred)
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
-    return oneapi::dpl::__internal::__ranges::__pattern_any_of(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__ranges::__pattern_any_of(__dispatch_tag, __exec,
                                                                views::all_read(::std::forward<_Range>(__rng)), __pred);
 }
 
@@ -616,7 +616,7 @@ for_each(_ExecutionPolicy&& __exec, _Range&& __rng, _Function __f)
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
-    oneapi::dpl::__internal::__ranges::__pattern_walk_n(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __f,
+    oneapi::dpl::__internal::__ranges::__pattern_walk_n(__dispatch_tag, __exec, __f,
                                                         views::all(::std::forward<_Range>(__rng)));
 }
 
@@ -628,8 +628,7 @@ find_if(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred)
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
-    return oneapi::dpl::__internal::__ranges::__pattern_find_if(__dispatch_tag,
-                                                                ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__ranges::__pattern_find_if(__dispatch_tag, __exec,
                                                                 views::all_read(::std::forward<_Range>(__rng)), __pred);
 }
 
@@ -663,7 +662,7 @@ find_end(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _BinaryP
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2);
 
     return oneapi::dpl::__internal::__ranges::__pattern_find_end(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng1)),
         views::all_read(::std::forward<_Range2>(__rng2)), __pred);
 }
 
@@ -686,7 +685,7 @@ find_first_of(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Bi
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2);
 
     return oneapi::dpl::__internal::__ranges::__pattern_find_first_of(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng1)),
         views::all_read(::std::forward<_Range2>(__rng2)), __pred);
 }
 
@@ -708,7 +707,7 @@ adjacent_find(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredicate __pred
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
     return oneapi::dpl::__internal::__ranges::__pattern_adjacent_find(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range>(__rng)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range>(__rng)),
         __pred, oneapi::dpl::__internal::__first_semantic());
 }
 
@@ -729,7 +728,7 @@ count_if(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred)
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
-    return oneapi::dpl::__internal::__ranges::__pattern_count(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__ranges::__pattern_count(__dispatch_tag, __exec,
                                                               views::all_read(::std::forward<_Range>(__rng)), __pred);
 }
 
@@ -753,7 +752,7 @@ search(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _BinaryPre
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2);
 
     return oneapi::dpl::__internal::__ranges::__pattern_search(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng1)),
         views::all_read(::std::forward<_Range2>(__rng2)), __pred);
 }
 
@@ -773,7 +772,7 @@ search_n(_ExecutionPolicy&& __exec, _Range&& __rng, _Size __count, const _Tp& __
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
     return oneapi::dpl::__internal::__ranges::__pattern_search_n(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range>(__rng)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range>(__rng)),
         __count, __value, __pred);
 }
 
@@ -794,7 +793,7 @@ copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result)
     auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng, __result);
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+        __dispatch_tag, __exec,
         oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _ExecutionPolicy>{},
         views::all_read(::std::forward<_Range1>(__rng)), views::all_write(::std::forward<_Range2>(__result)));
 }
@@ -807,7 +806,7 @@ copy_if(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, _Predica
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng, __result);
 
     return oneapi::dpl::__internal::__ranges::__pattern_copy_if(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng)),
         views::all_write(::std::forward<_Range2>(__result)), __pred, oneapi::dpl::__internal::__pstl_assign());
 }
 
@@ -824,7 +823,7 @@ swap_ranges(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
     using _ReferenceType2 = oneapi::dpl::__internal::__value_t<_Range2>&;
 
     return oneapi::dpl::__internal::__ranges::__pattern_swap(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all(::std::forward<_Range1>(__rng1)),
         views::all(::std::forward<_Range2>(__rng2)), [](_ReferenceType1 __x, _ReferenceType2 __y) {
             using ::std::swap;
             swap(__x, __y);
@@ -840,7 +839,7 @@ transform(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, _Unary
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng, __result);
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), [__op](auto x, auto& z) { z = __op(x); },
+        __dispatch_tag, __exec, [__op](auto x, auto& z) { z = __op(x); },
         views::all_read(::std::forward<_Range1>(__rng)), views::all_write(::std::forward<_Range2>(__result)));
 }
 
@@ -851,7 +850,7 @@ transform(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2, __result);
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), [__op](auto x, auto y, auto& z) { z = __op(x, y); },
+        __dispatch_tag, __exec, [__op](auto x, auto y, auto& z) { z = __op(x, y); },
         views::all_read(::std::forward<_Range1>(__rng1)), views::all_read(::std::forward<_Range2>(__rng2)),
         views::all_write(::std::forward<_Range3>(__result)));
 }
@@ -865,7 +864,7 @@ remove_if(_ExecutionPolicy&& __exec, _Range&& __rng, _UnaryPredicate __pred)
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
     return oneapi::dpl::__internal::__ranges::__pattern_remove_if(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all(::std::forward<_Range>(__rng)), __pred);
+        __dispatch_tag, __exec, views::all(::std::forward<_Range>(__rng)), __pred);
 }
 
 template <typename _ExecutionPolicy, typename _Range, typename _Tp>
@@ -908,7 +907,7 @@ unique(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredicate __pred)
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
-    return oneapi::dpl::__internal::__ranges::__pattern_unique(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__ranges::__pattern_unique(__dispatch_tag, __exec,
                                                                views::all(::std::forward<_Range>(__rng)), __pred);
 }
 
@@ -928,7 +927,7 @@ unique_copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, _Bin
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng, __result);
 
     return oneapi::dpl::__internal::__ranges::__pattern_unique_copy(
-        __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), views::all_read(std::forward<_Range1>(__rng)),
+        __dispatch_tag, __exec, views::all_read(std::forward<_Range1>(__rng)),
         views::all_write(std::forward<_Range2>(__result)), __pred);
 }
 
@@ -987,7 +986,7 @@ replace_if(_ExecutionPolicy&& __exec, _Range&& __rng, _UnaryPredicate __pred, co
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+        __dispatch_tag, __exec,
         oneapi::dpl::__internal::__replace_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>(__new_value, __pred),
@@ -1015,7 +1014,7 @@ replace_copy_if(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, 
 
     auto __src = views::all_read(::std::forward<_Range1>(__rng));
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+        __dispatch_tag, __exec,
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
             ::std::conditional_t<oneapi::dpl::__internal::__is_const_callable_object_v<_UnaryPredicate>,
@@ -1047,7 +1046,7 @@ sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
-    oneapi::dpl::__internal::__ranges::__pattern_stable_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    oneapi::dpl::__internal::__ranges::__pattern_stable_sort(__dispatch_tag, __exec,
                                                              views::all(::std::forward<_Range>(__rng)), __comp, __proj);
 }
 
@@ -1066,7 +1065,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
-    oneapi::dpl::__internal::__ranges::__pattern_stable_sort(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
+    oneapi::dpl::__internal::__ranges::__pattern_stable_sort(__dispatch_tag, __exec,
                                                              views::all(std::forward<_Range>(__rng)), __comp,
                                                              oneapi::dpl::identity{});
 }
@@ -1089,7 +1088,7 @@ is_sorted_until(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
 
     auto __view = views::all_read(::std::forward<_Range>(__rng));
     const auto __res = oneapi::dpl::__internal::__ranges::__pattern_adjacent_find(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __view,
+        __dispatch_tag, __exec, __view,
         oneapi::dpl::__internal::__reorder_pred<_Compare>(__comp), oneapi::dpl::__internal::__first_semantic());
 
     return __res == __view.size() ? __res : __res + 1;
@@ -1111,7 +1110,7 @@ is_sorted(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
 
     auto __view = views::all_read(::std::forward<_Range>(__rng));
     return oneapi::dpl::__internal::__ranges::__pattern_adjacent_find(
-               __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __view,
+               __dispatch_tag, __exec, __view,
                oneapi::dpl::__internal::__reorder_pred<_Compare>(__comp),
                oneapi::dpl::__internal::__or_semantic()) == __view.size();
 }
@@ -1132,7 +1131,7 @@ equal(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _BinaryPred
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2);
 
-    return oneapi::dpl::__internal::__ranges::__pattern_equal(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__ranges::__pattern_equal(__dispatch_tag, __exec,
                                                               views::all_read(::std::forward<_Range1>(__rng1)),
                                                               views::all_read(::std::forward<_Range2>(__rng2)), __p);
 }
@@ -1156,7 +1155,7 @@ move(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
     using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+        __dispatch_tag, __exec,
         oneapi::dpl::__internal::__brick_move<decltype(__dispatch_tag), _DecayedExecutionPolicy>{},
         views::all_read(::std::forward<_Range1>(__rng1)), views::all_write(::std::forward<_Range2>(__rng2)));
 }
@@ -1172,7 +1171,7 @@ merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& _
 
     auto __view_res = views::all_write(::std::forward<_Range3>(__rng3));
     oneapi::dpl::__internal::__ranges::__pattern_merge(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng1)),
         views::all_read(::std::forward<_Range2>(__rng2)), __view_res, __comp);
 
     return __view_res.size();
@@ -1197,8 +1196,7 @@ min_element(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
     return oneapi::dpl::__internal::__ranges::__pattern_min_element(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range>(__rng)),
-        __comp);
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range>(__rng)), __comp);
 }
 
 template <typename _ExecutionPolicy, typename _Range>
@@ -1235,8 +1233,7 @@ minmax_element(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
     return oneapi::dpl::__internal::__ranges::__pattern_minmax_element(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range>(__rng)),
-        __comp);
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range>(__rng)), __comp);
 }
 
 template <typename _ExecutionPolicy, typename _Range>
@@ -1260,7 +1257,7 @@ reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& __value
         oneapi::dpl::__ranges::__select_backend(__exec, __keys, __values, __out_keys, __out_values);
 
     return oneapi::dpl::__internal::__ranges::__pattern_reduce_by_segment(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__keys)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__keys)),
         views::all_read(::std::forward<_Range2>(__values)), views::all_write(::std::forward<_Range3>(__out_keys)),
         views::all_write(::std::forward<_Range4>(__out_values)), __binary_pred, __binary_op);
 }

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -267,8 +267,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
             oneapi::dpl::__internal::__select_backend(__exec, __first);
 #endif
 
-        return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, __exec,
-                                                          __first, __n,
+        return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, __exec, __first, __n,
                                                           [](_ReferenceType __val) { __val.~_ValueType(); });
     }
 }

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -243,7 +243,7 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
 #endif
 
         oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, __exec, __first,
-                                                 __last, [](_ReferenceType __val) { __val.~_ValueType(); });
+                                                 __last, [](_ReferenceType __val) { __val.~_ValueType(); }); // KSATODO need to move out
     }
 }
 
@@ -268,7 +268,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 #endif
 
         return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, __exec, __first, __n,
-                                                          [](_ReferenceType __val) { __val.~_ValueType(); });
+                                                          [](_ReferenceType __val) { __val.~_ValueType(); }); // KSATODO need to move out
     }
 }
 

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -53,13 +53,13 @@ uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
                   std::is_trivially_assignable_v<_OutRefType, _InRefType>)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            __dispatch_tag, __exec, __first, __last, __result,
             oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            __dispatch_tag, __exec, __first, __last, __result,
             oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{});
     }
 }
@@ -80,13 +80,13 @@ uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
                   std::is_trivially_assignable_v<_OutRefType, _InRefType>)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick_n(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            __dispatch_tag, __exec, __first, __n, __result,
             oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2_n(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            __dispatch_tag, __exec, __first, __n, __result,
             oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{});
     }
 }
@@ -109,13 +109,13 @@ uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
                   std::is_trivially_assignable_v<_OutRefType, _InRefType>)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            __dispatch_tag, __exec, __first, __last, __result,
             oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            __dispatch_tag, __exec, __first, __last, __result,
             oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{});
     }
 }
@@ -136,13 +136,13 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
                   std::is_trivially_assignable_v<_OutRefType, _InRefType>)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick_n(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            __dispatch_tag, __exec, __first, __n, __result,
             oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2_n(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            __dispatch_tag, __exec, __first, __n, __result,
             oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{});
     }
 }
@@ -163,14 +163,14 @@ uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Forward
                   std::is_trivially_copy_assignable_v<_ValueType>)
     {
         oneapi::dpl::__internal::__pattern_walk_brick(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, __exec, __first, __last,
             oneapi::dpl::__internal::__brick_fill<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
                 _ValueType(__value)});
     }
     else
     {
         oneapi::dpl::__internal::__pattern_walk1(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, __exec, __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value});
     }
 }
@@ -189,14 +189,14 @@ uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size 
                   std::is_trivially_copy_assignable_v<_ValueType>)
     {
         return oneapi::dpl::__internal::__pattern_walk_brick_n(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, __exec, __first, __n,
             oneapi::dpl::__internal::__brick_fill_n<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
                 _ValueType(__value)});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk1_n(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, __exec, __first, __n,
             oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value});
     }
 }
@@ -242,7 +242,7 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
             oneapi::dpl::__internal::__select_backend(__exec, __first);
 #endif
 
-        oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first,
+        oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, __exec, __first,
                                                  __last, [](_ReferenceType __val) { __val.~_ValueType(); });
     }
 }
@@ -267,7 +267,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
             oneapi::dpl::__internal::__select_backend(__exec, __first);
 #endif
 
-        return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
+        return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, __exec,
                                                           __first, __n,
                                                           [](_ReferenceType __val) { __val.~_ValueType(); });
     }
@@ -287,7 +287,7 @@ uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __fi
         const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
         oneapi::dpl::__internal::__pattern_walk1(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, __exec, __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{});
     }
 }
@@ -308,7 +308,7 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __
         const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
         return oneapi::dpl::__internal::__pattern_walk1_n(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, __exec, __first, __n,
             oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{});
     }
 }
@@ -328,14 +328,14 @@ uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __firs
                   std::is_trivially_copy_assignable_v<_ValueType>)
     {
         oneapi::dpl::__internal::__pattern_walk_brick(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, __exec, __first, __last,
             oneapi::dpl::__internal::__brick_fill<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
                 _ValueType()});
     }
     else
     {
         oneapi::dpl::__internal::__pattern_walk1(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __dispatch_tag, __exec, __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{});
     }
 }
@@ -353,14 +353,14 @@ uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __fi
                   std::is_trivially_copy_assignable_v<_ValueType>)
     {
         return oneapi::dpl::__internal::__pattern_walk_brick_n(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, __exec, __first, __n,
             oneapi::dpl::__internal::__brick_fill_n<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
                 _ValueType()});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk1_n(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            __dispatch_tag, __exec, __first, __n,
             oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{});
     }
 }

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -224,6 +224,18 @@ get_unvectorized_policy(const _ExecutionPolicy& __exec)
 
 #endif // (_PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN || _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN)
 
+namespace __internal
+{
+template <typename _ReferenceType>
+struct destroy_fn
+{
+    void operator()(_ReferenceType __val) const
+    {
+         __val.~_ValueType();
+    }
+};
+}; // namespace __internal
+
 // [specialized.destroy]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
@@ -243,7 +255,7 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
 #endif
 
         oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, __exec, __first,
-                                                 __last, [](_ReferenceType __val) { __val.~_ValueType(); }); // KSATODO need to move out
+                                                 __internal::destroy_fn<_ReferenceType>{}); // KSATODO moved out
     }
 }
 
@@ -268,7 +280,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 #endif
 
         return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, __exec, __first, __n,
-                                                          [](_ReferenceType __val) { __val.~_ValueType(); }); // KSATODO need to move out
+                                                          __internal::destroy_fn<_ReferenceType>{}); // KSATODO moved out
     }
 }
 

--- a/include/oneapi/dpl/pstl/glue_numeric_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_impl.h
@@ -74,7 +74,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Forward
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     return oneapi::dpl::__internal::__pattern_transform_reduce(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __init,
+        __dispatch_tag, __exec, __first1, __last1, __first2, __init,
         ::std::plus<_InputType>(), ::std::multiplies<_InputType>());
 }
 
@@ -86,7 +86,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Forward
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
-    return oneapi::dpl::__internal::__pattern_transform_reduce(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_transform_reduce(__dispatch_tag, __exec,
                                                                __first1, __last1, __first2, __init, __binary_op1,
                                                                __binary_op2);
 }
@@ -98,7 +98,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIt
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    return oneapi::dpl::__internal::__pattern_transform_reduce(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_transform_reduce(__dispatch_tag, __exec,
                                                                __first, __last, __init, __binary_op, __unary_op);
 }
 
@@ -225,7 +225,7 @@ transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, __exec,
                                                              __first, __last, __result, __unary_op, __init, __binary_op,
                                                              /*inclusive=*/::std::false_type());
 }
@@ -241,7 +241,7 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, __exec,
                                                              __first, __last, __result, __unary_op, __init, __binary_op,
                                                              /*inclusive=*/::std::true_type());
 }
@@ -254,7 +254,7 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, __exec,
                                                              __first, __last, __result, __unary_op, __binary_op,
                                                              /*inclusive=*/::std::true_type());
 }
@@ -272,7 +272,7 @@ adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Forwa
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __d_first);
 
     return oneapi::dpl::__internal::__pattern_adjacent_difference(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first, __op);
+        __dispatch_tag, __exec, __first, __last, __d_first, __op);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>

--- a/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
@@ -67,7 +67,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, 
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
     return oneapi::dpl::__internal::__ranges::__pattern_transform_reduce(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng1)),
         views::all_read(::std::forward<_Range2>(__rng2)), __init, ::std::plus<_ValueType>(),
         ::std::multiplies<_ValueType>());
 }
@@ -81,7 +81,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, 
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2);
 
     return oneapi::dpl::__internal::__ranges::__pattern_transform_reduce(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng1)),
         views::all_read(::std::forward<_Range2>(__rng2)), __init, __binary_op1, __binary_op2);
 }
 
@@ -93,7 +93,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _Range&& __rng, _Tp __init, _BinaryO
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
     return oneapi::dpl::__internal::__ranges::__pattern_transform_reduce(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range>(__rng)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range>(__rng)),
         __init, __binary_op, __unary_op);
 }
 
@@ -163,7 +163,7 @@ transform_exclusive_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& 
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2);
 
     return oneapi::dpl::__internal::__ranges::__pattern_transform_scan(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng1)),
         views::all_write(::std::forward<_Range2>(__rng2)), __unary_op, __init, __binary_op,
         /*inclusive=*/::std::false_type());
 }
@@ -180,7 +180,7 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& 
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2);
 
     return oneapi::dpl::__internal::__ranges::__pattern_transform_scan(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng1)),
         views::all_write(::std::forward<_Range2>(__rng2)), __unary_op, __init, __binary_op,
         /*inclusive=*/::std::true_type());
 }
@@ -195,7 +195,7 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& 
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2);
 
     return oneapi::dpl::__internal::__ranges::__pattern_transform_scan(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
+        __dispatch_tag, __exec, views::all_read(::std::forward<_Range1>(__rng1)),
         views::all_write(::std::forward<_Range2>(__rng2)), __unary_op, __binary_op, /*inclusive=*/::std::true_type());
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -45,7 +45,7 @@ namespace __internal
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
 void
-__pattern_walk1(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_walk1(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator __first, _ForwardIterator __last,
                 _Function __f)
 {
     auto __n = __last - __first;
@@ -57,7 +57,7 @@ __pattern_walk1(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
     auto __buf = __keep(__first, __last);
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__buf.all_view())>{
             __f, static_cast<std::size_t>(__n)},
         __n, __buf.all_view())
@@ -71,10 +71,10 @@ __pattern_walk1(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Size,
           typename _Function>
 _ForwardIterator
-__pattern_walk1_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n,
+__pattern_walk1_n(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first, _Size __n,
                   _Function __f)
 {
-    __pattern_walk1(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + __n, __f);
+    __pattern_walk1(__tag, __exec, __first, __first + __n, __f);
     return __first + __n;
 }
 
@@ -99,7 +99,7 @@ template <typename _WaitMode = __par_backend_hetero::__deferrable_mode,
           typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Function>
 _ForwardIterator2
-__pattern_walk2(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk2(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                 _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f)
 {
     auto __n = __last1 - __first1;
@@ -113,7 +113,7 @@ __pattern_walk2(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
                                                 decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view());
@@ -127,10 +127,10 @@ __pattern_walk2(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _Size,
           typename _ForwardIterator2, typename _Function>
 _ForwardIterator2
-__pattern_walk2_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Size __n,
+__pattern_walk2_n(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1, _Size __n,
                   _ForwardIterator2 __first2, _Function __f)
 {
-    return __pattern_walk2(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n, __first2, __f);
+    return __pattern_walk2(__tag, __exec, __first1, __first1 + __n, __first2, __f);
 }
 
 //------------------------------------------------------------------------
@@ -140,7 +140,7 @@ __pattern_walk2_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _F
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Function>
 _ForwardIterator2
-__pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_swap(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f)
 {
     const auto __n = __last1 - __first1;
@@ -156,7 +156,7 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIte
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::__brick_swap<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
                                     decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view());
@@ -182,7 +182,7 @@ template <typename _BackendTag, __par_backend_hetero::access_mode __acc_mode1 = 
           typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2, typename _ForwardIterator3,
           typename _Function>
 _ForwardIterator3
-__pattern_walk3(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk3(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                 _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f)
 {
     auto __n = __last1 - __first1;
@@ -197,7 +197,7 @@ __pattern_walk3(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
     auto __buf3 = __keep3(__first3, __first3 + __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
                                                 decltype(__buf2.all_view()), decltype(__buf3.all_view())>{
             __f, static_cast<std::size_t>(__n)},
@@ -216,7 +216,7 @@ struct __walk_brick_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
 void
-__pattern_walk_brick(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first,
+__pattern_walk_brick(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first,
                      _ForwardIterator __last, _Function __f)
 {
     if (__last - __first <= 0)
@@ -224,7 +224,7 @@ __pattern_walk_brick(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec,
 
     __pattern_walk1(
         __tag,
-        __par_backend_hetero::make_wrapped_policy<__walk_brick_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        __par_backend_hetero::make_wrapped_policy<__walk_brick_wrapper>(__exec),
         __first, __last, __f);
 }
 
@@ -234,12 +234,12 @@ struct __walk_brick_n_wrapper;
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Size,
           typename _Function>
 _ForwardIterator
-__pattern_walk_brick_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n,
+__pattern_walk_brick_n(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first, _Size __n,
                        _Function __f)
 {
     __pattern_walk1(
         __tag,
-        __par_backend_hetero::make_wrapped_policy<__walk_brick_n_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        __par_backend_hetero::make_wrapped_policy<__walk_brick_n_wrapper>(__exec),
         __first, __first + __n, __f);
     return __first + __n;
 }
@@ -254,12 +254,12 @@ struct __walk2_brick_wrapper;
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Brick>
 _ForwardIterator2
-__pattern_walk2_brick(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk2_brick(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                       _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Brick __brick)
 {
     return __pattern_walk2(
         __tag,
-        __par_backend_hetero::make_wrapped_policy<__walk2_brick_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        __par_backend_hetero::make_wrapped_policy<__walk2_brick_wrapper>(__exec),
         __first1, __last1, __first2, __brick);
 }
 
@@ -269,12 +269,12 @@ struct __walk2_brick_n_wrapper;
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _Size,
           typename _ForwardIterator2, typename _Brick>
 _ForwardIterator2
-__pattern_walk2_brick_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk2_brick_n(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                         _Size __n, _ForwardIterator2 __first2, _Brick __brick)
 {
     return __pattern_walk2(
         __tag,
-        __par_backend_hetero::make_wrapped_policy<__walk2_brick_n_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        __par_backend_hetero::make_wrapped_policy<__walk2_brick_n_wrapper>(__exec),
         __first1, __first1 + __n, __first2, __brick);
 }
 
@@ -288,7 +288,7 @@ struct __walk2_transform_if_wrapper;
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Function>
 _ForwardIterator2
-__pattern_walk2_transform_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk2_transform_if(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                              _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __func)
 {
     // Require `read_write` access mode for output sequence to force a copy in for host iterators to capture incoming
@@ -297,10 +297,8 @@ __pattern_walk2_transform_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&&
     // please see the comment above __pattern_walk2 and https://github.com/uxlfoundation/oneDPL/issues/1272.
     return __pattern_walk2</*_WaitMode*/ __par_backend_hetero::__deferrable_mode,
                            __par_backend_hetero::access_mode::read, __par_backend_hetero::access_mode::read_write>(
-        __tag,
-        __par_backend_hetero::make_wrapped_policy<__walk2_transform_if_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        __first1, __last1, __first2, __func);
+        __tag, __par_backend_hetero::make_wrapped_policy<__walk2_transform_if_wrapper>(__exec), __first1, __last1,
+        __first2, __func);
 }
 
 template <typename _Name>
@@ -309,7 +307,7 @@ struct __walk3_transform_if_wrapper;
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _ForwardIterator3, typename _Function>
 _ForwardIterator3
-__pattern_walk3_transform_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_walk3_transform_if(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                              _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator3 __first3,
                              _Function __func)
 {
@@ -319,10 +317,8 @@ __pattern_walk3_transform_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&&
     // please see the comment above __pattern_walk3 and https://github.com/uxlfoundation/oneDPL/issues/1272.
     return __pattern_walk3<_BackendTag, __par_backend_hetero::access_mode::read,
                            __par_backend_hetero::access_mode::read, __par_backend_hetero::access_mode::read_write>(
-        __tag,
-        __par_backend_hetero::make_wrapped_policy<__walk3_transform_if_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        __first1, __last1, __first2, __first3, __func);
+        __tag, __par_backend_hetero::make_wrapped_policy<__walk3_transform_if_wrapper>(__exec), __first1, __last1,
+        __first2, __first3, __func);
 }
 
 //------------------------------------------------------------------------
@@ -343,10 +339,10 @@ struct fill_functor
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _T>
 _ForwardIterator
-__pattern_fill(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first,
+__pattern_fill(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first,
                _ForwardIterator __last, const _T& __value)
 {
-    __pattern_walk1(__tag, ::std::forward<_ExecutionPolicy>(__exec),
+    __pattern_walk1(__tag, __exec,
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__first),
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__last),
                     fill_functor<_T>{__value});
@@ -355,10 +351,10 @@ __pattern_fill(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Forw
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, class _Size, typename _T>
 _ForwardIterator
-__pattern_fill_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count,
+__pattern_fill_n(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first, _Size __count,
                  const _T& __value)
 {
-    return __pattern_fill(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + __count, __value);
+    return __pattern_fill(__tag, __exec, __first, __first + __count, __value);
 }
 
 //------------------------------------------------------------------------
@@ -380,10 +376,10 @@ struct generate_functor
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Generator>
 _ForwardIterator
-__pattern_generate(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first,
+__pattern_generate(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first,
                    _ForwardIterator __last, _Generator __g)
 {
-    __pattern_walk1(__tag, ::std::forward<_ExecutionPolicy>(__exec),
+    __pattern_walk1(__tag, __exec,
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__first),
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__last),
                     generate_functor<_Generator>{__g});
@@ -392,10 +388,10 @@ __pattern_generate(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, class _Size, typename _Generator>
 _ForwardIterator
-__pattern_generate_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first,
+__pattern_generate_n(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first,
                      _Size __count, _Generator __g)
 {
-    return __pattern_generate(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __first + __count, __g);
+    return __pattern_generate(__tag, __exec, __first, __first + __count, __g);
 }
 
 //------------------------------------------------------------------------
@@ -465,7 +461,7 @@ struct __brick_fill_n<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 _Iterator
-__pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_min_element(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                       _Compare __comp)
 {
     if (__first == __last)
@@ -513,7 +509,7 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
     auto __buf = __keep(__first, __last);
 
     auto __ret_idx = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType, _Commutative>(
-                         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+                         _BackendTag{}, __exec, __reduce_fn, __transform_fn,
                          unseq_backend::__no_init_value{}, // no initial value
                          __buf.all_view())
                          .get();
@@ -541,7 +537,7 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 ::std::pair<_Iterator, _Iterator>
-__pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_minmax_element(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                          _Compare __comp)
 {
     if (__first == __last)
@@ -578,7 +574,7 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 
     auto __ret = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
                                                                                 ::std::false_type /*is_commutative*/>(
-                     _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+                     _BackendTag{}, __exec, __reduce_fn, __transform_fn,
                      unseq_backend::__no_init_value{}, // no initial value
                      __buf.all_view())
                      .get();
@@ -592,7 +588,7 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _BinaryPredicate>
 _Iterator
-__pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_adjacent_find(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                         _BinaryPredicate __predicate, oneapi::dpl::__internal::__or_semantic)
 {
     if (__last - __first < 2)
@@ -609,7 +605,7 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
     bool result = __par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, __par_backend_hetero::__parallel_or_tag{},
         oneapi::dpl::__ranges::make_zip_view(__buf1.all_view(), __buf2.all_view()));
 
@@ -620,7 +616,7 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _BinaryPredicate>
 _Iterator
-__pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_adjacent_find(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                         _BinaryPredicate __predicate, oneapi::dpl::__internal::__first_semantic)
 {
     if (__last - __first < 2)
@@ -630,7 +626,7 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
         oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, adjacent_find_fn<_BinaryPredicate>>;
 
     auto __result = __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         __par_backend_hetero::zip(
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first + 1)),
@@ -652,7 +648,7 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Predicate>
 typename ::std::iterator_traits<_Iterator>::difference_type
-__pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_count(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                 _Predicate __predicate)
 {
     if (__first == __last)
@@ -672,7 +668,7 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator 
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
                                                                           ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+               _BackendTag{}, __exec, __reduce_fn, __transform_fn,
                unseq_backend::__no_init_value{}, // no initial value
                __buf.all_view())
         .get();
@@ -684,7 +680,7 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator 
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Pred>
 bool
-__pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_any_of(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                  _Pred __pred)
 {
     if (__first == __last)
@@ -696,9 +692,7 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     auto __buf = __keep(__first, __last);
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
-        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
+        _BackendTag{}, __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>(__exec),
         _Predicate{__pred}, __par_backend_hetero::__parallel_or_tag{}, __buf.all_view());
 }
 
@@ -708,7 +702,7 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Pred>
 bool
-__pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __last1,
+__pattern_equal(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator1 __first1, _Iterator1 __last1,
                 _Iterator2 __first2, _Iterator2 __last2, _Pred __pred)
 {
     if (__last1 == __first1 || __last2 == __first2 || __last1 - __first1 != __last2 - __first2)
@@ -724,7 +718,7 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
     return !__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
+        _BackendTag{}, __exec, _Predicate{equal_predicate<_Pred>{__pred}},
         __par_backend_hetero::__parallel_or_tag{},
         oneapi::dpl::__ranges::make_zip_view(__buf1.all_view(), __buf2.all_view()));
 }
@@ -735,10 +729,10 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Pred>
 bool
-__pattern_equal(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __last1,
+__pattern_equal(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __first1, _Iterator1 __last1,
                 _Iterator2 __first2, _Pred __pred)
 {
-    return oneapi::dpl::__internal::__pattern_equal(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+    return oneapi::dpl::__internal::__pattern_equal(__tag, __exec, __first1, __last1,
                                                     __first2, __first2 + (__last1 - __first1), __pred);
 }
 
@@ -748,7 +742,7 @@ __pattern_equal(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Pred>
 _Iterator
-__pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_find_if(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                   _Pred __pred)
 {
     if (__first == __last)
@@ -757,7 +751,7 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
 
     return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__pred},
         ::std::true_type{});
@@ -769,7 +763,7 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Pred>
 _Iterator1
-__pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last,
+__pattern_find_end(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __first, _Iterator1 __last,
                    _Iterator2 __s_first, _Iterator2 __s_last, _Pred __pred)
 {
     if (__first == __last || __s_last == __s_first || __last - __first < __s_last - __s_first)
@@ -778,7 +772,7 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     if (__last - __first == __s_last - __s_first)
     {
         const bool __res =
-            __pattern_equal(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __pred);
+            __pattern_equal(__tag, __exec, __first, __last, __s_first, __pred);
         return __res ? __first : __last;
     }
     else
@@ -786,7 +780,7 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
         using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
 
         return __par_backend_hetero::__parallel_find(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            _BackendTag{}, __exec,
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_first),
@@ -801,7 +795,7 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Pred>
 _Iterator1
-__pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last,
+__pattern_find_first_of(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator1 __first, _Iterator1 __last,
                         _Iterator2 __s_first, _Iterator2 __s_last, _Pred __pred)
 {
     if (__first == __last || __s_last == __s_first)
@@ -812,7 +806,7 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     // TODO: To check whether it makes sense to iterate over the second sequence in case of
     // distance(__first, __last) < distance(__s_first, __s_last).
     return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_first),
@@ -831,7 +825,7 @@ class equal_wrapper
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Pred>
 _Iterator1
-__pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last,
+__pattern_search(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __first, _Iterator1 __last,
                  _Iterator2 __s_first, _Iterator2 __s_last, _Pred __pred)
 {
     if (__s_last == __s_first)
@@ -843,14 +837,14 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
     if (__last - __first == __s_last - __s_first)
     {
         const bool __res = __pattern_equal(
-            __tag, __par_backend_hetero::make_wrapped_policy<equal_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+            __tag, __par_backend_hetero::make_wrapped_policy<equal_wrapper>(__exec),
             __first, __last, __s_first, __pred);
         return __res ? __first : __last;
     }
 
     using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
     return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_first),
@@ -879,7 +873,7 @@ struct __search_n_unary_predicate
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Size, typename _Tp,
           typename _BinaryPredicate>
 _Iterator
-__pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_search_n(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                    _Size __count, const _Tp& __value, _BinaryPredicate __pred)
 {
     if (__count <= 0)
@@ -890,7 +884,7 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
 
     if (__last - __first == __count)
     {
-        return (!__internal::__pattern_any_of(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        return (!__internal::__pattern_any_of(__tag, __exec, __first, __last,
                                               __search_n_unary_predicate<_Tp, _BinaryPredicate>{__value, __pred}))
                    ? __first
                    : __last;
@@ -898,7 +892,7 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
 
     using _Predicate = unseq_backend::n_elem_match_pred<_ExecutionPolicy, _BinaryPredicate, _Tp, _Size>;
     return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
         _Predicate{__pred, __value, __count}, ::std::true_type{});
@@ -910,7 +904,7 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Pred>
 ::std::pair<_Iterator1, _Iterator2>
-__pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __last1,
+__pattern_mismatch(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator1 __first1, _Iterator1 __last1,
                    _Iterator2 __first2, _Iterator2 __last2, _Pred __pred)
 {
     auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
@@ -923,7 +917,7 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first1),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first2));
     auto __result = __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __first_zip, __first_zip + __n,
+        _BackendTag{}, __exec, __first_zip, __first_zip + __n,
         _Predicate{equal_predicate<_Pred>{__pred}}, ::std::true_type{});
     __n = __result - __first_zip;
     return ::std::make_pair(__first1 + __n, __first2 + __n);
@@ -936,7 +930,7 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _Predicate>
 _Iterator2
-__pattern_copy_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last,
+__pattern_copy_if(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator1 __first, _Iterator1 __last,
                   _Iterator2 __result_first, _Predicate __pred)
 {
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
@@ -951,7 +945,7 @@ __pattern_copy_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
     auto __buf2 = __keep2(__result_first, __result_first + __n);
 
-    auto __res = __par_backend_hetero::__parallel_copy_if(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+    auto __res = __par_backend_hetero::__parallel_copy_if(_BackendTag{}, __exec,
                                                           __buf1.all_view(), __buf2.all_view(), __n, __pred);
 
     ::std::size_t __num_copied = __res.get(); //is a blocking call
@@ -965,7 +959,7 @@ __pattern_copy_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _Iterator3, typename _UnaryPredicate>
 ::std::pair<_Iterator2, _Iterator3>
-__pattern_partition_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first,
+__pattern_partition_copy(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator1 __first,
                          _Iterator1 __last, _Iterator2 __result1, _Iterator3 __result2, _UnaryPredicate __pred)
 {
     if (__first == __last)
@@ -987,7 +981,7 @@ __pattern_partition_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
     auto __buf2 = __keep2(__zipped_res, __zipped_res + __n);
 
     auto __result = oneapi::dpl::__par_backend_hetero::__parallel_partition_copy(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
+        _BackendTag{}, __exec, __buf1.all_view(), __buf2.all_view(), __pred);
 
     _It1DifferenceType __num_true = __result.get(); // blocking call
 
@@ -1001,7 +995,7 @@ __pattern_partition_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _BinaryPredicate>
 _Iterator2
-__pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last,
+__pattern_unique_copy(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator1 __first, _Iterator1 __last,
                       _Iterator2 __result_first, _BinaryPredicate __pred)
 {
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
@@ -1014,7 +1008,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
     {
         // For a sequence of size 1, we can just copy the only element to the result.
         oneapi::dpl::__internal::__pattern_walk2_brick(
-            __hetero_tag<_BackendTag>{}, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result_first,
+            __hetero_tag<_BackendTag>{}, __exec, __first, __last, __result_first,
             oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
         return __result_first + 1;
     }
@@ -1025,7 +1019,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
     auto __buf2 = __keep2(__result_first, __result_first + __n);
 
     auto __result = oneapi::dpl::__par_backend_hetero::__parallel_unique_copy(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
+        _BackendTag{}, __exec, __buf1.all_view(), __buf2.all_view(), __pred);
 
     return __result_first + __result.get(); // is a blocking call
 }
@@ -1038,7 +1032,7 @@ struct copy_back_wrapper2;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Predicate>
 _Iterator
-__pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_remove_if(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                     _Predicate __pred)
 {
     if (__last == __first)
@@ -1057,13 +1051,13 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
     // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
     // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
     return __pattern_walk2(
-        __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec),
         __copy_first, __copy_last, __first, __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _BinaryPredicate>
 _Iterator
-__pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_unique(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                  _BinaryPredicate __pred)
 {
     if (__last - __first < 2)
@@ -1085,7 +1079,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
     return __pattern_walk2</*_WaitMode*/ __par_backend_hetero::__deferrable_mode,
                            __par_backend_hetero::access_mode::read_write,
                            __par_backend_hetero::access_mode::read_write>(
-        __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec),
         __copy_first, __copy_last, __first, __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 }
 
@@ -1103,7 +1097,7 @@ enum _IsPartitionedReduceType : signed char
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Predicate>
 bool
-__pattern_is_partitioned(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_is_partitioned(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                          _Predicate __predicate)
 {
     if (__last - __first < 2)
@@ -1125,7 +1119,7 @@ __pattern_is_partitioned(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 
     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
                                                                                 ::std::false_type /*is_commutative*/>(
-                     _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+                     _BackendTag{}, __exec, __reduce_fn, __transform_fn,
                      unseq_backend::__no_init_value{}, // no initial value
                      __buf.all_view())
                      .get();
@@ -1154,7 +1148,7 @@ struct __is_heap_check
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare>
 _RandomAccessIterator
-__pattern_is_heap_until(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_is_heap_until(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                         _RandomAccessIterator __last, _Compare __comp)
 {
     if (__last - __first < 2)
@@ -1164,7 +1158,7 @@ __pattern_is_heap_until(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
         oneapi::dpl::unseq_backend::single_match_pred_by_idx<_ExecutionPolicy, __is_heap_check<_Compare>>;
 
     return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__comp},
         ::std::true_type{});
@@ -1172,7 +1166,7 @@ __pattern_is_heap_until(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare>
 bool
-__pattern_is_heap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_is_heap(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                   _RandomAccessIterator __last, _Compare __comp)
 {
     if (__last - __first < 2)
@@ -1182,7 +1176,7 @@ __pattern_is_heap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomA
         oneapi::dpl::unseq_backend::single_match_pred_by_idx<_ExecutionPolicy, __is_heap_check<_Compare>>;
 
     return !__par_backend_hetero::__parallel_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__comp});
 }
@@ -1194,7 +1188,7 @@ __pattern_is_heap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomA
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _Iterator3, typename _Compare>
 _Iterator3
-__pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __last1,
+__pattern_merge(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __first1, _Iterator1 __last1,
                 _Iterator2 __first2, _Iterator2 __last2, _Iterator3 __d_first, _Compare __comp)
 {
     auto __n1 = __last1 - __first1;
@@ -1206,18 +1200,12 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
     //To consider the direct copying pattern call in case just one of sequences is empty.
     if (__n1 == 0)
         oneapi::dpl::__internal::__pattern_walk2_brick(
-            __tag,
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
-            __first2, __last2, __d_first,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+            __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec), __first2, __last2,
+            __d_first, oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
     else if (__n2 == 0)
         oneapi::dpl::__internal::__pattern_walk2_brick(
-            __tag,
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<copy_back_wrapper2>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
-            __first1, __last1, __d_first,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+            __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<copy_back_wrapper2>(__exec), __first1,
+            __last1, __d_first, oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
     else
     {
         auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -1228,7 +1216,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
         auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator3>();
         auto __buf3 = __keep3(__d_first, __d_first + __n);
 
-        __par_backend_hetero::__parallel_merge(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        __par_backend_hetero::__parallel_merge(_BackendTag{}, __exec,
                                                __buf1.all_view(), __buf2.all_view(), __buf3.all_view(), __comp)
             .__deferrable_wait();
     }
@@ -1241,7 +1229,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 void
-__pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first,
+__pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first,
                         _Iterator __middle, _Iterator __last, _Compare __comp)
 {
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
@@ -1268,7 +1256,7 @@ __pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __ex
     // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
     // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
     __pattern_walk2(
-        __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec),
         __copy_first, __copy_last, __first, __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 }
 
@@ -1277,7 +1265,7 @@ __pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __ex
 //------------------------------------------------------------------------
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare, typename _Proj>
 void
-__stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__stable_sort_with_projection(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                               _Compare __comp, _Proj __proj)
 {
     if (__last - __first < 2)
@@ -1286,7 +1274,7 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+    __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, __exec,
                                                  __buf.all_view(), __comp, __proj)
         .__deferrable_wait();
 }
@@ -1294,10 +1282,10 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare,
           typename _LeafSort = std::nullptr_t>
 void
-__pattern_sort(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_sort(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                _Compare __comp, _LeafSort = {})
 {
-    __stable_sort_with_projection(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+    __stable_sort_with_projection(__tag, __exec, __first, __last, __comp,
                                   oneapi::dpl::identity{});
 }
 
@@ -1308,7 +1296,7 @@ __pattern_sort(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iter
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Compare,
           typename _LeafSort = std::nullptr_t>
 void
-__pattern_sort_by_key(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __keys_first,
+__pattern_sort_by_key(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __keys_first,
                       _Iterator1 __keys_last, _Iterator2 __values_first, _Compare __comp, _LeafSort = {})
 {
     static_assert(std::is_move_constructible_v<typename std::iterator_traits<_Iterator1>::value_type> &&
@@ -1317,7 +1305,7 @@ __pattern_sort_by_key(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 
     auto __beg = oneapi::dpl::make_zip_iterator(__keys_first, __values_first);
     auto __end = __beg + (__keys_last - __keys_first);
-    __stable_sort_with_projection(__tag, std::forward<_ExecutionPolicy>(__exec), __beg, __end, __comp,
+    __stable_sort_with_projection(__tag, __exec, __beg, __end, __comp,
                                   [](const auto& __a) { return std::get<0>(__a); });
 }
 
@@ -1327,13 +1315,13 @@ __pattern_sort_by_key(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _UnaryPredicate>
 _Iterator
-__pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first,
+__pattern_stable_partition(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first,
                            _Iterator __last, _UnaryPredicate __pred)
 {
     if (__last == __first)
         return __last;
     else if (__last - __first < 2)
-        return __pattern_any_of(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred) ? __last
+        return __pattern_any_of(__tag, __exec, __first, __last, __pred) ? __last
                                                                                                           : __first;
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
@@ -1353,7 +1341,7 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
                     copy_result.first, __first, __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 
     __pattern_walk2(
-        __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper2>(::std::forward<_ExecutionPolicy>(__exec)),
+        __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper2>(__exec),
         __false_result, copy_result.second, __first + true_count,
         __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 
@@ -1367,11 +1355,11 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _UnaryPredicate>
 _Iterator
-__pattern_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_partition(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                     _UnaryPredicate __pred)
 {
     //TODO: consider nonstable approaches
-    return __pattern_stable_partition(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred);
+    return __pattern_stable_partition(__tag, __exec, __first, __last, __pred);
 }
 
 //------------------------------------------------------------------------
@@ -1380,7 +1368,7 @@ __pattern_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Compare>
 bool
-__pattern_lexicographical_compare(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first1,
+__pattern_lexicographical_compare(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator1 __first1,
                                   _Iterator1 __last1, _Iterator2 __first2, _Iterator2 __last2, _Compare __comp)
 {
     //trivial pre-checks
@@ -1418,7 +1406,7 @@ __pattern_lexicographical_compare(__hetero_tag<_BackendTag>, _ExecutionPolicy&& 
     auto __ret_idx =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
                                                                        ::std::false_type /*is_commutative*/>(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+            _BackendTag{}, __exec, __reduce_fn, __transform_fn,
             unseq_backend::__no_init_value{}, // no initial value
             __buf1.all_view(), __buf2.all_view())
             .get();
@@ -1429,7 +1417,7 @@ __pattern_lexicographical_compare(__hetero_tag<_BackendTag>, _ExecutionPolicy&& 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Compare>
 bool
-__pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_includes(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                    _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp)
 {
     //according to the spec
@@ -1446,7 +1434,7 @@ __pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Forwar
 
     using __brick_include_type = unseq_backend::__brick_includes<_ExecutionPolicy, _Compare, _Size1, _Size2>;
     return !__par_backend_hetero::__parallel_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first2),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last2),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first1),
@@ -1460,14 +1448,14 @@ __pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Forwar
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 void
-__pattern_partial_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __mid,
+__pattern_partial_sort(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __mid,
                        _Iterator __last, _Compare __comp)
 {
     if (__last - __first < 2)
         return;
 
     __par_backend_hetero::__parallel_partial_sort(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__mid),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__last), __comp)
@@ -1506,7 +1494,7 @@ struct __partial_sort_2
 template <typename _BackendTag, typename _ExecutionPolicy, typename _InIterator, typename _OutIterator,
           typename _Compare>
 _OutIterator
-__pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _InIterator __first,
+__pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _InIterator __first,
                             _InIterator __last, _OutIterator __out_first, _OutIterator __out_last, _Compare __comp)
 {
     using _ValueType = typename ::std::iterator_traits<_InIterator>::value_type;
@@ -1537,7 +1525,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         //__pattern_sort is a blocking call.
         __pattern_sort(
             __tag,
-            __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(::std::forward<_ExecutionPolicy>(__exec)),
+            __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(__exec),
             __out_first, __out_end, __comp);
 
         return __out_end;
@@ -1569,7 +1557,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__buf_last), __comp);
 
         return __pattern_walk2(
-            __tag, __par_backend_hetero::make_wrapped_policy<__copy_back>(::std::forward<_ExecutionPolicy>(__exec)),
+            __tag, __par_backend_hetero::make_wrapped_policy<__copy_back>(__exec),
             __buf_first, __buf_mid, __out_first, __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 
         // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
@@ -1583,7 +1571,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 void
-__pattern_nth_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __nth,
+__pattern_nth_element(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __nth,
                       _Iterator __last, _Compare __comp)
 {
     if (__first == __last || __nth == __last)
@@ -1592,7 +1580,7 @@ __pattern_nth_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     // TODO: check partition-based implementation
     // - try to avoid host dereference issue
     // - measure performance of the issue-free implementation
-    __pattern_partial_sort(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __nth + 1, __last, __comp);
+    __pattern_partial_sort(__tag, __exec, __first, __nth + 1, __last, __comp);
 }
 
 //------------------------------------------------------------------------
@@ -1601,7 +1589,7 @@ __pattern_nth_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator>
 void
-__pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last)
+__pattern_reverse(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last)
 {
     auto __n = __last - __first;
     if (__n <= 0)
@@ -1610,7 +1598,7 @@ __pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::__reverse_functor<typename std::iterator_traits<_Iterator>::difference_type,
                                          decltype(__buf.all_view())>{__n},
         __n / 2, __buf.all_view())
@@ -1623,7 +1611,7 @@ __pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _BidirectionalIterator, typename _ForwardIterator>
 _ForwardIterator
-__pattern_reverse_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _BidirectionalIterator __first,
+__pattern_reverse_copy(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _BidirectionalIterator __first,
                        _BidirectionalIterator __last, _ForwardIterator __result)
 {
     auto __n = __last - __first;
@@ -1637,7 +1625,7 @@ __pattern_reverse_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bi
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator>();
     auto __buf2 = __keep2(__result, __result + __n);
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::__reverse_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
                                       decltype(__buf1.all_view()), decltype(__buf2.all_view())>{__n},
         __n, __buf1.all_view(), __buf2.all_view())
@@ -1661,7 +1649,7 @@ class __rotate_wrapper
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator>
 _Iterator
-__pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __new_first,
+__pattern_rotate(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __new_first,
                  _Iterator __last)
 {
     auto __n = __last - __first;
@@ -1693,7 +1681,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     auto __brick =
         unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__temp_rng_rw),
                                                 decltype(__buf.all_view())>{_Function{}, static_cast<std::size_t>(__n)};
-    oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __brick,
+    oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec, __brick,
                                                       __n, __temp_rng_rw, __buf.all_view())
         .__deferrable_wait();
 
@@ -1709,7 +1697,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _BidirectionalIterator, typename _ForwardIterator>
 _ForwardIterator
-__pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _BidirectionalIterator __first,
+__pattern_rotate_copy(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _BidirectionalIterator __first,
                       _BidirectionalIterator __new_first, _BidirectionalIterator __last, _ForwardIterator __result)
 {
     auto __n = __last - __first;
@@ -1726,7 +1714,7 @@ __pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bid
     const auto __shift = __new_first - __first;
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, __exec,
         unseq_backend::__rotate_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
                                      decltype(__buf1.all_view()), decltype(__buf2.all_view())>{__n, __shift},
         __n, __buf1.all_view(), __buf2.all_view())
@@ -1738,7 +1726,7 @@ __pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bid
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _OutputIterator, typename _Compare, typename _IsOpDifference>
 _OutputIterator
-__pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_hetero_set_op(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                         _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                         _OutputIterator __result, _Compare __comp, _IsOpDifference __is_op_difference)
 {
@@ -1756,7 +1744,7 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _F
     auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
     auto __buf3 = __keep3(__result, __result + __n1);
 
-    auto __result_size = __par_backend_hetero::__parallel_set_op(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+    auto __result_size = __par_backend_hetero::__parallel_set_op(_BackendTag{}, __exec,
                                                                  __buf1.all_view(), __buf2.all_view(),
                                                                  __buf3.all_view(), __comp, __is_op_difference)
                              .get();
@@ -1767,7 +1755,7 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _F
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _OutputIterator, typename _Compare>
 _OutputIterator
-__pattern_set_intersection(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_set_intersection(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                            _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                            _OutputIterator __result, _Compare __comp)
 {
@@ -1775,7 +1763,7 @@ __pattern_set_intersection(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
     if (__first1 == __last1 || __first2 == __last2)
         return __result;
 
-    return __pattern_hetero_set_op(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+    return __pattern_hetero_set_op(__tag, __exec, __first1, __last1, __first2,
                                    __last2, __result, __comp, unseq_backend::_IntersectionTag());
 }
 
@@ -1788,7 +1776,7 @@ class __set_difference_copy_case_1
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _OutputIterator, typename _Compare>
 _OutputIterator
-__pattern_set_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_set_difference(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                          _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                          _OutputIterator __result, _Compare __comp)
 {
@@ -1800,14 +1788,12 @@ __pattern_set_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
     if (__first2 == __last2)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
-            __tag,
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_difference_copy_case_1>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
+            __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_difference_copy_case_1>(__exec),
             __first1, __last1, __result,
             oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
     }
 
-    return __pattern_hetero_set_op(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+    return __pattern_hetero_set_op(__tag, __exec, __first1, __last1, __first2,
                                    __last2, __result, __comp, unseq_backend::_DifferenceTag());
 }
 
@@ -1825,7 +1811,7 @@ class __set_union_copy_case_2
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _OutputIterator, typename _Compare>
 _OutputIterator
-__pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_set_union(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _ForwardIterator1 __first1,
                     _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                     _OutputIterator __result, _Compare __comp)
 {
@@ -1836,22 +1822,16 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
     if (__first1 == __last1)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
-            __tag,
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_1>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
-            __first2, __last2, __result,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+            __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_1>(__exec), __first2,
+            __last2, __result, oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
     }
 
     //{2} is empty
     if (__first2 == __last2)
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
-            __tag,
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_2>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
-            __first1, __last1, __result,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+            __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_2>(__exec), __first1,
+            __last1, __result, oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
     }
 
     typedef typename ::std::iterator_traits<_OutputIterator>::value_type _ValueType;
@@ -1869,10 +1849,8 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     //2. Merge {1} and the difference
     return oneapi::dpl::__internal::__pattern_merge(
-        __tag,
-        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_2>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        __first1, __last1, __buf, __buf + __n_diff, __result, __comp);
+        __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_2>(__exec), __first1,
+        __last1, __buf, __buf + __n_diff, __result, __comp);
 }
 
 //Dummy names to avoid kernel problems
@@ -1906,7 +1884,7 @@ class __set_symmetric_difference_phase_2
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _OutputIterator, typename _Compare>
 _OutputIterator
-__pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec,
+__pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec,
                                    _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
                                    _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp)
 {
@@ -1918,8 +1896,7 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
             __tag,
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_copy_case_1>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_copy_case_1>(__exec),
             __first2, __last2, __result,
             oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
     }
@@ -1930,7 +1907,7 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
         return oneapi::dpl::__internal::__pattern_walk2_brick(
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_copy_case_2>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
+                __exec),
             __first1, __last1, __result,
             oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
     }
@@ -1960,7 +1937,7 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
         __buf_2;
 
     //3. Merge the differences
-    return oneapi::dpl::__internal::__pattern_merge(__tag, ::std::forward<_ExecutionPolicy>(__exec), __buf_1,
+    return oneapi::dpl::__internal::__pattern_merge(__tag, __exec, __buf_1,
                                                     __buf_1 + __n_diff_1, __buf_2, __buf_2 + __n_diff_2, __result,
                                                     __comp);
 }
@@ -1970,7 +1947,7 @@ struct __shift_left_right;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range>
 oneapi::dpl::__internal::__difference_t<_Range>
-__pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range __rng,
+__pattern_shift_left(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Range __rng,
                      oneapi::dpl::__internal::__difference_t<_Range> __n)
 {
     //If (n > 0 && n < m), returns first + (m - n). Otherwise, if n  > 0, returns first. Otherwise, returns last.
@@ -1995,7 +1972,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
             unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__src), decltype(__dst)>{
                 _Function{}, static_cast<std::size_t>(__size_res)};
 
-        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec,
                                                           __brick, __size_res, __src, __dst)
             .__deferrable_wait();
     }
@@ -2003,10 +1980,8 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
     {
         auto __brick = unseq_backend::__brick_shift_left<_ExecutionPolicy, _DiffType, decltype(__rng)>{__size, __n};
         oneapi::dpl::__par_backend_hetero::__parallel_for(
-            _BackendTag{},
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__shift_left_right>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
-            __brick, __n, __rng)
+            _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__shift_left_right>(__exec), __brick,
+            __n, __rng)
             .__deferrable_wait();
     }
 
@@ -2015,7 +1990,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator>
 _Iterator
-__pattern_shift_left(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_shift_left(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                      typename ::std::iterator_traits<_Iterator>::difference_type __n)
 {
     //If (n > 0 && n < m), returns first + (m - n). Otherwise, if n  > 0, returns first. Otherwise, returns last.
@@ -2028,14 +2003,14 @@ __pattern_shift_left(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec,
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    auto __res = oneapi::dpl::__internal::__pattern_shift_left(__tag, ::std::forward<_ExecutionPolicy>(__exec),
+    auto __res = oneapi::dpl::__internal::__pattern_shift_left(__tag, __exec,
                                                                __buf.all_view(), __n);
     return __first + __res;
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator>
 _Iterator
-__pattern_shift_right(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
+__pattern_shift_right(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator __first, _Iterator __last,
                       typename ::std::iterator_traits<_Iterator>::difference_type __n)
 {
     //If (n > 0 && n < m), returns first + n. Otherwise, if n  > 0, returns last. Otherwise, returns first.
@@ -2051,7 +2026,7 @@ __pattern_shift_right(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     //A shift right is the shift left with a reverse logic.
     auto __rng = oneapi::dpl::__ranges::reverse_view_simple<decltype(__buf.all_view())>{__buf.all_view()};
     auto __res =
-        oneapi::dpl::__internal::__pattern_shift_left(__tag, ::std::forward<_ExecutionPolicy>(__exec), __rng, __n);
+        oneapi::dpl::__internal::__pattern_shift_left(__tag, __exec, __rng, __n);
 
     return __last - __res;
 }
@@ -2062,7 +2037,7 @@ struct __copy_keys_values_wrapper;
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _Iterator3, typename _Iterator4, typename _BinaryPredicate, typename _BinaryOperator>
 typename std::iterator_traits<_Iterator3>::difference_type
-__pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __keys_first,
+__pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __keys_first,
                             _Iterator1 __keys_last, _Iterator2 __values_first, _Iterator3 __out_keys_first,
                             _Iterator4 __out_values_first, _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
 {
@@ -2094,7 +2069,7 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator4>();
     auto __out_values = __keep_value_outputs(__out_values_first, __out_values_first + __n);
     return oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __keys.all_view(), __values.all_view(),
+        _BackendTag{}, __exec, __keys.all_view(), __values.all_view(),
         __out_keys.all_view(), __out_values.all_view(), __binary_pred, __binary_op);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1321,8 +1321,7 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, const _ExecutionPoli
     if (__last == __first)
         return __last;
     else if (__last - __first < 2)
-        return __pattern_any_of(__tag, __exec, __first, __last, __pred) ? __last
-                                                                                                          : __first;
+        return __pattern_any_of(__tag, __exec, __first, __last, __pred) ? __last : __first;
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -103,7 +103,7 @@ __pattern_for_each(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __ex
         [__f, __proj](auto&& __val) { std::invoke(__f, std::invoke(__proj, std::forward<decltype(__val)>(__val)));};
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(__tag, __exec, __f_1,
-                                                            oneapi::dpl::__ranges::views::all(std::forward<_R>(__r)));
+                                                        oneapi::dpl::__ranges::views::all(std::forward<_R>(__r)));
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -283,8 +283,7 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __ex
 
     if (__rng1.size() == __rng2.size())
     {
-        const bool __res = __ranges::__pattern_equal(__tag, __exec, __rng1,
-                                                     ::std::forward<_Range2>(__rng2), __pred);
+        const bool __res = __ranges::__pattern_equal(__tag, __exec, __rng1, ::std::forward<_Range2>(__rng2), __pred);
         return __res ? 0 : __rng1.size();
     }
 
@@ -422,8 +421,7 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __ex
     auto __s_rng = oneapi::dpl::experimental::ranges::views::iota(0, __count) |
                    oneapi::dpl::experimental::ranges::views::transform([__value](auto) { return __value; });
 
-    return __ranges::__pattern_search(__tag, __exec, std::forward<_Range>(__rng), __s_rng,
-                            __pred);
+    return __ranges::__pattern_search(__tag, __exec, std::forward<_Range>(__rng), __s_rng, __pred);
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -177,7 +177,7 @@ __pattern_swap(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Range
         const std::size_t __n = __rng1.size();
         auto __exec1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(__exec);
         oneapi::dpl::__par_backend_hetero::__parallel_for(
-            _BackendTag{}, std::move(__exec1),
+            _BackendTag{}, __exec1,
             unseq_backend::__brick_swap<decltype(__exec1), _Function, std::decay_t<_Range1>, std::decay_t<_Range2>>{
                 __f, __n},
             __n, __rng1, __rng2)
@@ -188,7 +188,7 @@ __pattern_swap(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Range
     auto __exec2 =
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(__exec);
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::move(__exec2),
+        _BackendTag{}, __exec2,
         unseq_backend::__brick_swap<decltype(__exec2), _Function, std::decay_t<_Range2>, std::decay_t<_Range1>>{__f,
                                                                                                                 __n},
         __n, __rng2, __rng1)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -175,8 +175,7 @@ __pattern_swap(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Range
     if (__rng1.size() <= __rng2.size())
     {
         const std::size_t __n = __rng1.size();
-        auto __exec1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(
-            __exec);
+        auto __exec1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(__exec);
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, std::move(__exec1),
             unseq_backend::__brick_swap<decltype(__exec1), _Function, std::decay_t<_Range1>, std::decay_t<_Range2>>{

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1107,7 +1107,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
     _NoOpFunctor __get_data_op;
 
     return __parallel_transform_scan_base(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
+        __backend_tag, __exec, std::forward<_Range1>(__in_rng),
         std::forward<_Range2>(__out_rng), __init,
         // local scan
         unseq_backend::__scan<_Inclusive, _ExecutionPolicy, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner,
@@ -1211,7 +1211,7 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
     oneapi::dpl::__par_backend_hetero::__buffer<int32_t> __mask_buf(__n);
 
     return __parallel_transform_scan_base(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec),
+        __backend_tag, __exec,
         oneapi::dpl::__ranges::zip_view(
             __in_rng, oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
                           __mask_buf.get_buffer())),
@@ -1258,7 +1258,7 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
                                                                decltype(__n)>;
         using _CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, _Assign, /*inclusive*/ std::true_type, 1>;
 
-        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
+        return __parallel_scan_copy(__backend_tag, __exec, std::forward<_Range1>(__rng),
                                     std::forward<_Range2>(__result), __n,
                                     _CreateOp{oneapi::dpl::__internal::__not_pred<_BinaryPredicate>{__pred}},
                                     _CopyOp{_ReduceOp{}, _Assign{}});
@@ -1320,7 +1320,7 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
         using _CreateOp = unseq_backend::__create_mask<_UnaryPredicate, decltype(__n)>;
         using _CopyOp = unseq_backend::__partition_by_mask<_ReduceOp, /*inclusive*/ std::true_type>;
 
-        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
+        return __parallel_scan_copy(__backend_tag, __exec, std::forward<_Range1>(__rng),
                                     std::forward<_Range2>(__result), __n, _CreateOp{__pred}, _CopyOp{_ReduceOp{}});
     }
 }
@@ -1353,7 +1353,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
         using _SizeBreakpoints = std::integer_sequence<std::uint16_t, 16, 32, 64, 128, 256, 512, 1024, 2048>;
 
         return __par_backend_hetero::__static_monotonic_dispatcher<_SizeBreakpoints>::__dispatch(
-            _SingleGroupInvoker{}, __n, std::forward<_ExecutionPolicy>(__exec), __n, std::forward<_InRng>(__in_rng),
+            _SingleGroupInvoker{}, __n, __exec, __n, std::forward<_InRng>(__in_rng),
             std::forward<_OutRng>(__out_rng), __pred, __assign);
     }
     else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
@@ -1373,7 +1373,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
         using _CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, _Assign,
                                                       /*inclusive*/ std::true_type, 1>;
 
-        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+        return __parallel_scan_copy(__backend_tag, __exec,
                                     std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
                                     _CreateOp{__pred}, _CopyOp{_ReduceOp{}, __assign});
     }
@@ -1446,7 +1446,7 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
     oneapi::dpl::__par_backend_hetero::__buffer<int32_t> __mask_buf(__n1);
 
     return __par_backend_hetero::__parallel_transform_scan_base(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec),
+        __backend_tag, __exec,
         oneapi::dpl::__ranges::make_zip_view(
             std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
             oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
@@ -1478,7 +1478,7 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, c
     }
     else
     {
-        return __parallel_set_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
+        return __parallel_set_scan(__backend_tag, __exec, std::forward<_Range1>(__rng1),
                                    std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp,
                                    __is_op_difference);
     }
@@ -1953,7 +1953,7 @@ __parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
         __backend_tag,
-        __par_backend_hetero::make_wrapped_policy<__or_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)), __f,
+        __par_backend_hetero::make_wrapped_policy<__or_policy_wrapper>(__exec), __f,
         __parallel_or_tag{}, __buf.all_view(), __s_buf.all_view());
 }
 
@@ -1970,7 +1970,7 @@ __parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
         __backend_tag,
-        __par_backend_hetero::make_wrapped_policy<__or_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)), __f,
+        __par_backend_hetero::make_wrapped_policy<__or_policy_wrapper>(__exec), __f,
         __parallel_or_tag{}, __buf.all_view());
 }
 
@@ -1997,8 +1997,7 @@ __parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, con
                                           __parallel_find_backward_tag<decltype(__buf.all_view())>>;
     return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
                          __backend_tag,
-                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
-                             ::std::forward<_ExecutionPolicy>(__exec)),
+                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(__exec),
                          __f, _TagType{}, __buf.all_view(), __s_buf.all_view());
 }
 
@@ -2017,8 +2016,7 @@ __parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, con
                                           __parallel_find_backward_tag<decltype(__buf.all_view())>>;
     return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
                          __backend_tag,
-                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
-                             ::std::forward<_ExecutionPolicy>(__exec)),
+                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(__exec),
                          __f, _TagType{}, __buf.all_view());
 }
 
@@ -2229,7 +2227,7 @@ auto
 __parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                        _Range&& __rng, _Compare __comp, _Proj __proj)
 {
-    return __parallel_sort_impl(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
+    return __parallel_sort_impl(__backend_tag, __exec, ::std::forward<_Range>(__rng),
                                 oneapi::dpl::__internal::__compare<_Compare, _Proj>{__comp, __proj});
 }
 
@@ -2250,7 +2248,7 @@ __parallel_partial_sort(oneapi::dpl::__internal::__device_backend_tag __backend_
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    return __parallel_partial_sort_impl(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __buf.all_view(),
+    return __parallel_partial_sort_impl(__backend_tag, __exec, __buf.all_view(),
                                         __partial_merge_kernel<decltype(__mid_idx)>{__mid_idx}, __comp);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1170,7 +1170,7 @@ struct __invoke_single_group_copy_if
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _GenMask,
           typename _WriteOp, typename _IsUniquePattern>
 auto
-__parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                                  _InRng&& __in_rng, _OutRng&& __out_rng, _Size, _GenMask __generate_mask,
                                  _WriteOp __write_op, _IsUniquePattern __is_unique_pattern)
 {
@@ -1243,9 +1243,9 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
 
-        return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
-                                                _GenMask{__pred}, _WriteOp{_Assign{}},
+        return __parallel_reduce_then_scan_copy(__backend_tag, __exec, std::forward<_Range1>(__rng),
+                                                std::forward<_Range2>(__result), __n, _GenMask{__pred},
+                                                _WriteOp{_Assign{}},
                                                 /*_IsUniquePattern=*/std::true_type{});
     }
     else
@@ -1308,7 +1308,7 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
         using _WriteOp =
             oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
 
-        return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+        return __parallel_reduce_then_scan_copy(__backend_tag, __exec,
                                                 std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
                                                 _GenMask{__pred, {}}, _WriteOp{},
                                                 /*_IsUniquePattern=*/std::false_type{});
@@ -1360,7 +1360,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
 
-        return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+        return __parallel_reduce_then_scan_copy(__backend_tag, __exec,
                                                 std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
                                                 _GenMask{__pred, {}}, _WriteOp{__assign},
                                                 /*_IsUniquePattern=*/std::false_type{});

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -486,7 +486,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
     template <typename _Policy, typename _InRng, typename _OutRng, typename _InitType, typename _BinaryOperation,
               typename _UnaryOp, typename _Assign>
     auto
-    operator()(_Policy&& __policy, _InRng&& __in_rng, _OutRng&& __out_rng, ::std::size_t __n, _InitType __init,
+    operator()(const _Policy& __policy, _InRng&& __in_rng, _OutRng&& __out_rng, ::std::size_t __n, _InitType __init,
                _BinaryOperation __bin_op, _UnaryOp __unary_op, _Assign __assign)
     {
         using _ValueType = ::std::uint16_t;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1076,7 +1076,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
             if (__group_scan_fits_in_slm<_Type>(__exec.queue(), __n, __n_uniform, __single_group_upper_limit))
             {
                 return __parallel_transform_scan_single_group(
-                    __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
+                    __backend_tag, __exec, std::forward<_Range1>(__in_rng),
                     std::forward<_Range2>(__out_rng), __n, __unary_op, __init, __binary_op, _Inclusive{});
             }
         }
@@ -1089,7 +1089,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
             _GenInput __gen_transform{__unary_op};
 
             return __parallel_transform_reduce_then_scan(
-                __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
+                __backend_tag, __exec, std::forward<_Range1>(__in_rng),
                 std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform, _ScanInputTransform{},
                 _WriteOp{}, __init, _Inclusive{}, /*_IsUniquePattern=*/std::false_type{});
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1052,7 +1052,7 @@ struct __write_to_id_if_else
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation, typename _InitType,
           typename _BinaryOperation, typename _Inclusive>
 auto
-__parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                           _Range1&& __in_rng, _Range2&& __out_rng, std::size_t __n, _UnaryOperation __unary_op,
                           _InitType __init, _BinaryOperation __binary_op, _Inclusive)
 {
@@ -1191,7 +1191,7 @@ __parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag _
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _CreateMaskOp,
           typename _CopyByMaskOp>
 auto
-__parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                      _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _CreateMaskOp __create_mask_op,
                      _CopyByMaskOp __copy_by_mask_op)
 {
@@ -1229,7 +1229,7 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinaryPredicate>
 auto
-__parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                        _Range1&& __rng, _Range2&& __result, _BinaryPredicate __pred)
 {
     using _Assign = oneapi::dpl::__internal::__pstl_assign;
@@ -1299,7 +1299,7 @@ __parallel_reduce_by_segment_reduce_then_scan(oneapi::dpl::__internal::__device_
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryPredicate>
 auto
-__parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                           _Range1&& __rng, _Range2&& __result, _UnaryPredicate __pred)
 {
     oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng.size();
@@ -1328,7 +1328,7 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _Pred,
           typename _Assign = oneapi::dpl::__internal::__pstl_assign>
 auto
-__parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                    _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _Pred __pred, _Assign __assign = _Assign{})
 {
     using _SingleGroupInvoker = __invoke_single_group_copy_if<_Size>;
@@ -1417,7 +1417,7 @@ __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
 auto
-__parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                     _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference)
 {
     using _Size1 = oneapi::dpl::__internal::__difference_t<_Range1>;
@@ -1466,7 +1466,7 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
 auto
-__parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                   _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
                   _IsOpDifference __is_op_difference)
 {
@@ -1943,7 +1943,7 @@ class __or_policy_wrapper
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Brick>
 bool
-__parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
               _Iterator1 __first, _Iterator1 __last, _Iterator2 __s_first, _Iterator2 __s_last, _Brick __f)
 {
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -1962,7 +1962,7 @@ __parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _Exec
 // backend code.
 template <typename _ExecutionPolicy, typename _Iterator, typename _Brick>
 bool
-__parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec, _Iterator __first,
+__parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec, _Iterator __first,
               _Iterator __last, _Brick __f)
 {
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
@@ -1985,7 +1985,7 @@ class __find_policy_wrapper
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Brick, typename _IsFirst>
 _Iterator1
-__parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                 _Iterator1 __first, _Iterator1 __last, _Iterator2 __s_first, _Iterator2 __s_last, _Brick __f, _IsFirst)
 {
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -2007,7 +2007,7 @@ __parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _Ex
 // backend code.
 template <typename _ExecutionPolicy, typename _Iterator, typename _Brick, typename _IsFirst>
 _Iterator
-__parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                 _Iterator __first, _Iterator __last, _Brick __f, _IsFirst)
 {
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
@@ -2213,7 +2213,7 @@ template <
     ::std::enable_if_t<
         __is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 auto
-__parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                        _Range&& __rng, _Compare, _Proj __proj)
 {
     return __parallel_radix_sort<__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value>(
@@ -2226,7 +2226,7 @@ template <
     ::std::enable_if_t<
         !__is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 auto
-__parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                        _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     return __parallel_sort_impl(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
@@ -2242,7 +2242,7 @@ __parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_t
 //       __full_merge_kernel in order to use __parallel_sort_impl routine
 template <typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 auto
-__parallel_partial_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_partial_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                         _Iterator __first, _Iterator __mid, _Iterator __last, _Compare __comp)
 {
     const auto __mid_idx = __mid - __first;
@@ -2392,7 +2392,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Range4,
           typename _BinaryPredicate, typename _BinaryOperator>
 oneapi::dpl::__internal::__difference_t<_Range3>
-__parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range1&& __keys,
+__parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Range1&& __keys,
                              _Range2&& __values, _Range3&& __out_keys, _Range4&& __out_values,
                              _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1268,7 +1268,7 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typenam
           typename _BinaryPredicate, typename _BinaryOperator>
 auto
 __parallel_reduce_by_segment_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
-                                              _ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& __values,
+                                              const _ExecutionPolicy& __exec, _Range1&& __keys, _Range2&& __values,
                                               _Range3&& __out_keys, _Range4&& __out_values,
                                               _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
 {
@@ -2413,7 +2413,7 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
         if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
         {
             auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan(
-                oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
+                oneapi::dpl::__internal::__device_backend_tag{}, __exec,
                 std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys),
                 std::forward<_Range4>(__out_values), __binary_pred, __binary_op);
             // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2276,7 +2276,7 @@ struct __assign_key2_wrapper;
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Range4,
           typename _BinaryPredicate, typename _BinaryOperator>
 oneapi::dpl::__internal::__difference_t<_Range3>
-__parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+__parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
                                       _Range1&& __keys, _Range2&& __values, _Range3&& __out_keys,
                                       _Range4&& __out_values, _BinaryPredicate __binary_pred,
                                       _BinaryOperator __binary_op,
@@ -2379,8 +2379,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     //reduce by segment
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         oneapi::dpl::__internal::__device_backend_tag{},
-        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce2_wrapper>(
-            std::forward<_ExecutionPolicy>(__exec)),
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce2_wrapper>(__exec),
         unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__intermediate_result_end), _Range4>(
             __binary_op, __intermediate_result_end),
         __result_end,
@@ -2424,10 +2423,9 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
     }
 #endif
     return __parallel_reduce_by_segment_fallback(
-        oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
-        std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys),
-        std::forward<_Range4>(__out_values), __binary_pred, __binary_op,
-        oneapi::dpl::unseq_backend::__has_known_identity<_BinaryOperator, __val_type>{});
+        oneapi::dpl::__internal::__device_backend_tag{}, __exec, std::forward<_Range1>(__keys),
+        std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values),
+        __binary_pred, __binary_op, oneapi::dpl::unseq_backend::__has_known_identity<_BinaryOperator, __val_type>{});
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1179,7 +1179,7 @@ __parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag _
     using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
-    return __parallel_transform_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+    return __parallel_transform_reduce_then_scan(__backend_tag, __exec,
                                                  std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng),
                                                  _GenReduceInput{__generate_mask}, _ReduceOp{},
                                                  _GenScanInput{__generate_mask, {}}, _ScanInputTransform{}, __write_op,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -658,7 +658,7 @@ __parallel_transform_scan_base(oneapi::dpl::__internal::__device_backend_tag, co
 
     return __parallel_scan_submitter<_CustomName, _PropagateKernel>()(
         __exec, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng),
-        __init, __local_scan, __group_scan, __global_scan);
+                                                __init, __local_scan, __group_scan, __global_scan);
 }
 
 template <typename _Type>
@@ -1381,7 +1381,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
 auto
-__parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                                 _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
                                 _IsOpDifference)
 {
@@ -1402,7 +1402,7 @@ __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __
     oneapi::dpl::__par_backend_hetero::__buffer<std::int32_t> __mask_buf(__rng1.size());
 
     return __parallel_transform_reduce_then_scan(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec),
+        __backend_tag, __exec,
         oneapi::dpl::__ranges::make_zip_view(
             std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
             oneapi::dpl::__ranges::all_view<std::int32_t, __par_backend_hetero::access_mode::read_write>(
@@ -1471,7 +1471,7 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _
 {
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
     {
-        return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+        return __parallel_set_reduce_then_scan(__backend_tag, __exec,
                                                std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
                                                std::forward<_Range3>(__result), __comp, __is_op_difference);
     }
@@ -1745,7 +1745,7 @@ struct __parallel_find_or_impl_one_wg<__or_tag_check, __internal::__optional_ker
     template <typename _ExecutionPolicy, typename _BrickTag, typename __FoundStateType, typename _Predicate,
               typename... _Ranges>
     __FoundStateType
-    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _BrickTag __brick_tag,
+    operator()(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _BrickTag __brick_tag,
                const std::size_t __rng_n, const std::size_t __wgroup_size, const __FoundStateType __init_value,
                _Predicate __pred, _Ranges&&... __rngs)
     {
@@ -1810,7 +1810,7 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
     template <typename _ExecutionPolicy, typename _BrickTag, typename _AtomicType, typename _Predicate,
               typename... _Ranges>
     _AtomicType
-    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _BrickTag __brick_tag,
+    operator()(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _BrickTag __brick_tag,
                const std::size_t __rng_n, const std::size_t __n_groups, const std::size_t __wgroup_size,
                const _AtomicType __init_value, _Predicate __pred, _Ranges&&... __rngs)
     {
@@ -1878,7 +1878,7 @@ template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typena
 ::std::conditional_t<
     ::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
     oneapi::dpl::__internal::__difference_t<typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>
-__parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
+__parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Brick __f,
                    _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
@@ -1909,7 +1909,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
         // Single WG implementation
         __result = __parallel_find_or_impl_one_wg<__or_tag_check, __find_or_one_wg_kernel_name>()(
-            oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __brick_tag,
+            oneapi::dpl::__internal::__device_backend_tag{}, __exec, __brick_tag,
             __rng_n, __wgroup_size, __init_value, __pred, std::forward<_Ranges>(__rngs)...);
     }
     else
@@ -1922,7 +1922,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
         // Multiple WG implementation
         __result = __parallel_find_or_impl_multiple_wgs<__or_tag_check, __find_or_kernel_name>()(
-            oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __brick_tag,
+            oneapi::dpl::__internal::__device_backend_tag{}, __exec, __brick_tag,
             __rng_n, __n_groups, __wgroup_size, __init_value, __pred, std::forward<_Ranges>(__rngs)...);
     }
 
@@ -2108,7 +2108,7 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
 {
     template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Merge, typename _Compare>
     auto
-    operator()(_BackendTag, _ExecutionPolicy&& __exec, _Range&& __rng, _Merge __merge, _Compare __comp) const
+    operator()(_BackendTag, const _ExecutionPolicy& __exec, _Range&& __rng, _Merge __merge, _Compare __comp) const
     {
         using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
         using _Size = oneapi::dpl::__internal::__difference_t<_Range>;
@@ -2176,7 +2176,7 @@ class __sort_global_kernel;
 
 template <typename _ExecutionPolicy, typename _Range, typename _Merge, typename _Compare>
 auto
-__parallel_partial_sort_impl(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range&& __rng,
+__parallel_partial_sort_impl(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Range&& __rng,
                              _Merge __merge, _Compare __comp)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
@@ -2186,7 +2186,7 @@ __parallel_partial_sort_impl(oneapi::dpl::__internal::__device_backend_tag, _Exe
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_copy_back_kernel<_CustomName>>;
 
     return __parallel_partial_sort_submitter<_GlobalSortKernel, _CopyBackKernel>()(
-        oneapi::dpl::__internal::__device_backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__internal::__device_backend_tag{}, __exec,
         ::std::forward<_Range>(__rng), __merge, __comp);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -558,7 +558,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _UnaryOperation, typename _InitType,
           typename _BinaryOperation, typename _Inclusive>
 auto
-__parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+__parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
                                        _InRng&& __in_rng, _OutRng&& __out_rng, ::std::size_t __n,
                                        _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op,
                                        _Inclusive)
@@ -594,7 +594,7 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
                         ::std::integral_constant<::std::uint16_t, __wg_size>,
                         ::std::integral_constant<::std::uint16_t, __num_elems_per_item>, _BinaryOperation,
                         /* _IsFullGroup= */ std::true_type, _Inclusive, _CustomName>>>()(
-                    ::std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                    __exec, std::forward<_InRng>(__in_rng),
                     std::forward<_OutRng>(__out_rng), __n, __init, __binary_op, __unary_op);
             else
                 __event = __parallel_transform_scan_static_single_group_submitter<
@@ -604,7 +604,7 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
                         ::std::integral_constant<::std::uint16_t, __wg_size>,
                         ::std::integral_constant<::std::uint16_t, __num_elems_per_item>, _BinaryOperation,
                         /* _IsFullGroup= */ ::std::false_type, _Inclusive, _CustomName>>>()(
-                    ::std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                    __exec, std::forward<_InRng>(__in_rng),
                     std::forward<_OutRng>(__out_rng), __n, __init, __binary_op, __unary_op);
             return __future(__event, __dummy_result_and_scratch);
         };
@@ -638,7 +638,7 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
 
         auto __event =
             __parallel_transform_scan_dynamic_single_group_submitter<_Inclusive::value, _DynamicGroupScanKernel>()(
-                std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                __exec, std::forward<_InRng>(__in_rng),
                 std::forward<_OutRng>(__out_rng), __n, __init, __binary_op, __unary_op, __max_wg_size);
         return __future(__event, __dummy_result_and_scratch);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1287,7 +1287,7 @@ __parallel_reduce_by_segment_reduce_then_scan(oneapi::dpl::__internal::__device_
     // __gen_red_by_seg_scan_input requires that __n > 1
     assert(__n > 1);
     return __parallel_transform_reduce_then_scan(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec),
+        __backend_tag, __exec,
         oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__keys), std::forward<_Range2>(__values)),
         oneapi::dpl::__ranges::make_zip_view(std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values)),
         _GenReduceInput{__binary_pred}, _ReduceOp{__binary_op}, _GenScanInput{__binary_pred, __n},

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -242,7 +242,8 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
 
         // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
         // because we always specialize this operator() calls only by _ExecutionPolicy as "const reference".
-        // So, from this template param point of view, only one specialization is possible.
+        // So, from this template param point of view, only one specialization is possible per concrete _ExecutionPolicy type.
+        // _ExecutionPolicy type information is embedded in _CustomName to distinguish between concrete policy types.
         using _LocalScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             __scan_local_kernel, _CustomName, _Range1, _Range2, _Type, _LocalScan, _GroupScan, _GlobalScan>;
         using _GroupScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2217,7 +2217,7 @@ __parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_t
                        _Range&& __rng, _Compare, _Proj __proj)
 {
     return __parallel_radix_sort<__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value>(
-        __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __proj);
+        __backend_tag, __exec, ::std::forward<_Range>(__rng), __proj);
 }
 #endif // _ONEDPL_USE_RADIX_SORT
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1129,7 +1129,7 @@ struct __invoke_single_group_copy_if
     template <std::uint16_t _Size, typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Pred,
               typename _Assign = oneapi::dpl::__internal::__pstl_assign>
     auto
-    operator()(_ExecutionPolicy&& __exec, std::size_t __n, _InRng&& __in_rng, _OutRng&& __out_rng, _Pred __pred,
+    operator()(const _ExecutionPolicy& __exec, std::size_t __n, _InRng&& __in_rng, _OutRng&& __out_rng, _Pred __pred,
                _Assign __assign)
     {
         constexpr ::std::uint16_t __wg_size = ::std::min(_Size, __targeted_wg_size);
@@ -1148,7 +1148,7 @@ struct __invoke_single_group_copy_if
             using _FullKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<_FullKernel>;
             return __par_backend_hetero::__parallel_copy_if_static_single_group_submitter<
                 _SizeType, __num_elems_per_item, __wg_size, true, _FullKernelName>()(
-                std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                __exec, std::forward<_InRng>(__in_rng),
                 std::forward<_OutRng>(__out_rng), __n, _InitType{}, _ReduceOp{}, __pred, __assign);
         }
         else
@@ -1161,7 +1161,7 @@ struct __invoke_single_group_copy_if
                 oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<_NonFullKernel>;
             return __par_backend_hetero::__parallel_copy_if_static_single_group_submitter<
                 _SizeType, __num_elems_per_item, __wg_size, false, _NonFullKernelName>()(
-                std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                __exec, std::forward<_InRng>(__in_rng),
                 std::forward<_OutRng>(__out_rng), __n, _InitType{}, _ReduceOp{}, __pred, __assign);
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -647,7 +647,7 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _InitType, typename _LocalScan,
           typename _GroupScan, typename _GlobalScan>
 auto
-__parallel_transform_scan_base(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+__parallel_transform_scan_base(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
                                _Range1&& __in_rng, _Range2&& __out_rng, _InitType __init, _LocalScan __local_scan,
                                _GroupScan __group_scan, _GlobalScan __global_scan)
 {
@@ -657,7 +657,7 @@ __parallel_transform_scan_base(oneapi::dpl::__internal::__device_backend_tag, _E
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__scan_propagate_kernel<_CustomName>>;
 
     return __parallel_scan_submitter<_CustomName, _PropagateKernel>()(
-        std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng),
+        __exec, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng),
         __init, __local_scan, __group_scan, __global_scan);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -235,10 +235,14 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _InitType,
               typename _LocalScan, typename _GroupScan, typename _GlobalScan>
     auto
-    operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _InitType __init,
+    operator()(const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2, _InitType __init,
                _LocalScan __local_scan, _GroupScan __group_scan, _GlobalScan __global_scan) const
     {
         using _Type = typename _InitType::__value_type;
+
+        // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
+        // because we always specialize this operator() calls only by _ExecutionPolicy as "const reference".
+        // So, from this template param point of view, only one specialization is possible.
         using _LocalScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             __scan_local_kernel, _CustomName, _Range1, _Range2, _Type, _LocalScan, _GroupScan, _GlobalScan>;
         using _GroupScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -176,7 +176,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
 //for some algorithms happens that size of processing range is n, but amount of iterations is n/2.
 template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
 auto
-__parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Fp __brick, _Index __count,
+__parallel_for(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Fp __brick, _Index __count,
                _Ranges&&... __rngs)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -58,7 +58,7 @@ struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name..
 {
     template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
     auto
-    operator()(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
+    operator()(const _ExecutionPolicy& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
         assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
         _PRINT_INFO_IN_DEBUG_MODE(__exec);
@@ -138,7 +138,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
 
     template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
     auto
-    operator()(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
+    operator()(const _ExecutionPolicy& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
         assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
         const std::size_t __work_group_size =
@@ -194,12 +194,10 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
     {
         if (__count >= __large_submitter::__estimate_best_start_size(__exec, __brick))
         {
-            return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
-                                       std::forward<_Ranges>(__rngs)...);
+            return __large_submitter{}(__exec, __brick, __count, std::forward<_Ranges>(__rngs)...);
         }
     }
-    return __small_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
-                               std::forward<_Ranges>(__rngs)...);
+    return __small_submitter{}(__exec, __brick, __count, std::forward<_Ranges>(__rngs)...);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -80,7 +80,7 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
 
 template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
 auto
-__parallel_for(oneapi::dpl::__internal::__fpga_backend_tag, _ExecutionPolicy&& __exec, _Fp __brick, _Index __count,
+__parallel_for(oneapi::dpl::__internal::__fpga_backend_tag, const _ExecutionPolicy& __exec, _Fp __brick, _Index __count,
                _Ranges&&... __rngs)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
@@ -97,7 +97,7 @@ __parallel_for(oneapi::dpl::__internal::__fpga_backend_tag, _ExecutionPolicy&& _
 // TODO: check if it makes sense to move these wrappers out of backend to a common place
 template <typename _ExecutionPolicy, typename _Event, typename _Range1, typename _Range2, typename _BinHashMgr>
 auto
-__parallel_histogram(oneapi::dpl::__internal::__fpga_backend_tag, _ExecutionPolicy&& __exec, const _Event& __init_event,
+__parallel_histogram(oneapi::dpl::__internal::__fpga_backend_tag, const _ExecutionPolicy& __exec, const _Event& __init_event,
                      _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
     static_assert(sizeof(oneapi::dpl::__internal::__value_t<_Range2>) <= sizeof(::std::uint32_t),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -86,8 +86,8 @@ __parallel_for(oneapi::dpl::__internal::__fpga_backend_tag, _ExecutionPolicy&& _
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using __parallel_for_name = __internal::__kernel_name_provider<_CustomName>;
 
-    return __parallel_for_fpga_submitter<__parallel_for_name>()(std::forward<_ExecutionPolicy>(__exec), __brick,
-                                                                __count, std::forward<_Ranges>(__rngs)...);
+    return __parallel_for_fpga_submitter<__parallel_for_name>()(__exec, __brick, __count,
+                                                                std::forward<_Ranges>(__rngs)...);
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -57,7 +57,7 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
 {
     template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
     auto
-    operator()(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
+    operator()(const _ExecutionPolicy& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
         assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -105,7 +105,7 @@ __parallel_histogram(oneapi::dpl::__internal::__fpga_backend_tag, const _Executi
 
     // workaround until we implement more performant version for patterns
     return oneapi::dpl::__par_backend_hetero::__parallel_histogram(
-        oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __init_event,
+        oneapi::dpl::__internal::__device_backend_tag{}, __exec, __init_event,
         std::forward<_Range1>(__input), std::forward<_Range2>(__bins), __binhash_manager);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -317,7 +317,7 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
 {
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
     auto
-    operator()(_ExecutionPolicy&& __exec, const sycl::event& __init_event, ::std::uint16_t __work_group_size,
+    operator()(const _ExecutionPolicy& __exec, const sycl::event& __init_event, ::std::uint16_t __work_group_size,
                _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
     {
         using _local_histogram_type = ::std::uint32_t;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -410,7 +410,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
 {
     template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
     auto
-    operator()(_BackendTag, _ExecutionPolicy&& __exec, const sycl::event& __init_event,
+    operator()(_BackendTag, const _ExecutionPolicy& __exec, const sycl::event& __init_event,
                ::std::uint16_t __min_iters_per_work_item, ::std::uint16_t __work_group_size, _Range1&& __input,
                _Range2&& __bins, const _BinHashMgr& __binhash_manager)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -215,7 +215,7 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
 {
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
     auto
-    operator()(_ExecutionPolicy&& __exec, const sycl::event& __init_event, ::std::uint16_t __work_group_size,
+    operator()(const _ExecutionPolicy& __exec, const sycl::event& __init_event, ::std::uint16_t __work_group_size,
                _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
     {
         const ::std::size_t __n = __input.size();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -480,7 +480,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
 };
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
 auto
-__histogram_general_private_global_atomics(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+__histogram_general_private_global_atomics(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
                                            const sycl::event& __init_event, ::std::uint16_t __min_iters_per_work_item,
                                            ::std::uint16_t __work_group_size, _Range1&& __input, _Range2&& __bins,
                                            const _BinHashMgr& __binhash_manager)
@@ -491,9 +491,8 @@ __histogram_general_private_global_atomics(oneapi::dpl::__internal::__device_bac
         __histo_kernel_private_glocal_atomics<_CustomName>>;
 
     return __histogram_general_private_global_atomics_submitter<_global_atomics_name>()(
-        oneapi::dpl::__internal::__device_backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __init_event,
-        __min_iters_per_work_item, __work_group_size, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins),
-        __binhash_manager);
+        oneapi::dpl::__internal::__device_backend_tag{}, __exec, __init_event, __min_iters_per_work_item,
+        __work_group_size, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins), __binhash_manager);
 }
 
 template <::std::uint16_t __iters_per_work_item, typename _ExecutionPolicy, typename _Range1, typename _Range2,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -499,7 +499,7 @@ template <::std::uint16_t __iters_per_work_item, typename _ExecutionPolicy, type
           typename _BinHashMgr>
 auto
 __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
-                                   _ExecutionPolicy&& __exec, const sycl::event& __init_event, _Range1&& __input,
+                                   const _ExecutionPolicy& __exec, const sycl::event& __init_event, _Range1&& __input,
                                    _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
     using _private_histogram_type = ::std::uint16_t;
@@ -518,8 +518,8 @@ __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag
     {
         return __future(
             __histogram_general_registers_local_reduction<__iters_per_work_item, __max_work_item_private_bins>(
-                __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, __work_group_size,
-                ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins), __binhash_manager));
+                __backend_tag, __exec, __init_event, __work_group_size, ::std::forward<_Range1>(__input),
+                ::std::forward<_Range2>(__bins), __binhash_manager));
     }
     // if bins fit into SLM, use local atomics
     else if (__num_bins * sizeof(_local_histogram_type) +
@@ -527,8 +527,8 @@ __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag
              __local_mem_size)
     {
         return __future(__histogram_general_local_atomics<__iters_per_work_item>(
-            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, __work_group_size,
-            ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins), __binhash_manager));
+            __backend_tag, __exec, __init_event, __work_group_size, ::std::forward<_Range1>(__input),
+            ::std::forward<_Range2>(__bins), __binhash_manager));
     }
     else // otherwise, use global atomics (private copies per workgroup)
     {
@@ -538,8 +538,8 @@ __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag
         // private copies of the histogram bins in global memory.  No unrolling is taken advantage of here because it
         // is a runtime argument.
         return __future(__histogram_general_private_global_atomics(
-            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, __iters_per_work_item,
-            __work_group_size, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins), __binhash_manager));
+            __backend_tag, __exec, __init_event, __iters_per_work_item, __work_group_size,
+            ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins), __binhash_manager));
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -288,7 +288,7 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
 template <::std::uint16_t __iters_per_work_item, ::std::uint8_t __bins_per_work_item, typename _ExecutionPolicy,
           typename _Range1, typename _Range2, typename _BinHashMgr>
 auto
-__histogram_general_registers_local_reduction(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+__histogram_general_registers_local_reduction(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
                                               const sycl::event& __init_event, ::std::uint16_t __work_group_size,
                                               _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
@@ -304,8 +304,8 @@ __histogram_general_registers_local_reduction(oneapi::dpl::__internal::__device_
 
     return __histogram_general_registers_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
                                                                    _RegistersLocalReducName>()(
-        ::std::forward<_ExecutionPolicy>(__exec), __init_event, __work_group_size, ::std::forward<_Range1>(__input),
-        ::std::forward<_Range2>(__bins), __binhash_manager);
+        __exec, __init_event, __work_group_size, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins),
+        __binhash_manager);
 }
 
 template <::std::uint16_t __iters_per_work_item, typename _KernelName>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -552,14 +552,14 @@ __parallel_histogram(oneapi::dpl::__internal::__device_backend_tag __backend_tag
     if (__input.size() < 1048576) // 2^20
     {
         return __parallel_histogram_select_kernel</*iters_per_workitem = */ 4>(
-            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, ::std::forward<_Range1>(__input),
-            ::std::forward<_Range2>(__bins), __binhash_manager);
+            __backend_tag, __exec, __init_event, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins),
+            __binhash_manager);
     }
     else
     {
         return __parallel_histogram_select_kernel</*iters_per_workitem = */ 32>(
-            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, ::std::forward<_Range1>(__input),
-            ::std::forward<_Range2>(__bins), __binhash_manager);
+            __backend_tag, __exec, __init_event, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins),
+            __binhash_manager);
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -383,7 +383,7 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
 template <::std::uint16_t __iters_per_work_item, typename _ExecutionPolicy, typename _Range1, typename _Range2,
           typename _BinHashMgr>
 auto
-__histogram_general_local_atomics(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+__histogram_general_local_atomics(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
                                   const sycl::event& __init_event, ::std::uint16_t __work_group_size, _Range1&& __input,
                                   _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
@@ -398,8 +398,8 @@ __histogram_general_local_atomics(oneapi::dpl::__internal::__device_backend_tag,
         __histo_kernel_local_atomics<_iters_per_work_item_t, _CustomName>>;
 
     return __histogram_general_local_atomics_submitter<__iters_per_work_item, _local_atomics_name>()(
-        ::std::forward<_ExecutionPolicy>(__exec), __init_event, __work_group_size, ::std::forward<_Range1>(__input),
-        ::std::forward<_Range2>(__bins), __binhash_manager);
+        __exec, __init_event, __work_group_size, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins),
+        __binhash_manager);
 }
 
 template <typename _KernelName>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -546,7 +546,7 @@ __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
 auto
-__parallel_histogram(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_histogram(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                      const sycl::event& __init_event, _Range1&& __input, _Range2&& __bins,
                      const _BinHashMgr& __binhash_manager)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -288,9 +288,10 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
 template <::std::uint16_t __iters_per_work_item, ::std::uint8_t __bins_per_work_item, typename _ExecutionPolicy,
           typename _Range1, typename _Range2, typename _BinHashMgr>
 auto
-__histogram_general_registers_local_reduction(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
-                                              const sycl::event& __init_event, ::std::uint16_t __work_group_size,
-                                              _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
+__histogram_general_registers_local_reduction(oneapi::dpl::__internal::__device_backend_tag,
+                                              const _ExecutionPolicy& __exec, const sycl::event& __init_event,
+                                              ::std::uint16_t __work_group_size, _Range1&& __input, _Range2&& __bins,
+                                              const _BinHashMgr& __binhash_manager)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
@@ -480,10 +481,10 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
 };
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
 auto
-__histogram_general_private_global_atomics(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
-                                           const sycl::event& __init_event, ::std::uint16_t __min_iters_per_work_item,
-                                           ::std::uint16_t __work_group_size, _Range1&& __input, _Range2&& __bins,
-                                           const _BinHashMgr& __binhash_manager)
+__histogram_general_private_global_atomics(oneapi::dpl::__internal::__device_backend_tag,
+                                           const _ExecutionPolicy& __exec, const sycl::event& __init_event,
+                                           ::std::uint16_t __min_iters_per_work_item, ::std::uint16_t __work_group_size,
+                                           _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -206,7 +206,7 @@ struct __parallel_merge_submitter<_OutSizeLimit, _IdType, __internal::__optional
 {
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare>
     auto
-    operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
+    operator()(const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
     {
         const _IdType __n1 = __rng1.size();
         const _IdType __n2 = __rng2.size();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -420,7 +420,7 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
   public:
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare>
     auto
-    operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
+    operator()(const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
     {
         const _IdType __n1 = __rng1.size();
         const _IdType __n2 = __rng2.size();
@@ -480,7 +480,7 @@ __get_starting_size_limit_for_large_submitter<int>()
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _OutSizeLimit = std::false_type>
 auto
-__parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range1&& __rng1,
+__parallel_merge(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Range1&& __rng1,
                  _Range2&& __rng2, _Range3&& __rng3, _Compare __comp, _OutSizeLimit = {})
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -313,7 +313,7 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
     // Calculation of split points on each base diagonal
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Compare, typename _Storage>
     sycl::event
-    eval_split_points_for_groups(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _IdType __n,
+    eval_split_points_for_groups(const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2, _IdType __n,
                                  _Compare __comp, const nd_range_params& __nd_range_params,
                                  _Storage& __base_diagonals_sp_global_storage) const
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -350,7 +350,7 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
               typename _Storage>
     sycl::event
-    run_parallel_merge(const sycl::event& __event, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
+    run_parallel_merge(const sycl::event& __event, const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2,
                        _Range3&& __rng3, _Compare __comp, const nd_range_params& __nd_range_params,
                        const _Storage& __base_diagonals_sp_global_storage) const
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -495,8 +495,8 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
         using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __merge_kernel_name<_CustomName, _WiIndex>>;
         return __parallel_merge_submitter<_OutSizeLimit, _WiIndex, _MergeKernelName>()(
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-            std::forward<_Range3>(__rng3), __comp);
+            __exec, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2), std::forward<_Range3>(__rng3),
+            __comp);
     }
     else
     {
@@ -508,9 +508,9 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
             using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
                 __merge_kernel_name_large<_CustomName, _WiIndex>>;
             return __parallel_merge_submitter_large<_OutSizeLimit, _WiIndex, _CustomName, _DiagonalsKernelName,
-                                                    _MergeKernelName>()(
-                std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                std::forward<_Range3>(__rng3), __comp);
+                                                    _MergeKernelName>()(__exec, std::forward<_Range1>(__rng1),
+                                                                        std::forward<_Range2>(__rng2),
+                                                                        std::forward<_Range3>(__rng3), __comp);
         }
         else
         {
@@ -520,9 +520,9 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
             using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
                 __merge_kernel_name_large<_CustomName, _WiIndex>>;
             return __parallel_merge_submitter_large<_OutSizeLimit, _WiIndex, _CustomName, _DiagonalsKernelName,
-                                                    _MergeKernelName>()(
-                std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                std::forward<_Range3>(__rng3), __comp);
+                                                    _MergeKernelName>()(__exec, std::forward<_Range1>(__rng1),
+                                                                        std::forward<_Range2>(__rng2),
+                                                                        std::forward<_Range3>(__rng3), __comp);
         }
     }
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -206,7 +206,8 @@ struct __parallel_merge_submitter<_OutSizeLimit, _IdType, __internal::__optional
 {
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare>
     auto
-    operator()(const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
+    operator()(const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3,
+               _Compare __comp) const
     {
         const _IdType __n1 = __rng1.size();
         const _IdType __n2 = __rng2.size();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -296,7 +296,7 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
     // Calculate nd-range parameters
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2>
     nd_range_params
-    eval_nd_range_params(_ExecutionPolicy&& __exec, const _Range1& __rng1, const _Range2& __rng2,
+    eval_nd_range_params(const _ExecutionPolicy& __exec, const _Range1& __rng1, const _Range2& __rng2,
                          const std::size_t __n) const
     {
         // Empirical number of values to process per work-item

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -786,7 +786,7 @@ __submit_selecting_leaf(const _ExecutionPolicy& __exec, _Range&& __rng, _Compare
     __wg_size = oneapi::dpl::__internal::__dpl_bit_floor(__wg_size);
 
     _Leaf __leaf(__rng, __comp, __data_per_workitem, __wg_size);
-    return __merge_sort<_IndexT>(std::forward<_ExecutionPolicy>(__exec), std::forward<_Range>(__rng), __comp, __leaf);
+    return __merge_sort<_IndexT>(__exec, std::forward<_Range>(__rng), __comp, __leaf);
 };
 
 template <typename _ExecutionPolicy, typename _Range, typename _Compare>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -570,7 +570,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
   public:
     template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _TempBuf, typename _LeafSizeT>
     std::tuple<sycl::event, bool, std::shared_ptr<__result_and_scratch_storage_base>>
-    operator()(_ExecutionPolicy&& __exec, _Range& __rng, _Compare __comp, _LeafSizeT __leaf_size, _TempBuf& __temp_buf,
+    operator()(const _ExecutionPolicy& __exec, _Range& __rng, _Compare __comp, _LeafSizeT __leaf_size, _TempBuf& __temp_buf,
                sycl::event __event_chain) const
     {
         // 1 final base diagonal for save final sp(0,0)
@@ -738,7 +738,7 @@ __merge_sort(const _ExecutionPolicy& __exec, _Range&& __rng, _Compare __comp, _L
 
 template <typename _IndexT, typename _ExecutionPolicy, typename _Range, typename _Compare>
 auto
-__submit_selecting_leaf(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
+__submit_selecting_leaf(const _ExecutionPolicy& __exec, _Range&& __rng, _Compare __comp)
 {
     using _Leaf = __leaf_sorter<std::decay_t<_Range>, _Compare>;
     using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
@@ -791,18 +791,16 @@ __submit_selecting_leaf(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __co
 
 template <typename _ExecutionPolicy, typename _Range, typename _Compare>
 auto
-__parallel_sort_impl(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range&& __rng,
+__parallel_sort_impl(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Range&& __rng,
                      _Compare __comp)
 {
     if (__rng.size() <= std::numeric_limits<std::uint32_t>::max())
     {
-        return __submit_selecting_leaf<std::uint32_t>(std::forward<_ExecutionPolicy>(__exec),
-                                                      std::forward<_Range>(__rng), __comp);
+        return __submit_selecting_leaf<std::uint32_t>(__exec, std::forward<_Range>(__rng), __comp);
     }
     else
     {
-        return __submit_selecting_leaf<std::uint64_t>(std::forward<_ExecutionPolicy>(__exec),
-                                                      std::forward<_Range>(__rng), __comp);
+        return __submit_selecting_leaf<std::uint64_t>(__exec, std::forward<_Range>(__rng), __comp);
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -211,11 +211,11 @@ struct __merge_sort_leaf_submitter;
 template <typename... _LeafSortName>
 struct __merge_sort_leaf_submitter<__internal::__optional_kernel_name<_LeafSortName...>>
 {
-    template <typename _Range, typename _LeafSorter>
+    template <typename _ExecutionPolicy, typename _Range, typename _LeafSorter>
     sycl::event
-    operator()(sycl::queue& __q, _Range& __rng, _LeafSorter& __leaf_sorter) const
+    operator()(const _ExecutionPolicy& __exec, _Range& __rng, _LeafSorter& __leaf_sorter) const
     {
-        return __q.submit([&__rng, &__leaf_sorter](sycl::handler& __cgh) {
+        return __exec.queue().submit([&__rng, &__leaf_sorter](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng);
             auto __storage_acc = __leaf_sorter.create_storage_accessor(__cgh);
             const std::uint32_t __wg_count =
@@ -663,11 +663,11 @@ struct __merge_sort_copy_back_submitter;
 template <typename... _CopyBackName>
 struct __merge_sort_copy_back_submitter<__internal::__optional_kernel_name<_CopyBackName...>>
 {
-    template <typename _Range, typename _TempBuf>
+    template <typename _ExecutionPolicy, typename _Range, typename _TempBuf>
     sycl::event
-    operator()(sycl::queue& __q, _Range& __rng, _TempBuf& __temp_buf, sycl::event __event_chain) const
+    operator()(const _ExecutionPolicy& __exec, _Range& __rng, _TempBuf& __temp_buf, sycl::event __event_chain) const
     {
-        return __q.submit([&__rng, &__temp_buf, &__event_chain](sycl::handler& __cgh) {
+        return __exec.queue().submit([&__rng, &__temp_buf, &__event_chain](sycl::handler& __cgh) {
             __cgh.depends_on(__event_chain);
             oneapi::dpl::__ranges::__require_access(__cgh, __rng);
             auto __temp_acc = __temp_buf.template get_access<access_mode::read>(__cgh);
@@ -698,7 +698,7 @@ class __sort_copy_back_kernel;
 
 template <typename _IndexT, typename _ExecutionPolicy, typename _Range, typename _Compare, typename _LeafSorter>
 auto
-__merge_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _LeafSorter& __leaf_sorter)
+__merge_sort(const _ExecutionPolicy& __exec, _Range&& __rng, _Compare __comp, _LeafSorter& __leaf_sorter)
 {
     using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
 
@@ -718,10 +718,8 @@ __merge_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _LeafSo
     assert((__leaf_sorter.__process_size & (__leaf_sorter.__process_size - 1)) == 0 &&
            "Leaf size must be a power of 2");
 
-    sycl::queue __q = __exec.queue();
-
     // 1. Perform sorting of the leaves of the merge sort tree
-    sycl::event __event_leaf_sort = __merge_sort_leaf_submitter<_LeafSortKernel>()(__q, __rng, __leaf_sorter);
+    sycl::event __event_leaf_sort = __merge_sort_leaf_submitter<_LeafSortKernel>()(__exec, __rng, __leaf_sorter);
 
     // 2. Merge sorting
     oneapi::dpl::__par_backend_hetero::__buffer<_Tp> __temp(__rng.size());
@@ -733,7 +731,7 @@ __merge_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _LeafSo
     // 3. If the data remained in the temporary buffer then copy it back
     if (__data_in_temp)
     {
-        __event_sort = __merge_sort_copy_back_submitter<_CopyBackKernel>()(__q, __rng, __temp_buf, __event_sort);
+        __event_sort = __merge_sort_copy_back_submitter<_CopyBackKernel>()(__exec, __rng, __temp_buf, __event_sort);
     }
     return __future(__event_sort, std::move(__temp_sp_storages));
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -507,10 +507,9 @@ template <typename _KernelName, ::std::uint32_t __radix_bits, bool __is_ascendin
 #endif
           >
 sycl::event
-__radix_sort_reorder_submit(const _ExecutionPolicy& __exec, ::std::size_t __segments,
-                            ::std::size_t __sg_size, ::std::uint32_t __radix_offset, _InRange&& __input_rng,
-                            _OutRange&& __output_rng, _OffsetBuf& __offset_buf, sycl::event __dependency_event,
-                            _Proj __proj
+__radix_sort_reorder_submit(const _ExecutionPolicy& __exec, ::std::size_t __segments, ::std::size_t __sg_size,
+                            ::std::uint32_t __radix_offset, _InRange&& __input_rng, _OutRange&& __output_rng,
+                            _OffsetBuf& __offset_buf, sycl::event __dependency_event, _Proj __proj
 #if _ONEDPL_COMPILE_KERNEL
                             , _Kernel& __kernel
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -658,16 +658,16 @@ struct __parallel_radix_sort_iteration
         // because we always specialize this submit() calls only by _ExecutionPolicy as "const reference".
         // So, from this template param point of view, only one specialization is possible.
         using _RadixCountKernel =
-            __internal::__kernel_name_generator<__count_phase, _CustomName, ::std::decay_t<_InRange>,
-                                                ::std::decay_t<_TmpBuf>, _Proj>;
+            __internal::__kernel_name_generator<__count_phase, _CustomName, std::decay_t<_InRange>,
+                                                std::decay_t<_TmpBuf>, _Proj>;
         using _RadixLocalScanKernel =
-            __internal::__kernel_name_generator<__local_scan_phase, _CustomName, ::std::decay_t<_TmpBuf>>;
+            __internal::__kernel_name_generator<__local_scan_phase, _CustomName, std::decay_t<_TmpBuf>>;
         using _RadixReorderPeerKernel =
             __internal::__kernel_name_generator<__reorder_peer_phase, _CustomName, std::decay_t<_InRange>,
-                                                ::std::decay_t<_OutRange>, _Proj>;
+                                                std::decay_t<_OutRange>, _Proj>;
         using _RadixReorderKernel =
-            __internal::__kernel_name_generator<__reorder_phase, _CustomName, ::std::decay_t<_InRange>,
-                                                ::std::decay_t<_OutRange>, _Proj>;
+            __internal::__kernel_name_generator<__reorder_phase, _CustomName, std::decay_t<_InRange>,
+                                                std::decay_t<_OutRange>, _Proj>;
 
         ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
         ::std::size_t __reorder_sg_size = __max_sg_size;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -168,7 +168,7 @@ template <typename _KernelName, ::std::uint32_t __radix_bits, bool __is_ascendin
 #endif
           >
 sycl::event
-__radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, ::std::size_t __wg_size,
+__radix_sort_count_submit(const _ExecutionPolicy& __exec, ::std::size_t __segments, ::std::size_t __wg_size,
                           ::std::uint32_t __radix_offset, _ValRange&& __val_rng, _CountBuf& __count_buf,
                           sycl::event __dependency_event, _Proj __proj
 #if _ONEDPL_COMPILE_KERNEL

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -272,7 +272,7 @@ template <typename _KernelName, ::std::uint32_t __radix_bits, typename _Executio
 #endif
           >
 sycl::event
-__radix_sort_scan_submit(_ExecutionPolicy&& __exec, ::std::size_t __scan_wg_size, ::std::size_t __segments,
+__radix_sort_scan_submit(const _ExecutionPolicy& __exec, ::std::size_t __scan_wg_size, ::std::size_t __segments,
                          _CountBuf& __count_buf, ::std::size_t __n, sycl::event __dependency_event
 #if _ONEDPL_COMPILE_KERNEL
                          , _Kernel& __kernel

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -507,7 +507,7 @@ template <typename _KernelName, ::std::uint32_t __radix_bits, bool __is_ascendin
 #endif
           >
 sycl::event
-__radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
+__radix_sort_reorder_submit(const _ExecutionPolicy& __exec, ::std::size_t __segments,
                             ::std::size_t __sg_size, ::std::uint32_t __radix_offset, _InRange&& __input_rng,
                             _OutRange&& __output_rng, _OffsetBuf& __offset_buf, sycl::event __dependency_event,
                             _Proj __proj

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -792,45 +792,40 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
 
     //TODO: 1.to reduce number of the kernels; 2.to define work group size in runtime, depending on number of elements
     constexpr std::size_t __wg_size = 64;
-    const auto __subgroup_sizes = __exec.queue().get_device().template get_info<sycl::info::device::sub_group_sizes>();
-    const bool __dev_has_sg16 = std::find(__subgroup_sizes.begin(), __subgroup_sizes.end(),
-                                          static_cast<std::size_t>(16)) != __subgroup_sizes.end();
-
-    //TODO: with _RadixSortKernel also the following a couple of compile time constants is used for unique kernel name
-    using _RadixSortKernel = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+    const bool __dev_has_sg16 = oneapi::dpl::__internal::__supports_sub_group_size(__exec, 16);
 
     if (__n <= 64 && __wg_size <= __max_wg_size)
-        __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size, 1, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
+        __event = __subgroup_radix_sort<__wg_size, 1, __radix_bits, __is_ascending>{}(
+            __exec, ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 128 && __wg_size * 2 <= __max_wg_size)
-        __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 2, 1, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
+        __event = __subgroup_radix_sort<__wg_size * 2, 1, __radix_bits, __is_ascending>{}(
+            __exec, ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 256 && __wg_size * 2 <= __max_wg_size)
-        __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 2, 2, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
+        __event = __subgroup_radix_sort<__wg_size * 2, 2, __radix_bits, __is_ascending>{}(
+            __exec, ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 512 && __wg_size * 2 <= __max_wg_size)
-        __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 2, 4, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
+        __event = __subgroup_radix_sort<__wg_size * 2, 4, __radix_bits, __is_ascending>{}(
+            __exec, ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 1024 && __wg_size * 2 <= __max_wg_size)
-        __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 2, 8, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
+        __event = __subgroup_radix_sort<__wg_size * 2, 8, __radix_bits, __is_ascending>{}(
+            __exec, ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 2048 && __wg_size * 4 <= __max_wg_size)
-        __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 4, 8, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
+        __event = __subgroup_radix_sort<__wg_size * 4, 8, __radix_bits, __is_ascending>{}(
+            __exec, ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 4096 && __wg_size * 4 <= __max_wg_size)
-        __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 4, 16, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
+        __event = __subgroup_radix_sort<__wg_size * 4, 16, __radix_bits, __is_ascending>{}(
+            __exec, ::std::forward<_Range>(__in_rng), __proj);
     // In __subgroup_radix_sort, we request a sub-group size of 16 via _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED
     // for compilation targets that support this option. For the below cases, register spills that result in
     // runtime exceptions have been observed on accelerators that do not support the requested sub-group size of 16.
     // For the above cases that request but may not receive a sub-group size of 16, inputs are small enough to avoid
     // register spills on assessed hardware.
     else if (__n <= 8192 && __wg_size * 8 <= __max_wg_size && __dev_has_sg16)
-        __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 8, 16, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
+        __event = __subgroup_radix_sort<__wg_size * 8, 16, __radix_bits, __is_ascending>{}(
+            __exec, ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 16384 && __wg_size * 8 <= __max_wg_size && __dev_has_sg16)
-        __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 8, 32, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
+        __event = __subgroup_radix_sort<__wg_size * 8, 32, __radix_bits, __is_ascending>{}(
+            __exec, ::std::forward<_Range>(__in_rng), __proj);
     else
     {
         constexpr ::std::uint32_t __radix_iters = __get_buckets_in_type<_KeyT>(__radix_bits);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -655,7 +655,8 @@ struct __parallel_radix_sort_iteration
 
         // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
         // because we always specialize this submit() calls only by _ExecutionPolicy as "const reference".
-        // So, from this template param point of view, only one specialization is possible.
+        // So, from this template param point of view, only one specialization is possible per concrete _ExecutionPolicy type.
+        // _ExecutionPolicy type information is embedded in _CustomName to distinguish between concrete policy types.
         using _RadixCountKernel =
             __internal::__kernel_name_generator<__count_phase, _CustomName, std::decay_t<_InRange>,
                                                 std::decay_t<_TmpBuf>, _Proj>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -771,7 +771,7 @@ struct __parallel_radix_sort_iteration
 //-----------------------------------------------------------------------
 template <bool __is_ascending, typename _Range, typename _ExecutionPolicy, typename _Proj>
 auto
-__parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range&& __in_rng,
+__parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Range&& __in_rng,
                       _Proj __proj)
 {
     const ::std::size_t __n = __in_rng.size();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -159,7 +159,7 @@ struct __subgroup_radix_sort
         template <typename _ExecutionPolicy, typename _RangeIn, typename _Proj, typename _SLM_tag_val,
                   typename _SLM_counter>
         auto
-        operator()(_ExecutionPolicy&& __exec, _RangeIn&& __src, _Proj __proj, _SLM_tag_val, _SLM_counter)
+        operator()(const _ExecutionPolicy& __exec, _RangeIn&& __src, _Proj __proj, _SLM_tag_val, _SLM_counter)
         {
             uint16_t __n = __src.size();
             assert(__n <= __block_size * __wg_size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -156,7 +156,8 @@ struct __subgroup_radix_sort
     template <typename... _Name>
     struct __one_group_submitter<__internal::__optional_kernel_name<_Name...>>
     {
-        template <typename _ExecutionPolicy, typename _RangeIn, typename _Proj, typename _SLM_tag_val, typename _SLM_counter>
+        template <typename _ExecutionPolicy, typename _RangeIn, typename _Proj, typename _SLM_tag_val,
+                  typename _SLM_counter>
         auto
         operator()(_ExecutionPolicy&& __exec, _RangeIn&& __src, _Proj __proj, _SLM_tag_val, _SLM_counter)
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -236,9 +236,10 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
 {
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _InitType>
     auto
-    operator()(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, sycl::event& __reduce_event,
-               const _Size __n, const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
-               _InitType __init, const __result_and_scratch_storage<_ExecutionPolicy, _Tp>& __scratch_container) const
+    operator()(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
+               sycl::event& __reduce_event, const _Size __n, const _Size __work_group_size,
+               const _Size __iters_per_work_item, _ReduceOp __reduce_op, _InitType __init,
+               const __result_and_scratch_storage<_ExecutionPolicy, _Tp>& __scratch_container) const
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
@@ -312,9 +313,9 @@ struct __parallel_transform_reduce_impl
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
               typename... _Ranges>
     static auto
-    submit(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Size __n, _Size __work_group_size,
-           const _Size __iters_per_work_item, _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init,
-           _Ranges&&... __rngs)
+    submit(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Size __n,
+           _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
+           _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
     {
         using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -446,7 +446,7 @@ struct __parallel_transform_reduce_impl
 template <typename _Tp, typename _Commutative, typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp,
           typename _InitType, typename... _Ranges>
 auto
-__parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+__parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __backend_tag, const _ExecutionPolicy& __exec,
                             _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -322,7 +322,8 @@ struct __parallel_transform_reduce_impl
 
         // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
         // because we always specialize this submit() calls only by _ExecutionPolicy as "const reference".
-        // So, from this template param point of view, only one specialization is possible.
+        // So, from this template param point of view, only one specialization is possible per concrete _ExecutionPolicy type.
+        // _ExecutionPolicy type information is embedded in _CustomName to distinguish between concrete policy types.
         using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             __reduce_kernel, _CustomName, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -126,7 +126,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
               typename... _Ranges>
     auto
-    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, const _Size __n,
+    operator()(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, const _Size __n,
                const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs) const
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -277,7 +277,7 @@ template <typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename _
           typename _ReduceOp, typename _TransformOp, typename _InitType, typename... _Ranges>
 auto
 __parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
-                                     _ExecutionPolicy&& __exec, const _Size __n, const _Size __work_group_size,
+                                     const _ExecutionPolicy& __exec, const _Size __n, const _Size __work_group_size,
                                      const _Size __iters_per_work_item_device_kernel,
                                      const _Size __iters_per_work_item_work_group_kernel, _ReduceOp __reduce_op,
                                      _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
@@ -301,8 +301,8 @@ __parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_t
     // __n_groups preliminary results from the device kernel.
     return __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative, _VecSize,
                                                                    _ReduceWorkGroupKernel>()(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec), __reduce_event, __n_groups, __work_group_size,
-        __iters_per_work_item_work_group_kernel, __reduce_op, __init, __scratch_container);
+        __backend_tag, __exec, __reduce_event, __n_groups, __work_group_size, __iters_per_work_item_work_group_kernel,
+        __reduce_op, __init, __scratch_container);
 }
 
 // General implementation using a tree reduction

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -163,7 +163,7 @@ template <typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename _
           typename _ReduceOp, typename _TransformOp, typename _InitType, typename... _Ranges>
 auto
 __parallel_transform_reduce_small_impl(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
-                                       _ExecutionPolicy&& __exec, const _Size __n, const _Size __work_group_size,
+                                       const _ExecutionPolicy& __exec, const _Size __n, const _Size __work_group_size,
                                        const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                                        _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
@@ -172,8 +172,8 @@ __parallel_transform_reduce_small_impl(oneapi::dpl::__internal::__device_backend
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__reduce_small_kernel<_CustomName>>;
 
     return __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize, _ReduceKernel>()(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size, __iters_per_work_item,
-        __reduce_op, __transform_op, __init, std::forward<_Ranges>(__rngs)...);
+        __backend_tag, __exec, __n, __work_group_size, __iters_per_work_item, __reduce_op, __transform_op, __init,
+        std::forward<_Ranges>(__rngs)...);
 }
 
 // Submits the first kernel of the parallel_transform_reduce for mid-sized arrays.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -312,12 +312,16 @@ struct __parallel_transform_reduce_impl
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
               typename... _Ranges>
     static auto
-    submit(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Size __n, _Size __work_group_size,
+    submit(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec, _Size __n, _Size __work_group_size,
            const _Size __iters_per_work_item, _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init,
            _Ranges&&... __rngs)
     {
         using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+
+        // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
+        // because we always specialize this submit() calls only by _ExecutionPolicy as "const reference".
+        // So, from this template param point of view, only one specialization is possible.
         using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             __reduce_kernel, _CustomName, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -479,8 +479,8 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __back
         std::uint16_t __iters_per_work_item = oneapi::dpl::__internal::__dpl_ceiling_div(__n_short, __work_group_size);
         __iters_per_work_item = __adjust_iters_per_work_item<__vector_size>(__iters_per_work_item);
         return __parallel_transform_reduce_small_impl<_Tp, _Commutative, __vector_size>(
-            __backend_tag, std::forward<_ExecutionPolicy>(__exec), __n_short, __work_group_size_short,
-            __iters_per_work_item, __reduce_op, __transform_op, __init, std::forward<_Ranges>(__rngs)...);
+            __backend_tag, __exec, __n_short, __work_group_size_short, __iters_per_work_item, __reduce_op,
+            __transform_op, __init, std::forward<_Ranges>(__rngs)...);
     }
     // Use two-step tree reduction.
     // First step reduces __work_group_size * __iters_per_work_item_device_kernel elements.
@@ -513,15 +513,15 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __back
         __iters_per_work_item_work_group_kernel =
             __adjust_iters_per_work_item<__vector_size>(__iters_per_work_item_work_group_kernel);
         return __parallel_transform_reduce_mid_impl<_Tp, _Commutative, __vector_size>(
-            __backend_tag, std::forward<_ExecutionPolicy>(__exec), __n_short, __work_group_size_short,
-            __iters_per_work_item_device_kernel, __iters_per_work_item_work_group_kernel, __reduce_op, __transform_op,
-            __init, std::forward<_Ranges>(__rngs)...);
+            __backend_tag, __exec, __n_short, __work_group_size_short, __iters_per_work_item_device_kernel,
+            __iters_per_work_item_work_group_kernel, __reduce_op, __transform_op, __init,
+            std::forward<_Ranges>(__rngs)...);
     }
     // Otherwise use a recursive tree reduction with __max_iters_per_work_item __iters_per_work_item.
     const auto __work_group_size_long = static_cast<_Size>(__work_group_size);
     return __parallel_transform_reduce_impl<_Tp, _Commutative, __vector_size>::submit(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size_long, __max_iters_per_work_item,
-        __reduce_op, __transform_op, __init, std::forward<_Ranges>(__rngs)...);
+        __backend_tag, __exec, __n, __work_group_size_long, __max_iters_per_work_item, __reduce_op, __transform_op,
+        __init, std::forward<_Ranges>(__rngs)...);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -98,8 +98,9 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
     // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
-    // because we always specialize this __parallel_reduce_by_segment_fallback calls only by _ExecutionPolicy as "const reference".
-    // So, from this template param point of view, only one specialization is possible.
+    // because we always specialize this __parallel_reduce_by_segment_fallback() calls only by _ExecutionPolicy as "const reference".
+    // So, from this template param point of view, only one specialization is possible per concrete _ExecutionPolicy type.
+    // _ExecutionPolicy type information is embedded in _CustomName to distinguish between concrete policy types.
     using _SegReduceCountKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
         _SegReduceCountPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
     using _SegReduceOffsetKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -89,7 +89,7 @@ using _SegReducePrefixPhase = __seg_reduce_prefix_kernel<_Name...>;
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Range4,
           typename _BinaryPredicate, typename _BinaryOperator>
 oneapi::dpl::__internal::__difference_t<_Range3>
-__parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+__parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
                                       _Range1&& __keys, _Range2&& __values, _Range3&& __out_keys,
                                       _Range4&& __out_values, _BinaryPredicate __binary_pred,
                                       _BinaryOperator __binary_op,
@@ -97,18 +97,17 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
+    // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
+    // because we always specialize this __parallel_reduce_by_segment_fallback calls only by _ExecutionPolicy as "const reference".
+    // So, from this template param point of view, only one specialization is possible.
     using _SegReduceCountKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        _SegReduceCountPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate,
-        _BinaryOperator>;
+        _SegReduceCountPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
     using _SegReduceOffsetKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        _SegReduceOffsetPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate,
-        _BinaryOperator>;
+        _SegReduceOffsetPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
     using _SegReduceWgKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        _SegReduceWgPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate,
-        _BinaryOperator>;
+        _SegReduceWgPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
     using _SegReducePrefixKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        _SegReducePrefixPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate,
-        _BinaryOperator>;
+        _SegReducePrefixPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
 
     using __diff_type = oneapi::dpl::__internal::__difference_t<_Range3>;
     using __key_type = oneapi::dpl::__internal::__value_t<_Range1>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -764,7 +764,7 @@ template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename
           typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
           typename _Inclusive, typename _IsUniquePattern>
 auto
-__parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+__parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag, const _ExecutionPolicy& __exec,
                                       _InRng&& __in_rng, _OutRng&& __out_rng, _GenReduceInput __gen_reduce_input,
                                       _ReduceOp __reduce_op, _GenScanInput __gen_scan_input,
                                       _ScanInputTransform __scan_input_transform, _WriteOp __write_op, _InitType __init,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -439,8 +439,8 @@ struct __parallel_reduce_then_scan_scan_submitter<
 
     template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _TmpStorageAcc>
     sycl::event
-    operator()(const _ExecutionPolicy& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
-               _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
+    operator()(const _ExecutionPolicy& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
+               _OutRng&& __out_rng, _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::uint32_t __inputs_per_sub_group, const std::uint32_t __inputs_per_item,
                const std::size_t __block_num) const
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -163,21 +163,21 @@ zip(T... args)
 template <template <typename> class _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_Policy, int> = 0>
 auto
-make_wrapped_policy(_Policy&& __policy)
+make_wrapped_policy(const _Policy& __policy)
 {
     return oneapi::dpl::execution::make_device_policy<
-        _NewKernelName<oneapi::dpl::__internal::__policy_kernel_name<_Policy>>>(::std::forward<_Policy>(__policy));
+        _NewKernelName<oneapi::dpl::__internal::__policy_kernel_name<_Policy>>>(__policy);
 }
 
 #if _ONEDPL_FPGA_DEVICE
 template <template <typename> class _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_Policy, int> = 0>
 auto
-make_wrapped_policy(_Policy&& __policy)
+make_wrapped_policy(const _Policy& __policy)
 {
     return oneapi::dpl::execution::make_fpga_policy<
         oneapi::dpl::__internal::__policy_unroll_factor<_Policy>,
-        _NewKernelName<oneapi::dpl::__internal::__policy_kernel_name<_Policy>>>(::std::forward<_Policy>(__policy));
+        _NewKernelName<oneapi::dpl::__internal::__policy_kernel_name<_Policy>>>(__policy);
 }
 #endif
 

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -118,7 +118,7 @@ struct __hist_fill_zeros_wrapper;
 template <typename _BackendTag, typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size,
           typename _BinHash, typename _RandomAccessIterator2>
 void
-__pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_histogram(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                     _RandomAccessIterator1 __last, _Size __num_bins, _BinHash&& __func,
                     _RandomAccessIterator2 __histogram_first)
 {
@@ -157,7 +157,7 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
                                                         _RandomAccessIterator1>();
             auto __input_buf = __keep_input(__first, __last);
 
-            __parallel_histogram(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __init_event,
+            __parallel_histogram(_BackendTag{}, __exec, __init_event,
                                  __input_buf.all_view(), ::std::move(__bins), __binhash_manager)
                 .__deferrable_wait();
         }

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -40,7 +40,7 @@ namespace __internal
 template <typename _BackendTag, typename _ExecutionPolicy, typename _RandomAccessIterator1,
           typename _RandomAccessIterator2, typename _Tp, typename _BinaryOperation1, typename _BinaryOperation2>
 _Tp
-__pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_transform_reduce(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                            _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _Tp __init,
                            _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2)
 {
@@ -60,7 +60,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
                                                                           ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
+               _BackendTag{}, __exec, __binary_op1, _Functor{__binary_op2},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                __buf1.all_view(), __buf2.all_view())
         .get();
@@ -73,7 +73,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Tp,
           typename _BinaryOperation, typename _UnaryOperation>
 _Tp
-__pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator __first,
+__pattern_transform_reduce(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _ForwardIterator __first,
                            _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op,
                            _UnaryOperation __unary_op)
 {
@@ -88,7 +88,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
                                                                           ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
+               _BackendTag{}, __exec, __binary_op, _Functor{__unary_op},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                __buf.all_view())
         .get();
@@ -125,7 +125,7 @@ __iterators_possibly_equal(const sycl_iterator<_Mode1, _T, _Allocator>& __it1,
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _UnaryOperation, typename _InitType, typename _BinaryOperation, typename _Inclusive>
 _Iterator2
-__pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first,
+__pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __first,
                               _Iterator1 __last, _Iterator2 __result, _UnaryOperation __unary_op, _InitType __init,
                               _BinaryOperation __binary_op, _Inclusive)
 {
@@ -145,7 +145,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         auto __buf2 = __keep2(__result, __result + __n);
 
         oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n,
+            _BackendTag{}, __exec, __buf1.all_view(), __buf2.all_view(), __n,
             __unary_op, __init, __binary_op, _Inclusive{})
             .__deferrable_wait();
     }
@@ -158,7 +158,8 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         using _Type = typename _InitType::__value_type;
 
         auto __policy =
-            __par_backend_hetero::make_wrapped_policy<ExecutionPolicyWrapper>(::std::forward<_ExecutionPolicy>(__exec));
+            __par_backend_hetero::make_wrapped_policy<ExecutionPolicyWrapper>(__exec);
+        using _NewExecutionPolicy = decltype(__policy);
 
         // Create temporary buffer
         oneapi::dpl::__par_backend_hetero::__buffer<_Type> __tmp_buf(__n);
@@ -186,14 +187,14 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _UnaryOperation, typename _Type, typename _BinaryOperation, typename _Inclusive>
 _Iterator2
-__pattern_transform_scan(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first,
+__pattern_transform_scan(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __first,
                          _Iterator1 __last, _Iterator2 __result, _UnaryOperation __unary_op, _Type __init,
                          _BinaryOperation __binary_op, _Inclusive)
 {
     using _RepackedType = __par_backend_hetero::__repacked_tuple_t<_Type>;
     using _InitType = unseq_backend::__init_value<_RepackedType>;
 
-    return __pattern_transform_scan_base(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+    return __pattern_transform_scan_base(__tag, __exec, __first, __last, __result,
                                          __unary_op, _InitType{__init}, __binary_op, _Inclusive{});
 }
 
@@ -201,7 +202,7 @@ __pattern_transform_scan(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _UnaryOperation, typename _BinaryOperation, typename _Inclusive>
 _Iterator2
-__pattern_transform_scan(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first,
+__pattern_transform_scan(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Iterator1 __first,
                          _Iterator1 __last, _Iterator2 __result, _UnaryOperation __unary_op,
                          _BinaryOperation __binary_op, _Inclusive)
 {
@@ -209,7 +210,7 @@ __pattern_transform_scan(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
     using _RepackedType = __par_backend_hetero::__repacked_tuple_t<_Type>;
     using _InitType = unseq_backend::__no_init_value<_RepackedType>;
 
-    return __pattern_transform_scan_base(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+    return __pattern_transform_scan_base(__tag, __exec, __first, __last, __result,
                                          __unary_op, _InitType{}, __binary_op, _Inclusive{});
 }
 
@@ -226,8 +227,9 @@ struct adjacent_difference_wrapper
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _BinaryOperation>
 _ForwardIterator2
-__pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first,
-                              _ForwardIterator1 __last, _ForwardIterator2 __d_first, _BinaryOperation __op)
+__pattern_adjacent_difference(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec,
+                              _ForwardIterator1 __first, _ForwardIterator1 __last,
+                              _ForwardIterator2 __d_first, _BinaryOperation __op)
 {
     auto __n = __last - __first;
     if (__n <= 0)
@@ -243,7 +245,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     if (__n == 1)
     {
         auto __wrapped_policy = __par_backend_hetero::make_wrapped_policy<adjacent_difference_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec));
+            __exec);
 
         __internal::__pattern_walk2_brick(__hetero_tag<_BackendTag>{}, __wrapped_policy, __first, __last, __d_first,
                                           __internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -244,8 +244,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, const _ExecutionPolicy&
     // if we have the only element, just copy it according to the specification
     if (__n == 1)
     {
-        auto __wrapped_policy = __par_backend_hetero::make_wrapped_policy<adjacent_difference_wrapper>(
-            __exec);
+        auto __wrapped_policy = __par_backend_hetero::make_wrapped_policy<adjacent_difference_wrapper>(__exec);
 
         __internal::__pattern_walk2_brick(__hetero_tag<_BackendTag>{}, __wrapped_policy, __first, __last, __d_first,
                                           __internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -80,7 +80,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     if (__first == __last)
         return __init;
 
-    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _UnaryOperation>;
+    using _Functor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, _UnaryOperation>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -42,7 +42,7 @@ namespace __ranges
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Tp,
           typename _BinaryOperation1, typename _BinaryOperation2>
 _Tp
-__pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
+__pattern_transform_reduce(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2,
                            _Tp __init, _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2)
 {
     if (__rng1.empty())
@@ -53,7 +53,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
                                                                           ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
+               _BackendTag{}, __exec, __binary_op1, _Functor{__binary_op2},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2))
         .get();
@@ -66,7 +66,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Tp, typename _BinaryOperation,
           typename _UnaryOperation>
 _Tp
-__pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng, _Tp __init,
+__pattern_transform_reduce(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Range&& __rng, _Tp __init,
                            _BinaryOperation __binary_op, _UnaryOperation __unary_op)
 {
     if (__rng.empty())
@@ -77,7 +77,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
                                                                           ::std::true_type /*is_commutative*/>(
-               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
+               _BackendTag{}, __exec, __binary_op, _Functor{__unary_op},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                ::std::forward<_Range>(__rng))
         .get();
@@ -90,7 +90,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation,
           typename _InitType, typename _BinaryOperation, typename _Inclusive>
 oneapi::dpl::__internal::__difference_t<_Range2>
-__pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
+__pattern_transform_scan_base(__hetero_tag<_BackendTag>, const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2,
                               _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op, _Inclusive)
 {
     oneapi::dpl::__internal::__difference_t<_Range2> __n = __rng1.size();
@@ -98,7 +98,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
         return 0;
 
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
+        _BackendTag{}, __exec, std::forward<_Range1>(__rng1),
         std::forward<_Range2>(__rng2), __n, __unary_op, __init, __binary_op, _Inclusive{})
         .__deferrable_wait();
     return __n;
@@ -107,13 +107,13 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation,
           typename _Type, typename _BinaryOperation, typename _Inclusive>
 oneapi::dpl::__internal::__difference_t<_Range2>
-__pattern_transform_scan(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
+__pattern_transform_scan(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2,
                          _UnaryOperation __unary_op, _Type __init, _BinaryOperation __binary_op, _Inclusive)
 {
     using _RepackedType = __par_backend_hetero::__repacked_tuple_t<_Type>;
     using _InitType = unseq_backend::__init_value<_RepackedType>;
 
-    return __pattern_transform_scan_base(__tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return __pattern_transform_scan_base(__tag, __exec,
                                          ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2), __unary_op,
                                          _InitType{__init}, __binary_op, _Inclusive{});
 }
@@ -122,14 +122,14 @@ __pattern_transform_scan(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation,
           typename _BinaryOperation, typename _Inclusive>
 oneapi::dpl::__internal::__difference_t<_Range2>
-__pattern_transform_scan(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
+__pattern_transform_scan(__hetero_tag<_BackendTag> __tag, const _ExecutionPolicy& __exec, _Range1&& __rng1, _Range2&& __rng2,
                          _UnaryOperation __unary_op, _BinaryOperation __binary_op, _Inclusive)
 {
     using _Type = oneapi::dpl::__internal::__value_t<_Range1>;
     using _RepackedType = __par_backend_hetero::__repacked_tuple_t<_Type>;
     using _InitType = unseq_backend::__no_init_value<_RepackedType>;
 
-    return __pattern_transform_scan_base(__tag, ::std::forward<_ExecutionPolicy>(__exec),
+    return __pattern_transform_scan_base(__tag, __exec,
                                          ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2), __unary_op,
                                          _InitType{}, __binary_op, _Inclusive{});
 }

--- a/include/oneapi/dpl/pstl/histogram_impl.h
+++ b/include/oneapi/dpl/pstl/histogram_impl.h
@@ -52,13 +52,13 @@ __brick_histogram(_ForwardIterator __first, _ForwardIterator __last, _IdxHashFun
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Size, class _IdxHashFunc,
           class _RandomAccessIterator>
 void
-__pattern_histogram(_Tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_histogram(_Tag, const _ExecutionPolicy& __exec, _ForwardIterator __first, _ForwardIterator __last,
                     _Size __num_bins, _IdxHashFunc __func, _RandomAccessIterator __histogram_first)
 {
     using _HistogramValueT = typename std::iterator_traits<_RandomAccessIterator>::value_type;
     static_assert(oneapi::dpl::__internal::__is_serial_tag_v<_Tag> ||
                   oneapi::dpl::__internal::__is_parallel_forward_tag_v<_Tag>);
-    __pattern_fill(_Tag{}, std::forward<_ExecutionPolicy>(__exec), __histogram_first, __histogram_first + __num_bins,
+    __pattern_fill(_Tag{}, __exec, __histogram_first, __histogram_first + __num_bins,
                    _HistogramValueT{0});
     __brick_histogram(__first, __last, __func, __histogram_first, typename _Tag::__is_vector{});
 }
@@ -66,7 +66,7 @@ __pattern_histogram(_Tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _Size, class _IdxHashFunc,
           class _RandomAccessIterator2>
 void
-__pattern_histogram(oneapi::dpl::__internal::__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
+__pattern_histogram(oneapi::dpl::__internal::__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec,
                     _RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _Size __num_bins,
                     _IdxHashFunc __func, _RandomAccessIterator2 __histogram_first)
 {
@@ -78,7 +78,7 @@ __pattern_histogram(oneapi::dpl::__internal::__parallel_tag<_IsVector>, _Executi
     if (__n == 0)
     {
         // when n == 0, we must fill the output histogram with zeros
-        __pattern_fill(oneapi::dpl::__internal::__parallel_tag<_IsVector>{}, std::forward<_ExecutionPolicy>(__exec),
+        __pattern_fill(oneapi::dpl::__internal::__parallel_tag<_IsVector>{}, __exec,
                        __histogram_first, __histogram_first + __num_bins, _HistogramValueT{0});
     }
     else
@@ -97,7 +97,7 @@ __pattern_histogram(oneapi::dpl::__internal::__parallel_tag<_IsVector>, _Executi
         // now accumulate temporary storage into output histogram
         const std::size_t __num_temporary_copies = __tls.size();
         __par_backend::__parallel_for(
-            __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), _Size{0}, __num_bins,
+            __backend_tag{}, __exec, _Size{0}, __num_bins,
             [__num_temporary_copies, __histogram_first, &__tls](auto __hist_start_id, auto __hist_end_id) {
                 const _DiffType __local_n = __hist_end_id - __hist_start_id;
                 //initialize output histogram with first local histogram via assign
@@ -121,7 +121,7 @@ __pattern_histogram(oneapi::dpl::__internal::__parallel_tag<_IsVector>, _Executi
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size, typename _ValueType,
           typename _RandomAccessIterator2>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator2>
-histogram(_ExecutionPolicy&& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last, _Size num_bins,
+histogram(const _ExecutionPolicy& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last, _Size num_bins,
           _ValueType first_bin_min_val, _ValueType last_bin_max_val, _RandomAccessIterator2 histogram_first)
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(exec, first, histogram_first);
@@ -136,7 +136,7 @@ histogram(_ExecutionPolicy&& exec, _RandomAccessIterator1 first, _RandomAccessIt
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _RandomAccessIterator3>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator3>
-histogram(_ExecutionPolicy&& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last,
+histogram(const _ExecutionPolicy& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last,
           _RandomAccessIterator2 boundary_first, _RandomAccessIterator2 boundary_last,
           _RandomAccessIterator3 histogram_first)
 {

--- a/include/oneapi/dpl/pstl/histogram_impl.h
+++ b/include/oneapi/dpl/pstl/histogram_impl.h
@@ -127,7 +127,7 @@ histogram(const _ExecutionPolicy& exec, _RandomAccessIterator1 first, _RandomAcc
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(exec, first, histogram_first);
 
     oneapi::dpl::__internal::__pattern_histogram(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(exec), first, last, num_bins,
+        __dispatch_tag, exec, first, last, num_bins,
         oneapi::dpl::__internal::__evenly_divided_binhash<_ValueType>(first_bin_min_val, last_bin_max_val, num_bins),
         histogram_first);
     return histogram_first + num_bins;
@@ -144,7 +144,7 @@ histogram(const _ExecutionPolicy& exec, _RandomAccessIterator1 first, _RandomAcc
 
     ::std::ptrdiff_t num_bins = boundary_last - boundary_first - 1;
     oneapi::dpl::__internal::__pattern_histogram(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(exec), first, last, num_bins,
+        __dispatch_tag, exec, first, last, num_bins,
         oneapi::dpl::__internal::__custom_boundary_binhash{boundary_first, boundary_last}, histogram_first);
     return histogram_first + num_bins;
 }

--- a/include/oneapi/dpl/pstl/numeric_fwd.h
+++ b/include/oneapi/dpl/pstl/numeric_fwd.h
@@ -44,13 +44,13 @@ _Tp __brick_transform_reduce(_ForwardIterator1, _ForwardIterator1, _ForwardItera
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp,
           class _BinaryOperation1, class _BinaryOperation2>
 _Tp
-__pattern_transform_reduce(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _Tp,
+__pattern_transform_reduce(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _Tp,
                            _BinaryOperation1, _BinaryOperation2) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Tp, class _BinaryOperation1, class _BinaryOperation2>
 _Tp
-__pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
+__pattern_transform_reduce(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1,
                            _RandomAccessIterator1, _RandomAccessIterator2, _Tp, _BinaryOperation1, _BinaryOperation2);
 
 //------------------------------------------------------------------------
@@ -68,25 +68,25 @@ _Tp __brick_transform_reduce(_ForwardIterator, _ForwardIterator, _Tp, _BinaryOpe
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp,
           class _BinaryOperation1, class _BinaryOperation2>
 _Tp
-__pattern_transform_reduce(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _Tp,
+__pattern_transform_reduce(_Tag, const _ExecutionPolicy&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2, _Tp,
                            _BinaryOperation1, _BinaryOperation2 __bnary_op2) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Tp, class _BinaryOperation1, class _BinaryOperation2>
 _Tp
-__pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
+__pattern_transform_reduce(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1,
                            _RandomAccessIterator1, _RandomAccessIterator2, _Tp, _BinaryOperation1, _BinaryOperation2);
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation,
           class _UnaryOperation>
 _Tp
-__pattern_transform_reduce(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Tp, _BinaryOperation,
+__pattern_transform_reduce(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _Tp, _BinaryOperation,
                            _UnaryOperation) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Tp, class _BinaryOperation,
           class _UnaryOperation>
 _Tp
-__pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_transform_reduce(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                            _Tp, _BinaryOperation, _UnaryOperation);
 
 //------------------------------------------------------------------------
@@ -108,26 +108,26 @@ template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperat
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _UnaryOperation,
           class _Tp, class _BinaryOperation, class _Inclusive>
 _OutputIterator
-__pattern_transform_scan(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _OutputIterator, _UnaryOperation,
+__pattern_transform_scan(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _OutputIterator, _UnaryOperation,
                          _Tp, _BinaryOperation, _Inclusive) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator,
           class _UnaryOperation, class _Tp, class _BinaryOperation, class _Inclusive>
 ::std::enable_if_t<!::std::is_floating_point_v<_Tp>, _OutputIterator>
-__pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_transform_scan(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                          _OutputIterator, _UnaryOperation, _Tp, _BinaryOperation, _Inclusive);
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator,
           class _UnaryOperation, class _Tp, class _BinaryOperation, class _Inclusive>
 ::std::enable_if_t<::std::is_floating_point_v<_Tp>, _OutputIterator>
-__pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+__pattern_transform_scan(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator, _RandomAccessIterator,
                          _OutputIterator, _UnaryOperation, _Tp, _BinaryOperation, _Inclusive);
 
 // transform_scan without initial element
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _UnaryOperation,
           class _BinaryOperation, class _Inclusive>
 _OutputIterator
-__pattern_transform_scan(_Tag, _ExecutionPolicy&& __exec, _ForwardIterator, _ForwardIterator, _OutputIterator,
+__pattern_transform_scan(_Tag, const _ExecutionPolicy& __exec, _ForwardIterator, _ForwardIterator, _OutputIterator,
                          _UnaryOperation, _BinaryOperation, _Inclusive);
 
 //------------------------------------------------------------------------
@@ -145,13 +145,13 @@ _OutputIterator __brick_adjacent_difference(_RandomAccessIterator, _RandomAccess
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _BinaryOperation>
 _OutputIterator
-__pattern_adjacent_difference(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _OutputIterator,
+__pattern_adjacent_difference(_Tag, const _ExecutionPolicy&, _ForwardIterator, _ForwardIterator, _OutputIterator,
                               _BinaryOperation) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryOperation>
 _RandomAccessIterator2
-__pattern_adjacent_difference(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
+__pattern_adjacent_difference(__parallel_tag<_IsVector>, const _ExecutionPolicy&, _RandomAccessIterator1,
                               _RandomAccessIterator1, _RandomAccessIterator2, _BinaryOperation);
 
 } // namespace __internal

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -64,7 +64,7 @@ __brick_transform_reduce(_RandomAccessIterator1 __first1, _RandomAccessIterator1
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp,
           class _BinaryOperation1, class _BinaryOperation2>
 _Tp
-__pattern_transform_reduce(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_transform_reduce(_Tag, const _ExecutionPolicy&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                            _ForwardIterator2 __first2, _Tp __init, _BinaryOperation1 __binary_op1,
                            _BinaryOperation2 __binary_op2) noexcept
 {
@@ -77,7 +77,7 @@ __pattern_transform_reduce(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1,
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _Tp, class _BinaryOperation1, class _BinaryOperation2>
 _Tp
-__pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+__pattern_transform_reduce(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first1,
                            _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _Tp __init,
                            _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2)
 {
@@ -85,7 +85,7 @@ __pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
 
     return __internal::__except_handler([&]() {
         return __par_backend::__parallel_transform_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            __backend_tag{}, __exec, __first1, __last1,
             [__first1, __first2, __binary_op2](_RandomAccessIterator1 __i) mutable {
                 return __binary_op2(*__i, *(__first2 + (__i - __first1)));
             },
@@ -130,7 +130,7 @@ __brick_transform_reduce(_RandomAccessIterator __first, _RandomAccessIterator __
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation,
           class _UnaryOperation>
 _Tp
-__pattern_transform_reduce(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+__pattern_transform_reduce(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
                            _BinaryOperation __binary_op, _UnaryOperation __unary_op) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -142,7 +142,7 @@ __pattern_transform_reduce(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Tp, class _BinaryOperation,
           class _UnaryOperation>
 _Tp
-__pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_transform_reduce(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                            _RandomAccessIterator __last, _Tp __init, _BinaryOperation __binary_op,
                            _UnaryOperation __unary_op)
 {
@@ -150,7 +150,7 @@ __pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
 
     return __internal::__except_handler([&]() {
         return __par_backend::__parallel_transform_reduce(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            __backend_tag{}, __exec, __first, __last,
             [__unary_op](_RandomAccessIterator __i) mutable { return __unary_op(*__i); }, __init, __binary_op,
             [__unary_op, __binary_op](_RandomAccessIterator __i, _RandomAccessIterator __j, _Tp __init) {
                 return __internal::__brick_transform_reduce(__i, __j, __init, __binary_op, __unary_op, _IsVector{});
@@ -239,7 +239,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _UnaryOperation,
           class _Tp, class _BinaryOperation, class _Inclusive>
 _OutputIterator
-__pattern_transform_scan(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_transform_scan(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                          _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
                          _Inclusive) noexcept
 {
@@ -253,7 +253,7 @@ __pattern_transform_scan(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Fo
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator,
           class _UnaryOperation, class _Tp, class _BinaryOperation, class _Inclusive>
 ::std::enable_if_t<!::std::is_floating_point_v<_Tp>, _OutputIterator>
-__pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_transform_scan(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                          _RandomAccessIterator __last, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
                          _BinaryOperation __binary_op, _Inclusive)
 {
@@ -263,7 +263,7 @@ __pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_transform_scan(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __last - __first,
+            __backend_tag{}, __exec, __last - __first,
             [__first, __unary_op](_DifferenceType __i) mutable { return __unary_op(__first[__i]); }, __init,
             __binary_op,
             [__first, __unary_op, __binary_op](_DifferenceType __i, _DifferenceType __j, _Tp __init) {
@@ -284,7 +284,7 @@ __pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator,
           class _UnaryOperation, class _Tp, class _BinaryOperation, class _Inclusive>
 ::std::enable_if_t<::std::is_floating_point_v<_Tp>, _OutputIterator>
-__pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
+__pattern_transform_scan(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator __first,
                          _RandomAccessIterator __last, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
                          _BinaryOperation __binary_op, _Inclusive)
 {
@@ -300,7 +300,7 @@ __pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_strict_scan(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, __init,
+            __backend_tag{}, __exec, __n, __init,
             [__first, __unary_op, __binary_op, __result](_DifferenceType __i, _DifferenceType __len) {
                 return __internal::__brick_transform_scan(__first + __i, __first + (__i + __len), __result + __i,
                                                           __unary_op, _Tp{}, __binary_op, _Inclusive(), _IsVector{})
@@ -324,7 +324,7 @@ __pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _UnaryOperation,
           class _BinaryOperation, class _Inclusive>
 _OutputIterator
-__pattern_transform_scan(_Tag __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_transform_scan(_Tag __tag, const _ExecutionPolicy& __exec, _ForwardIterator __first, _ForwardIterator __last,
                          _OutputIterator __result, _UnaryOperation __unary_op, _BinaryOperation __binary_op, _Inclusive)
 {
     static_assert(__is_host_dispatch_tag_v<_Tag>);
@@ -335,7 +335,7 @@ __pattern_transform_scan(_Tag __tag, _ExecutionPolicy&& __exec, _ForwardIterator
         _ValueType __tmp = __unary_op(*__first);
         *__result = __tmp;
 
-        return __pattern_transform_scan(__tag, ::std::forward<_ExecutionPolicy>(__exec), ++__first, __last, ++__result,
+        return __pattern_transform_scan(__tag, __exec, ++__first, __last, ++__result,
                                         __unary_op, __tmp, __binary_op, _Inclusive());
     }
     else
@@ -376,7 +376,7 @@ __brick_adjacent_difference(_RandomAccessIterator1 __first, _RandomAccessIterato
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _BinaryOperation>
 _OutputIterator
-__pattern_adjacent_difference(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_adjacent_difference(_Tag, const _ExecutionPolicy&, _ForwardIterator __first, _ForwardIterator __last,
                               _OutputIterator __d_first, _BinaryOperation __op) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
@@ -387,7 +387,7 @@ __pattern_adjacent_difference(_Tag, _ExecutionPolicy&&, _ForwardIterator __first
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryOperation>
 _RandomAccessIterator2
-__pattern_adjacent_difference(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first,
+__pattern_adjacent_difference(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _RandomAccessIterator1 __first,
                               _RandomAccessIterator1 __last, _RandomAccessIterator2 __d_first, _BinaryOperation __op)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -400,7 +400,7 @@ __pattern_adjacent_difference(__parallel_tag<_IsVector>, _ExecutionPolicy&& __ex
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last - 1,
+            __backend_tag{}, __exec, __first, __last - 1,
             [&__op, __d_first, __first](_RandomAccessIterator1 __b, _RandomAccessIterator1 __e) {
                 _RandomAccessIterator2 __d_b = __d_first + (__b - __first);
                 __internal::__brick_walk3(

--- a/include/oneapi/dpl/pstl/omp/parallel_for.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for.h
@@ -49,7 +49,7 @@ __parallel_for_body(_Index __first, _Index __last, _Fp __f, std::size_t __grains
 
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
-__parallel_for(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f,
+__parallel_for(oneapi::dpl::__internal::__omp_backend_tag, const _ExecutionPolicy&, _Index __first, _Index __last, _Fp __f,
                std::size_t __grainsize = __default_chunk_size)
 {
     if (omp_in_parallel())

--- a/include/oneapi/dpl/pstl/omp/parallel_for_each.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for_each.h
@@ -44,7 +44,7 @@ __parallel_for_each_body(_ForwardIterator __first, _ForwardIterator __last, _Fp 
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
-__parallel_for_each(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _ForwardIterator __first,
+__parallel_for_each(oneapi::dpl::__internal::__omp_backend_tag, const _ExecutionPolicy&, _ForwardIterator __first,
                     _ForwardIterator __last, _Fp __f)
 {
     if (omp_in_parallel())

--- a/include/oneapi/dpl/pstl/omp/parallel_invoke.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_invoke.h
@@ -38,7 +38,7 @@ __parallel_invoke_body(_F1&& __f1, _F2&& __f2)
 
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
-__parallel_invoke(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _F1&& __f1, _F2&& __f2)
+__parallel_invoke(oneapi::dpl::__internal::__omp_backend_tag, const _ExecutionPolicy&, _F1&& __f1, _F2&& __f2)
 {
     if (omp_in_parallel())
     {

--- a/include/oneapi/dpl/pstl/omp/parallel_merge.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_merge.h
@@ -71,7 +71,7 @@ __parallel_merge_body(std::size_t __size_x, std::size_t __size_y, _RandomAccessI
 template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
 void
-__parallel_merge(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&& /*__exec*/, _RandomAccessIterator1 __xs,
+__parallel_merge(oneapi::dpl::__internal::__omp_backend_tag, const _ExecutionPolicy& /*__exec*/, _RandomAccessIterator1 __xs,
                  _RandomAccessIterator1 __xe, _RandomAccessIterator2 __ys, _RandomAccessIterator2 __ye,
                  _RandomAccessIterator3 __zs, _Compare __comp, _LeafMerge __leaf_merge)
 {

--- a/include/oneapi/dpl/pstl/omp/parallel_reduce.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_reduce.h
@@ -52,7 +52,7 @@ __parallel_reduce_body(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Value, typename _RealBody, typename _Reduction>
 _Value
-__parallel_reduce(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _RandomAccessIterator __first,
+__parallel_reduce(oneapi::dpl::__internal::__omp_backend_tag, const _ExecutionPolicy&, _RandomAccessIterator __first,
                   _RandomAccessIterator __last, _Value __identity, _RealBody __real_body, _Reduction __reduction)
 {
     // We don't create a nested parallel region in an existing parallel region:

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -129,7 +129,7 @@ __parallel_strict_scan(oneapi::dpl::__internal::__omp_backend_tag, const _Execut
 
     if (omp_in_parallel())
     {
-        oneapi::dpl::__omp_backend::__parallel_strict_scan_body(::std::forward<_ExecutionPolicy>(__exec), __n,
+        oneapi::dpl::__omp_backend::__parallel_strict_scan_body(__exec, __n,
                                                                 __initial, __reduce, __combine, __scan, __apex);
     }
     else
@@ -137,7 +137,7 @@ __parallel_strict_scan(oneapi::dpl::__internal::__omp_backend_tag, const _Execut
         _PSTL_PRAGMA(omp parallel)
         _PSTL_PRAGMA(omp single nowait)
         {
-            oneapi::dpl::__omp_backend::__parallel_strict_scan_body(::std::forward<_ExecutionPolicy>(__exec), __n,
+            oneapi::dpl::__omp_backend::__parallel_strict_scan_body(__exec, __n,
                                                                     __initial, __reduce, __combine, __scan, __apex);
         }
     }

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -82,7 +82,7 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 template <typename _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp,
           typename _Ap>
 void
-__parallel_strict_scan_body(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine,
+__parallel_strict_scan_body(const _ExecutionPolicy& __exec, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine,
                             _Sp __scan, _Ap __apex)
 {
     _Index __p = omp_get_num_threads();
@@ -109,7 +109,7 @@ __parallel_strict_scan_body(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial
 
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
-__parallel_strict_scan(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&& __exec, _Index __n, _Tp __initial,
+__parallel_strict_scan(oneapi::dpl::__internal::__omp_backend_tag, const _ExecutionPolicy& __exec, _Index __n, _Tp __initial,
                        _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
 {
     if (__n <= __default_chunk_size)

--- a/include/oneapi/dpl/pstl/omp/parallel_stable_sort.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_stable_sort.h
@@ -123,7 +123,7 @@ __parallel_stable_sort_body(_RandomAccessIterator __xs, _RandomAccessIterator __
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
 void
-__parallel_stable_sort(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&& /*__exec*/,
+__parallel_stable_sort(oneapi::dpl::__internal::__omp_backend_tag, const _ExecutionPolicy& /*__exec*/,
                        _RandomAccessIterator __xs, _RandomAccessIterator __xe, _Compare __comp, _LeafSort __leaf_sort,
                        std::size_t __nsort = 0)
 {

--- a/include/oneapi/dpl/pstl/omp/parallel_transform_reduce.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_transform_reduce.h
@@ -86,7 +86,7 @@ __transform_reduce_body(_RandomAccessIterator __first, _RandomAccessIterator __l
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _UnaryOp, class _Value, class _Combiner,
           class _Reduction>
 _Value
-__parallel_transform_reduce(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&,
+__parallel_transform_reduce(oneapi::dpl::__internal::__omp_backend_tag, const _ExecutionPolicy&,
                             _RandomAccessIterator __first, _RandomAccessIterator __last, _UnaryOp __unary_op,
                             _Value __init, _Combiner __combiner, _Reduction __reduction)
 {

--- a/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
@@ -27,7 +27,7 @@ namespace __omp_backend
 
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
 _Tp
-__parallel_transform_scan(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _Index __n, _Up /* __u */,
+__parallel_transform_scan(oneapi::dpl::__internal::__omp_backend_tag, const _ExecutionPolicy&, _Index __n, _Up /* __u */,
                           _Tp __init, _Cp /* __combine */, _Rp /* __brick_reduce */, _Sp __scan)
 {
     // TODO: parallelize this function.

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -86,7 +86,7 @@ __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)
 
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
-__parallel_for(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last,
+__parallel_for(oneapi::dpl::__internal::__serial_backend_tag, const _ExecutionPolicy&, _Index __first, _Index __last,
                _Fp __f, std::size_t /*__grainsize*/ = 1)
 {
     __f(__first, __last);
@@ -94,7 +94,7 @@ __parallel_for(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&
 
 template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
 _Value
-__parallel_reduce(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last,
+__parallel_reduce(oneapi::dpl::__internal::__serial_backend_tag, const _ExecutionPolicy&, _Index __first, _Index __last,
                   const _Value& __identity, const _RealBody& __real_body, const _Reduction&)
 {
     if (__first == __last)
@@ -109,7 +109,7 @@ __parallel_reduce(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolic
 
 template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce>
 _Tp
-__parallel_transform_reduce(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __first,
+__parallel_transform_reduce(oneapi::dpl::__internal::__serial_backend_tag, const _ExecutionPolicy&, _Index __first,
                             _Index __last, _UnaryOp, _Tp __init, _BinaryOp, _Reduce __reduce)
 {
     return __reduce(__first, __last, __init);
@@ -117,7 +117,7 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__serial_backend_tag, _Exec
 
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
-__parallel_strict_scan(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,
+__parallel_strict_scan(oneapi::dpl::__internal::__serial_backend_tag, const _ExecutionPolicy&, _Index __n, _Tp __initial,
                        _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
 {
     _Tp __sum = __initial;
@@ -130,7 +130,7 @@ __parallel_strict_scan(oneapi::dpl::__internal::__serial_backend_tag, _Execution
 
 template <class _ExecutionPolicy, class _Index, class _UnaryOp, class _Tp, class _BinaryOp, class _Reduce, class _Scan>
 _Tp
-__parallel_transform_scan(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __n, _UnaryOp,
+__parallel_transform_scan(oneapi::dpl::__internal::__serial_backend_tag, const _ExecutionPolicy&, _Index __n, _UnaryOp,
                           _Tp __init, _BinaryOp, _Reduce, _Scan __scan)
 {
     return __scan(_Index(0), __n, __init);
@@ -138,7 +138,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__serial_backend_tag, _Execut
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
 void
-__parallel_stable_sort(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _RandomAccessIterator __first,
+__parallel_stable_sort(oneapi::dpl::__internal::__serial_backend_tag, const _ExecutionPolicy&, _RandomAccessIterator __first,
                        _RandomAccessIterator __last, _Compare __comp, _LeafSort __leaf_sort, ::std::size_t = 0)
 {
     __leaf_sort(__first, __last, __comp);
@@ -147,7 +147,7 @@ __parallel_stable_sort(oneapi::dpl::__internal::__serial_backend_tag, _Execution
 template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
 void
-__parallel_merge(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _RandomAccessIterator1 __first1,
+__parallel_merge(oneapi::dpl::__internal::__serial_backend_tag, const _ExecutionPolicy&, _RandomAccessIterator1 __first1,
                  _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
                  _RandomAccessIterator3 __outit, _Compare __comp, _LeafMerge __leaf_merge)
 {
@@ -156,7 +156,7 @@ __parallel_merge(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy
 
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
-__parallel_invoke(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _F1&& __f1, _F2&& __f2)
+__parallel_invoke(oneapi::dpl::__internal::__serial_backend_tag, const _ExecutionPolicy&, _F1&& __f1, _F2&& __f2)
 {
     ::std::forward<_F1>(__f1)();
     ::std::forward<_F2>(__f2)();
@@ -164,7 +164,7 @@ __parallel_invoke(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolic
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
-__parallel_for_each(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _ForwardIterator __begin,
+__parallel_for_each(oneapi::dpl::__internal::__serial_backend_tag, const _ExecutionPolicy&, _ForwardIterator __begin,
                     _ForwardIterator __end, _Fp __f)
 {
     for (auto __iter = __begin; __iter != __end; ++__iter)

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -92,7 +92,7 @@ class __parallel_for_body
 // wrapper over tbb::parallel_for
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
-__parallel_for(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f,
+__parallel_for(oneapi::dpl::__internal::__tbb_backend_tag, const _ExecutionPolicy&, _Index __first, _Index __last, _Fp __f,
                std::size_t __grainsize = 1 /*matches the default grainsize value of tbb::blocked_range according to
                the specification*/)
 {
@@ -106,7 +106,7 @@ __parallel_for(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _
 // wrapper over tbb::parallel_reduce
 template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
 _Value
-__parallel_reduce(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last,
+__parallel_reduce(oneapi::dpl::__internal::__tbb_backend_tag, const _ExecutionPolicy&, _Index __first, _Index __last,
                   const _Value& __identity, const _RealBody& __real_body, const _Reduction& __reduction)
 {
     return tbb::this_task_arena::isolate([__first, __last, &__identity, &__real_body, &__reduction]() -> _Value {
@@ -187,7 +187,7 @@ struct __par_trans_red_body
 
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp>
 _Tp
-__parallel_transform_reduce(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __first,
+__parallel_transform_reduce(oneapi::dpl::__internal::__tbb_backend_tag, const _ExecutionPolicy&, _Index __first,
                             _Index __last, _Up __u, _Tp __init, _Cp __combine, _Rp __brick_reduce)
 {
     __tbb_backend::__par_trans_red_body<_Index, _Up, _Tp, _Cp, _Rp> __body(__u, __init, __combine, __brick_reduce);
@@ -356,7 +356,7 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 // T must have a trivial constructor and destructor.
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
-__parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&& __exec, _Index __n, _Tp __initial,
+__parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, const _ExecutionPolicy& __exec, _Index __n, _Tp __initial,
                        _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
 {
     tbb::this_task_arena::isolate([=, &__combine]() {
@@ -396,7 +396,7 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
 
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
 _Tp
-__parallel_transform_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __n, _Up __u,
+__parallel_transform_scan(oneapi::dpl::__internal::__tbb_backend_tag, const _ExecutionPolicy&, _Index __n, _Up __u,
                           _Tp __init, _Cp __combine, _Rp __brick_reduce, _Sp __scan)
 {
     __trans_scan_body<_Index, _Up, _Tp, _Cp, _Rp, _Sp> __body(__u, __init, __combine, __brick_reduce, __scan);
@@ -1164,7 +1164,7 @@ __stable_sort_func<_RandomAccessIterator1, _RandomAccessIterator2, _Compare, _Le
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
 void
-__parallel_stable_sort(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&& __exec,
+__parallel_stable_sort(oneapi::dpl::__internal::__tbb_backend_tag, const _ExecutionPolicy& __exec,
                        _RandomAccessIterator __xs, _RandomAccessIterator __xe, _Compare __comp, _LeafSort __leaf_sort,
                        ::std::size_t __nsort)
 {
@@ -1256,7 +1256,7 @@ operator()(__task* __self)
 template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
 void
-__parallel_merge(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _RandomAccessIterator1 __xs,
+__parallel_merge(oneapi::dpl::__internal::__tbb_backend_tag, const _ExecutionPolicy&, _RandomAccessIterator1 __xs,
                  _RandomAccessIterator1 __xe, _RandomAccessIterator2 __ys, _RandomAccessIterator2 __ye,
                  _RandomAccessIterator3 __zs, _Compare __comp, _LeafMerge __leaf_merge)
 {
@@ -1287,7 +1287,7 @@ __parallel_merge(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&,
 
 template <class _ExecutionPolicy, typename _F1, typename _F2>
 void
-__parallel_invoke(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _F1&& __f1, _F2&& __f2)
+__parallel_invoke(oneapi::dpl::__internal::__tbb_backend_tag, const _ExecutionPolicy&, _F1&& __f1, _F2&& __f2)
 {
     //TODO: a version of tbb::this_task_arena::isolate with variadic arguments pack should be added in the future
     tbb::this_task_arena::isolate(
@@ -1300,7 +1300,7 @@ __parallel_invoke(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
-__parallel_for_each(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _ForwardIterator __begin,
+__parallel_for_each(oneapi::dpl::__internal::__tbb_backend_tag, const _ExecutionPolicy&, _ForwardIterator __begin,
                     _ForwardIterator __end, _Fp __f)
 {
     tbb::this_task_arena::isolate([&]() { tbb::parallel_for_each(__begin, __end, __f); });

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -47,7 +47,7 @@ __parallel_find(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _Inde
 
     ::std::atomic<_DifferenceType> __extremum(__initial_dist);
     // TODO: find out what is better here: parallel_for or parallel_reduce
-    __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+    __par_backend::__parallel_for(__backend_tag{}, __exec, __first, __last,
                                   [__comp, __f, __first, &__extremum](_Index __i, _Index __j) {
                                       // See "Reducing Contention Through Priority Updates", PPoPP '13, for discussion of
                                       // why using a shared variable scales fairly well in this situation.
@@ -80,7 +80,7 @@ __parallel_or(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _Index 
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     ::std::atomic<bool> __found(false);
-    __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+    __par_backend::__parallel_for(__backend_tag{}, __exec, __first, __last,
                                   [__f, &__found](_Index __i, _Index __j) {
                                       if (!__found.load(::std::memory_order_relaxed) && __f(__i, __j))
                                       {

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -34,7 +34,7 @@ namespace __internal
 Each f[i,j) must return a value in [i,j). */
 template <class _IsVector, class _ExecutionPolicy, class _Index, class _Brick, class _IsFirst>
 _Index
-__parallel_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick __f,
+__parallel_find(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _Index __first, _Index __last, _Brick __f,
                 _IsFirst)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
@@ -75,7 +75,7 @@ __parallel_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __f
 //! Return true if brick f[i,j) returns true for some subrange [i,j) of [first,last)
 template <class _IsVector, class _ExecutionPolicy, class _Index, class _Brick>
 bool
-__parallel_or(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick __f)
+__parallel_or(__parallel_tag<_IsVector>, const _ExecutionPolicy& __exec, _Index __first, _Index __last, _Brick __f)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -63,6 +63,19 @@ int main() {
     auto red_val = ::std::reduce(policy, buf_begin, buf_end, 1);
     EXPECT_TRUE(red_val == 2001, "wrong return value from reduce");
 #endif // __SYCL_UNNAMED_LAMBDA__
+
+
+    {
+        const auto policy1 = TestUtils::default_dpcpp_policy;
+
+        const auto red_val1 = std::reduce(policy1, buf_begin, buf_end, 1);
+        EXPECT_TRUE(red_val1 == 42001, "wrong return value from reduce #1");
+        const auto red_val11 = std::reduce(policy1, buf_begin, buf_end, 1);
+        EXPECT_TRUE(red_val11 == 42001, "wrong return value from reduce #1");
+        const auto red_val2 = std::reduce(std::move(policy1), buf_begin, buf_end, 1);
+        EXPECT_TRUE(red_val2 == 42001, "wrong return value from reduce #2");
+    }
+
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
     return done(TEST_DPCPP_BACKEND_PRESENT);


### PR DESCRIPTION
In this PR we fix the issue https://github.com/uxlfoundation/oneDPL/issues/2083 and https://github.com/uxlfoundation/oneDPL/issues/2041

## The problem statement.
Usually, `oneDPL` submitters which do `sycl::queue::submit()` calls are implemented in three ways:
- `operator()` implementation inside some `class` / `struct`;
- `submit()` function implementation inside some `class` / `struct`;
- some free function.

In all cases, these functions are template functions parametrized by `_ExecutioPolicy` type. Also they have `_ExecutioPolicy&& __exec` in the list of functions parameters.
This approach means that we may have two specializations of these functions:
- one specialization for the case when `__exec` is `r-value`;
- another specialization for other cases.

### The problems of this approach which already implemented in `oneDPL`:
- we should generate unique Kernel-names using not only `_ExecutionPolicy` type but also their qualifiers (`l-value`, `r-value`);
- we increase the amount of sycl-kernel code and their compile-time;
- we increase the amount of host code in compile-time.

## The solution
As solution in this PR proposed the idea of @akukanov - to declare `_ExecutionPolicy` in submitters and on one upper level as `const _ExecutionPolicy&` (const reference).
This approach fixes all point of the problem described below.


### Some key changes in the code
* the usage of `_ExecutionPolicy` is not required inside `__kernel_name_generator` template parameters anymore:
-- before:
```C++
    template <typename... _Name>
    using _SegScanPrefixPhase = __seg_scan_prefix_kernel<__is_inclusive, _Name...>;

    template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
              typename _BinaryPredicate, typename _BinaryOperator, typename _T>
    void
    operator()(_BackendTag, _ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& __values, _Range3&& __out_values,
               _BinaryPredicate __binary_pred, _BinaryOperator __binary_op, _T __init, _T __identity)
    {
        using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;

        using _SegScanWgKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
            _SegScanWgPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _BinaryPredicate,
            _BinaryOperator>;

        // ...
    }
```
-- now:
```C++
    template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
              typename _BinaryPredicate, typename _BinaryOperator, typename _T>
    void
    operator()(_BackendTag, const _ExecutionPolicy& __exec, _Range1&& __keys, _Range2&& __values, _Range3&& __out_values,
               _BinaryPredicate __binary_pred, _BinaryOperator __binary_op, _T __init, _T __identity)
    {
        using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;

        // We should avoid using _ExecutionPolicy in __kernel_name_generator template params
        // because we always specialize this operator() calls only by _ExecutionPolicy as "const reference".
        // So, from this template param point of view, only one specialization is possible.
        using _SegScanWgKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
            _SegScanWgPhase, _CustomName, _Range1, _Range2, _Range3, _BinaryPredicate, _BinaryOperator>;

        // ...
    }
```

Now we able to detect a lot of errors as described in https://github.com/uxlfoundation/oneDPL/issues/2041 - this test coverage implemented in the PR https://github.com/uxlfoundation/oneDPL/pull/2102

Another approach has been prepared in https://github.com/uxlfoundation/oneDPL/pull/2082

## Please review this PR under switched off option "File changed - Gear button - Hide whitespace"