### PR TITLE
Fix `sizeLimit` type in tests

### DIFF
--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -378,8 +378,8 @@ struct iterator_invoker
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
-        invoke_if<Iterator>()(n <= sizeLimit<typename std::iterator_traits<Iterator>::difference_type>, op, exec,
-                              make_iterator<Iterator>()(begin), n, ::std::forward<Rest>(rest)...);
+        invoke_if<Iterator>()(n <= sizeLimit<decltype(n)>, op, exec, make_iterator<Iterator>()(begin), n,
+                              ::std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -224,7 +224,8 @@ struct MakeIterator
 
 // Useful constant variables
 constexpr ::std::size_t GuardSize = 5;
-constexpr ::std::size_t sizeLimit = 1000;
+template <typename T>
+constexpr T sizeLimit = 1000;
 // Construction below is needed for using SFINAE-friendliness that available in C++17
 
 template <typename Iter, typename Void = void> // local iterator_traits for non-iterators
@@ -377,8 +378,8 @@ struct iterator_invoker
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
-        invoke_if<Iterator>()(n <= sizeLimit, op, exec, make_iterator<Iterator>()(begin), n,
-                              ::std::forward<Rest>(rest)...);
+        invoke_if<Iterator>()(n <= sizeLimit<typename std::iterator_traits<Iterator>::difference_type>, op, exec,
+                              make_iterator<Iterator>()(begin), n, ::std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
@@ -386,9 +387,9 @@ struct iterator_invoker
                            !::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
-        invoke_if<Iterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
-                              make_iterator<Iterator>()(inputBegin), make_iterator<Iterator>()(inputEnd),
-                              ::std::forward<Rest>(rest)...);
+        invoke_if<Iterator>()(
+            std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>, op, exec,
+            make_iterator<Iterator>()(inputBegin), make_iterator<Iterator>()(inputEnd), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
@@ -396,9 +397,10 @@ struct iterator_invoker
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
-        invoke_if<InputIterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
-                                   make_iterator<InputIterator>()(inputBegin), make_iterator<InputIterator>()(inputEnd),
-                                   make_iterator<OutputIterator>()(outputBegin), ::std::forward<Rest>(rest)...);
+        invoke_if<InputIterator>()(
+            std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>, op, exec,
+            make_iterator<InputIterator>()(inputBegin), make_iterator<InputIterator>()(inputEnd),
+            make_iterator<OutputIterator>()(outputBegin), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
@@ -406,10 +408,11 @@ struct iterator_invoker
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
-        invoke_if<InputIterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
-                                   make_iterator<InputIterator>()(inputBegin), make_iterator<InputIterator>()(inputEnd),
-                                   make_iterator<OutputIterator>()(outputBegin),
-                                   make_iterator<OutputIterator>()(outputEnd), ::std::forward<Rest>(rest)...);
+        invoke_if<InputIterator>()(
+            std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>, op, exec,
+            make_iterator<InputIterator>()(inputBegin), make_iterator<InputIterator>()(inputEnd),
+            make_iterator<OutputIterator>()(outputBegin), make_iterator<OutputIterator>()(outputEnd),
+            std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -419,10 +422,11 @@ struct iterator_invoker
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
         invoke_if<InputIterator1>()(
-            ::std::distance(inputBegin1, inputEnd1) <= sizeLimit, op, exec, make_iterator<InputIterator1>()(inputBegin1),
-            make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator2>()(inputBegin2),
-            make_iterator<InputIterator2>()(inputEnd2), make_iterator<OutputIterator>()(outputBegin),
-            make_iterator<OutputIterator>()(outputEnd), ::std::forward<Rest>(rest)...);
+            std::distance(inputBegin1, inputEnd1) <= sizeLimit<decltype(std::distance(inputBegin1, inputEnd1))>, op,
+            exec, make_iterator<InputIterator1>()(inputBegin1), make_iterator<InputIterator1>()(inputEnd1),
+            make_iterator<InputIterator2>()(inputBegin2), make_iterator<InputIterator2>()(inputEnd2),
+            make_iterator<OutputIterator>()(outputBegin), make_iterator<OutputIterator>()(outputEnd),
+            std::forward<Rest>(rest)...);
     }
     
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename InputIterator3, typename OutputIterator,
@@ -433,11 +437,12 @@ struct iterator_invoker
                OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
         invoke_if<InputIterator1>()(
-            ::std::distance(inputBegin1, inputEnd1) <= sizeLimit, op, exec, make_iterator<InputIterator1>()(inputBegin1),
-            make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator2>()(inputBegin2),
-            make_iterator<InputIterator2>()(inputEnd2), make_iterator<InputIterator3>()(inputBegin3),
-            make_iterator<InputIterator3>()(inputEnd3), make_iterator<OutputIterator>()(outputBegin),
-            make_iterator<OutputIterator>()(outputEnd), ::std::forward<Rest>(rest)...);
+            std::distance(inputBegin1, inputEnd1) <= sizeLimit<decltype(std::distance(inputBegin1, inputEnd1))>, op,
+            exec, make_iterator<InputIterator1>()(inputBegin1), make_iterator<InputIterator1>()(inputEnd1),
+            make_iterator<InputIterator2>()(inputBegin2), make_iterator<InputIterator2>()(inputEnd2),
+            make_iterator<InputIterator3>()(inputBegin3), make_iterator<InputIterator3>()(inputEnd3),
+            make_iterator<OutputIterator>()(outputBegin), make_iterator<OutputIterator>()(outputEnd),
+            std::forward<Rest>(rest)...);
     }
 };
 
@@ -473,7 +478,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
-        if (n <= sizeLimit)
+        if (n <= sizeLimit<decltype(n)>)
             op(exec, make_iterator<Iterator>()(begin + n), n, ::std::forward<Rest>(rest)...);
     }
 
@@ -482,7 +487,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected,
         Rest&&... rest)
     {
-        if (n <= sizeLimit)
+        if (n <= sizeLimit<decltype(n)>)
             op(exec, make_iterator<Iterator>()(begin + n), n, make_iterator<Iterator>()(expected + n), ::std::forward<Rest>(rest)...);
     }
 
@@ -490,7 +495,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     ::std::enable_if_t<is_same_iterator_category_v<Iterator, ::std::bidirectional_iterator_tag>>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected, Rest&&... rest)
     {
-        if (n <= sizeLimit)
+        if (n <= sizeLimit<decltype(n)>)
             op(exec, make_iterator<Iterator>()(std::next(begin, n)), n, make_iterator<Iterator>()(std::next(expected, n)), ::std::forward<Rest>(rest)...);
     }
 
@@ -499,9 +504,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
                          !::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
-        if (::std::distance(inputBegin, inputEnd) <= sizeLimit)
+        if (std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>)
             op(exec, make_iterator<Iterator>()(inputEnd), make_iterator<Iterator>()(inputBegin),
-               ::std::forward<Rest>(rest)...);
+               std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
@@ -509,9 +514,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
-        if (::std::distance(inputBegin, inputEnd) <= sizeLimit)
+        if (std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>)
             op(exec, make_iterator<InputIterator>()(inputEnd), make_iterator<InputIterator>()(inputBegin),
-               make_iterator<OutputIterator>()(outputBegin + (inputEnd - inputBegin)), ::std::forward<Rest>(rest)...);
+               make_iterator<OutputIterator>()(outputBegin + (inputEnd - inputBegin)), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
@@ -519,10 +524,10 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
-        if (::std::distance(inputBegin, inputEnd) <= sizeLimit)
+        if (std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>)
             op(exec, make_iterator<InputIterator>()(inputEnd), make_iterator<InputIterator>()(inputBegin),
                make_iterator<OutputIterator>()(outputEnd), make_iterator<OutputIterator>()(outputBegin),
-               ::std::forward<Rest>(rest)...);
+               std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -531,11 +536,11 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
-        if (::std::distance(inputBegin1, inputEnd1) <= sizeLimit)
+        if (std::distance(inputBegin1, inputEnd1) <= sizeLimit<decltype(std::distance(inputBegin1, inputEnd1))>)
             op(exec, make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator1>()(inputBegin1),
                make_iterator<InputIterator2>()(inputEnd2), make_iterator<InputIterator2>()(inputBegin2),
                make_iterator<OutputIterator>()(outputEnd), make_iterator<OutputIterator>()(outputBegin),
-               ::std::forward<Rest>(rest)...);
+               std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename InputIterator3,
@@ -545,12 +550,12 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
                InputIterator2 inputEnd2, InputIterator3 inputBegin3, InputIterator3 inputEnd3,
                OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
-        if (::std::distance(inputBegin1, inputEnd1) <= sizeLimit)
+        if (std::distance(inputBegin1, inputEnd1) <= sizeLimit<decltype(std::distance(inputBegin1, inputEnd1))>)
             op(exec, make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator1>()(inputBegin1),
                make_iterator<InputIterator2>()(inputEnd2), make_iterator<InputIterator2>()(inputBegin2),
                make_iterator<InputIterator3>()(inputEnd3), make_iterator<InputIterator3>()(inputBegin3),
                make_iterator<OutputIterator>()(outputEnd), make_iterator<OutputIterator>()(outputBegin),
-               ::std::forward<Rest>(rest)...);
+               std::forward<Rest>(rest)...);
     }
 
 };


### PR DESCRIPTION
In this PR we fix `sizeLimit` type in tests to avoid warning about comparison signed and unsigned data types in tests for `g++` compiler.