### PR TITLE
Fix unused variable and lambda capture warnings in device tests

### DIFF
--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -53,7 +53,7 @@ main()
     }
 
     //check result
-    int expected1[max_n], expected2[max_n], expected3[max_n];
+    int expected1[max_n], expected2[max_n];
     ::std::exclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected1, 100);
     ::std::exclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected2, 100, ::std::plus<int>());
 

--- a/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
@@ -52,8 +52,8 @@ main()
         res1 = find(make_new_policy<new_kernel_name<Policy, 1>>(exec), A, val);    //check passing sycl::buffer directly
         res2 = find_if(make_new_policy<new_kernel_name<Policy, 2>>(exec), view, [val](auto a) { return a == val;});
         res2 = find_if(make_new_policy<new_kernel_name<Policy, 3>>(exec), A, [val](auto a) { return a == val;});
-        res3 = find_if_not(make_new_policy<new_kernel_name<Policy, 4>>(exec), view, [val](auto a) { return a >= 0;});
-        res3 = find_if_not(make_new_policy<new_kernel_name<Policy, 5>>(exec), A, [val](auto a) { return a >= 0;});
+        res3 = find_if_not(make_new_policy<new_kernel_name<Policy, 4>>(exec), view, [](auto a) { return a >= 0;});
+        res3 = find_if_not(make_new_policy<new_kernel_name<Policy, 5>>(exec), A, [](auto a) { return a >= 0;});
     }
 
     //check result

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -45,22 +45,21 @@ main()
 
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res1 = ranges::all_view<int, sycl::access::mode::write>(B1);
-        auto view_res2 = ranges::all_view<int, sycl::access::mode::write>(B2);
         auto view_res3 = ranges::all_view<int, sycl::access::mode::write>(B3);
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
 
         ranges::inclusive_scan(exec, A, view_res1);
-        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, ::std::plus<int>());
-        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 1>>(exec), view, view_res3, ::std::plus<int>(), 100);
+        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, std::plus<int>());
+        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 1>>(exec), view, view_res3, std::plus<int>(), 100);
     }
 
     //check result
     int expected1[max_n], expected2[max_n], expected3[max_n];
-    ::std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected1);
-    ::std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected2, ::std::plus<int>());
-    ::std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected3, ::std::plus<int>(), 100);
+    std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected1);
+    std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected2, std::plus<int>());
+    std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected3, std::plus<int>(), 100);
 
     EXPECT_EQ_N(expected1, data1, max_n, "wrong effect from inclusive_scan with sycl ranges");
     EXPECT_EQ_N(expected2, data2, max_n, "wrong effect from inclusive_scan with binary operation, sycl ranges");

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -51,15 +51,15 @@ main()
         using Policy = decltype(TestUtils::default_dpcpp_policy);
 
         ranges::inclusive_scan(exec, A, view_res1);
-        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, std::plus<int>());
-        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 1>>(exec), view, view_res3, std::plus<int>(), 100);
+        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, ::std::plus<int>());
+        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 1>>(exec), view, view_res3, ::std::plus<int>(), 100);
     }
 
     //check result
     int expected1[max_n], expected2[max_n], expected3[max_n];
-    std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected1);
-    std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected2, std::plus<int>());
-    std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected3, std::plus<int>(), 100);
+    ::std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected1);
+    ::std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected2, ::std::plus<int>());
+    ::std::inclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected3, ::std::plus<int>(), 100);
 
     EXPECT_EQ_N(expected1, data1, max_n, "wrong effect from inclusive_scan with sycl ranges");
     EXPECT_EQ_N(expected2, data2, max_n, "wrong effect from inclusive_scan with binary operation, sycl ranges");

--- a/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
@@ -46,7 +46,8 @@ main()
 
     auto exec = TestUtils::default_dpcpp_policy;
 
-    auto res = reduce_by_segment(exec, views::all_read(A), views::all_read(B), views::all_write(C), views::all_write(D));
+    [[maybe_unused]] auto res = reduce_by_segment(exec, views::all_read(A), views::all_read(B),
+                                                  views::all_write(C), views::all_write(D));
 
     int key_exp[n_res] = {1, 3, 2, 1};    // expected keys
     int value_exp[n_res] = {9, 21, 9, 3}; // expected values

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -37,7 +37,7 @@ main()
 
     //the name nano::ranges::views::all is not injected into oneapi::dpl::experimental::ranges namespace
     auto view = __nanorange::nano::views::all(data);
-    auto z = zip_view(__nanorange::nano::views::all(data), __nanorange::nano::views::all(key));
+    auto z = zip_view(view, __nanorange::nano::views::all(key));
 
     //check access
     EXPECT_TRUE(::std::get<0>(z[2]) == 'g', "wrong effect with zip_view");


### PR DESCRIPTION
It should fix the remaining warnings arising with [CPU,bknd=dpcpp,cmplr=icpx,ubuntu-latest,std=с++17,cfg=release](https://github.com/uxlfoundation/oneDPL/actions/runs/13680766496#summary-38252303253) configuration. 