### PR TITLE
Brick `__brick_copy` specialized by `_ExecutionPolicy` without `std::decay_t`

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -79,10 +79,12 @@ copy_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterato
 {
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk2_brick_async(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _ExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     return ret_val;
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2767,8 +2767,9 @@ void
 __pattern_fill(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
-    __internal::__brick_fill<_Tag, _ExecutionPolicy, _Tp>{__value}(__first, __last, typename _Tag::__is_vector{});
+    __internal::__brick_fill<_Tag, _DecayedExecutionPolicy, _Tp>{__value}(__first, __last, typename _Tag::__is_vector{});
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Tp>
@@ -2777,11 +2778,12 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
                _RandomAccessIterator __last, const _Tp& __value)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     return __internal::__except_handler([&__exec, __first, __last, &__value]() {
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                       [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
-                                          __internal::__brick_fill<__parallel_tag<_IsVector>, _ExecutionPolicy, _Tp>{
+                                          __internal::__brick_fill<__parallel_tag<_IsVector>, _DecayedExecutionPolicy, _Tp>{
                                               __value}(__begin, __end, _IsVector{});
                                       });
         return __last;

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1939,9 +1939,11 @@ __brick_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccess
                     _RandomAccessIterator1 __middle, _RandomAccessIterator1 __last,
                     _RandomAccessIterator2 __result) noexcept
 {
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     _RandomAccessIterator2 __res =
-        __brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(__middle, __last, __result);
-    return __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(__first, __middle, __res);
+        __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(__middle, __last, __result);
+    return __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(__first, __middle, __res);
 }
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator>
@@ -1961,12 +1963,13 @@ __pattern_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
                       _RandomAccessIterator1 __middle, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             [__first, __last, __middle, __result](_RandomAccessIterator1 __b, _RandomAccessIterator1 __e) {
-                __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy> __copy{};
+                __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy> __copy{};
                 if (__b > __middle)
                 {
                     __copy(__b, __e, __result + (__b - __middle), _IsVector{});
@@ -2532,6 +2535,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                             _RandomAccessIterator2 __d_last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     if (__last == __first || __d_last == __d_first)
     {
@@ -2549,7 +2553,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                     _RandomAccessIterator1 __j1 = __first + (__j - __d_first);
 
                     // 1. Copy elements from input to output
-                    __brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(__i1, __j1, __i, _IsVector{});
+                    __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(__i1, __j1, __i, _IsVector{});
                     // 2. Sort elements in output sequence
                     ::std::sort(__i, __j, __comp);
                 },
@@ -3379,13 +3383,14 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
                         _OutputIterator __result, _Compare __comp, _SetUnionOp __set_union_op)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
 
     const auto __n1 = __last1 - __first1;
     const auto __n2 = __last2 - __first2;
 
-    __brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy> __copy_range{};
+    __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy> __copy_range{};
 
     // {1} {}: parallel copying just first sequence
     if (__n2 == 0)
@@ -3706,6 +3711,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator3>::value_type _T;
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     const auto __n1 = __last1 - __first1;
     const auto __n2 = __last2 - __first2;
@@ -3717,21 +3723,21 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     // {1} \ {}: parallel copying just first sequence
     if (__n2 == 0)
         return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
-                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{});
+                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 = ::std::lower_bound(__first1, __last1, *__first2, __comp);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
         return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
-                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{});
+                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 = ::std::lower_bound(__first2, __last2, *__first1, __comp);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)
         return __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
-                                                 __result, __brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{});
+                                                 __result, __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
 
     if (__n1 + __n2 > __set_algo_cut_off)
         return __parallel_set_op(

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2820,8 +2820,10 @@ __pattern_fill_n(_Tag, _ExecutionPolicy&&, _OutputIterator __first, _Size __coun
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    return __internal::__brick_fill_n<_Tag, _ExecutionPolicy, _Tp>{__value}(__first, __count,
-                                                                            typename _Tag::__is_vector{});
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
+    return __internal::__brick_fill_n<_Tag, _DecayedExecutionPolicy, _Tp>{__value}(__first, __count,
+                                                                                   typename _Tag::__is_vector{});
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Tp>

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1054,6 +1054,8 @@ template <class _Tag, typename _ExecutionPolicy>
 struct __brick_copy_n<_Tag, _ExecutionPolicy,
                       ::std::enable_if_t<oneapi::dpl::__internal::__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2>
     _RandomAccessIterator2
     operator()(_RandomAccessIterator1 __first, _Size __n, _RandomAccessIterator2 __result,
@@ -1079,6 +1081,8 @@ struct __brick_copy_n<_Tag, _ExecutionPolicy,
 template <class _Tag, typename _ExecutionPolicy>
 struct __brick_copy<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
     operator()(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result,
@@ -1111,6 +1115,8 @@ struct __brick_copy<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatc
 template <class _Tag, typename _ExecutionPolicy>
 struct __brick_move<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
     operator()(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result,
@@ -1139,6 +1145,8 @@ struct __brick_move<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatc
 template <class _Tag, typename _ExecutionPolicy, typename = ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 struct __brick_move_destroy
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
     operator()(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result,
@@ -2727,6 +2735,8 @@ __pattern_nth_element(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec
 template <class _Tag, typename _ExecutionPolicy, typename _Tp>
 struct __brick_fill<_Tag, _ExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     const _Tp& __value;
 
     template <typename _RandomAccessIterator>
@@ -2775,6 +2785,8 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
 template <class _Tag, typename _ExecutionPolicy, typename _Tp>
 struct __brick_fill_n<_Tag, _ExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     const _Tp& __value;
 
     template <typename _RandomAccessIterator, typename _Size>

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1861,6 +1861,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                  _RandomAccessIterator __middle, _RandomAccessIterator __last)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     auto __n = __last - __first;
@@ -1878,7 +1879,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
                                           [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __b, __e, __b + (__last - __middle), _IsVector{});
                                           });
 
@@ -1904,7 +1905,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
                                           [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __b, __e, __first + (__b - __middle), _IsVector{});
                                           });
 
@@ -4365,6 +4366,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                      typename ::std::iterator_traits<_RandomAccessIterator>::difference_type __n)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     //If (n > 0 && n < m), returns first + (m - n). Otherwise, if n  > 0, returns first. Otherwise, returns last.
     if (__n <= 0)
@@ -4384,7 +4386,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
         {
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, __size,
                                           [__first, __n](_DiffType __i, _DiffType __j) {
-                                              __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __first + __i, __first + __j, __first + __i - __n, _IsVector{});
                                           });
         }
@@ -4396,7 +4398,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                 auto __end = ::std::min(__k + __n, __size);
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __k, __end,
                                               [__first, __n](_DiffType __i, _DiffType __j) {
-                                                  __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                                  __brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                       __first + __i, __first + __j, __first + __i - __n, _IsVector{});
                                               });
             }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1450,6 +1450,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                   _RandomAccessIterator __last, _CalcMask __calc_mask)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
@@ -1514,7 +1515,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         // 3. Elements from result are moved to [first, last)
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                       __result + __m, [__result, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                          __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                               __i, __j, __first + (__i - __result), _IsVector{});
                                       });
         return __first + __m;
@@ -1885,7 +1886,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + (__n - __m), [__first, __result](_Tp* __b, _Tp* __e) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __b, __e, __first + (__b - __result), _IsVector{});
                                           });
 
@@ -1911,7 +1912,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + __m, [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
                                           });
 
@@ -2590,7 +2591,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
             // 3. Move elements from temporary buffer to output
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
                                           [__r, __d_first](_T1* __i, _T1* __j) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
                                           });
 
@@ -3169,6 +3170,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
                         _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     if (__first == __last || __first == __middle || __middle == __last)
     {
@@ -3199,7 +3201,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
             });
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n,
                                       [__r, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                          __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                               __i, __j, __first + (__i - __r), _IsVector{});
                                       });
     });
@@ -3294,6 +3296,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_OutputIterator>::value_type _T;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     struct _SetRange
     {
@@ -3316,7 +3319,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         _DifferenceType __m{};
         auto __scan = [=](_DifferenceType, _DifferenceType, const _SetRange& __s) { // Scan
             if (!__s.empty())
-                __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                     __tmp_memory + __s.__buf_pos, __tmp_memory + (__s.__buf_pos + __s.__len), __result + __s.__pos,
                     _IsVector{});
         };

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -393,11 +393,13 @@ __pattern_copy(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRan
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
+    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
+
     assert(std::ranges::size(__in_r) <= std::ranges::size(__out_r)); // for debug purposes only
 
     oneapi::dpl::__internal::__pattern_walk2_brick(__tag, std::forward<_ExecutionPolicy>(__exec),
         std::ranges::begin(__in_r), std::ranges::begin(__in_r) + std::ranges::size(__in_r), std::ranges::begin(__out_r),
-        oneapi::dpl::__internal::__brick_copy<decltype(__tag), _ExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy<decltype(__tag), _DecayedExecutionPolicy>{});
 }
 
 template<typename _ExecutionPolicy, typename _InRange, typename _OutRange>

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -270,9 +270,11 @@ copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __l
 {
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     return oneapi::dpl::__internal::__pattern_walk2_brick(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _ExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2>

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -796,9 +796,11 @@ copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result)
 {
     auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng, __result);
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _ExecutionPolicy>{},
+        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{},
         views::all_read(::std::forward<_Range1>(__rng)), views::all_write(::std::forward<_Range2>(__result)));
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1464,8 +1464,9 @@ __pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Forwar
 
     typedef typename ::std::iterator_traits<_ForwardIterator1>::difference_type _Size1;
     typedef typename ::std::iterator_traits<_ForwardIterator2>::difference_type _Size2;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
-    using __brick_include_type = unseq_backend::__brick_includes<_ExecutionPolicy, _Compare, _Size1, _Size2>;
+    using __brick_include_type = unseq_backend::__brick_includes<_DecayedExecutionPolicy, _Compare, _Size1, _Size2>;
     return !__par_backend_hetero::__parallel_or(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first2),

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -2033,7 +2033,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
     }
     else //2. n < size/2; 'n' parallel copying
     {
-        auto __brick = unseq_backend::__brick_shift_left<_ExecutionPolicy, _DiffType, decltype(__rng)>{__size, __n};
+        auto __brick = unseq_backend::__brick_shift_left<_DecayedExecutionPolicy, _DiffType, decltype(__rng)>{__size, __n};
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__shift_left_right>(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -405,6 +405,8 @@ __pattern_generate_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec,
 template <typename _BackendTag, typename _ExecutionPolicy>
 struct __brick_copy_n<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _SourceT, typename _TargetT>
     void
     operator()(_SourceT&& __source, _TargetT&& __target) const
@@ -416,6 +418,8 @@ struct __brick_copy_n<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 template <typename _BackendTag, typename _ExecutionPolicy>
 struct __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _SourceT, typename _TargetT>
     void
     operator()(_SourceT&& __source, _TargetT&& __target) const
@@ -427,6 +431,8 @@ struct __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 template <typename _BackendTag, typename _ExecutionPolicy>
 struct __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _SourceT, typename _TargetT>
     void
     operator()(_SourceT&& __source, _TargetT&& __target) const
@@ -438,6 +444,8 @@ struct __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 template <typename _BackendTag, typename _ExecutionPolicy, typename _SourceT>
 struct __brick_fill<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _SourceT __value;
     template <typename _TargetT>
     void
@@ -450,6 +458,8 @@ struct __brick_fill<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
 template <typename _BackendTag, typename _ExecutionPolicy, typename _SourceT>
 struct __brick_fill_n<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _SourceT __value;
     template <typename _TargetT>
     void

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -147,6 +147,8 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIte
     if (__n == 0)
         return __first2;
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _ForwardIterator1>();
     auto __buf1 = __keep1(__first1, __last1);
@@ -157,7 +159,7 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIte
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__brick_swap<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
+        unseq_backend::__brick_swap<_DecayedExecutionPolicy, _Function, decltype(__buf1.all_view()),
                                     decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view());
     __future.wait(__par_backend_hetero::__deferrable_mode{});

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -146,11 +146,13 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _InRange, ty
 void
 __pattern_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r)
 {
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     assert(std::ranges::size(__in_r) <= std::ranges::size(__out_r)); // for debug purposes only
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         __tag, ::std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__internal::__brick_copy<decltype(__tag), _ExecutionPolicy>{},
+        oneapi::dpl::__internal::__brick_copy<decltype(__tag), _DecayedExecutionPolicy>{},
         oneapi::dpl::__ranges::views::all_read(std::forward<_InRange>(__in_r)),
         oneapi::dpl::__ranges::views::all_write(std::forward<_OutRange>(__out_r)));
 }
@@ -619,6 +621,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
         return __rng.size();
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
@@ -629,7 +632,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         __tag, ::std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{}, __copy_rng_truncated,
+        oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{}, __copy_rng_truncated,
         ::std::forward<_Range>(__rng));
 
     return __copy_last_id;
@@ -648,13 +651,15 @@ oneapi::dpl::__internal::__difference_t<_Range2>
 __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result,
                       _BinaryPredicate __pred)
 {
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     oneapi::dpl::__internal::__difference_t<_Range2> __n = __rng.size();
     if (__n == 0)
         return 0;
     if (__n == 1)
     {
         // For a sequence of size 1, we can just copy the only element to the result.
-        using _CopyBrick = oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>;
+        using _CopyBrick = oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>;
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_wrapper>(
@@ -689,6 +694,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
         return __rng.size();
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto res_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
@@ -699,7 +705,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     __ranges::__pattern_walk_n(
         __tag,
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_wrapper>(std::forward<_ExecutionPolicy>(__exec)),
-        __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{}, res_rng, std::forward<_Range>(__rng));
+        __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{}, res_rng, std::forward<_Range>(__rng));
     return res;
 }
 
@@ -726,6 +732,8 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ran
     if (__rng3.empty())
         return {0, 0};
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     const auto __n1 = __rng1.size();
     const auto __n2 = __rng2.size();
 
@@ -736,7 +744,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ran
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy1_wrapper>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{},
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{},
             ::std::forward<_Range2>(__rng2), ::std::forward<_Range3>(__rng3));
         return {0, __res};
     }
@@ -747,7 +755,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ran
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy2_wrapper>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{},
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{},
             ::std::forward<_Range1>(__rng1), ::std::forward<_Range3>(__rng3));
         return {__res, 0};
     }
@@ -944,6 +952,8 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
                             _Range2&& __values, _Range3&& __out_keys, _Range4&& __out_values,
                             _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
 {
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     // The algorithm reduces values in __values where the
     // associated keys for the values are equal to the adjacent key.
     //
@@ -960,7 +970,7 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
     if (__n == 1)
     {
-        __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy> __copy_range{};
+        __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy> __copy_range{};
 
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
             __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_keys_values_range_wrapper>(__exec),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1415,6 +1415,7 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
 {
     using _Size1 = oneapi::dpl::__internal::__difference_t<_Range1>;
     using _Size2 = oneapi::dpl::__internal::__difference_t<_Range2>;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     _Size1 __n1 = __rng1.size();
     _Size2 __n2 = __rng2.size();
@@ -1432,7 +1433,7 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
     _DataAcc __get_data_op;
     unseq_backend::__copy_by_mask<_ReduceOp, oneapi::dpl::__internal::__pstl_assign, /*inclusive*/ std::true_type, 2>
         __copy_by_mask_op;
-    unseq_backend::__brick_set_op<_ExecutionPolicy, _Compare, _Size1, _Size2, _IsOpDifference> __create_mask_op{
+    unseq_backend::__brick_set_op<_DecayedExecutionPolicy, _Compare, _Size1, _Size2, _IsOpDifference> __create_mask_op{
         __comp, __n1, __n2};
 
     // temporary buffer to store boolean mask

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1095,6 +1095,8 @@ struct __scan
 template <typename _ExecutionPolicy, typename _Compare, typename _Size1, typename _Size2>
 struct __brick_includes
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Compare __comp;
     _Size1 __na;
     _Size2 __nb;
@@ -1359,6 +1361,8 @@ struct _DifferenceTag : public ::std::true_type
 template <typename _ExecutionPolicy, typename _Compare, typename _Size1, typename _Size2, typename _IsOpDifference>
 class __brick_set_op
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Compare __comp;
     _Size1 __na;
     _Size2 __nb;
@@ -1419,6 +1423,8 @@ class __brick_set_op
 template <typename _ExecutionPolicy, typename _DiffType, typename _Range>
 struct __brick_shift_left
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
   private:
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
     // Maximum size supported by compilers to generate vector instructions
@@ -1561,6 +1567,8 @@ struct __brick_reduce_idx : public walk_scalar_base<_Range>
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
   private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -132,6 +132,8 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
     if (__first == __last)
         return __result;
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     const auto __n = __last - __first;
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -177,7 +179,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         // Move data from temporary buffer into results
         oneapi::dpl::__internal::__pattern_walk2_brick(
             __tag, ::std::move(__policy), __first_tmp, __last_tmp, __result,
-            oneapi::dpl::__internal::__brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_move<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
 
         //TODO: optimize copy back depending on Iterator, i.e. set_final_data for host iterator/pointer
     }

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -237,6 +237,7 @@ __pattern_adjacent_difference([[maybe_unused]] __hetero_tag<_BackendTag> __tag, 
 
     using _It1ValueT = typename ::std::iterator_traits<_ForwardIterator1>::value_type;
     using _It2ValueTRef = typename ::std::iterator_traits<_ForwardIterator2>::reference;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     _ForwardIterator2 __d_last = __d_first + __n;
 
@@ -248,7 +249,7 @@ __pattern_adjacent_difference([[maybe_unused]] __hetero_tag<_BackendTag> __tag, 
             ::std::forward<_ExecutionPolicy>(__exec));
 
         __internal::__pattern_walk2_brick(__tag, __wrapped_policy, __first, __last, __d_first,
-                                          __internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+                                          __internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
     }
     else
 #endif


### PR DESCRIPTION
In this PR we fix the issue https://github.com/uxlfoundation/oneDPL/issues/2110