### PR TITLE
Fix warnings in tests: unused variable, function, typedef

### DIFF
--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
@@ -83,7 +83,7 @@ main()
 
 #if !TEST_DPCPP_BACKEND_PRESENT && !_PSTL_ICC_18_TEST_EARLY_EXIT_MONOTONIC_RELEASE_BROKEN &&               \
     !_PSTL_ICC_19_TEST_IS_PARTITIONED_RELEASE_BROKEN
-    test<LocalWrapper<float64_t>>([](const LocalWrapper<float64_t>& x) { return true; });
+    test<LocalWrapper<float64_t>>([](const LocalWrapper<float64_t>&) { return true; });
     test_algo_basic_single<std::int32_t>(run_for_rnd_fw<test_non_const>());
 #endif
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -38,7 +38,6 @@ struct test_one_policy
     void
     check_and_reset(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, OutputIterator out_first)
     {
-        typedef typename ::std::iterator_traits<OutputIterator>::value_type Out;
         typename ::std::iterator_traits<OutputIterator>::difference_type k = 0;
         for (; first1 != last1; ++first1, ++first2, ++out_first, ++k)
         {
@@ -70,7 +69,7 @@ struct test_one_policy
     {
         return Out(1.5) + std::get<0>(t1) - std::get<0>(t2);
     }
-    
+
     template <typename T>
     auto&
     get_actual(oneapi::dpl::__internal::tuple<T&>&& t)

--- a/test/parallel_api/algorithm/alg.nonmodifying/find.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find.pass.cpp
@@ -76,8 +76,8 @@ main()
 {
     // Note that the "hit" and "miss" functions here avoid overflow issues.
 #if !TEST_DPCPP_BACKEND_PRESENT
-    test<Number>(Weird(42, OddTag()), [](std::int32_t j) { return Number(42, OddTag()); }, // hit
-                 [](std::int32_t j) { return Number(j == 42 ? 0 : j, OddTag()); });        // miss
+    test<Number>(Weird(42, OddTag()), [](std::int32_t) { return Number(42, OddTag()); }, // hit
+                 [](std::int32_t j) { return Number(j == 42 ? 0 : j, OddTag()); });      // miss
 #endif
 
     // Test with value that is equal to two different bit patterns (-0.0 and 0.0)

--- a/test/parallel_api/algorithm/alg.nonmodifying/transform_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/transform_if.pass.cpp
@@ -195,7 +195,6 @@ template <typename _Type>
 void
 test_inplace()
 {
-    const ::std::int64_t init_val = 999;
     for (size_t n : TestUtils::get_pattern_for_test_sizes())
     {
         {

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -66,19 +66,19 @@ struct test_brick_partial_sort
         ::std::copy_n(first, n, exp_first);
         ::std::copy_n(first, n, tmp_first);
 
-        for (::std::size_t p = 0; p < n; p = p <= 16 ? p + 1 : ::std::size_t(31.415 * p))
+        for (::std::size_t m = 0; m < n; m = m <= 16 ? m + 1 : ::std::size_t(31.415 * m))
         {
-            auto m1 = tmp_first + p;
-            auto m2 = exp_first + p;
+            auto m1 = tmp_first + m;
+            auto m2 = exp_first + m;
 
             ::std::partial_sort(exp_first, m2, exp_last, compare);
-#if !TEST_DPCPP_BACKEND_PRESENT
+#if !TEST_DPCPP_BACKEND_PRESENT && PSTL_USE_DEBUG
             count_comp = 0;
 #endif
             ::std::partial_sort(exec, tmp_first, m1, tmp_last, compare);
-            EXPECT_EQ_N(exp_first, tmp_first, p, "wrong effect from partial_sort with predicate");
+            EXPECT_EQ_N(exp_first, tmp_first, m, "wrong effect from partial_sort with predicate");
 
-#if !TEST_DPCPP_BACKEND_PRESENT
+#if !TEST_DPCPP_BACKEND_PRESENT && PSTL_USE_DEBUG
             //checking upper bound number of comparisons; O(p*(last-first)log(middle-first)); where p - number of threads;
             if (m1 - tmp_first > 1)
             {
@@ -88,15 +88,12 @@ struct test_brick_partial_sort
 #else
                 auto p = 1;
 #endif
-
-#if PSTL_USE_DEBUG
                 if (count_comp > complex * p)
                 {
                     ::std::cout << "complexity exceeded" << ::std::endl;
                 }
-#endif
             }
-#endif // !TEST_DPCPP_BACKEND_PRESENT
+#endif // !TEST_DPCPP_BACKEND_PRESENT && PSTL_USE_DEBUG
         }
     }
 

--- a/test/parallel_api/dynamic_selection/test_auto_tune_policy_inline.pass.cpp
+++ b/test/parallel_api/dynamic_selection/test_auto_tune_policy_inline.pass.cpp
@@ -238,7 +238,7 @@ test_auto_submit_wait_on_group(UniverseContainer u, int best_resource)
                 return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
             };
             auto s = oneapi::dpl::experimental::select(p, f);
-            auto e = oneapi::dpl::experimental::submit(s, f);
+            oneapi::dpl::experimental::submit(s, f);
         }
         else
         {

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -272,7 +272,6 @@ struct test_transform_iterator {
         transform_functor new_functor;
         ref_transform_functor ref_functor;
         //check default constructibility of transform_iterator with default constructible components
-        oneapi::dpl::transform_iterator<T1*, transform_functor> _it0;
         oneapi::dpl::transform_iterator<typename ::std::vector<T1>::iterator, transform_functor> _it1(in1.begin());
         oneapi::dpl::transform_iterator<typename ::std::vector<T1>::iterator, transform_functor> _it2(in1.begin(), new_functor);
 
@@ -280,7 +279,7 @@ struct test_transform_iterator {
         auto list_it1 = oneapi::dpl::make_transform_iterator(f_list.begin(), ref_functor);
         auto list_it2 = oneapi::dpl::make_transform_iterator(f_list.end(), ref_functor);
         ::std::fill(list_it1, list_it2, 7);
-        EXPECT_TRUE(::std::all_of(f_list.begin(), f_list.end(), [](int x){ return x == 7; }), 
+        EXPECT_TRUE(::std::all_of(f_list.begin(), f_list.end(), [](int x){ return x == 7; }),
             "wrong result from fill with forward_iterator wrapped with transform_iterator");
 
         auto test_lambda = [](T2& x){ return x + 1; };

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -272,6 +272,7 @@ struct test_transform_iterator {
         transform_functor new_functor;
         ref_transform_functor ref_functor;
         //check default constructibility of transform_iterator with default constructible components
+        [[maybe_unused]] oneapi::dpl::transform_iterator<T1*, transform_functor> _it0;
         oneapi::dpl::transform_iterator<typename ::std::vector<T1>::iterator, transform_functor> _it1(in1.begin());
         oneapi::dpl::transform_iterator<typename ::std::vector<T1>::iterator, transform_functor> _it2(in1.begin(), new_functor);
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
@@ -50,8 +50,6 @@ DEFINE_TEST_PERM_IT(test_sort, PermItIndexTag)
             test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                 [&](auto permItBegin, auto permItEnd)
                 {
-                    using ValueType = typename ::std::iterator_traits<decltype(permItBegin)>::value_type;
-
                     const auto testing_n = permItEnd - permItBegin;
 
                     // Fill full source data set (not only values iterated by permutation iterator)

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -191,8 +191,6 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
-
-        typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
         typedef typename ::std::iterator_traits<Iterator2>::value_type ValT;
 
         const ValT zero = 0;

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -172,8 +172,6 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
-        typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
-
         // call algorithm with no optional arguments
         initialize_data(keys_first, vals_first, val_res_first, n);
         auto res1 = oneapi::dpl::inclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first);

--- a/test/parallel_api/ranges/std_ranges_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_copy.pass.cpp
@@ -27,7 +27,7 @@ main()
     {
         const auto size = std::ranges::min(std::ranges::size(r_in), std::ranges::size(r_out));
 
-        auto res = std::ranges::copy(std::ranges::take_view(r_in, size), std::ranges::take_view(r_out, size).begin());
+        std::ranges::copy(std::ranges::take_view(r_in, size), std::ranges::take_view(r_out, size).begin());
 
         using ret_type = std::ranges::copy_result<std::ranges::borrowed_iterator_t<decltype(r_in)>,
             std::ranges::borrowed_iterator_t<decltype(r_out)>>;

--- a/test/parallel_api/ranges/std_ranges_transform.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_transform.pass.cpp
@@ -30,7 +30,7 @@ main()
             std::ranges::range_size_t<decltype(r_out)>>;
         Size size = std::ranges::min((Size)std::ranges::size(r_out), (Size)std::ranges::size(r_in));
 
-        auto res = std::ranges::transform(std::ranges::take_view(r_in, size),
+        std::ranges::transform(std::ranges::take_view(r_in, size),
             std::ranges::take_view(r_out, size).begin(), std::forward<decltype(args)>(args)...);
 
         using ret_type = std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<decltype(r_in)>,
@@ -56,7 +56,7 @@ main()
         if constexpr(std::ranges::sized_range<decltype(r_2)>)
             size = std::ranges::min(size, (Size)std::ranges::size(r_2));
 
-        auto res = std::ranges::transform(std::ranges::subrange(std::ranges::begin(r_1), std::ranges::begin(r_1) + size),
+        std::ranges::transform(std::ranges::subrange(std::ranges::begin(r_1), std::ranges::begin(r_1) + size),
             std::ranges::subrange(std::ranges::begin(r_2), std::ranges::begin(r_2) + size),
             std::ranges::take_view(r_out, size).begin(), std::forward<decltype(args)>(args)...);
 

--- a/test/support/test_dynamic_selection_utils.h
+++ b/test/support/test_dynamic_selection_utils.h
@@ -72,7 +72,6 @@ test_initialization(const std::vector<T>& u)
     using my_policy_t = Policy;
     my_policy_t p{u};
     auto u2 = oneapi::dpl::experimental::get_resources(p);
-    auto u2s = u2.size();
     if (!std::equal(std::begin(u2), std::end(u2), std::begin(u)))
     {
         std::cout << "ERROR: provided resources and queried resources are not equal\n";
@@ -95,7 +94,6 @@ test_initialization(const std::vector<T>& u)
     }
     p2.initialize(u);
     auto u3 = oneapi::dpl::experimental::get_resources(p);
-    auto u3s = u3.size();
     if (!std::equal(std::begin(u3), std::end(u3), std::begin(u)))
     {
         std::cout << "ERROR: reported resources and queried resources are not equal after deferred initialization\n";
@@ -183,7 +181,7 @@ test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, int off
                     return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
             };
             auto s = oneapi::dpl::experimental::select(p);
-            auto e = oneapi::dpl::experimental::submit(s, func);
+            oneapi::dpl::experimental::submit(s, func);
         }
         oneapi::dpl::experimental::wait(p.get_submission_group());
     }

--- a/test/support/test_offset_utils.h
+++ b/test/support/test_offset_utils.h
@@ -133,7 +133,7 @@ test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, size_t 
                     return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
             };
             auto s = oneapi::dpl::experimental::select(p);
-            auto e = oneapi::dpl::experimental::submit(s, func);
+            oneapi::dpl::experimental::submit(s, func);
         }
         oneapi::dpl::experimental::wait(p.get_submission_group());
     }

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -118,10 +118,9 @@ static std::atomic<std::int32_t> KeyCount;
 //! One more than highest index in array to be sorted.
 static std::uint32_t LastIndex;
 
-//! Keeping Equal() static and a friend of ParanoidKey class (C++, paragraphs 3.5/7.1.1)
 class ParanoidKey;
 
-static bool
+inline bool
 Equal(const ParanoidKey& x, const ParanoidKey& y, bool);
 
 //! A key to be sorted, with lots of checking.
@@ -226,21 +225,21 @@ class KeyCompare
     }
 };
 
-static bool
+inline bool
 Equal(const ParanoidKey& x, const ParanoidKey& y, bool is_stable)
 {
     return (x.value == y.value && !is_stable) || (x.index == y.index);
 }
 
 template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
-static bool
+bool
 Equal(const T& x, const T& y, bool /*is_stable*/)
 {
     return x == y;
 }
 
 #if TEST_DPCPP_BACKEND_PRESENT
-static bool
+inline bool
 Equal(const sycl::half& x, const sycl::half& y, bool /*is_stable*/)
 {
     return x == y;


### PR DESCRIPTION
It fixes warnings:
 - `-Wunused-function`:
 For example, |utils_sort.h:230:1: warning: unused function 'Equal'"
 - `-Wunused-variable`
 For example, transform_if.pass.cpp:198:26: warning: unused variable 'init_val'
 - `-Wunused-local-typedef`
For example, transform_binary.pass.cpp:41:77: warning: unused typedef 'Out'

Additionally, the PR renamed `p` variable to `m` in `partial_sort.pass.cpp` to denote "middle" parameter and avoid variable shadowing with another `p` which means "number of processors". Also some macros were reordered in this test to avoid unused-variable warning. 