### PR TITLE
Improve warning parsing in CI

### DIFF
--- a/.github/scripts/job_summary.py
+++ b/.github/scripts/job_summary.py
@@ -36,7 +36,7 @@ def generate_environment_table(os_info, compiler_version, cmake_version, cpu_mod
 def generate_warning_table(build_log_content):
     warning_regex = re.compile(
         r"""
-            \[(\-W[a-zA-Z0-9\-]+)\] |  # GCC/Clang warnings: "[-W<some-flag>]"
+            \[(\-W[a-zA-Z0-9\-=]+)\] |  # GCC/Clang warnings: "[-W<some-flag>]" or "[-W<some-flag>=<value>]"
             ((?:STL|C|D|LNK)\d{4})     # MSVC warnings: "<STL|C|D|LNK>xxxx"
         """,
         re.VERBOSE


### PR DESCRIPTION
This will also allow detecting warnings like that:

> warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]