### PR TITLE
Removing invalid link to Yocto instructions.

### DIFF
--- a/documentation/library_guide/common_cross_document_links.txt
+++ b/documentation/library_guide/common_cross_document_links.txt
@@ -27,6 +27,3 @@
 
 .. |fpga_handbook| replace:: Intel® oneAPI FPGA Handbook
 .. _fpga_handbook: https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/2025-0/intel-oneapi-fpga-handbook.html
-
-.. |yocto_layers| replace:: Layers for Yocto* Project
-.. _yocto_layers: https://www.intel.com/content/www/us/en/docs/oneapi-iot-toolkit/get-started-guide-linux/2025-0/adding-oneapi-components-to-yocto-project-builds.html

--- a/documentation/library_guide/introduction/onedpl_gsg.rst
+++ b/documentation/library_guide/introduction/onedpl_gsg.rst
@@ -216,8 +216,6 @@ Find More
      - Check the release notes to learn about updates in the latest release.
    * - `oneDPL Samples <https://github.com/oneapi-src/oneAPI-samples/tree/master/Libraries/oneDPL>`_
      - Learn how to use |onedpl_short| with samples.
-   * - |yocto_layers|_
-     - Add oneAPI components to a Yocto project build using the meta-intel layers.
    * - `oneAPI Samples Catalog <https://oneapi-src.github.io/oneAPI-samples/>`_
      - Explore the complete list of oneAPI code samples in the oneAPI Samples Catalog (GitHub*).
        These samples were designed to help you develop, offload, and optimize multiarchitecture applications targeting CPUs, GPUs, and FPGAs.

--- a/documentation/library_guide/onedpl_gsg.rst
+++ b/documentation/library_guide/onedpl_gsg.rst
@@ -225,8 +225,6 @@ Find More
      - Check the release notes to learn about updates in the latest release.
    * - `oneDPL Samples <https://github.com/oneapi-src/oneAPI-samples/tree/master/Libraries/oneDPL>`_
      - Learn how to use |onedpl_short| with samples.
-   * - |yocto_layers|_
-     - Add oneAPI components to a Yocto project build using the meta-intel layers.
    * - `oneAPI Samples Catalog <https://oneapi-src.github.io/oneAPI-samples/>`_
      - Explore the complete list of oneAPI code samples in the oneAPI Samples Catalog (GitHub*).
        These samples were designed to help you develop, offload, and optimize multiarchitecture applications targeting CPUs, GPUs, and FPGAs.


### PR DESCRIPTION
@dcbenito notified me that the Yocto instructions have been removed from the IoT Toolkit and there's not a redirect or replacement available.  Removing the dead link from the getting started guide.