### PR TITLE
Fix int-in-bool-context warning in all_of test

### DIFF
--- a/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
@@ -20,6 +20,8 @@
 
 #include "support/utils.h"
 
+#include <type_traits>
+
 /*
   TODO: consider implementing the following tests for a better code coverage
   - correctness
@@ -69,7 +71,9 @@ test(size_t bits)
         Sequence<T> in(n, [n, bits](size_t) { return T(2 * HashBits(n, bits - 1) ^ 1); });
 
         // Even value, or false when T is bool.
-        T spike(2 * HashBits(n, bits - 1));
+        T spike = 0;
+        if constexpr (!std::is_same_v<T, bool>)
+            spike = 2 * HashBits(n, bits - 1);
         Sequence<T> inCopy(in);
 
         invoke_on_all_policies<0>()(test_all_of<T>(), in.begin(), in.end(), Parity<T>(1), true);


### PR DESCRIPTION
It fixes warning:
> all_of.pass.cpp:72:19: warning: ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool-context]