### PR TITLE
Forward execution policy in __pattern_walk1 of hetero backend

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -57,7 +57,7 @@ __pattern_walk1(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
     auto __buf = __keep(__first, __last);
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, __exec,
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__buf.all_view())>{
             __f, static_cast<std::size_t>(__n)},
         __n, __buf.all_view())


### PR DESCRIPTION
We only use `__exec` once here, so we can forward the forwarding reference to the `__parallel_for` call from `__pattern_walk1`.