### PR TITLE
Fix int-in-bool-context warning in any_of and none_of

### DIFF
--- a/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
@@ -20,6 +20,8 @@
 
 #include "support/utils.h"
 
+#include <type_traits>
+
 /*
   TODO: consider implementing the following tests for a better code coverage
   - correctness
@@ -55,7 +57,9 @@ test(size_t bits)
         Sequence<T> in(n, [n, bits](size_t) { return T(2 * HashBits(n, bits - 1) ^ 1); });
 
         // Even value, or false when T is bool.
-        T spike(2 * HashBits(n, bits - 1));
+        T spike = 0;
+        if constexpr (!std::is_same_v<T, bool>)
+            spike = 2 * HashBits(n, bits - 1);
         Sequence<T> inCopy(in);
 
         invoke_on_all_policies<0>()(test_any_of<T>(), in.begin(), in.end(), is_equal_to<T>(spike), false);

--- a/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
@@ -20,6 +20,8 @@
 
 #include "support/utils.h"
 
+#include <type_traits>
+
 /*
   TODO: consider implementing the following tests for a better code coverage
   - correctness
@@ -53,7 +55,9 @@ test(size_t bits)
         Sequence<T> in(n, [n, bits](size_t) { return T(2 * HashBits(n, bits - 1) ^ 1); });
 
         // Even value, or false when T is bool.
-        T spike(2 * HashBits(n, bits - 1));
+        T spike = 0;
+        if constexpr (!std::is_same_v<T, bool>)
+            spike = 2 * HashBits(n, bits - 1);
 
         invoke_on_all_policies<0>()(test_none_of<T>(), in.begin(), in.end(), is_equal_to<T>(spike), true);
         invoke_on_all_policies<1>()(test_none_of<T>(), in.cbegin(), in.cend(), is_equal_to<T>(spike), true);


### PR DESCRIPTION
It fixes the same warning as in #2120, but in other tests which slipped my attention.