### PR TITLE
Fix missing-field-initializers warning

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -995,7 +995,7 @@ struct __gen_expand_count_mask
         return std::tuple(mask ? _SizeType{1} : _SizeType{0}, mask, ele);
     }
     _GenMask __gen_mask;
-    _RangeTransform __rng_transform;
+    _RangeTransform __rng_transform{};
 };
 
 struct __get_zeroth_element

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -884,7 +884,7 @@ struct __gen_mask
         return __pred((__rng_transform(std::forward<_InRng>(__in_rng)))[__id]);
     }
     _Predicate __pred;
-    _RangeTransform __rng_transform;
+    _RangeTransform __rng_transform{};
 };
 
 template <typename _BinaryPredicate>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -884,7 +884,7 @@ struct __gen_mask
         return __pred((__rng_transform(std::forward<_InRng>(__in_rng)))[__id]);
     }
     _Predicate __pred;
-    _RangeTransform __rng_transform{};
+    _RangeTransform __rng_transform;
 };
 
 template <typename _BinaryPredicate>
@@ -995,7 +995,7 @@ struct __gen_expand_count_mask
         return std::tuple(mask ? _SizeType{1} : _SizeType{0}, mask, ele);
     }
     _GenMask __gen_mask;
-    _RangeTransform __rng_transform{};
+    _RangeTransform __rng_transform;
 };
 
 struct __get_zeroth_element
@@ -1175,11 +1175,12 @@ __parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag _
     using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
-    return __parallel_transform_reduce_then_scan(
-        __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
-        std::forward<_OutRng>(__out_rng), _GenReduceInput{__generate_mask}, _ReduceOp{}, _GenScanInput{__generate_mask},
-        _ScanInputTransform{}, __write_op, oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
-        /*_Inclusive=*/std::true_type{}, __is_unique_pattern);
+    return __parallel_transform_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                                 std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng),
+                                                 _GenReduceInput{__generate_mask}, _ReduceOp{},
+                                                 _GenScanInput{__generate_mask, {}}, _ScanInputTransform{}, __write_op,
+                                                 oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
+                                                 /*_Inclusive=*/std::true_type{}, __is_unique_pattern);
 }
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _CreateMaskOp,
@@ -1305,7 +1306,8 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
 
         return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
                                                 std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
-                                                _GenMask{__pred}, _WriteOp{}, /*_IsUniquePattern=*/std::false_type{});
+                                                _GenMask{__pred, {}}, _WriteOp{},
+                                                /*_IsUniquePattern=*/std::false_type{});
     }
     else
     {
@@ -1356,7 +1358,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
 
         return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
                                                 std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
-                                                _GenMask{__pred}, _WriteOp{__assign},
+                                                _GenMask{__pred, {}}, _WriteOp{__assign},
                                                 /*_IsUniquePattern=*/std::false_type{});
     }
     else


### PR DESCRIPTION
The PR fixes:
> parallel_backend_sycl.h(1308,64): warning: missing field '__rng_transform' initializer [-Wmissing-field-initializers]


I believe that the original behavior was also correct, which relied on that[ aggregate initialization](https://en.cppreference.com/w/cpp/language/aggregate_initialization) rule:
> Otherwise, if the element is not a reference, the element is [copy-initialized](https://en.cppreference.com/w/cpp/language/copy_initialization) from an empty initializer list.

Hence, `__gen_mask{pred}` was an equivalent of `__gen_mask{pred, {}}` (but with the use of a copy constructor). It resulted in the warning, though.