### PR TITLE
Fix deprecated-copy-with-user-provided-copy warning

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -62,13 +62,6 @@ struct sycl_iterator
         auto old_iter = sycl_iterator<inMode, T, Allocator>{in.get_buffer(), 0};
         idx = in - old_iter;
     }
-    sycl_iterator&
-    operator=(const sycl_iterator& in)
-    {
-        buffer = in.buffer;
-        idx = in.idx;
-        return *this;
-    }
     sycl_iterator
     operator+(difference_type forward) const
     {


### PR DESCRIPTION
This PR fixes a warning:
> sycl_iterator.h(66,5): warning: definition of implicit copy constructor for 'sycl_iterator<sycl::access::mode::read, int>' is deprecated because it has a user-provided copy assignment operator [-Wdeprecated-copy-with-user-provided-copy]

The copy assignment operator was removed to avoid the warning. An implicitly generated operator will do the same operations.
Note, the change will allow an implicit generation of a move constructor and a move assignment operator. I see no issues here, rather the opposite, but I would like to highlight that in case you see any potential problems.