### PR TITLE
Some bricks specialized by `ExecutionPolicy` without apply `std::decay_t`

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -97,7 +97,7 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
+        unseq_backend::walk3_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, decltype(__buf1.all_view()),
                                                 decltype(__buf2.all_view()), decltype(__buf3.all_view())>{
             __f, static_cast<size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view(), __buf3.all_view());

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -44,7 +44,7 @@ __pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__buf.all_view())>{
+        unseq_backend::walk1_vector_or_scalar<std::decay_t<_ExecutionPolicy>, _Function, decltype(__buf.all_view())>{
             __f, static_cast<std::size_t>(__n)},
         __n, __buf.all_view());
     return __future_obj;

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -130,8 +130,7 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& _
 {
     assert(__first1 < __last1);
 
-    using _Policy = _ExecutionPolicy;
-    using _Functor = unseq_backend::walk_n<_Policy, _BinaryOperation2>;
+    using _Functor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, _BinaryOperation2>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
 
     auto __n = __last1 - __first1;
@@ -162,8 +161,7 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& _
 {
     assert(__first < __last);
 
-    using _Policy = _ExecutionPolicy;
-    using _Functor = unseq_backend::walk_n<_Policy, _UnaryOperation>;
+    using _Functor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, _UnaryOperation>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -69,7 +69,7 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
+        unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, decltype(__buf1.all_view()),
                                                 decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view());
 

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -79,10 +79,12 @@ copy_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterato
 {
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk2_brick_async(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _ExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
     return ret_val;
 }
 

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -79,12 +79,10 @@ copy_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterato
 {
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk2_brick_async(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{});
     return ret_val;
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2767,8 +2767,9 @@ void
 __pattern_fill(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
-    __internal::__brick_fill<_Tag, _ExecutionPolicy, _Tp>{__value}(__first, __last, typename _Tag::__is_vector{});
+    __internal::__brick_fill<_Tag, _DecayedExecutionPolicy, _Tp>{__value}(__first, __last, typename _Tag::__is_vector{});
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Tp>
@@ -2777,11 +2778,12 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
                _RandomAccessIterator __last, const _Tp& __value)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     return __internal::__except_handler([&__exec, __first, __last, &__value]() {
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                       [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
-                                          __internal::__brick_fill<__parallel_tag<_IsVector>, _ExecutionPolicy, _Tp>{
+                                          __internal::__brick_fill<__parallel_tag<_IsVector>, _DecayedExecutionPolicy, _Tp>{
                                               __value}(__begin, __end, _IsVector{});
                                       });
         return __last;

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1939,9 +1939,11 @@ __brick_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccess
                     _RandomAccessIterator1 __middle, _RandomAccessIterator1 __last,
                     _RandomAccessIterator2 __result) noexcept
 {
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     _RandomAccessIterator2 __res =
-        __brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(__middle, __last, __result);
-    return __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(__first, __middle, __res);
+        __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(__middle, __last, __result);
+    return __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(__first, __middle, __res);
 }
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator>
@@ -1961,12 +1963,13 @@ __pattern_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
                       _RandomAccessIterator1 __middle, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             [__first, __last, __middle, __result](_RandomAccessIterator1 __b, _RandomAccessIterator1 __e) {
-                __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy> __copy{};
+                __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy> __copy{};
                 if (__b > __middle)
                 {
                     __copy(__b, __e, __result + (__b - __middle), _IsVector{});
@@ -2532,6 +2535,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                             _RandomAccessIterator2 __d_last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     if (__last == __first || __d_last == __d_first)
     {
@@ -2549,7 +2553,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                     _RandomAccessIterator1 __j1 = __first + (__j - __d_first);
 
                     // 1. Copy elements from input to output
-                    __brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(__i1, __j1, __i, _IsVector{});
+                    __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(__i1, __j1, __i, _IsVector{});
                     // 2. Sort elements in output sequence
                     ::std::sort(__i, __j, __comp);
                 },
@@ -3379,13 +3383,14 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
                         _OutputIterator __result, _Compare __comp, _SetUnionOp __set_union_op)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
 
     const auto __n1 = __last1 - __first1;
     const auto __n2 = __last2 - __first2;
 
-    __brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy> __copy_range{};
+    __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy> __copy_range{};
 
     // {1} {}: parallel copying just first sequence
     if (__n2 == 0)
@@ -3706,6 +3711,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator3>::value_type _T;
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     const auto __n1 = __last1 - __first1;
     const auto __n2 = __last2 - __first2;
@@ -3717,21 +3723,21 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     // {1} \ {}: parallel copying just first sequence
     if (__n2 == 0)
         return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
-                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{});
+                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 = ::std::lower_bound(__first1, __last1, *__first2, __comp);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
         return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
-                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{});
+                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 = ::std::lower_bound(__first2, __last2, *__first1, __comp);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)
         return __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
-                                                 __result, __brick_copy<__parallel_tag<_IsVector>, _ExecutionPolicy>{});
+                                                 __result, __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
 
     if (__n1 + __n2 > __set_algo_cut_off)
         return __parallel_set_op(

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1450,7 +1450,6 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                   _RandomAccessIterator __last, _CalcMask __calc_mask)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
@@ -1515,7 +1514,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         // 3. Elements from result are moved to [first, last)
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                       __result + __m, [__result, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                                          __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                                               __i, __j, __first + (__i - __result), _IsVector{});
                                       });
         return __first + __m;
@@ -1862,7 +1861,6 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                  _RandomAccessIterator __middle, _RandomAccessIterator __last)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     auto __n = __last - __first;
@@ -1881,14 +1879,14 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
             __par_backend::__parallel_for(
                 __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
                 [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                    __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                    __internal::__brick_move<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                         __b, __e, __b + (__last - __middle), _IsVector{});
                 });
 
             __par_backend::__parallel_for(
                 __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result, __result + (__n - __m),
                 [__first, __result](_Tp* __b, _Tp* __e) {
-                    __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                    __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                         __b, __e, __first + (__b - __result), _IsVector{});
                 });
 
@@ -1909,14 +1907,14 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
             __par_backend::__parallel_for(
                 __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
                 [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                    __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                    __internal::__brick_move<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                         __b, __e, __first + (__b - __middle), _IsVector{});
                 });
 
             __par_backend::__parallel_for(
                 __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result, __result + __m,
                 [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
-                    __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                    __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                         __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
                 });
 
@@ -1945,11 +1943,9 @@ __brick_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccess
                     _RandomAccessIterator1 __middle, _RandomAccessIterator1 __last,
                     _RandomAccessIterator2 __result) noexcept
 {
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     _RandomAccessIterator2 __res =
-        __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(__middle, __last, __result);
-    return __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(__first, __middle, __res);
+        __brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(__middle, __last, __result);
+    return __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(__first, __middle, __res);
 }
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator>
@@ -1969,13 +1965,12 @@ __pattern_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
                       _RandomAccessIterator1 __middle, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_for(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             [__first, __last, __middle, __result](_RandomAccessIterator1 __b, _RandomAccessIterator1 __e) {
-                __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy> __copy{};
+                __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>> __copy{};
                 if (__b > __middle)
                 {
                     __copy(__b, __e, __result + (__b - __middle), _IsVector{});
@@ -2541,7 +2536,6 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                             _RandomAccessIterator2 __d_last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     if (__last == __first || __d_last == __d_first)
     {
@@ -2559,7 +2553,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                     _RandomAccessIterator1 __j1 = __first + (__j - __d_first);
 
                     // 1. Copy elements from input to output
-                    __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(__i1, __j1, __i, _IsVector{});
+                    __brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(__i1, __j1, __i, _IsVector{});
                     // 2. Sort elements in output sequence
                     ::std::sort(__i, __j, __comp);
                 },
@@ -2596,7 +2590,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
             __par_backend::__parallel_for(
                 __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
                 [__r, __d_first](_T1* __i, _T1* __j) {
-                    __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                    __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                         __i, __j, __d_first + (__i - __r), _IsVector{});
                 });
 
@@ -2772,9 +2766,8 @@ void
 __pattern_fill(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
-    __internal::__brick_fill<_Tag, _DecayedExecutionPolicy, _Tp>{__value}(__first, __last,
+    __internal::__brick_fill<_Tag, std::decay_t<_ExecutionPolicy>, _Tp>{__value}(__first, __last,
                                                                           typename _Tag::__is_vector{});
 }
 
@@ -2784,13 +2777,12 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
                _RandomAccessIterator __last, const _Tp& __value)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     return __internal::__except_handler([&__exec, __first, __last, &__value]() {
         __par_backend::__parallel_for(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
-                __internal::__brick_fill<__parallel_tag<_IsVector>, _DecayedExecutionPolicy, _Tp>{__value}(
+                __internal::__brick_fill<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>, _Tp>{__value}(
                     __begin, __end, _IsVector{});
             });
         return __last;
@@ -2827,9 +2819,7 @@ __pattern_fill_n(_Tag, _ExecutionPolicy&&, _OutputIterator __first, _Size __coun
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
-    return __internal::__brick_fill_n<_Tag, _DecayedExecutionPolicy, _Tp>{__value}(__first, __count,
+    return __internal::__brick_fill_n<_Tag, std::decay_t<_ExecutionPolicy>, _Tp>{__value}(__first, __count,
                                                                                    typename _Tag::__is_vector{});
 }
 
@@ -3181,7 +3171,6 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
                         _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     if (__first == __last || __first == __middle || __middle == __last)
     {
@@ -3212,7 +3201,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
             });
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n,
                                       [__r, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                                          __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                                               __i, __j, __first + (__i - __r), _IsVector{});
                                       });
     });
@@ -3307,7 +3296,6 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_OutputIterator>::value_type _T;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     struct _SetRange
     {
@@ -3330,7 +3318,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         _DifferenceType __m{};
         auto __scan = [=](_DifferenceType, _DifferenceType, const _SetRange& __s) { // Scan
             if (!__s.empty())
-                __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                     __tmp_memory + __s.__buf_pos, __tmp_memory + (__s.__buf_pos + __s.__len), __result + __s.__pos,
                     _IsVector{});
         };
@@ -3398,14 +3386,13 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
                         _OutputIterator __result, _Compare __comp, _SetUnionOp __set_union_op)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
 
     const auto __n1 = __last1 - __first1;
     const auto __n2 = __last2 - __first2;
 
-    __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy> __copy_range{};
+    __brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>> __copy_range{};
 
     // {1} {}: parallel copying just first sequence
     if (__n2 == 0)
@@ -3726,7 +3713,6 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator3>::value_type _T;
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     const auto __n1 = __last1 - __first1;
     const auto __n2 = __last2 - __first2;
@@ -3738,14 +3724,14 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     // {1} \ {}: parallel copying just first sequence
     if (__n2 == 0)
         return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
-                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
+                                     __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 = ::std::lower_bound(__first1, __last1, *__first2, __comp);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
         return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
-                                     __internal::__brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
+                                     __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 = ::std::lower_bound(__first2, __last2, *__first1, __comp);
@@ -3753,7 +3739,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     if (__left_bound_seq_2 == __last2)
         return __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
                                                  __result,
-                                                 __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
+                                                 __brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{});
 
     if (__n1 + __n2 > __set_algo_cut_off)
         return __parallel_set_op(
@@ -4381,7 +4367,6 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                      typename ::std::iterator_traits<_RandomAccessIterator>::difference_type __n)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     //If (n > 0 && n < m), returns first + (m - n). Otherwise, if n  > 0, returns first. Otherwise, returns last.
     if (__n <= 0)
@@ -4401,7 +4386,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
         {
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, __size,
                                           [__first, __n](_DiffType __i, _DiffType __j) {
-                                              __brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                                              __brick_move<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                                                   __first + __i, __first + __j, __first + __i - __n, _IsVector{});
                                           });
         }
@@ -4413,7 +4398,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                 auto __end = ::std::min(__k + __n, __size);
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __k, __end,
                                               [__first, __n](_DiffType __i, _DiffType __j) {
-                                                  __brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                                                  __brick_move<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
                                                       __first + __i, __first + __j, __first + __i - __n, _IsVector{});
                                               });
             }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2820,8 +2820,10 @@ __pattern_fill_n(_Tag, _ExecutionPolicy&&, _OutputIterator __first, _Size __coun
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    return __internal::__brick_fill_n<_Tag, _ExecutionPolicy, _Tp>{__value}(__first, __count,
-                                                                            typename _Tag::__is_vector{});
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
+    return __internal::__brick_fill_n<_Tag, _DecayedExecutionPolicy, _Tp>{__value}(__first, __count,
+                                                                                   typename _Tag::__is_vector{});
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Tp>

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1050,11 +1050,11 @@ __pattern_search_n(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
 // clear that doing so is worth the trouble and extra layers of call chain.
 // Sometimes a little duplication for sake of regularity is better than the alternative.
 
-template <class _Tag, typename _ExecutionPolicy>
-struct __brick_copy_n<_Tag, _ExecutionPolicy,
+template <class _Tag, typename _DecayedExecutionPolicy>
+struct __brick_copy_n<_Tag, _DecayedExecutionPolicy,
                       ::std::enable_if_t<oneapi::dpl::__internal::__is_host_dispatch_tag_v<_Tag>>>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     template <typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2>
     _RandomAccessIterator2
@@ -1078,10 +1078,10 @@ struct __brick_copy_n<_Tag, _ExecutionPolicy,
 // copy
 //------------------------------------------------------------------------
 
-template <class _Tag, typename _ExecutionPolicy>
-struct __brick_copy<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
+template <class _Tag, typename _DecayedExecutionPolicy>
+struct __brick_copy<_Tag, _DecayedExecutionPolicy, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
@@ -1112,10 +1112,10 @@ struct __brick_copy<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatc
 // move
 //------------------------------------------------------------------------
 
-template <class _Tag, typename _ExecutionPolicy>
-struct __brick_move<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
+template <class _Tag, typename _DecayedExecutionPolicy>
+struct __brick_move<_Tag, _DecayedExecutionPolicy, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
@@ -1142,10 +1142,10 @@ struct __brick_move<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatc
     }
 };
 
-template <class _Tag, typename _ExecutionPolicy, typename = ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
+template <class _Tag, typename _DecayedExecutionPolicy, typename = ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 struct __brick_move_destroy
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
@@ -2740,10 +2740,10 @@ __pattern_nth_element(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec
 //------------------------------------------------------------------------
 // fill, fill_n
 //------------------------------------------------------------------------
-template <class _Tag, typename _ExecutionPolicy, typename _Tp>
-struct __brick_fill<_Tag, _ExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
+template <class _Tag, typename _DecayedExecutionPolicy, typename _Tp>
+struct __brick_fill<_Tag, _DecayedExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     const _Tp& __value;
 
@@ -2792,10 +2792,10 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
     });
 }
 
-template <class _Tag, typename _ExecutionPolicy, typename _Tp>
-struct __brick_fill_n<_Tag, _ExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
+template <class _Tag, typename _DecayedExecutionPolicy, typename _Tp>
+struct __brick_fill_n<_Tag, _DecayedExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     const _Tp& __value;
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1054,6 +1054,8 @@ template <class _Tag, typename _ExecutionPolicy>
 struct __brick_copy_n<_Tag, _ExecutionPolicy,
                       ::std::enable_if_t<oneapi::dpl::__internal::__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2>
     _RandomAccessIterator2
     operator()(_RandomAccessIterator1 __first, _Size __n, _RandomAccessIterator2 __result,
@@ -1079,6 +1081,8 @@ struct __brick_copy_n<_Tag, _ExecutionPolicy,
 template <class _Tag, typename _ExecutionPolicy>
 struct __brick_copy<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
     operator()(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result,
@@ -1111,6 +1115,8 @@ struct __brick_copy<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatc
 template <class _Tag, typename _ExecutionPolicy>
 struct __brick_move<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
     operator()(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result,
@@ -1139,6 +1145,8 @@ struct __brick_move<_Tag, _ExecutionPolicy, ::std::enable_if_t<__is_host_dispatc
 template <class _Tag, typename _ExecutionPolicy, typename = ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 struct __brick_move_destroy
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
     operator()(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _RandomAccessIterator2 __result,
@@ -2727,6 +2735,8 @@ __pattern_nth_element(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec
 template <class _Tag, typename _ExecutionPolicy, typename _Tp>
 struct __brick_fill<_Tag, _ExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     const _Tp& __value;
 
     template <typename _RandomAccessIterator>
@@ -2775,6 +2785,8 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
 template <class _Tag, typename _ExecutionPolicy, typename _Tp>
 struct __brick_fill_n<_Tag, _ExecutionPolicy, _Tp, ::std::enable_if_t<__is_host_dispatch_tag_v<_Tag>>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     const _Tp& __value;
 
     template <typename _RandomAccessIterator, typename _Size>

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1861,6 +1861,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                  _RandomAccessIterator __middle, _RandomAccessIterator __last)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     auto __n = __last - __first;
@@ -1878,7 +1879,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
                                           [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __b, __e, __b + (__last - __middle), _IsVector{});
                                           });
 
@@ -1904,7 +1905,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
                                           [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __b, __e, __first + (__b - __middle), _IsVector{});
                                           });
 
@@ -4365,6 +4366,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                      typename ::std::iterator_traits<_RandomAccessIterator>::difference_type __n)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     //If (n > 0 && n < m), returns first + (m - n). Otherwise, if n  > 0, returns first. Otherwise, returns last.
     if (__n <= 0)
@@ -4384,7 +4386,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
         {
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __n, __size,
                                           [__first, __n](_DiffType __i, _DiffType __j) {
-                                              __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __first + __i, __first + __j, __first + __i - __n, _IsVector{});
                                           });
         }
@@ -4396,7 +4398,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                 auto __end = ::std::min(__k + __n, __size);
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __k, __end,
                                               [__first, __n](_DiffType __i, _DiffType __j) {
-                                                  __brick_move<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                                  __brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                       __first + __i, __first + __j, __first + __i - __n, _IsVector{});
                                               });
             }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1878,17 +1878,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                                                   __b, __e, __result + (__b - __middle), _IsVector{});
                                           });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
-                                          [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
-                                                  __b, __e, __b + (__last - __middle), _IsVector{});
-                                          });
+            __par_backend::__parallel_for(
+                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
+                [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
+                    __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                        __b, __e, __b + (__last - __middle), _IsVector{});
+                });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
-                                          __result + (__n - __m), [__first, __result](_Tp* __b, _Tp* __e) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
-                                                  __b, __e, __first + (__b - __result), _IsVector{});
-                                          });
+            __par_backend::__parallel_for(
+                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result, __result + (__n - __m),
+                [__first, __result](_Tp* __b, _Tp* __e) {
+                    __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                        __b, __e, __first + (__b - __result), _IsVector{});
+                });
 
             return __first + (__last - __middle);
         });
@@ -1904,17 +1906,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                                                   __b, __e, __result + (__b - __first), _IsVector{});
                                           });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
-                                          [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
-                                              __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
-                                                  __b, __e, __first + (__b - __middle), _IsVector{});
-                                          });
+            __par_backend::__parallel_for(
+                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
+                [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
+                    __internal::__brick_move<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                        __b, __e, __first + (__b - __middle), _IsVector{});
+                });
 
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
-                                          __result + __m, [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
-                                                  __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
-                                          });
+            __par_backend::__parallel_for(
+                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result, __result + __m,
+                [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
+                    __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                        __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
+                });
 
             return __first + (__last - __middle);
         });
@@ -2589,11 +2593,12 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                 __n2);
 
             // 3. Move elements from temporary buffer to output
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
-                                          [__r, __d_first](_T1* __i, _T1* __j) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
-                                                  __i, __j, __d_first + (__i - __r), _IsVector{});
-                                          });
+            __par_backend::__parallel_for(
+                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
+                [__r, __d_first](_T1* __i, _T1* __j) {
+                    __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
+                        __i, __j, __d_first + (__i - __r), _IsVector{});
+                });
 
             if constexpr (!::std::is_trivially_destructible_v<_T1>)
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
@@ -2769,7 +2774,8 @@ __pattern_fill(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardItera
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
     using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
-    __internal::__brick_fill<_Tag, _DecayedExecutionPolicy, _Tp>{__value}(__first, __last, typename _Tag::__is_vector{});
+    __internal::__brick_fill<_Tag, _DecayedExecutionPolicy, _Tp>{__value}(__first, __last,
+                                                                          typename _Tag::__is_vector{});
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Tp>
@@ -2781,11 +2787,12 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
     using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     return __internal::__except_handler([&__exec, __first, __last, &__value]() {
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                      [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
-                                          __internal::__brick_fill<__parallel_tag<_IsVector>, _DecayedExecutionPolicy, _Tp>{
-                                              __value}(__begin, __end, _IsVector{});
-                                      });
+        __par_backend::__parallel_for(
+            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
+                __internal::__brick_fill<__parallel_tag<_IsVector>, _DecayedExecutionPolicy, _Tp>{__value}(
+                    __begin, __end, _IsVector{});
+            });
         return __last;
     });
 }
@@ -3745,7 +3752,8 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)
         return __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
-                                                 __result, __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
+                                                 __result,
+                                                 __brick_copy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{});
 
     if (__n1 + __n2 > __set_algo_cut_off)
         return __parallel_set_op(

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1512,11 +1512,12 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
             [&__m](_DifferenceType __total) { __m = __total; });
 
         // 3. Elements from result are moved to [first, last)
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
-                                      __result + __m, [__result, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
-                                              __i, __j, __first + (__i - __result), _IsVector{});
-                                      });
+        __par_backend::__parallel_for(
+            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result, __result + __m,
+            [__result, __first](_Tp* __i, _Tp* __j) {
+                __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
+                    __i, __j, __first + (__i - __result), _IsVector{});
+            });
         return __first + __m;
     });
 }
@@ -1945,7 +1946,8 @@ __brick_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccess
 {
     _RandomAccessIterator2 __res =
         __brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(__middle, __last, __result);
-    return __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(__first, __middle, __res);
+    return __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(__first, __middle,
+                                                                                                 __res);
 }
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator>
@@ -2553,7 +2555,8 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                     _RandomAccessIterator1 __j1 = __first + (__j - __d_first);
 
                     // 1. Copy elements from input to output
-                    __brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(__i1, __j1, __i, _IsVector{});
+                    __brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(__i1, __j1, __i,
+                                                                                              _IsVector{});
                     // 2. Sort elements in output sequence
                     ::std::sort(__i, __j, __comp);
                 },
@@ -2768,7 +2771,7 @@ __pattern_fill(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardItera
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
     __internal::__brick_fill<_Tag, std::decay_t<_ExecutionPolicy>, _Tp>{__value}(__first, __last,
-                                                                          typename _Tag::__is_vector{});
+                                                                                 typename _Tag::__is_vector{});
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Tp>
@@ -2820,7 +2823,7 @@ __pattern_fill_n(_Tag, _ExecutionPolicy&&, _OutputIterator __first, _Size __coun
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
     return __internal::__brick_fill_n<_Tag, std::decay_t<_ExecutionPolicy>, _Tp>{__value}(__first, __count,
-                                                                                   typename _Tag::__is_vector{});
+                                                                                          typename _Tag::__is_vector{});
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Tp>
@@ -3199,11 +3202,12 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
                                                     __move_sequences, __move_sequences);
                 return __f3 + (__l1 - __f1) + (__l2 - __f2);
             });
-        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n,
-                                      [__r, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
-                                              __i, __j, __first + (__i - __r), _IsVector{});
-                                      });
+        __par_backend::__parallel_for(
+            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n,
+            [__r, __first](_Tp* __i, _Tp* __j) {
+                __brick_move_destroy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
+                    __i, __j, __first + (__i - __r), _IsVector{});
+            });
     });
 }
 
@@ -3723,23 +3727,25 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 
     // {1} \ {}: parallel copying just first sequence
     if (__n2 == 0)
-        return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
-                                     __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{});
+        return __pattern_walk2_brick(
+            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
+            __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 = ::std::lower_bound(__first1, __last1, *__first2, __comp);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
-        return __pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
-                                     __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{});
+        return __pattern_walk2_brick(
+            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
+            __internal::__brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{});
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 = ::std::lower_bound(__first2, __last2, *__first1, __comp);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)
-        return __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
-                                                 __result,
-                                                 __brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{});
+        return __internal::__pattern_walk2_brick(
+            __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
+            __brick_copy<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{});
 
     if (__n1 + __n2 > __set_algo_cut_off)
         return __parallel_set_op(
@@ -4396,11 +4402,12 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
             for (auto __k = __n; __k < __size; __k += __n)
             {
                 auto __end = ::std::min(__k + __n, __size);
-                __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __k, __end,
-                                              [__first, __n](_DiffType __i, _DiffType __j) {
-                                                  __brick_move<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
-                                                      __first + __i, __first + __j, __first + __i - __n, _IsVector{});
-                                              });
+                __par_backend::__parallel_for(
+                    __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __k, __end,
+                    [__first, __n](_DiffType __i, _DiffType __j) {
+                        __brick_move<__parallel_tag<_IsVector>, std::decay_t<_ExecutionPolicy>>{}(
+                            __first + __i, __first + __j, __first + __i - __n, _IsVector{});
+                    });
             }
         }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1450,6 +1450,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                   _RandomAccessIterator __last, _CalcMask __calc_mask)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
@@ -1514,7 +1515,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         // 3. Elements from result are moved to [first, last)
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                       __result + __m, [__result, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                          __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                               __i, __j, __first + (__i - __result), _IsVector{});
                                       });
         return __first + __m;
@@ -1885,7 +1886,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + (__n - __m), [__first, __result](_Tp* __b, _Tp* __e) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __b, __e, __first + (__b - __result), _IsVector{});
                                           });
 
@@ -1911,7 +1912,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + __m, [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
                                           });
 
@@ -2590,7 +2591,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
             // 3. Move elements from temporary buffer to output
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
                                           [__r, __d_first](_T1* __i, _T1* __j) {
-                                              __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                              __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
                                           });
 
@@ -3169,6 +3170,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
                         _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     if (__first == __last || __first == __middle || __middle == __last)
     {
@@ -3199,7 +3201,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
             });
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n,
                                       [__r, __first](_Tp* __i, _Tp* __j) {
-                                          __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                                          __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                                               __i, __j, __first + (__i - __r), _IsVector{});
                                       });
     });
@@ -3294,6 +3296,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_OutputIterator>::value_type _T;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     struct _SetRange
     {
@@ -3316,7 +3319,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         _DifferenceType __m{};
         auto __scan = [=](_DifferenceType, _DifferenceType, const _SetRange& __s) { // Scan
             if (!__s.empty())
-                __brick_move_destroy<__parallel_tag<_IsVector>, _ExecutionPolicy>{}(
+                __brick_move_destroy<__parallel_tag<_IsVector>, _DecayedExecutionPolicy>{}(
                     __tmp_memory + __s.__buf_pos, __tmp_memory + (__s.__buf_pos + __s.__len), __result + __s.__pos,
                     _IsVector{});
         };

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -397,8 +397,9 @@ __pattern_copy(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRan
 
     assert(std::ranges::size(__in_r) <= std::ranges::size(__out_r)); // for debug purposes only
 
-    oneapi::dpl::__internal::__pattern_walk2_brick(__tag, std::forward<_ExecutionPolicy>(__exec),
-        std::ranges::begin(__in_r), std::ranges::begin(__in_r) + std::ranges::size(__in_r), std::ranges::begin(__out_r),
+    oneapi::dpl::__internal::__pattern_walk2_brick(
+        __tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__in_r),
+        std::ranges::begin(__in_r) + std::ranges::size(__in_r), std::ranges::begin(__out_r),
         oneapi::dpl::__internal::__brick_copy<decltype(__tag), _DecayedExecutionPolicy>{});
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -393,14 +393,12 @@ __pattern_copy(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRan
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
-    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
-
     assert(std::ranges::size(__in_r) <= std::ranges::size(__out_r)); // for debug purposes only
 
     oneapi::dpl::__internal::__pattern_walk2_brick(
         __tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__in_r),
         std::ranges::begin(__in_r) + std::ranges::size(__in_r), std::ranges::begin(__out_r),
-        oneapi::dpl::__internal::__brick_copy<decltype(__tag), _DecayedExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy<decltype(__tag), std::decay_t<_ExecutionPolicy>>{});
 }
 
 template<typename _ExecutionPolicy, typename _InRange, typename _OutRange>

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -393,11 +393,13 @@ __pattern_copy(_Tag __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRan
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
+    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
+
     assert(std::ranges::size(__in_r) <= std::ranges::size(__out_r)); // for debug purposes only
 
     oneapi::dpl::__internal::__pattern_walk2_brick(__tag, std::forward<_ExecutionPolicy>(__exec),
         std::ranges::begin(__in_r), std::ranges::begin(__in_r) + std::ranges::size(__in_r), std::ranges::begin(__out_r),
-        oneapi::dpl::__internal::__brick_copy<decltype(__tag), _ExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy<decltype(__tag), _DecayedExecutionPolicy>{});
 }
 
 template<typename _ExecutionPolicy, typename _InRange, typename _OutRange>

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -270,24 +270,20 @@ copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __l
 {
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     return oneapi::dpl::__internal::__pattern_walk2_brick(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{});
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _ForwardIterator2 __result)
 {
-    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
-
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_walk2_brick_n(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-        oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{});
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
@@ -838,13 +834,11 @@ template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterato
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first)
 {
-    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
-
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __d_first);
 
     return oneapi::dpl::__internal::__pattern_walk2_brick(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first,
-        oneapi::dpl::__internal::__brick_move<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_move<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{});
 }
 
 // [partial.sort]

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -270,9 +270,11 @@ copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __l
 {
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     return oneapi::dpl::__internal::__pattern_walk2_brick(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _ExecutionPolicy>{});
+        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2>

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -796,11 +796,9 @@ copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result)
 {
     auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng, __result);
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{},
+        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{},
         views::all_read(::std::forward<_Range1>(__rng)), views::all_write(::std::forward<_Range2>(__result)));
 }
 
@@ -1158,11 +1156,9 @@ move(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
 {
     auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng1, __rng2);
 
-    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
-
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__internal::__brick_move<decltype(__dispatch_tag), _DecayedExecutionPolicy>{},
+        oneapi::dpl::__internal::__brick_move<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{},
         views::all_read(::std::forward<_Range1>(__rng1)), views::all_write(::std::forward<_Range2>(__rng2)));
 }
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -796,9 +796,11 @@ copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result)
 {
     auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng, __result);
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _ExecutionPolicy>{},
+        oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{},
         views::all_read(::std::forward<_Range1>(__rng)), views::all_write(::std::forward<_Range2>(__result)));
 }
 

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -44,7 +44,6 @@ uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _OutValueType;
     typedef typename std::iterator_traits<_ForwardIterator>::reference  _OutRefType;
     typedef typename std::iterator_traits<_InputIterator>::reference    _InRefType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
@@ -54,13 +53,13 @@ uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-            oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-            oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__op_uninitialized_copy<std::decay_t<_ExecutionPolicy>>{});
     }
 }
 
@@ -71,7 +70,6 @@ uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _OutValueType;
     typedef typename std::iterator_traits<_ForwardIterator>::reference  _OutRefType;
     typedef typename std::iterator_traits<_InputIterator>::reference    _InRefType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
@@ -81,13 +79,13 @@ uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick_n(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-            oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2_n(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-            oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__op_uninitialized_copy<std::decay_t<_ExecutionPolicy>>{});
     }
 }
 
@@ -100,7 +98,6 @@ uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _OutValueType;
     typedef typename std::iterator_traits<_ForwardIterator>::reference  _OutRefType;
     typedef typename std::iterator_traits<_InputIterator>::reference    _InRefType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
@@ -110,13 +107,13 @@ uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-            oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-            oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__op_uninitialized_move<std::decay_t<_ExecutionPolicy>>{});
     }
 }
 
@@ -127,7 +124,6 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _OutValueType;
     typedef typename std::iterator_traits<_ForwardIterator>::reference  _OutRefType;
     typedef typename std::iterator_traits<_InputIterator>::reference    _InRefType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
@@ -137,13 +133,13 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
     {
         return oneapi::dpl::__internal::__pattern_walk2_brick_n(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-            oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy_n<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>>{});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk2_n(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-            oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__op_uninitialized_move<std::decay_t<_ExecutionPolicy>>{});
     }
 }
 
@@ -154,7 +150,6 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
@@ -164,14 +159,14 @@ uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Forward
     {
         oneapi::dpl::__internal::__pattern_walk_brick(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
-            oneapi::dpl::__internal::__brick_fill<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
+            oneapi::dpl::__internal::__brick_fill<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>, _ValueType>{
                 _ValueType(__value)});
     }
     else
     {
         oneapi::dpl::__internal::__pattern_walk1(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
-            oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value});
+            oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, std::decay_t<_ExecutionPolicy>>{__value});
     }
 }
 
@@ -180,7 +175,6 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, const _Tp& __value)
 {
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
@@ -190,14 +184,14 @@ uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size 
     {
         return oneapi::dpl::__internal::__pattern_walk_brick_n(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
-            oneapi::dpl::__internal::__brick_fill_n<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
+            oneapi::dpl::__internal::__brick_fill_n<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>, _ValueType>{
                 _ValueType(__value)});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk1_n(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
-            oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value});
+            oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, std::decay_t<_ExecutionPolicy>>{__value});
     }
 }
 
@@ -280,7 +274,6 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     if constexpr (!std::is_trivially_default_constructible_v<_ValueType>)
     {
@@ -288,7 +281,7 @@ uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __fi
 
         oneapi::dpl::__internal::__pattern_walk1(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
-            oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__op_uninitialized_default_construct<std::decay_t<_ExecutionPolicy>>{});
     }
 }
 
@@ -297,7 +290,6 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 {
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     if constexpr (std::is_trivially_default_constructible_v<_ValueType>)
     {
@@ -309,7 +301,7 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __
 
         return oneapi::dpl::__internal::__pattern_walk1_n(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
-            oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__op_uninitialized_default_construct<std::decay_t<_ExecutionPolicy>>{});
     }
 }
 
@@ -320,7 +312,6 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
@@ -329,14 +320,14 @@ uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __firs
     {
         oneapi::dpl::__internal::__pattern_walk_brick(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
-            oneapi::dpl::__internal::__brick_fill<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
+            oneapi::dpl::__internal::__brick_fill<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>, _ValueType>{
                 _ValueType()});
     }
     else
     {
         oneapi::dpl::__internal::__pattern_walk1(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
-            oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__op_uninitialized_value_construct<std::decay_t<_ExecutionPolicy>>{});
     }
 }
 
@@ -345,7 +336,6 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 {
     typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
@@ -354,14 +344,14 @@ uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __fi
     {
         return oneapi::dpl::__internal::__pattern_walk_brick_n(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
-            oneapi::dpl::__internal::__brick_fill_n<decltype(__dispatch_tag), _DecayedExecutionPolicy, _ValueType>{
+            oneapi::dpl::__internal::__brick_fill_n<decltype(__dispatch_tag), std::decay_t<_ExecutionPolicy>, _ValueType>{
                 _ValueType()});
     }
     else
     {
         return oneapi::dpl::__internal::__pattern_walk1_n(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __n,
-            oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__op_uninitialized_value_construct<std::decay_t<_ExecutionPolicy>>{});
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -147,8 +147,6 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIte
     if (__n == 0)
         return __first2;
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _ForwardIterator1>();
     auto __buf1 = __keep1(__first1, __last1);
@@ -159,7 +157,7 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIte
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__brick_swap<_DecayedExecutionPolicy, _Function, decltype(__buf1.all_view()),
+        unseq_backend::__brick_swap<std::decay_t<_ExecutionPolicy>, _Function, decltype(__buf1.all_view()),
                                     decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view());
     __future.wait(__par_backend_hetero::__deferrable_mode{});
@@ -1017,7 +1015,6 @@ __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
                       _Iterator2 __result_first, _BinaryPredicate __pred)
 {
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     _It1DifferenceType __n = __last - __first;
 
@@ -1028,7 +1025,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
         // For a sequence of size 1, we can just copy the only element to the result.
         oneapi::dpl::__internal::__pattern_walk2_brick(
             __hetero_tag<_BackendTag>{}, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result_first,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
         return __result_first + 1;
     }
 
@@ -1057,8 +1054,6 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
     if (__last == __first)
         return __last;
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __last - __first);
@@ -1073,7 +1068,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
     // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
     return __pattern_walk2(
         __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
-        __copy_first, __copy_last, __first, __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+        __copy_first, __copy_last, __first, __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _BinaryPredicate>
@@ -1083,8 +1078,6 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
 {
     if (__last - __first < 2)
         return __last;
-
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
@@ -1103,7 +1096,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
                            __par_backend_hetero::access_mode::read_write,
                            __par_backend_hetero::access_mode::read_write>(
         __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
-        __copy_first, __copy_last, __first, __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+        __copy_first, __copy_last, __first, __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 }
 
 //------------------------------------------------------------------------
@@ -1214,8 +1207,6 @@ _Iterator3
 __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __last1,
                 _Iterator2 __first2, _Iterator2 __last2, _Iterator3 __d_first, _Compare __comp)
 {
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     auto __n1 = __last1 - __first1;
     auto __n2 = __last2 - __first2;
     auto __n = __n1 + __n2;
@@ -1229,14 +1220,14 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first2, __last2, __d_first,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
     else if (__n2 == 0)
         oneapi::dpl::__internal::__pattern_walk2_brick(
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<copy_back_wrapper2>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first1, __last1, __d_first,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
     else
     {
         auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -1264,7 +1255,6 @@ __pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __ex
                         _Iterator __middle, _Iterator __last, _Compare __comp)
 {
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     if (__first == __middle || __middle == __last || __first == __last)
         return;
@@ -1289,7 +1279,7 @@ __pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __ex
     // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
     __pattern_walk2(
         __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
-        __copy_first, __copy_last, __first, __brick_move<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+        __copy_first, __copy_last, __first, __brick_move<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 }
 
 //------------------------------------------------------------------------
@@ -1357,7 +1347,6 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
                                                                                                           : __first;
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     auto __n = __last - __first;
 
@@ -1371,12 +1360,12 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
 
     //TODO: optimize copy back if possible (inplace, decrease number of submits)
     __pattern_walk2(__tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec), __true_result,
-                    copy_result.first, __first, __brick_move<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+                    copy_result.first, __first, __brick_move<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 
     __pattern_walk2(
         __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper2>(::std::forward<_ExecutionPolicy>(__exec)),
         __false_result, copy_result.second, __first + true_count,
-        __brick_move<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+        __brick_move<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 
     //TODO: A buffer is constructed from a range, the destructor does not need to block.
     // The synchronization between these patterns is not required due to the data are being processed independently.
@@ -1464,9 +1453,8 @@ __pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Forwar
 
     typedef typename ::std::iterator_traits<_ForwardIterator1>::difference_type _Size1;
     typedef typename ::std::iterator_traits<_ForwardIterator2>::difference_type _Size2;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
-    using __brick_include_type = unseq_backend::__brick_includes<_DecayedExecutionPolicy, _Compare, _Size1, _Size2>;
+    using __brick_include_type = unseq_backend::__brick_includes<std::decay_t<_ExecutionPolicy>, _Compare, _Size1, _Size2>;
     return !__par_backend_hetero::__parallel_or(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first2),
@@ -1532,7 +1520,6 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
                             _InIterator __last, _OutIterator __out_first, _OutIterator __out_last, _Compare __comp)
 {
     using _ValueType = typename ::std::iterator_traits<_InIterator>::value_type;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     auto __in_size = __last - __first;
     auto __out_size = __out_last - __out_first;
@@ -1549,7 +1536,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         // full sort on them.
         auto __out_end = __pattern_walk2<__par_backend_hetero::__sync_mode>(
             __tag, __par_backend_hetero::make_wrapped_policy<__initial_copy_1>(__exec), __first, __last, __out_first,
-            __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 
         // TODO: __pattern_walk2 is a blocking call here, so there is a synchronization between the patterns.
         // But, when the input iterators are a kind of hetero iterator on top of sycl::buffer, SYCL
@@ -1577,7 +1564,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
         auto __buf_last = __pattern_walk2<__par_backend_hetero::__async_mode>(
             __tag, __par_backend_hetero::make_wrapped_policy<__initial_copy_2>(__exec), __first, __last, __buf_first,
-            __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 
         auto __buf_mid = __buf_first + __out_size;
 
@@ -1593,7 +1580,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
         return __pattern_walk2(
             __tag, __par_backend_hetero::make_wrapped_policy<__copy_back>(::std::forward<_ExecutionPolicy>(__exec)),
-            __buf_first, __buf_mid, __out_first, __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            __buf_first, __buf_mid, __out_first, __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 
         // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
         // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
@@ -1692,7 +1679,6 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
         return __first;
 
     using _Tp = typename ::std::iterator_traits<_Iterator>::value_type;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
@@ -1711,7 +1697,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     //An explicit wait isn't required here because we are working with a temporary sycl::buffer and sycl accessors and
     //SYCL runtime makes a dependency graph to prevent the races between two __parallel_for patterns.
 
-    using _Function = __brick_move<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>;
+    using _Function = __brick_move<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>;
     auto __temp_rng_rw =
         oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::read_write>(__temp_buf.get_buffer());
     auto __brick =
@@ -1820,8 +1806,6 @@ __pattern_set_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
     if (__first1 == __last1)
         return __result;
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     // {1} \ {}: the difference is {1}
     if (__first2 == __last2)
     {
@@ -1830,7 +1814,7 @@ __pattern_set_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_difference_copy_case_1>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first1, __last1, __result,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
     }
 
     return __pattern_hetero_set_op(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
@@ -1858,8 +1842,6 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
     if (__first1 == __last1 && __first2 == __last2)
         return __result;
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     //{1} is empty
     if (__first1 == __last1)
     {
@@ -1868,7 +1850,7 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_1>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first2, __last2, __result,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
     }
 
     //{2} is empty
@@ -1879,7 +1861,7 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_2>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first1, __last1, __result,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
     }
 
     typedef typename ::std::iterator_traits<_OutputIterator>::value_type _ValueType;
@@ -1941,8 +1923,6 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
     if (__first1 == __last1 && __first2 == __last2)
         return __result;
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     //{1} is empty
     if (__first1 == __last1)
     {
@@ -1951,7 +1931,7 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_copy_case_1>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first2, __last2, __result,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
     }
 
     //{2} is empty
@@ -1962,7 +1942,7 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_copy_case_2>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first1, __last1, __result,
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
     }
 
     typedef typename ::std::iterator_traits<_OutputIterator>::value_type _ValueType;
@@ -2003,8 +1983,6 @@ oneapi::dpl::__internal::__difference_t<_Range>
 __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range __rng,
                      oneapi::dpl::__internal::__difference_t<_Range> __n)
 {
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     //If (n > 0 && n < m), returns first + (m - n). Otherwise, if n  > 0, returns first. Otherwise, returns last.
     using _DiffType = oneapi::dpl::__internal::__difference_t<_Range>;
     _DiffType __size = __rng.size();
@@ -2017,7 +1995,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
     //1. n >= size/2; 'size - _n' parallel copying
     if (__n >= __mid)
     {
-        using _Function = __brick_move<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>;
+        using _Function = __brick_move<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>;
 
         //TODO: to consider use just "read" access mode for a source range and just "write" - for a destination range.
         auto __src = oneapi::dpl::__ranges::drop_view_simple<_Range, _DiffType>(__rng, __n);
@@ -2034,7 +2012,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
     else //2. n < size/2; 'n' parallel copying
     {
         auto __brick =
-            unseq_backend::__brick_shift_left<_DecayedExecutionPolicy, _DiffType, decltype(__rng)>{__size, __n};
+            unseq_backend::__brick_shift_left<std::decay_t<_ExecutionPolicy>, _DiffType, decltype(__rng)>{__size, __n};
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__shift_left_right>(
@@ -2099,8 +2077,6 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
                             _Iterator1 __keys_last, _Iterator2 __values_first, _Iterator3 __out_keys_first,
                             _Iterator4 __out_values_first, _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
 {
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     std::size_t __n = std::distance(__keys_first, __keys_last);
 
     if (__n == 0)
@@ -2108,7 +2084,7 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
     if (__n == 1)
     {
-        __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy> __copy_op{};
+        __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>> __copy_op{};
 
         oneapi::dpl::__internal::__pattern_walk2_n(
             __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_keys_values_wrapper>(__exec),

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -818,7 +818,7 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     if (__first == __last || __s_last == __s_first)
         return __last;
 
-    using _Predicate = unseq_backend::first_match_pred<_ExecutionPolicy, _Pred>;
+    using _Predicate = unseq_backend::first_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
 
     // TODO: To check whether it makes sense to iterate over the second sequence in case of
     // distance(__first, __last) < distance(__s_first, __s_last).

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1464,8 +1464,9 @@ __pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Forwar
 
     typedef typename ::std::iterator_traits<_ForwardIterator1>::difference_type _Size1;
     typedef typename ::std::iterator_traits<_ForwardIterator2>::difference_type _Size2;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
-    using __brick_include_type = unseq_backend::__brick_includes<_ExecutionPolicy, _Compare, _Size1, _Size2>;
+    using __brick_include_type = unseq_backend::__brick_includes<_DecayedExecutionPolicy, _Compare, _Size1, _Size2>;
     return !__par_backend_hetero::__parallel_or(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first2),

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -2033,7 +2033,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
     }
     else //2. n < size/2; 'n' parallel copying
     {
-        auto __brick = unseq_backend::__brick_shift_left<_ExecutionPolicy, _DiffType, decltype(__rng)>{__size, __n};
+        auto __brick = unseq_backend::__brick_shift_left<_DecayedExecutionPolicy, _DiffType, decltype(__rng)>{__size, __n};
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__shift_left_right>(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -405,6 +405,8 @@ __pattern_generate_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec,
 template <typename _BackendTag, typename _ExecutionPolicy>
 struct __brick_copy_n<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _SourceT, typename _TargetT>
     void
     operator()(_SourceT&& __source, _TargetT&& __target) const
@@ -416,6 +418,8 @@ struct __brick_copy_n<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 template <typename _BackendTag, typename _ExecutionPolicy>
 struct __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _SourceT, typename _TargetT>
     void
     operator()(_SourceT&& __source, _TargetT&& __target) const
@@ -427,6 +431,8 @@ struct __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 template <typename _BackendTag, typename _ExecutionPolicy>
 struct __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     template <typename _SourceT, typename _TargetT>
     void
     operator()(_SourceT&& __source, _TargetT&& __target) const
@@ -438,6 +444,8 @@ struct __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>
 template <typename _BackendTag, typename _ExecutionPolicy, typename _SourceT>
 struct __brick_fill<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _SourceT __value;
     template <typename _TargetT>
     void
@@ -450,6 +458,8 @@ struct __brick_fill<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
 template <typename _BackendTag, typename _ExecutionPolicy, typename _SourceT>
 struct __brick_fill_n<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _SourceT __value;
     template <typename _TargetT>
     void

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -794,7 +794,7 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     }
     else
     {
-        using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
+        using _Predicate = unseq_backend::multiple_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
 
         return __par_backend_hetero::__parallel_find(
             _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
@@ -859,7 +859,7 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
         return __res ? __first : __last;
     }
 
-    using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
+    using _Predicate = unseq_backend::multiple_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
     return __par_backend_hetero::__parallel_find(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -147,6 +147,8 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIte
     if (__n == 0)
         return __first2;
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _ForwardIterator1>();
     auto __buf1 = __keep1(__first1, __last1);
@@ -157,7 +159,7 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIte
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__brick_swap<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
+        unseq_backend::__brick_swap<_DecayedExecutionPolicy, _Function, decltype(__buf1.all_view()),
                                     decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view());
     __future.wait(__par_backend_hetero::__deferrable_mode{});

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1360,7 +1360,8 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
 
     //TODO: optimize copy back if possible (inplace, decrease number of submits)
     __pattern_walk2(__tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec), __true_result,
-                    copy_result.first, __first, __brick_move<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
+                    copy_result.first, __first,
+                    __brick_move<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 
     __pattern_walk2(
         __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper2>(::std::forward<_ExecutionPolicy>(__exec)),
@@ -1454,7 +1455,8 @@ __pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Forwar
     typedef typename ::std::iterator_traits<_ForwardIterator1>::difference_type _Size1;
     typedef typename ::std::iterator_traits<_ForwardIterator2>::difference_type _Size2;
 
-    using __brick_include_type = unseq_backend::__brick_includes<std::decay_t<_ExecutionPolicy>, _Compare, _Size1, _Size2>;
+    using __brick_include_type =
+        unseq_backend::__brick_includes<std::decay_t<_ExecutionPolicy>, _Compare, _Size1, _Size2>;
     return !__par_backend_hetero::__parallel_or(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first2),
@@ -1580,7 +1582,8 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
         return __pattern_walk2(
             __tag, __par_backend_hetero::make_wrapped_policy<__copy_back>(::std::forward<_ExecutionPolicy>(__exec)),
-            __buf_first, __buf_mid, __out_first, __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
+            __buf_first, __buf_mid, __out_first,
+            __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 
         // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
         // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -114,7 +114,7 @@ __pattern_walk2(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
+        unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, decltype(__buf1.all_view()),
                                                 decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view());
 
@@ -1706,7 +1706,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     auto __temp_rng_rw =
         oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::read_write>(__temp_buf.get_buffer());
     auto __brick =
-        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__temp_rng_rw),
+        unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, decltype(__temp_rng_rw),
                                                 decltype(__buf.all_view())>{_Function{}, static_cast<std::size_t>(__n)};
     oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __brick,
                                                       __n, __temp_rng_rw, __buf.all_view())
@@ -2007,7 +2007,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
         auto __dst = oneapi::dpl::__ranges::take_view_simple<_Range, _DiffType>(__rng, __size_res);
 
         auto __brick =
-            unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__src), decltype(__dst)>{
+            unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, decltype(__src), decltype(__dst)>{
                 _Function{}, static_cast<std::size_t>(__size_res)};
 
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -2007,8 +2007,8 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
         auto __dst = oneapi::dpl::__ranges::take_view_simple<_Range, _DiffType>(__rng, __size_res);
 
         auto __brick =
-            unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, decltype(__src), decltype(__dst)>{
-                _Function{}, static_cast<std::size_t>(__size_res)};
+            unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, decltype(__src),
+                                                    decltype(__dst)>{_Function{}, static_cast<std::size_t>(__size_res)};
 
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                           __brick, __size_res, __src, __dst)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -198,7 +198,7 @@ __pattern_walk3(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
+        unseq_backend::walk3_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, decltype(__buf1.all_view()),
                                                 decltype(__buf2.all_view()), decltype(__buf3.all_view())>{
             __f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view(), __buf3.all_view())

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -58,7 +58,7 @@ __pattern_walk1(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__buf.all_view())>{
+        unseq_backend::walk1_vector_or_scalar<std::decay_t<_ExecutionPolicy>, _Function, decltype(__buf.all_view())>{
             __f, static_cast<std::size_t>(__n)},
         __n, __buf.all_view())
         .__deferrable_wait();

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -608,8 +608,8 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     if (__last - __first < 2)
         return __last;
 
-    using _Predicate =
-        oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, adjacent_find_fn<_BinaryPredicate>>;
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>,
+                                                                     adjacent_find_fn<_BinaryPredicate>>;
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf1 = __keep1(__first, __last - 1);
@@ -636,8 +636,8 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     if (__last - __first < 2)
         return __last;
 
-    using _Predicate =
-        oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, adjacent_find_fn<_BinaryPredicate>>;
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>,
+                                                                     adjacent_find_fn<_BinaryPredicate>>;
 
     auto __result = __par_backend_hetero::__parallel_find(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
@@ -700,7 +700,7 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     if (__first == __last)
         return false;
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
@@ -724,7 +724,8 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
     if (__last1 == __first1 || __last2 == __first2 || __last1 - __first1 != __last2 - __first2)
         return false;
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, equal_predicate<_Pred>>;
+    using _Predicate =
+        oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>, equal_predicate<_Pred>>;
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first1, __last1);
@@ -764,7 +765,7 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     if (__first == __last)
         return __last;
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
 
     return __par_backend_hetero::__parallel_find(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
@@ -927,7 +928,8 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
     if (__n <= 0)
         return ::std::make_pair(__first1, __first2);
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, equal_predicate<_Pred>>;
+    using _Predicate =
+        oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>, equal_predicate<_Pred>>;
 
     auto __first_zip = __par_backend_hetero::zip(
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first1),
@@ -1171,7 +1173,7 @@ __pattern_is_heap_until(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
         return __last;
 
     using _Predicate =
-        oneapi::dpl::unseq_backend::single_match_pred_by_idx<_ExecutionPolicy, __is_heap_check<_Compare>>;
+        oneapi::dpl::unseq_backend::single_match_pred_by_idx<std::decay_t<_ExecutionPolicy>, __is_heap_check<_Compare>>;
 
     return __par_backend_hetero::__parallel_find(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
@@ -1189,7 +1191,7 @@ __pattern_is_heap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomA
         return true;
 
     using _Predicate =
-        oneapi::dpl::unseq_backend::single_match_pred_by_idx<_ExecutionPolicy, __is_heap_check<_Compare>>;
+        oneapi::dpl::unseq_backend::single_match_pred_by_idx<std::decay_t<_ExecutionPolicy>, __is_heap_check<_Compare>>;
 
     return !__par_backend_hetero::__parallel_or(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -2033,7 +2033,8 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
     }
     else //2. n < size/2; 'n' parallel copying
     {
-        auto __brick = unseq_backend::__brick_shift_left<_DecayedExecutionPolicy, _DiffType, decltype(__rng)>{__size, __n};
+        auto __brick =
+            unseq_backend::__brick_shift_left<_DecayedExecutionPolicy, _DiffType, decltype(__rng)>{__size, __n};
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__shift_left_right>(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -907,7 +907,7 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
                    : __last;
     }
 
-    using _Predicate = unseq_backend::n_elem_match_pred<_ExecutionPolicy, _BinaryPredicate, _Tp, _Size>;
+    using _Predicate = unseq_backend::n_elem_match_pred<std::decay_t<_ExecutionPolicy>, _BinaryPredicate, _Tp, _Size>;
     return __par_backend_hetero::__parallel_find(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -402,10 +402,10 @@ __pattern_generate_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec,
 // brick_copy, brick_move
 //------------------------------------------------------------------------
 
-template <typename _BackendTag, typename _ExecutionPolicy>
-struct __brick_copy_n<__hetero_tag<_BackendTag>, _ExecutionPolicy>
+template <typename _BackendTag, typename _DecayedExecutionPolicy>
+struct __brick_copy_n<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     template <typename _SourceT, typename _TargetT>
     void
@@ -415,10 +415,10 @@ struct __brick_copy_n<__hetero_tag<_BackendTag>, _ExecutionPolicy>
     }
 };
 
-template <typename _BackendTag, typename _ExecutionPolicy>
-struct __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>
+template <typename _BackendTag, typename _DecayedExecutionPolicy>
+struct __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     template <typename _SourceT, typename _TargetT>
     void
@@ -428,10 +428,10 @@ struct __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>
     }
 };
 
-template <typename _BackendTag, typename _ExecutionPolicy>
-struct __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>
+template <typename _BackendTag, typename _DecayedExecutionPolicy>
+struct __brick_move<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     template <typename _SourceT, typename _TargetT>
     void
@@ -441,10 +441,10 @@ struct __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>
     }
 };
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _SourceT>
-struct __brick_fill<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
+template <typename _BackendTag, typename _DecayedExecutionPolicy, typename _SourceT>
+struct __brick_fill<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy, _SourceT>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _SourceT __value;
     template <typename _TargetT>
@@ -455,10 +455,10 @@ struct __brick_fill<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
     }
 };
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _SourceT>
-struct __brick_fill_n<__hetero_tag<_BackendTag>, _ExecutionPolicy, _SourceT>
+template <typename _BackendTag, typename _DecayedExecutionPolicy, typename _SourceT>
+struct __brick_fill_n<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy, _SourceT>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _SourceT __value;
     template <typename _TargetT>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -654,7 +654,8 @@ __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
     if (__n == 1)
     {
         // For a sequence of size 1, we can just copy the only element to the result.
-        using _CopyBrick = oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>;
+        using _CopyBrick =
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>;
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_wrapper>(
@@ -699,7 +700,8 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     __ranges::__pattern_walk_n(
         __tag,
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_wrapper>(std::forward<_ExecutionPolicy>(__exec)),
-        __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{}, res_rng, std::forward<_Range>(__rng));
+        __brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{}, res_rng,
+        std::forward<_Range>(__rng));
     return res;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -64,7 +64,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
+                unseq_backend::walk1_vector_or_scalar<std::decay_t<_ExecutionPolicy>, _Function, std::decay_t<_Ranges>...>{
                     __f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -292,7 +292,7 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
         return __res ? 0 : __rng1.size();
     }
 
-    using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
+    using _Predicate = unseq_backend::multiple_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
     using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_Range1>;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
@@ -385,7 +385,7 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
         return __res ? 0 : __rng1.size();
     }
 
-    using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
+    using _Predicate = unseq_backend::multiple_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -208,7 +208,8 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
     if (__rng1.empty() || __rng2.empty() || __rng1.size() != __rng2.size())
         return false;
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, equal_predicate<_Pred>>;
+    using _Predicate =
+        oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>, equal_predicate<_Pred>>;
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
@@ -247,7 +248,7 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&&
     if (__rng.empty())
         return __rng.size();
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
@@ -336,7 +337,7 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& 
     if (__rng.empty())
         return false;
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<oneapi::dpl::__par_backend_hetero::__or_policy_wrapper>(
@@ -465,8 +466,8 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     if (__rng.size() < 2)
         return __rng.size();
 
-    using _Predicate =
-        oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, adjacent_find_fn<_BinaryPredicate>>;
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<std::decay_t<_ExecutionPolicy>,
+                                                                     adjacent_find_fn<_BinaryPredicate>>;
     using _TagType = ::std::conditional_t<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
                                           oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -315,7 +315,7 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     if (__rng1.empty() || __rng2.empty())
         return __rng1.size();
 
-    using _Predicate = unseq_backend::first_match_pred<_ExecutionPolicy, _Pred>;
+    using _Predicate = unseq_backend::first_match_pred<std::decay_t<_ExecutionPolicy>, _Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
 
     //TODO: To check whether it makes sense to iterate over the second sequence in case of __rng1.size() < __rng2.size()

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -73,7 +73,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
+                unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, std::decay_t<_Ranges>...>{
                     __f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
@@ -661,7 +661,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_wrapper>(
                 std::forward<_ExecutionPolicy>(__exec)),
-            unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _CopyBrick, std::decay_t<_Range1>,
+            unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _CopyBrick, std::decay_t<_Range1>,
                                                     std::decay_t<_Range2>>{_CopyBrick{}, static_cast<std::size_t>(__n)},
             __n, std::forward<_Range1>(__rng), std::forward<_Range2>(__result))
             .get();

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -82,7 +82,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
+                unseq_backend::walk3_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, std::decay_t<_Ranges>...>{
                     __f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -632,8 +632,8 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         __tag, ::std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{}, __copy_rng_truncated,
-        ::std::forward<_Range>(__rng));
+        oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{},
+        __copy_rng_truncated, ::std::forward<_Range>(__rng));
 
     return __copy_last_id;
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -64,8 +64,8 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::walk1_vector_or_scalar<std::decay_t<_ExecutionPolicy>, _Function, std::decay_t<_Ranges>...>{
-                    __f, static_cast<std::size_t>(__n)},
+                unseq_backend::walk1_vector_or_scalar<std::decay_t<_ExecutionPolicy>, _Function,
+                                                      std::decay_t<_Ranges>...>{__f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
@@ -73,8 +73,8 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, std::decay_t<_Ranges>...>{
-                    __f, static_cast<std::size_t>(__n)},
+                unseq_backend::walk2_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function,
+                                                        std::decay_t<_Ranges>...>{__f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
@@ -82,8 +82,8 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::walk3_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function, std::decay_t<_Ranges>...>{
-                    __f, static_cast<std::size_t>(__n)},
+                unseq_backend::walk3_vectors_or_scalars<std::decay_t<_ExecutionPolicy>, _Function,
+                                                        std::decay_t<_Ranges>...>{__f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -146,11 +146,13 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _InRange, ty
 void
 __pattern_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r)
 {
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     assert(std::ranges::size(__in_r) <= std::ranges::size(__out_r)); // for debug purposes only
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         __tag, ::std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__internal::__brick_copy<decltype(__tag), _ExecutionPolicy>{},
+        oneapi::dpl::__internal::__brick_copy<decltype(__tag), _DecayedExecutionPolicy>{},
         oneapi::dpl::__ranges::views::all_read(std::forward<_InRange>(__in_r)),
         oneapi::dpl::__ranges::views::all_write(std::forward<_OutRange>(__out_r)));
 }
@@ -619,6 +621,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
         return __rng.size();
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
@@ -629,7 +632,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         __tag, ::std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{}, __copy_rng_truncated,
+        oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{}, __copy_rng_truncated,
         ::std::forward<_Range>(__rng));
 
     return __copy_last_id;
@@ -648,13 +651,15 @@ oneapi::dpl::__internal::__difference_t<_Range2>
 __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result,
                       _BinaryPredicate __pred)
 {
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     oneapi::dpl::__internal::__difference_t<_Range2> __n = __rng.size();
     if (__n == 0)
         return 0;
     if (__n == 1)
     {
         // For a sequence of size 1, we can just copy the only element to the result.
-        using _CopyBrick = oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>;
+        using _CopyBrick = oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>;
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_wrapper>(
@@ -689,6 +694,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
         return __rng.size();
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto res_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
@@ -699,7 +705,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     __ranges::__pattern_walk_n(
         __tag,
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_wrapper>(std::forward<_ExecutionPolicy>(__exec)),
-        __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{}, res_rng, std::forward<_Range>(__rng));
+        __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{}, res_rng, std::forward<_Range>(__rng));
     return res;
 }
 
@@ -726,6 +732,8 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ran
     if (__rng3.empty())
         return {0, 0};
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     const auto __n1 = __rng1.size();
     const auto __n2 = __rng2.size();
 
@@ -736,7 +744,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ran
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy1_wrapper>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{},
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{},
             ::std::forward<_Range2>(__rng2), ::std::forward<_Range3>(__rng3));
         return {0, __res};
     }
@@ -747,7 +755,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ran
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy2_wrapper>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{},
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{},
             ::std::forward<_Range1>(__rng1), ::std::forward<_Range3>(__rng3));
         return {__res, 0};
     }
@@ -944,6 +952,8 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
                             _Range2&& __values, _Range3&& __out_keys, _Range4&& __out_values,
                             _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
 {
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     // The algorithm reduces values in __values where the
     // associated keys for the values are equal to the adjacent key.
     //
@@ -960,7 +970,7 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
     if (__n == 1)
     {
-        __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy> __copy_range{};
+        __brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy> __copy_range{};
 
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
             __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_keys_values_range_wrapper>(__exec),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1417,7 +1417,6 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
 {
     using _Size1 = oneapi::dpl::__internal::__difference_t<_Range1>;
     using _Size2 = oneapi::dpl::__internal::__difference_t<_Range2>;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     _Size1 __n1 = __rng1.size();
     _Size2 __n2 = __rng2.size();
@@ -1435,7 +1434,7 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
     _DataAcc __get_data_op;
     unseq_backend::__copy_by_mask<_ReduceOp, oneapi::dpl::__internal::__pstl_assign, /*inclusive*/ std::true_type, 2>
         __copy_by_mask_op;
-    unseq_backend::__brick_set_op<_DecayedExecutionPolicy, _Compare, _Size1, _Size2, _IsOpDifference> __create_mask_op{
+    unseq_backend::__brick_set_op<std::decay_t<_ExecutionPolicy>, _Compare, _Size1, _Size2, _IsOpDifference> __create_mask_op{
         __comp, __n1, __n2};
 
     // temporary buffer to store boolean mask

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1434,8 +1434,8 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
     _DataAcc __get_data_op;
     unseq_backend::__copy_by_mask<_ReduceOp, oneapi::dpl::__internal::__pstl_assign, /*inclusive*/ std::true_type, 2>
         __copy_by_mask_op;
-    unseq_backend::__brick_set_op<std::decay_t<_ExecutionPolicy>, _Compare, _Size1, _Size2, _IsOpDifference> __create_mask_op{
-        __comp, __n1, __n2};
+    unseq_backend::__brick_set_op<std::decay_t<_ExecutionPolicy>, _Compare, _Size1, _Size2, _IsOpDifference>
+        __create_mask_op{__comp, __n1, __n2};
 
     // temporary buffer to store boolean mask
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1613,6 +1613,8 @@ __is_backward_tag(_TagType)
 template <typename _ExecutionPolicy, typename _Pred>
 struct __early_exit_find_or
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Pred __pred;
 
     template <typename _NDItemId, typename _SrcDataSize, typename _IterationDataSize, typename _LocalFoundState,
@@ -1890,7 +1892,8 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
     using _AtomicType = typename _BrickTag::_AtomicType;
     const _AtomicType __init_value = _BrickTag::__init_value(__rng_n);
-    const auto __pred = oneapi::dpl::__par_backend_hetero::__early_exit_find_or<_ExecutionPolicy, _Brick>{__f};
+    const auto __pred =
+        oneapi::dpl::__par_backend_hetero::__early_exit_find_or<std::decay_t<_ExecutionPolicy>, _Brick>{__f};
 
     constexpr bool __or_tag_check = std::is_same_v<_BrickTag, __parallel_or_tag>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1417,6 +1417,7 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
 {
     using _Size1 = oneapi::dpl::__internal::__difference_t<_Range1>;
     using _Size2 = oneapi::dpl::__internal::__difference_t<_Range2>;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     _Size1 __n1 = __rng1.size();
     _Size2 __n2 = __rng2.size();
@@ -1434,7 +1435,7 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
     _DataAcc __get_data_op;
     unseq_backend::__copy_by_mask<_ReduceOp, oneapi::dpl::__internal::__pstl_assign, /*inclusive*/ std::true_type, 2>
         __copy_by_mask_op;
-    unseq_backend::__brick_set_op<_ExecutionPolicy, _Compare, _Size1, _Size2, _IsOpDifference> __create_mask_op{
+    unseq_backend::__brick_set_op<_DecayedExecutionPolicy, _Compare, _Size1, _Size2, _IsOpDifference> __create_mask_op{
         __comp, __n1, __n2};
 
     // temporary buffer to store boolean mask

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1094,8 +1094,8 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
     //else use multi pass scan implementation
     using _Assigner = unseq_backend::__scan_assigner;
     using _NoAssign = unseq_backend::__scan_no_assign;
-    using _UnaryFunctor = unseq_backend::walk_n<_ExecutionPolicy, _UnaryOperation>;
-    using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+    using _UnaryFunctor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, _UnaryOperation>;
+    using _NoOpFunctor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, oneapi::dpl::__internal::__no_op>;
 
     _Assigner __assign_op;
     _NoAssign __no_assign_op;
@@ -1194,7 +1194,7 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
     using _Assigner = unseq_backend::__scan_assigner;
     using _NoAssign = unseq_backend::__scan_no_assign;
     using _MaskAssigner = unseq_backend::__mask_assigner<1>;
-    using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+    using _DataAcc = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, oneapi::dpl::__internal::__no_op>;
     using _InitType = unseq_backend::__no_init_value<_Size>;
 
     _Assigner __assign_op;
@@ -1427,7 +1427,7 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
     using _NoAssign = unseq_backend::__scan_no_assign;
     using _MaskAssigner = unseq_backend::__mask_assigner<2>;
     using _InitType = unseq_backend::__no_init_value<_Size1>;
-    using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+    using _DataAcc = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, oneapi::dpl::__internal::__no_op>;
 
     _ReduceOp __reduce_op;
     _Assigner __assign_op;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1610,10 +1610,10 @@ __is_backward_tag(_TagType)
 // early_exit (find_or)
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Pred>
+template <typename _DecayedExecutionPolicy, typename _Pred>
 struct __early_exit_find_or
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _Pred __pred;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -131,9 +131,10 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
                _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
-                __reduce_op, __transform_op};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative,
+                                            _VecSize>{__reduce_op, __transform_op};
+        auto __reduce_pattern =
+            unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
         using __result_and_scratch_storage_t = __result_and_scratch_storage<_ExecutionPolicy, _Tp>;
@@ -195,9 +196,10 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
                _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
-                __reduce_op, __transform_op};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative,
+                                            _VecSize>{__reduce_op, __transform_op};
+        auto __reduce_pattern =
+            unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
 
         // number of buffer elements processed within workgroup
         const _Size __size_per_work_group = __iters_per_work_item * __work_group_size;
@@ -242,9 +244,10 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
     {
         using _NoOpFunctor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
-            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _NoOpFunctor, _Tp, _Commutative, _VecSize>{
-                __reduce_op, _NoOpFunctor{}};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _NoOpFunctor, _Tp, _Commutative,
+                                            _VecSize>{__reduce_op, _NoOpFunctor{}};
+        auto __reduce_pattern =
+            unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
 
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
@@ -322,12 +325,13 @@ struct __parallel_transform_reduce_impl
             __reduce_kernel, _CustomName, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
 
         auto __transform_pattern1 =
-            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
-                __reduce_op, __transform_op};
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative,
+                                            _VecSize>{__reduce_op, __transform_op};
         auto __transform_pattern2 =
-            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _NoOpFunctor, _Tp, _Commutative, _VecSize>{
-                __reduce_op, _NoOpFunctor{}};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _NoOpFunctor, _Tp, _Commutative,
+                                            _VecSize>{__reduce_op, _NoOpFunctor{}};
+        auto __reduce_pattern =
+            unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
 
 #if _ONEDPL_COMPILE_KERNEL
         auto __kernel = __internal::__kernel_compiler<_ReduceKernel>::__compile(__exec);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -131,7 +131,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
                _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
                 __reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
@@ -195,7 +195,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
                _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
                 __reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -242,7 +242,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
     {
         using _NoOpFunctor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, _ReduceOp, _NoOpFunctor, _Tp, _Commutative, _VecSize>{
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _NoOpFunctor, _Tp, _Commutative, _VecSize>{
                 __reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -322,10 +322,10 @@ struct __parallel_transform_reduce_impl
             __reduce_kernel, _CustomName, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
 
         auto __transform_pattern1 =
-            unseq_backend::transform_reduce<_ExecutionPolicy, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
                 __reduce_op, __transform_op};
         auto __transform_pattern2 =
-            unseq_backend::transform_reduce<_ExecutionPolicy, _ReduceOp, _NoOpFunctor, _Tp, _Commutative, _VecSize>{
+            unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _NoOpFunctor, _Tp, _Commutative, _VecSize>{
                 __reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -240,7 +240,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
                const _Size __n, const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _InitType __init, const __result_and_scratch_storage<_ExecutionPolicy, _Tp>& __scratch_container) const
     {
-        using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+        using _NoOpFunctor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
             unseq_backend::transform_reduce<_ExecutionPolicy, _ReduceOp, _NoOpFunctor, _Tp, _Commutative, _VecSize>{
                 __reduce_op, _NoOpFunctor{}};
@@ -317,7 +317,7 @@ struct __parallel_transform_reduce_impl
            _Ranges&&... __rngs)
     {
         using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-        using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+        using _NoOpFunctor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, oneapi::dpl::__internal::__no_op>;
         using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             __reduce_kernel, _CustomName, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -133,7 +133,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
         auto __transform_pattern =
             unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
                 __reduce_op, __transform_op};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
+        auto __reduce_pattern = unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
         using __result_and_scratch_storage_t = __result_and_scratch_storage<_ExecutionPolicy, _Tp>;
@@ -197,7 +197,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
         auto __transform_pattern =
             unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{
                 __reduce_op, __transform_op};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
+        auto __reduce_pattern = unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
 
         // number of buffer elements processed within workgroup
         const _Size __size_per_work_group = __iters_per_work_item * __work_group_size;
@@ -244,7 +244,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
         auto __transform_pattern =
             unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _NoOpFunctor, _Tp, _Commutative, _VecSize>{
                 __reduce_op, _NoOpFunctor{}};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
+        auto __reduce_pattern = unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
 
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
@@ -327,7 +327,7 @@ struct __parallel_transform_reduce_impl
         auto __transform_pattern2 =
             unseq_backend::transform_reduce<std::decay_t<_ExecutionPolicy>, _ReduceOp, _NoOpFunctor, _Tp, _Commutative, _VecSize>{
                 __reduce_op, _NoOpFunctor{}};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
+        auto __reduce_pattern = unseq_backend::reduce_over_group<std::decay_t<_ExecutionPolicy>, _ReduceOp, _Tp>{__reduce_op};
 
 #if _ONEDPL_COMPILE_KERNEL
         auto __kernel = __internal::__kernel_compiler<_ReduceKernel>::__compile(__exec);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -653,6 +653,8 @@ struct reduce_over_group
 template <typename _ExecutionPolicy, typename _Pred>
 struct single_match_pred_by_idx
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Pred __pred;
 
     template <typename _Idx, typename _Acc>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -668,6 +668,8 @@ struct single_match_pred_by_idx
 template <typename _ExecutionPolicy, typename _Pred>
 struct single_match_pred : single_match_pred_by_idx<_ExecutionPolicy, walk_n<_ExecutionPolicy, _Pred>>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     single_match_pred(_Pred __p) : single_match_pred_by_idx<_ExecutionPolicy, walk_n<_ExecutionPolicy, _Pred>>{__p} {}
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1095,6 +1095,8 @@ struct __scan
 template <typename _ExecutionPolicy, typename _Compare, typename _Size1, typename _Size2>
 struct __brick_includes
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Compare __comp;
     _Size1 __na;
     _Size2 __nb;
@@ -1359,6 +1361,8 @@ struct _DifferenceTag : public ::std::true_type
 template <typename _ExecutionPolicy, typename _Compare, typename _Size1, typename _Size2, typename _IsOpDifference>
 class __brick_set_op
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Compare __comp;
     _Size1 __na;
     _Size2 __nb;
@@ -1419,6 +1423,8 @@ class __brick_set_op
 template <typename _ExecutionPolicy, typename _DiffType, typename _Range>
 struct __brick_shift_left
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
   private:
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
     // Maximum size supported by compilers to generate vector instructions
@@ -1561,6 +1567,8 @@ struct __brick_reduce_idx : public walk_scalar_base<_Range>
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
   private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -205,6 +205,8 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
   private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -676,6 +676,8 @@ struct single_match_pred : single_match_pred_by_idx<_ExecutionPolicy, walk_n<_Ex
 template <typename _ExecutionPolicy, typename _Pred>
 struct multiple_match_pred
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Pred __pred;
 
     template <typename _Idx, typename _Acc1, typename _Acc2>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -253,6 +253,8 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2, typename _Range3>
 struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2, _Range3>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
   private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2, _Range3>;
     _F __f;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -311,6 +311,8 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
 template <typename _ExecutionPolicy>
 struct walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     oneapi::dpl::__internal::__no_op __f;
 
     template <typename _ItemId, typename _Range>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -166,6 +166,8 @@ struct walk_scalar_base
 template <typename _ExecutionPolicy, typename _F, typename _Range>
 struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
   private:
     using __base_t = walk_vector_or_scalar_base<_Range>;
     _F __f;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -587,6 +587,8 @@ struct transform_reduce
 template <typename _ExecutionPolicy, typename _BinaryOperation1, typename _Tp>
 struct reduce_over_group
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _BinaryOperation1 __bin_op1;
 
     // Reduce on local memory with subgroups

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -330,6 +330,8 @@ struct walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
   private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -440,6 +440,8 @@ template <typename _ExecutionPolicy, typename _Operation1, typename _Operation2,
           std::uint8_t _VecSize>
 struct transform_reduce
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Operation1 __binary_op;
     _Operation2 __unary_op;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -103,6 +103,8 @@ inline constexpr _Tp __known_identity =
 template <typename _ExecutionPolicy, typename _F>
 struct walk_n
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _F __f;
 
     template <typename _ItemId, typename... _Ranges>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -100,10 +100,10 @@ inline constexpr _Tp __known_identity =
     __known_identity_for_plus<_BinaryOp, _Tp>::value; //for plus only
 #endif
 
-template <typename _ExecutionPolicy, typename _F>
+template <typename _DecayedExecutionPolicy, typename _F>
 struct walk_n
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _F __f;
 
@@ -163,10 +163,10 @@ struct walk_scalar_base
         __bytes_per_item / (__min_type_size * __preferred_vector_size);
 };
 
-template <typename _ExecutionPolicy, typename _F, typename _Range>
+template <typename _DecayedExecutionPolicy, typename _F, typename _Range>
 struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
   private:
     using __base_t = walk_vector_or_scalar_base<_Range>;
@@ -202,10 +202,10 @@ struct walk1_vector_or_scalar : public walk_vector_or_scalar_base<_Range>
     }
 };
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
+template <typename _DecayedExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
   private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
@@ -250,10 +250,10 @@ struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
     }
 };
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2, typename _Range3>
+template <typename _DecayedExecutionPolicy, typename _F, typename _Range1, typename _Range2, typename _Range3>
 struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2, _Range3>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
   private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2, _Range3>;
@@ -308,10 +308,10 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
 // If read accessor returns temporary value then __no_op returns lvalue reference to it.
 // After temporary value destroying it will be a reference on invalid object.
 // So let's don't call functor in case of __no_op
-template <typename _ExecutionPolicy>
-struct walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>
+template <typename _DecayedExecutionPolicy>
+struct walk_n<_DecayedExecutionPolicy, oneapi::dpl::__internal::__no_op>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     oneapi::dpl::__internal::__no_op __f;
 
@@ -327,10 +327,10 @@ struct walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>
 // walk_adjacent_difference
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
+template <typename _DecayedExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
   private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
@@ -436,11 +436,11 @@ struct __init_processing
 
 // Load elements consecutively from global memory, transform them, and apply a local reduction. Each local result is
 // stored in local memory.
-template <typename _ExecutionPolicy, typename _Operation1, typename _Operation2, typename _Tp, typename _Commutative,
+template <typename _DecayedExecutionPolicy, typename _Operation1, typename _Operation2, typename _Tp, typename _Commutative,
           std::uint8_t _VecSize>
 struct transform_reduce
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _Operation1 __binary_op;
     _Operation2 __unary_op;
@@ -584,10 +584,10 @@ struct transform_reduce
 // Reduce local reductions of each work item to a single reduced element per work group. The local reductions are held
 // in local memory. sycl::reduce_over_group is used for supported data types and operations. All other operations are
 // processed in order and without a known identity.
-template <typename _ExecutionPolicy, typename _BinaryOperation1, typename _Tp>
+template <typename _DecayedExecutionPolicy, typename _BinaryOperation1, typename _Tp>
 struct reduce_over_group
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _BinaryOperation1 __bin_op1;
 
@@ -650,10 +650,10 @@ struct reduce_over_group
 
 // Matchers for early_exit_or and early_exit_find
 
-template <typename _ExecutionPolicy, typename _Pred>
+template <typename _DecayedExecutionPolicy, typename _Pred>
 struct single_match_pred_by_idx
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _Pred __pred;
 
@@ -665,18 +665,18 @@ struct single_match_pred_by_idx
     }
 };
 
-template <typename _ExecutionPolicy, typename _Pred>
-struct single_match_pred : single_match_pred_by_idx<_ExecutionPolicy, walk_n<_ExecutionPolicy, _Pred>>
+template <typename _DecayedExecutionPolicy, typename _Pred>
+struct single_match_pred : single_match_pred_by_idx<_DecayedExecutionPolicy, walk_n<_DecayedExecutionPolicy, _Pred>>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
-    single_match_pred(_Pred __p) : single_match_pred_by_idx<_ExecutionPolicy, walk_n<_ExecutionPolicy, _Pred>>{__p} {}
+    single_match_pred(_Pred __p) : single_match_pred_by_idx<_DecayedExecutionPolicy, walk_n<_DecayedExecutionPolicy, _Pred>>{__p} {}
 };
 
-template <typename _ExecutionPolicy, typename _Pred>
+template <typename _DecayedExecutionPolicy, typename _Pred>
 struct multiple_match_pred
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _Pred __pred;
 
@@ -707,10 +707,10 @@ struct multiple_match_pred
     }
 };
 
-template <typename _ExecutionPolicy, typename _Pred, typename _Tp, typename _Size>
+template <typename _DecayedExecutionPolicy, typename _Pred, typename _Tp, typename _Size>
 struct n_elem_match_pred
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _Pred __pred;
     _Tp __value;
@@ -731,10 +731,10 @@ struct n_elem_match_pred
     }
 };
 
-template <typename _ExecutionPolicy, typename _Pred>
+template <typename _DecayedExecutionPolicy, typename _Pred>
 struct first_match_pred
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _Pred __pred;
 
@@ -1118,10 +1118,10 @@ struct __scan
 // __brick_includes
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Compare, typename _Size1, typename _Size2>
+template <typename _DecayedExecutionPolicy, typename _Compare, typename _Size1, typename _Size2>
 struct __brick_includes
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _Compare __comp;
     _Size1 __na;
@@ -1384,10 +1384,10 @@ struct _DifferenceTag : public ::std::true_type
 {
 };
 
-template <typename _ExecutionPolicy, typename _Compare, typename _Size1, typename _Size2, typename _IsOpDifference>
+template <typename _DecayedExecutionPolicy, typename _Compare, typename _Size1, typename _Size2, typename _IsOpDifference>
 class __brick_set_op
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
     _Compare __comp;
     _Size1 __na;
@@ -1446,10 +1446,10 @@ class __brick_set_op
     }
 };
 
-template <typename _ExecutionPolicy, typename _DiffType, typename _Range>
+template <typename _DecayedExecutionPolicy, typename _DiffType, typename _Range>
 struct __brick_shift_left
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
   private:
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
@@ -1590,10 +1590,10 @@ struct __brick_reduce_idx : public walk_scalar_base<_Range>
 
 // std::swap_ranges is unique in that both sets of provided ranges will be modified. Due to this,
 // we define a separate functor from __walk2_vectors_or_scalars with a customized vectorization path.
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
+template <typename _DecayedExecutionPolicy, typename _F, typename _Range1, typename _Range2>
 struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
 {
-    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+    static_assert(std::is_same_v<_DecayedExecutionPolicy, std::decay_t<_DecayedExecutionPolicy>>);
 
   private:
     using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -710,6 +710,8 @@ struct multiple_match_pred
 template <typename _ExecutionPolicy, typename _Pred, typename _Tp, typename _Size>
 struct n_elem_match_pred
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Pred __pred;
     _Tp __value;
     _Size __count;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -734,6 +734,8 @@ struct n_elem_match_pred
 template <typename _ExecutionPolicy, typename _Pred>
 struct first_match_pred
 {
+    static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
+
     _Pred __pred;
 
     template <typename _Idx, typename _Acc1, typename _Acc2>

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -143,8 +143,8 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
 
         auto __init_event = oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__hist_fill_zeros_wrapper>(__exec),
-            unseq_backend::walk1_vector_or_scalar<std::decay_t<_ExecutionPolicy>, decltype(__fill_func), decltype(__bins)>{
-                __fill_func, static_cast<std::size_t>(__num_bins)},
+            unseq_backend::walk1_vector_or_scalar<std::decay_t<_ExecutionPolicy>, decltype(__fill_func),
+                                                  decltype(__bins)>{__fill_func, static_cast<std::size_t>(__num_bins)},
             __num_bins, __bins);
 
         if (__n > 0)

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -143,7 +143,7 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
 
         auto __init_event = oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__hist_fill_zeros_wrapper>(__exec),
-            unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, decltype(__fill_func), decltype(__bins)>{
+            unseq_backend::walk1_vector_or_scalar<std::decay_t<_ExecutionPolicy>, decltype(__fill_func), decltype(__bins)>{
                 __fill_func, static_cast<std::size_t>(__num_bins)},
             __num_bins, __bins);
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -132,8 +132,6 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
     if (__first == __last)
         return __result;
 
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
-
     const auto __n = __last - __first;
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -179,7 +177,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         // Move data from temporary buffer into results
         oneapi::dpl::__internal::__pattern_walk2_brick(
             __tag, ::std::move(__policy), __first_tmp, __last_tmp, __result,
-            oneapi::dpl::__internal::__brick_move<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_move<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
 
         //TODO: optimize copy back depending on Iterator, i.e. set_final_data for host iterator/pointer
     }
@@ -238,7 +236,6 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 
     using _It1ValueT = typename ::std::iterator_traits<_ForwardIterator1>::value_type;
     using _It2ValueTRef = typename ::std::iterator_traits<_ForwardIterator2>::reference;
-    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     _ForwardIterator2 __d_last = __d_first + __n;
 
@@ -250,7 +247,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
             ::std::forward<_ExecutionPolicy>(__exec));
 
         __internal::__pattern_walk2_brick(__hetero_tag<_BackendTag>{}, __wrapped_policy, __first, __last, __d_first,
-                                          __internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
+                                          __internal::__brick_copy<__hetero_tag<_BackendTag>, std::decay_t<_ExecutionPolicy>>{});
     }
     else
 #endif

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -47,7 +47,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     if (__first1 == __last1)
         return __init;
 
-    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _BinaryOperation2>;
+    using _Functor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, _BinaryOperation2>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
 
     auto __n = __last1 - __first1;
@@ -80,7 +80,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     if (__first == __last)
         return __init;
 
-    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _UnaryOperation>;
+    using _Functor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, _UnaryOperation>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -132,6 +132,8 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
     if (__first == __last)
         return __result;
 
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
+
     const auto __n = __last - __first;
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -177,7 +179,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         // Move data from temporary buffer into results
         oneapi::dpl::__internal::__pattern_walk2_brick(
             __tag, ::std::move(__policy), __first_tmp, __last_tmp, __result,
-            oneapi::dpl::__internal::__brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+            oneapi::dpl::__internal::__brick_move<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
 
         //TODO: optimize copy back depending on Iterator, i.e. set_final_data for host iterator/pointer
     }

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -264,7 +264,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
         auto __buf2 = __keep2(__d_first, __d_last);
 
         using _Function =
-            unseq_backend::walk_adjacent_difference<_ExecutionPolicy, decltype(__fn), decltype(__buf1.all_view()),
+            unseq_backend::walk_adjacent_difference<std::decay_t<_ExecutionPolicy>, decltype(__fn), decltype(__buf1.all_view()),
                                                     decltype(__buf2.all_view())>;
 
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec,

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -236,6 +236,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 
     using _It1ValueT = typename ::std::iterator_traits<_ForwardIterator1>::value_type;
     using _It2ValueTRef = typename ::std::iterator_traits<_ForwardIterator2>::reference;
+    using _DecayedExecutionPolicy = std::decay_t<_ExecutionPolicy>;
 
     _ForwardIterator2 __d_last = __d_first + __n;
 
@@ -247,7 +248,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
             ::std::forward<_ExecutionPolicy>(__exec));
 
         __internal::__pattern_walk2_brick(__hetero_tag<_BackendTag>{}, __wrapped_policy, __first, __last, __d_first,
-                                          __internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+                                          __internal::__brick_copy<__hetero_tag<_BackendTag>, _DecayedExecutionPolicy>{});
     }
     else
 #endif

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -264,8 +264,8 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
         auto __buf2 = __keep2(__d_first, __d_last);
 
         using _Function =
-            unseq_backend::walk_adjacent_difference<std::decay_t<_ExecutionPolicy>, decltype(__fn), decltype(__buf1.all_view()),
-                                                    decltype(__buf2.all_view())>;
+            unseq_backend::walk_adjacent_difference<std::decay_t<_ExecutionPolicy>, decltype(__fn),
+                                                    decltype(__buf1.all_view()), decltype(__buf2.all_view())>;
 
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec,
                                                           _Function{__fn, static_cast<std::size_t>(__n)}, __n,

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -48,7 +48,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     if (__rng1.empty())
         return __init;
 
-    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _BinaryOperation2>;
+    using _Functor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, _BinaryOperation2>;
     using _RepackedTp = oneapi::dpl::__par_backend_hetero::__repacked_tuple_t<_Tp>;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
@@ -72,7 +72,7 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     if (__rng.empty())
         return __init;
 
-    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _UnaryOperation>;
+    using _Functor = unseq_backend::walk_n<std::decay_t<_ExecutionPolicy>, _UnaryOperation>;
     using _RepackedTp = oneapi::dpl::__par_backend_hetero::__repacked_tuple_t<_Tp>;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,


### PR DESCRIPTION
In this PR we fix the issue https://github.com/uxlfoundation/oneDPL/issues/2110

As we discussed with @rarutyun we still need to have `EcecutionPolicy` in bricks from architecture point of view.

This PR is a new copy of https://github.com/uxlfoundation/oneDPL/pull/2112

## Implementation details
Now in all `struct __brick_...` implementations we have new `static_assert` :
```C++
static_assert(std::is_same_v<_ExecutionPolicy, std::decay_t<_ExecutionPolicy>>);
```
So we will have compile error if we use `brick` with non-decayed policy.