### PR TITLE
Correct reduce-then-scan -O0 workaround behavior with different host and device optimization levels

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -880,8 +880,11 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     // with sufficiently large L2 / L3 caches.
     for (std::size_t __b = 0; __b < __num_blocks; ++__b)
     {
-        const std::uint32_t __inputs_per_item = __inputs_remaining >= __max_inputs_per_block ? __max_inputs_per_item :
-            oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_remaining, __num_work_groups * __work_group_size);
+        const std::uint32_t __inputs_per_item = __inputs_remaining >= __max_inputs_per_block
+                                                    ? __max_inputs_per_item
+                                                    : oneapi::dpl::__internal::__dpl_ceiling_div(
+                                                          oneapi::dpl::__internal::__dpl_bit_ceil(__inputs_remaining),
+                                                          __num_work_groups * __work_group_size);
         std::uint32_t __workitems_in_block = oneapi::dpl::__internal::__dpl_ceiling_div(
             std::min(__inputs_remaining, std::size_t{__max_inputs_per_block}), __inputs_per_item);
         std::uint32_t __workitems_in_block_round_up_workgroup =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <tuple>
 #include <type_traits>
 
 #include "sycl_defs.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -565,9 +565,6 @@ inline constexpr auto __level_zero_backend = sycl::backend::level_zero;
 #    endif
 #endif
 
-// Unique PCI vendor ID for Intel architectures.
-inline std::uint32_t __intel_vendor_id = 0x8086;
-
 } // namespace __dpl_sycl
 
 #endif // _ONEDPL_SYCL_DEFS_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -565,6 +565,9 @@ inline constexpr auto __level_zero_backend = sycl::backend::level_zero;
 #    endif
 #endif
 
+// Unique PCI vendor ID for Intel architectures.
+inline std::uint32_t __intel_vendor_id = 0x8086;
+
 } // namespace __dpl_sycl
 
 #endif // _ONEDPL_SYCL_DEFS_H


### PR DESCRIPTION
https://github.com/uxlfoundation/oneDPL/pull/2046 introduced a workaround for a hardware bug that prevents sub-group sizes of 32 from being used with `-O0` compilation on certain devices based on the detection of optimization via the `__OPTIMIZE__` macro. However, this approach does not work when the host and device compiler use different optimization levels, specifically when only one of the two phases uses `-O0` compilation. The integral sub-group size constant is embedded in the kernel name causing the host to call a kernel not compiled by the device which results in "Kernel not found" errors.

To support these cases where the host and device compiler optimization levels may differ, we need to make the following changes:

1. Remove the sub-group size from the kernel name. This can be done through removing it as an integral template parameter to the submitters which gets reflected in the kernel naming scheme.
2. Allocate sufficient temporary storage on the host to handle both sub-group sizes of 16 and 32. We store one partial result per sub-group, so the sub-group size of 16 case requires more temporary storage.
3. Compute all sub-group specific fields (e.g. `__num_sub_groups_local`, `__num_sub_groups_global`, etc.) on the device itself as the true sub-group size can only be determined when on the device.
4.  Conditionally, enable sub-group sizes of 16 when optimization is not enabled **AND** we are compiling to a SPIR-V (Intel) target GPU. This enables other targets to use a sub-group size of 32 for all cases.