### PR TITLE
Correct deprecation syntax of oneapi::dpl::experimental::kt::esimd namespace

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -174,12 +174,13 @@ radix_sort_by_key(sycl::queue __q, _KeysIterator1 __keys_first, _KeysIterator1 _
 
 namespace oneapi::dpl::experimental::kt
 {
-namespace esimd
+namespace
 #if !defined(__SYCL_DEVICE_ONLY__)
     [[deprecated("Use of oneapi::dpl::experimental::kt::esimd namespace is deprecated "
                  "and will be removed in a future release. "
                  "Use oneapi::dpl::experimental::kt::gpu::esimd instead")]]
 #endif
+esimd
 {
 using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort;
 using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key;


### PR DESCRIPTION
When including `<oneapi/dpl/experimental/kernel_templates>` with newer compilers, I see the following compilation error:
```
In file included from ../repos/oneDPL/include/oneapi/dpl/experimental/kernel_templates:18:
../repos/oneDPL/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h:179:5: error: an attribute list cannot appear here
  179 |     [[deprecated("Use of oneapi::dpl::experimental::kt::esimd namespace is deprecated "
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  180 |                  "and will be removed in a future release. "
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  181 |                  "Use oneapi::dpl::experimental::kt::gpu::esimd instead")]]
```
According to https://en.cppreference.com/w/cpp/language/attributes/deprecated, it appears the proper syntax to deprecate a namespace is `namespace [[deprecated]] NS { ... }`. Our deprecation attribute is provided after the namespace's name which appears incorrect.

After correcting this, I see the proper warning when trying to compile using the deprecated namespace:
```
 warning: 'esimd' is deprecated: Use of oneapi::dpl::experimental::kt::esimd namespace is deprecated and will be removed in a future release. Use oneapi::dpl::experimental::kt::gpu::esimd instead [-Wdeprecated-declarations]
```