### PR TITLE
Remove use of inheritance from parallel-for bricks in SYCL backend

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -44,7 +44,7 @@ __pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__buf.all_view())>{
+        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function>{
             __f, static_cast<std::size_t>(__n)},
         __n, __buf.all_view());
     return __future_obj;
@@ -69,8 +69,7 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
-                                                decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
+        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view());
 
     return __future.__make_future(__first2 + __n);
@@ -97,8 +96,7 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
-                                                decltype(__buf2.all_view()), decltype(__buf3.all_view())>{
+        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function>{
             __f, static_cast<size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view(), __buf3.all_view());
 

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -44,9 +44,8 @@ __pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function>{
-            __f, static_cast<std::size_t>(__n)},
-        __n, __buf.all_view());
+        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function>{__f, static_cast<std::size_t>(__n)}, __n,
+        __buf.all_view());
     return __future_obj;
 }
 
@@ -69,8 +68,8 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function>{__f, static_cast<std::size_t>(__n)},
-        __n, __buf1.all_view(), __buf2.all_view());
+        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function>{__f, static_cast<std::size_t>(__n)}, __n,
+        __buf1.all_view(), __buf2.all_view());
 
     return __future.__make_future(__first2 + __n);
 }
@@ -96,9 +95,8 @@ __pattern_walk3_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function>{
-            __f, static_cast<size_t>(__n)},
-        __n, __buf1.all_view(), __buf2.all_view(), __buf3.all_view());
+        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function>{__f, static_cast<size_t>(__n)}, __n,
+        __buf1.all_view(), __buf2.all_view(), __buf3.all_view());
 
     return __future.__make_future(__first3 + __n);
 }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -38,9 +38,12 @@ enum class search_algorithm
 };
 
 #if _ONEDPL_BACKEND_SYCL
-template <typename Comp, typename T, typename _Range, search_algorithm func>
-struct __custom_brick : oneapi::dpl::unseq_backend::walk_scalar_base<_Range>
+template <typename Comp, typename T, search_algorithm func>
+struct __custom_brick
 {
+    constexpr static bool __can_vectorize = false;
+    constexpr static bool __can_process_multiple_iters = true;
+
     Comp comp;
     T size;
     bool use_32bit_indexing;
@@ -74,20 +77,14 @@ struct __custom_brick : oneapi::dpl::unseq_backend::walk_scalar_base<_Range>
             get<2>(acc[idx]) = (value != end_orig) && (get<1>(acc[idx]) == get<0>(acc[value]));
         }
     }
-    template <typename _IsFull, typename _ItemId, typename _Acc>
+    template <typename _IsFull, typename _Params, typename _Acc>
     void
-    __scalar_path_impl(_IsFull, _ItemId idx, _Acc acc) const
+    operator()(_IsFull, const std::size_t idx, _Params, _Acc acc) const
     {
         if (use_32bit_indexing)
             search_impl<std::uint32_t>(idx, acc);
         else
             search_impl<std::uint64_t>(idx, acc);
-    }
-    template <typename _IsFull, typename _ItemId, typename _Acc>
-    void
-    operator()(_IsFull __is_full, _ItemId idx, _Acc acc) const
-    {
-        __scalar_path_impl(__is_full, idx, acc);
     }
 };
 #endif
@@ -165,11 +162,10 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
-    __bknd::__parallel_for(
-        _BackendTag{}, ::std::forward<decltype(policy)>(policy),
-        __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::lower_bound>{
-            comp, size, use_32bit_indexing},
-        value_size, zip_vw)
+    __bknd::__parallel_for(_BackendTag{}, ::std::forward<decltype(policy)>(policy),
+                           __custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::lower_bound>{
+                               comp, size, use_32bit_indexing},
+                           value_size, zip_vw)
         .__deferrable_wait();
     return result + value_size;
 }
@@ -198,11 +194,10 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
-    __bknd::__parallel_for(
-        _BackendTag{}, std::forward<decltype(policy)>(policy),
-        __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::upper_bound>{
-            comp, size, use_32bit_indexing},
-        value_size, zip_vw)
+    __bknd::__parallel_for(_BackendTag{}, std::forward<decltype(policy)>(policy),
+                           __custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::upper_bound>{
+                               comp, size, use_32bit_indexing},
+                           value_size, zip_vw)
         .__deferrable_wait();
     return result + value_size;
 }
@@ -231,11 +226,10 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
-    __bknd::__parallel_for(
-        _BackendTag{}, std::forward<decltype(policy)>(policy),
-        __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::binary_search>{
-            comp, size, use_32bit_indexing},
-        value_size, zip_vw)
+    __bknd::__parallel_for(_BackendTag{}, std::forward<decltype(policy)>(policy),
+                           __custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::binary_search>{
+                               comp, size, use_32bit_indexing},
+                           value_size, zip_vw)
         .__deferrable_wait();
     return result + value_size;
 }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -162,7 +162,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
-    __bknd::__parallel_for(_BackendTag{}, ::std::forward<decltype(policy)>(policy),
+    __bknd::__parallel_for(_BackendTag{}, std::forward<decltype(policy)>(policy),
                            __custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::lower_bound>{
                                comp, size, use_32bit_indexing},
                            value_size, zip_vw)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -113,9 +113,8 @@ __pattern_walk2(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
-                                                decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
-        __n, __buf1.all_view(), __buf2.all_view());
+        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function>{__f, static_cast<std::size_t>(__n)}, __n,
+        __buf1.all_view(), __buf2.all_view());
 
     // Call no wait, wait or deferrable wait depending on _WaitMode
     __future.wait(_WaitMode{});
@@ -156,9 +155,8 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIte
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__brick_swap<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
-                                    decltype(__buf2.all_view())>{__f, static_cast<std::size_t>(__n)},
-        __n, __buf1.all_view(), __buf2.all_view());
+        unseq_backend::__brick_swap<_ExecutionPolicy, _Function>{__f, static_cast<std::size_t>(__n)}, __n,
+        __buf1.all_view(), __buf2.all_view());
     __future.wait(__par_backend_hetero::__deferrable_mode{});
     return __first2 + __n;
 }
@@ -197,10 +195,8 @@ __pattern_walk3(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__buf1.all_view()),
-                                                decltype(__buf2.all_view()), decltype(__buf3.all_view())>{
-            __f, static_cast<std::size_t>(__n)},
-        __n, __buf1.all_view(), __buf2.all_view(), __buf3.all_view())
+        unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function>{__f, static_cast<std::size_t>(__n)}, __n,
+        __buf1.all_view(), __buf2.all_view(), __buf3.all_view())
         .__deferrable_wait();
 
     return __first3 + __n;
@@ -1610,9 +1606,8 @@ __pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     auto __buf = __keep(__first, __last);
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__reverse_functor<typename std::iterator_traits<_Iterator>::difference_type,
-                                         decltype(__buf.all_view())>{__n},
-        __n / 2, __buf.all_view())
+        unseq_backend::__reverse_functor<typename std::iterator_traits<_Iterator>::difference_type>{__n}, __n / 2,
+        __buf.all_view())
         .__deferrable_wait();
 }
 
@@ -1637,9 +1632,8 @@ __pattern_reverse_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bi
     auto __buf2 = __keep2(__result, __result + __n);
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__reverse_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
-                                      decltype(__buf1.all_view()), decltype(__buf2.all_view())>{__n},
-        __n, __buf1.all_view(), __buf2.all_view())
+        unseq_backend::__reverse_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type>{__n}, __n,
+        __buf1.all_view(), __buf2.all_view())
         .__deferrable_wait();
 
     return __result + __n;
@@ -1679,9 +1673,8 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     const auto __shift = __new_first - __first;
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec),
-        unseq_backend::__rotate_copy<typename std::iterator_traits<_Iterator>::difference_type,
-                                     decltype(__buf.all_view()), decltype(__temp_rng_w)>{__n, __shift},
-        __n, __buf.all_view(), __temp_rng_w);
+        unseq_backend::__rotate_copy<typename std::iterator_traits<_Iterator>::difference_type>{__n, __shift}, __n,
+        __buf.all_view(), __temp_rng_w);
 
     //An explicit wait isn't required here because we are working with a temporary sycl::buffer and sycl accessors and
     //SYCL runtime makes a dependency graph to prevent the races between two __parallel_for patterns.
@@ -1689,9 +1682,8 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     using _Function = __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>;
     auto __temp_rng_rw =
         oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::read_write>(__temp_buf.get_buffer());
-    auto __brick =
-        unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__temp_rng_rw),
-                                                decltype(__buf.all_view())>{_Function{}, static_cast<std::size_t>(__n)};
+    auto __brick = unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function>{_Function{},
+                                                                                        static_cast<std::size_t>(__n)};
     oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __brick,
                                                       __n, __temp_rng_rw, __buf.all_view())
         .__deferrable_wait();
@@ -1726,8 +1718,8 @@ __pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bid
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__rotate_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
-                                     decltype(__buf1.all_view()), decltype(__buf2.all_view())>{__n, __shift},
+        unseq_backend::__rotate_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type>{__n,
+                                                                                                             __shift},
         __n, __buf1.all_view(), __buf2.all_view())
         .__deferrable_wait();
 
@@ -1990,9 +1982,8 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
         auto __src = oneapi::dpl::__ranges::drop_view_simple<_Range, _DiffType>(__rng, __n);
         auto __dst = oneapi::dpl::__ranges::take_view_simple<_Range, _DiffType>(__rng, __size_res);
 
-        auto __brick =
-            unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, decltype(__src), decltype(__dst)>{
-                _Function{}, static_cast<std::size_t>(__size_res)};
+        auto __brick = unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function>{
+            _Function{}, static_cast<std::size_t>(__size_res)};
 
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                           __brick, __size_res, __src, __dst)
@@ -2000,7 +1991,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
     }
     else //2. n < size/2; 'n' parallel copying
     {
-        auto __brick = unseq_backend::__brick_shift_left<_ExecutionPolicy, _DiffType, decltype(__rng)>{__size, __n};
+        auto __brick = unseq_backend::__brick_shift_left<_ExecutionPolicy, _DiffType>{__size, __n};
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__shift_left_right>(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -58,9 +58,8 @@ __pattern_walk1(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, decltype(__buf.all_view())>{
-            __f, static_cast<std::size_t>(__n)},
-        __n, __buf.all_view())
+        unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function>{__f, static_cast<std::size_t>(__n)}, __n,
+        __buf.all_view())
         .__deferrable_wait();
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -64,8 +64,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
-                    __f, static_cast<std::size_t>(__n)},
+                unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, _Function>{__f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -72,8 +72,8 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
-                    __f, static_cast<std::size_t>(__n)},
+                unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _Function>{__f,
+                                                                                     static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
@@ -81,8 +81,8 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
         {
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function, std::decay_t<_Ranges>...>{
-                    __f, static_cast<std::size_t>(__n)},
+                unseq_backend::walk3_vectors_or_scalars<_ExecutionPolicy, _Function>{__f,
+                                                                                     static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
                 .__deferrable_wait();
         }
@@ -177,10 +177,8 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& _
         auto __exec1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(
             std::forward<_ExecutionPolicy>(__exec));
         oneapi::dpl::__par_backend_hetero::__parallel_for(
-            _BackendTag{}, std::move(__exec1),
-            unseq_backend::__brick_swap<decltype(__exec1), _Function, std::decay_t<_Range1>, std::decay_t<_Range2>>{
-                __f, __n},
-            __n, __rng1, __rng2)
+            _BackendTag{}, std::move(__exec1), unseq_backend::__brick_swap<decltype(__exec1), _Function>{__f, __n}, __n,
+            __rng1, __rng2)
             .__deferrable_wait();
         return __n;
     }
@@ -188,10 +186,8 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& _
     auto __exec2 =
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(std::forward<_ExecutionPolicy>(__exec));
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::move(__exec2),
-        unseq_backend::__brick_swap<decltype(__exec2), _Function, std::decay_t<_Range2>, std::decay_t<_Range1>>{__f,
-                                                                                                                __n},
-        __n, __rng2, __rng1)
+        _BackendTag{}, std::move(__exec2), unseq_backend::__brick_swap<decltype(__exec2), _Function>{__f, __n}, __n,
+        __rng2, __rng1)
         .__deferrable_wait();
     return __n;
 }
@@ -658,8 +654,8 @@ __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
             _BackendTag{},
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_wrapper>(
                 std::forward<_ExecutionPolicy>(__exec)),
-            unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _CopyBrick, std::decay_t<_Range1>,
-                                                    std::decay_t<_Range2>>{_CopyBrick{}, static_cast<std::size_t>(__n)},
+            unseq_backend::walk2_vectors_or_scalars<_ExecutionPolicy, _CopyBrick>{_CopyBrick{},
+                                                                                  static_cast<std::size_t>(__n)},
             __n, std::forward<_Range1>(__rng), std::forward<_Range2>(__result))
             .get();
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2336,8 +2336,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         oneapi::dpl::__internal::__device_backend_tag{},
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce1_wrapper>(__exec),
-        unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__n), _Range2>(__binary_op, __n),
-        __intermediate_result_end,
+        unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__n)>(__binary_op, __n), __intermediate_result_end,
         oneapi::dpl::__ranges::take_view_simple(oneapi::dpl::__ranges::views::all_read(__idx),
                                                 __intermediate_result_end),
         std::forward<_Range2>(__values), oneapi::dpl::__ranges::views::all_write(__tmp_out_values))
@@ -2383,7 +2382,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
         oneapi::dpl::__internal::__device_backend_tag{},
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce2_wrapper>(
             std::forward<_ExecutionPolicy>(__exec)),
-        unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__intermediate_result_end), _Range4>(
+        unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__intermediate_result_end)>(
             __binary_op, __intermediate_result_end),
         __result_end,
         oneapi::dpl::__ranges::take_view_simple(oneapi::dpl::__ranges::views::all_read(__idx), __result_end),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -51,7 +51,7 @@ struct __pfor_params
   public:
     constexpr static bool __b_vectorize =
         __can_vectorize_brick &&
-        //(oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Ranges>>::value && ...) &&
+        (oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Ranges>>::value && ...) &&
         (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
     constexpr static std::uint8_t __vector_size =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -67,8 +67,9 @@ struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name..
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
             __cgh.parallel_for<_Name...>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item_id) {
-                // Override any vectorization properties of the brick to evenly spread work across compute units.
-                __pfor_params</*__is_brick_vectorizable=*/false, false, _Ranges...> __params;
+                // Disable vectorization and multiple iterations per item within the brick to evenly spread work across
+                // compute units.
+                __pfor_params<false, false, _Ranges...> __params;
                 const std::size_t __idx = __item_id.get_linear_id();
                 __brick(std::true_type{}, __idx, __params, __rngs...);
             });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -51,7 +51,6 @@ struct __pfor_params
   public:
     constexpr static bool __b_vectorize =
         __can_vectorize_brick &&
-        (oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Ranges>>::value && ...) &&
         (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
     constexpr static std::uint8_t __vector_size =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -92,7 +92,8 @@ struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name..
             __cgh.parallel_for<_Name...>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item_id) {
                 // Disable vectorization and multiple iterations per item within the brick to evenly spread work across
                 // compute units.
-                __pfor_params<false, false, _Ranges...> __params;
+                __pfor_params<false /*__can_vectorize_brick*/, false /*__can_brick_process_multiple_iters*/, _Ranges...>
+                    __params;
                 const std::size_t __idx = __item_id.get_linear_id();
                 __brick(std::true_type{}, __idx, __params, __rngs...);
             });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -49,9 +49,9 @@ struct __pfor_params
     constexpr static std::uint8_t __max_vector_size = 4;
 
   public:
-    constexpr static bool __b_vectorize =
-        __can_vectorize_brick &&
-        (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
+    constexpr static bool __b_vectorize = __can_vectorize_brick &&
+                                          (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) &&
+                                          __min_type_size < 4;
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
     constexpr static std::uint8_t __vector_size =
         __b_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -37,6 +37,29 @@ namespace dpl
 namespace __par_backend_hetero
 {
 
+template <bool __can_vectorize_brick, bool __can_brick_process_multiple_iters, typename... _Ranges>
+struct __pfor_params
+{
+  private:
+    using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
+    constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
+    // Empirically determined 'bytes-in-flight' to maximize bandwidth utilization
+    constexpr static std::uint8_t __bytes_per_item = 16;
+    // Maximum size supported by compilers to generate vector instructions
+    constexpr static std::uint8_t __max_vector_size = 4;
+
+  public:
+    constexpr static bool __b_vectorize =
+        __can_vectorize_brick &&
+        //(oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Ranges>>::value && ...) &&
+        (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
+    // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
+    constexpr static std::uint8_t __vector_size =
+        __b_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
+    constexpr static std::uint8_t __iters_per_item =
+        __can_brick_process_multiple_iters ? __bytes_per_item / (__min_type_size * __vector_size) : 1;
+};
+
 template <typename... Name>
 class __parallel_for_small_kernel;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -28,6 +28,7 @@
 #include "parallel_backend_sycl_utils.h"
 // workaround until we implement more performant optimization for patterns
 #include "parallel_backend_sycl.h"
+#include "parallel_backend_sycl_for.h"
 #include "parallel_backend_sycl_histogram.h"
 #include "../../execution_impl.h"
 #include "execution_sycl_defs.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -67,10 +67,12 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
             __cgh.single_task<_Name...>([=]() {
+                // Disable vectorization and multiple iterations per item.
+                __pfor_params<false, false, _Ranges...> __params;
 #pragma unroll(::std::decay <_ExecutionPolicy>::type::unroll_factor)
                 for (auto __idx = 0; __idx < __count; ++__idx)
                 {
-                    __brick.__scalar_path_impl(std::true_type{}, __idx, __rngs...);
+                    __brick(std::true_type{}, __idx, __params, __rngs...);
                 }
             });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -69,7 +69,8 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
 
             __cgh.single_task<_Name...>([=]() {
                 // Disable vectorization and multiple iterations per item.
-                __pfor_params<false, false, _Ranges...> __params;
+                __pfor_params<false /*__can_vectorize_brick*/, false /*__can_brick_process_multiple_iters*/, _Ranges...>
+                    __params;
 #pragma unroll(::std::decay <_ExecutionPolicy>::type::unroll_factor)
                 for (auto __idx = 0; __idx < __count; ++__idx)
                 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -1031,29 +1031,6 @@ struct __strided_loop
     }
 };
 
-template <bool __can_vectorize_brick, bool __can_brick_process_multiple_iters, typename... _Ranges>
-struct __pfor_params
-{
-  private:
-    using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
-    constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
-    // Empirically determined 'bytes-in-flight' to maximize bandwidth utilization
-    constexpr static std::uint8_t __bytes_per_item = 16;
-    // Maximum size supported by compilers to generate vector instructions
-    constexpr static std::uint8_t __max_vector_size = 4;
-
-  public:
-    constexpr static bool __b_vectorize =
-        __can_vectorize_brick &&
-        (oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Ranges>>::value && ...) &&
-        (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
-    // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
-    constexpr static std::uint8_t __vector_size =
-        __b_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
-    constexpr static std::uint8_t __iters_per_item =
-        __can_brick_process_multiple_iters ? __bytes_per_item / (__min_type_size * __vector_size) : 1;
-};
-
 } // namespace __par_backend_hetero
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -1046,12 +1046,12 @@ struct __pfor_params</*_IsBrickVectorizable=*/true, _Ranges...>
     constexpr static std::uint8_t __max_vector_size = 4;
 
   public:
-    constexpr static bool __do_vectorize =
+    constexpr static bool __b_vectorize =
         (oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Ranges>>::value && ...) &&
         (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
     constexpr static std::uint8_t __vector_size =
-        __do_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
+        __b_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
     constexpr static std::uint8_t __iters_per_item = __bytes_per_item / (__min_type_size * __vector_size);
 };
 
@@ -1065,7 +1065,7 @@ struct __pfor_params</*_IsBrickVectorizable=*/false, _Ranges...>
     constexpr static std::uint8_t __bytes_per_item = 16;
 
   public:
-    constexpr static bool __do_vectorize = false;
+    constexpr static bool __b_vectorize = false;
     constexpr static std::uint8_t __vector_size = 1;
     constexpr static std::uint8_t __iters_per_item = __bytes_per_item / (__min_type_size * __vector_size);
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -1031,11 +1031,8 @@ struct __strided_loop
     }
 };
 
-template <bool _IsBrickVectorizable, typename... _Ranges>
-struct __pfor_params;
-
-template <typename... _Ranges>
-struct __pfor_params</*_IsBrickVectorizable=*/true, _Ranges...>
+template <bool __can_vectorize_brick, bool __can_brick_process_multiple_iters, typename... _Ranges>
+struct __pfor_params
 {
   private:
     using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
@@ -1047,27 +1044,14 @@ struct __pfor_params</*_IsBrickVectorizable=*/true, _Ranges...>
 
   public:
     constexpr static bool __b_vectorize =
+        __can_vectorize_brick &&
         (oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Ranges>>::value && ...) &&
         (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
     constexpr static std::uint8_t __vector_size =
         __b_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
-    constexpr static std::uint8_t __iters_per_item = __bytes_per_item / (__min_type_size * __vector_size);
-};
-
-template <typename... _Ranges>
-struct __pfor_params</*_IsBrickVectorizable=*/false, _Ranges...>
-{
-  private:
-    using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
-    constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
-    // Empirically determined 'bytes-in-flight' to maximize bandwidth utilization
-    constexpr static std::uint8_t __bytes_per_item = 16;
-
-  public:
-    constexpr static bool __b_vectorize = false;
-    constexpr static std::uint8_t __vector_size = 1;
-    constexpr static std::uint8_t __iters_per_item = __bytes_per_item / (__min_type_size * __vector_size);
+    constexpr static std::uint8_t __iters_per_item =
+        __can_brick_process_multiple_iters ? __bytes_per_item / (__min_type_size * __vector_size) : 1;
 };
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -368,7 +368,7 @@ namespace oneapi::dpl::unseq_backend
 template <typename _ExecutionPolicy, typename _F>
 struct walk_n;
 
-template <typename _ExecutionPolicy, typename _F, typename _Range>
+template <typename _ExecutionPolicy, typename _F>
 struct walk1_vector_or_scalar;
 
 template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
@@ -438,9 +438,9 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backen
 {
 };
 
-template <typename _ExecutionPolicy, typename _F, typename _Range>
+template <typename _ExecutionPolicy, typename _F>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backend::walk1_vector_or_scalar,
-                                                       _ExecutionPolicy, _F, _Range)>
+                                                       _ExecutionPolicy, _F)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_F>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -371,13 +371,13 @@ struct walk_n;
 template <typename _ExecutionPolicy, typename _F>
 struct walk1_vector_or_scalar;
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
+template <typename _ExecutionPolicy, typename _F>
 struct walk2_vectors_or_scalars;
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2, typename _Range3>
+template <typename _ExecutionPolicy, typename _F>
 struct walk3_vectors_or_scalars;
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
+template <typename _ExecutionPolicy, typename _F>
 struct walk_adjacent_difference;
 
 template <typename _ExecutionPolicy, typename _Operation1, typename _Operation2, typename _Tp, typename _Commutative,
@@ -427,7 +427,7 @@ struct __brick_includes;
 template <typename _ExecutionPolicy, typename _Compare, typename _Size1, typename _Size2, typename _IsOpDifference>
 class __brick_set_op;
 
-template <typename _BinaryOperator, typename _Size, typename _Range>
+template <typename _BinaryOperator, typename _Size>
 struct __brick_reduce_idx;
 
 } // namespace oneapi::dpl::unseq_backend
@@ -445,23 +445,23 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backen
 {
 };
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
+template <typename _ExecutionPolicy, typename _F>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backend::walk2_vectors_or_scalars,
-                                                       _ExecutionPolicy, _F, _Range1, _Range2)>
+                                                       _ExecutionPolicy, _F)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_F>
 {
 };
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2, typename _Range3>
+template <typename _ExecutionPolicy, typename _F>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backend::walk3_vectors_or_scalars,
-                                                       _ExecutionPolicy, _F, _Range1, _Range2, _Range3)>
+                                                       _ExecutionPolicy, _F)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_F>
 {
 };
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
+template <typename _ExecutionPolicy, typename _F>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backend::walk_adjacent_difference,
-                                                       _ExecutionPolicy, _F, _Range1, _Range2)>
+                                                       _ExecutionPolicy, _F)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_F>
 {
 };
@@ -573,9 +573,9 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backen
 {
 };
 
-template <typename _BinaryOperator, typename _Size, typename _Range>
+template <typename _BinaryOperator, typename _Size>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backend::__brick_reduce_idx, _BinaryOperator,
-                                                       _Size, _Range)>
+                                                       _Size)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryOperator, _Size>
 {
 };
@@ -585,7 +585,7 @@ namespace oneapi::dpl::internal
 
 enum class search_algorithm;
 
-template <typename Comp, typename T, typename _Range, search_algorithm func>
+template <typename Comp, typename T, search_algorithm func>
 struct __custom_brick;
 
 template <typename T, typename Predicate>
@@ -605,8 +605,8 @@ class transform_if_stencil_fun;
 
 } // namespace oneapi::dpl::internal
 
-template <typename Comp, typename T, typename _Range, oneapi::dpl::internal::search_algorithm func>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::__custom_brick, Comp, T, _Range, func)>
+template <typename Comp, typename T, oneapi::dpl::internal::search_algorithm func>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::__custom_brick, Comp, T, func)>
     : oneapi::dpl::__internal::__are_all_device_copyable<Comp, T>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1340,11 +1340,6 @@ class __brick_set_op
 template <typename _ExecutionPolicy, typename _DiffType>
 struct __brick_shift_left
 {
-  private:
-    // Maximum size supported by compilers to generate vector instructions
-    constexpr static std::uint8_t __max_vector_size = 4;
-
-  public:
     // Multiple iterations per item are manually processed in the brick with a nd-range strided approach.
     constexpr static bool __can_vectorize = true;
     constexpr static bool __can_process_multiple_iters = false;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -220,7 +220,7 @@ struct walk3_vectors_or_scalars
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2, typename _Range3,
               std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    operator()(_IsFull, const std::size_t __idx, _Params, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3) const
     {
 
         __f(__rng1[__idx], __rng2[__idx], __rng3[__idx]);
@@ -264,7 +264,7 @@ struct walk_adjacent_difference
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
               std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    operator()(_IsFull, const std::size_t __idx, _Params, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
         // just copy an element if it is the first one
         if (__idx == 0)
@@ -275,7 +275,7 @@ struct walk_adjacent_difference
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
               std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    operator()(_IsFull __is_full, const std::size_t __idx, _Params, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
         _ValueType __rng1_vector[_Params::__vector_size + 1];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -172,7 +172,7 @@ struct walk1_vector_or_scalar
 
     walk1_vector_or_scalar(_F __f, std::size_t __n) : __f(std::move(__f)), __n(__n) {}
 
-    template <typename _IsFull, typename _Range, typename _Params, std::enable_if_t<_Params::__do_vectorize, int> = 0>
+    template <typename _IsFull, typename _Range, typename _Params, std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
     operator()(_IsFull __is_full, const std::size_t __idx, _Params __params, _Range&& __rng) const
     {
@@ -181,7 +181,7 @@ struct walk1_vector_or_scalar
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
-    template <typename _IsFull, typename _Range, typename _Params, std::enable_if_t<!_Params::__do_vectorize, int> = 0>
+    template <typename _IsFull, typename _Range, typename _Params, std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -113,53 +113,6 @@ struct walk_n
     }
 };
 
-// Base class which establishes tuning parameters including vectorization / scalar path decider at compile time
-// for walk / for based algorithms
-template <typename... _Ranges>
-struct walk_vector_or_scalar_base
-{
-  private:
-    using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
-    constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
-    // Empirically determined 'bytes-in-flight' to maximize bandwidth utilization
-    constexpr static std::uint8_t __bytes_per_item = 16;
-    // Maximum size supported by compilers to generate vector instructions
-    constexpr static std::uint8_t __max_vector_size = 4;
-
-  public:
-    constexpr static bool __can_vectorize =
-        (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
-    // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
-    constexpr static std::uint8_t __preferred_vector_size =
-        __can_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
-    constexpr static std::uint8_t __preferred_iters_per_item =
-        __bytes_per_item / (__min_type_size * __preferred_vector_size);
-
-  protected:
-    using __vec_load_t = oneapi::dpl::__par_backend_hetero::__vector_load<__preferred_vector_size>;
-    using __vec_store_t = oneapi::dpl::__par_backend_hetero::__vector_store<__preferred_vector_size>;
-    using __vec_reverse_t = oneapi::dpl::__par_backend_hetero::__vector_reverse<__preferred_vector_size>;
-    using __vec_walk_t = oneapi::dpl::__par_backend_hetero::__vector_walk<__preferred_vector_size>;
-};
-
-// Path that intentionally disables vectorization for algorithms with a scattered access pattern (e.g. binary_search)
-template <typename... _Ranges>
-struct walk_scalar_base
-{
-  private:
-    using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
-    constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
-    constexpr static std::uint8_t __bytes_per_item = 16;
-
-  public:
-    constexpr static bool __can_vectorize = false;
-    // With no vectorization, the vector size is 1
-    constexpr static std::uint8_t __preferred_vector_size = 1;
-    // To achieve full bandwidth utilization, multiple iterations need to be processed by a work item
-    constexpr static std::uint8_t __preferred_iters_per_item =
-        __bytes_per_item / (__min_type_size * __preferred_vector_size);
-};
-
 template <typename _ExecutionPolicy, typename _F>
 struct walk1_vector_or_scalar
 {
@@ -168,20 +121,19 @@ struct walk1_vector_or_scalar
     std::size_t __n;
 
   public:
-    constexpr static bool __is_vectorizable = true;
-
+    constexpr static bool __can_vectorize = true;
+    constexpr static bool __can_process_multiple_iters = true;
     walk1_vector_or_scalar(_F __f, std::size_t __n) : __f(std::move(__f)), __n(__n) {}
 
     template <typename _IsFull, typename _Range, typename _Params, std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    operator()(_IsFull __is_full, const std::size_t __idx, _Params __params, _Range&& __rng) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range&& __rng) const
     {
-        typename oneapi::dpl::__par_backend_hetero::__vector_walk<_Params::__vector_size>{__n}(
-            __is_full, __idx, __f, std::forward<_Range>(__rng));
+        __vec_walk_t<_Params::__vector_size>{__n}(__is_full, __idx, __f, std::forward<_Range>(__rng));
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
-    template <typename _IsFull, typename _Range, typename _Params, std::enable_if_t<!_Params::__b_vectorize, int> = 0>
+    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
@@ -189,75 +141,71 @@ struct walk1_vector_or_scalar
     }
 };
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
-struct walk2_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2>
+template <typename _ExecutionPolicy, typename _F>
+struct walk2_vectors_or_scalars
 {
   private:
-    using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;
     std::size_t __n;
 
   public:
+    constexpr static bool __can_vectorize = true;
+    constexpr static bool __can_process_multiple_iters = true;
     walk2_vectors_or_scalars(_F __f, std::size_t __n) : __f(std::move(__f)), __n(__n) {}
 
-    template <typename _IsFull>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    __vector_path_impl(_IsFull __is_full, const std::size_t __idx, _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
         using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
-        _ValueType1 __rng1_vector[__base_t::__preferred_vector_size];
+        _ValueType1 __rng1_vector[_Params::__vector_size];
         // 1. Load input into a vector
-        typename __base_t::__vec_load_t{__n}(__is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_load_op{},
-                                             __rng1, __rng1_vector);
+        __vec_load_t<_Params::__vector_size>{__n}(
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_load_op{}, __rng1, __rng1_vector);
         // 2. Apply functor to vector and store into global memory
-        typename __base_t::__vec_store_t{__n}(__is_full, __idx,
-                                              oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<_F>{__f},
-                                              __rng1_vector, __rng2);
+        __vec_store_t<_Params::__vector_size>{__n}(
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<_F>{__f}, __rng1_vector,
+            __rng2);
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    __scalar_path_impl(_IsFull, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
-
         __f(__rng1[__idx], __rng2[__idx]);
-    }
-
-    template <typename _IsFull, typename _ItemId>
-    void
-    operator()(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2) const
-    {
-        if constexpr (__base_t::__can_vectorize)
-            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
-        else
-            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
     }
 };
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2, typename _Range3>
-struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Range2, _Range3>
+template <typename _ExecutionPolicy, typename _F>
+struct walk3_vectors_or_scalars
 {
   private:
-    using __base_t = walk_vector_or_scalar_base<_Range1, _Range2, _Range3>;
     _F __f;
     std::size_t __n;
 
   public:
+    constexpr static bool __can_vectorize = true;
+    constexpr static bool __can_process_multiple_iters = true;
+
     walk3_vectors_or_scalars(_F __f, std::size_t __n) : __f(std::move(__f)), __n(__n) {}
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2, typename _Range3,
+              std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    __vector_path_impl(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2,
+               _Range3&& __rng3) const
     {
         using _ValueType1 = oneapi::dpl::__internal::__value_t<_Range1>;
         using _ValueType2 = oneapi::dpl::__internal::__value_t<_Range2>;
 
-        _ValueType1 __rng1_vector[__base_t::__preferred_vector_size];
-        _ValueType2 __rng2_vector[__base_t::__preferred_vector_size];
+        _ValueType1 __rng1_vector[_Params::__vector_size];
+        _ValueType2 __rng2_vector[_Params::__vector_size];
 
-        typename __base_t::__vec_load_t __vec_load{__n};
-        typename __base_t::__vec_store_t __vec_store{__n};
+        __vec_load_t<_Params::__vector_size> __vec_load{__n};
+        __vec_store_t<_Params::__vector_size> __vec_store{__n};
         oneapi::dpl::__par_backend_hetero::__scalar_load_op __load_op;
 
         // 1. Load inputs into vectors
@@ -269,22 +217,13 @@ struct walk3_vectors_or_scalars : public walk_vector_or_scalar_base<_Range1, _Ra
     }
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2, typename _Range3,
+              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    __scalar_path_impl(_IsFull, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
     {
 
         __f(__rng1[__idx], __rng2[__idx], __rng3[__idx]);
-    }
-
-    template <typename _IsFull, typename _ItemId>
-    void
-    operator()(_IsFull __is_full, const _ItemId __idx, _Range1 __rng1, _Range2 __rng2, _Range3 __rng3) const
-    {
-        if constexpr (__base_t::__can_vectorize)
-            __vector_path_impl(__is_full, __idx, __rng1, __rng2, __rng3);
-        else
-            __scalar_path_impl(__is_full, __idx, __rng1, __rng2, __rng3);
     }
 };
 
@@ -308,21 +247,24 @@ struct walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>
 // walk_adjacent_difference
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
-struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Range2>
+template <typename _ExecutionPolicy, typename _F>
+struct walk_adjacent_difference
 {
   private:
-    using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;
     std::size_t __n;
     oneapi::dpl::__internal::__pstl_assign __assigner;
 
   public:
+    constexpr static bool __can_vectorize = true;
+    constexpr static bool __can_process_multiple_iters = true;
+
     walk_adjacent_difference(_F __f, std::size_t __n) : __f(std::move(__f)), __n(__n) {}
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    __scalar_path_impl(_IsFull, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull, const std::size_t __idx, _Params, const _Range1 __rng1, _Range2 __rng2) const
     {
         // just copy an element if it is the first one
         if (__idx == 0)
@@ -330,34 +272,26 @@ struct walk_adjacent_difference : public walk_vector_or_scalar_base<_Range1, _Ra
         else
             __f(__rng1[__idx + (-1)], __rng1[__idx], __rng2[__idx]);
     }
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    __vector_path_impl(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, const _Range1 __rng1, _Range2 __rng2) const
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
-        _ValueType __rng1_vector[__base_t::__preferred_vector_size + 1];
+        _ValueType __rng1_vector[_Params::__vector_size + 1];
         // 1. Establish a vector of __preferred_vector_size + 1 where a scalar load is performed on the first element
         // followed by a vector load of the specified length.
         __assigner(__idx != 0 ? __rng1[__idx - 1] : __rng1[0], __rng1_vector[0]);
-        typename __base_t::__vec_load_t{__n}(__is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_load_op{},
-                                             __rng1, &__rng1_vector[1]);
+        __vec_load_t<_Params::__vector_size>{__n}(
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_load_op{}, __rng1, &__rng1_vector[1]);
         // 2. Perform a vector store of __preferred_vector_size adjacent differences.
-        typename __base_t::__vec_store_t{__n}(__is_full, __idx,
-                                              oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<_F>{__f},
-                                              __rng1_vector, &__rng1_vector[1], __rng2);
+        __vec_store_t<_Params::__vector_size>{__n}(
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<_F>{__f}, __rng1_vector,
+            &__rng1_vector[1], __rng2);
         // A dummy value is first written to global memory followed by an overwrite for the first index. Pulling the vector loads / stores into an if branch
         // to better handle this results in performance degradation.
         if (__idx == 0)
             __assigner(__rng1_vector[0], __rng2[0]);
-    }
-    template <typename _IsFull, typename _ItemId>
-    void
-    operator()(_IsFull __is_full, const _ItemId __idx, const _Range1 __rng1, _Range2 __rng2) const
-    {
-        if constexpr (__base_t::__can_vectorize)
-            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
-        else
-            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
     }
 };
 
@@ -1137,21 +1071,22 @@ struct __brick_includes
 //------------------------------------------------------------------------
 // reverse
 //------------------------------------------------------------------------
-template <typename _Size, typename _Range>
-struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
+template <typename _Size>
+struct __reverse_functor
 {
   private:
-    using __base_t = walk_vector_or_scalar_base<_Range>;
-    using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
     _Size __size;
 
   public:
+    constexpr static bool __can_vectorize = true;
+    constexpr static bool __can_process_multiple_iters = true;
     __reverse_functor(_Size __size) : __size(__size) {}
 
-    template <typename _IsFull>
+    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    __vector_path_impl(_IsFull, const std::size_t __left_start_idx, _Range __rng) const
+    operator()(_IsFull, const std::size_t __left_start_idx, _Params, _Range&& __rng) const
     {
+        using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
         const std::size_t __n = __size;
 
         // In the below implementation, we see that _IsFull is ignored in favor of std::true_type{} in all cases.
@@ -1161,14 +1096,14 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
         // reverses middle elements. This extra processing of elements <= __vec_size is more performant than applying
         // additional branching (such as in reverse_copy).
 
-        const std::size_t __right_start_idx = __size - __left_start_idx - __base_t::__preferred_vector_size;
+        const std::size_t __right_start_idx = __size - __left_start_idx - _Params::__vector_size;
 
-        _ValueType __rng_left_vector[__base_t::__preferred_vector_size];
-        _ValueType __rng_right_vector[__base_t::__preferred_vector_size];
+        _ValueType __rng_left_vector[_Params::__vector_size];
+        _ValueType __rng_right_vector[_Params::__vector_size];
 
-        typename __base_t::__vec_load_t __vec_load{__n};
-        typename __base_t::__vec_reverse_t __vec_reverse;
-        typename __base_t::__vec_store_t __vec_store{__n};
+        __vec_load_t<_Params::__vector_size> __vec_load{__n};
+        __vec_reverse_t<_Params::__vector_size> __vec_reverse;
+        __vec_store_t<_Params::__vector_size> __vec_store{__n};
         oneapi::dpl::__par_backend_hetero::__scalar_load_op __load_op;
         oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<oneapi::dpl::__internal::__pstl_assign>
             __store_op;
@@ -1184,67 +1119,61 @@ struct __reverse_functor : public walk_vector_or_scalar_base<_Range>
         __vec_store(std::true_type{}, __right_start_idx, __store_op, __rng_left_vector, __rng);
         __vec_store(std::true_type{}, __left_start_idx, __store_op, __rng_right_vector, __rng);
     }
-    template <typename _IsFull>
+    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    __scalar_path_impl(_IsFull, const std::size_t __idx, _Range __rng) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
         using ::std::swap;
         swap(__rng[__idx], __rng[__size - __idx - 1]);
-    }
-    template <typename _IsFull>
-    void
-    operator()(_IsFull __is_full, const std::size_t __idx, _Range __rng) const
-    {
-        if constexpr (__base_t::__can_vectorize)
-            __vector_path_impl(__is_full, __idx, __rng);
-        else
-            __scalar_path_impl(__is_full, __idx, __rng);
     }
 };
 
 //------------------------------------------------------------------------
 // reverse_copy
 //------------------------------------------------------------------------
-template <typename _Size, typename _Range1, typename _Range2>
-struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
+template <typename _Size>
+struct __reverse_copy
 {
   private:
-    using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
-    using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
     _Size __size;
     oneapi::dpl::__internal::__pstl_assign __assigner;
 
   public:
+    constexpr static bool __can_vectorize = true;
+    constexpr static bool __can_process_multiple_iters = true;
     __reverse_copy(_Size __size) : __size(__size) {}
 
-    template <typename _IsFull>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    __scalar_path_impl(_IsFull, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
         __rng2[__idx] = __rng1[__size - __idx - 1];
     }
-    template <typename _IsFull>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    __vector_path_impl(_IsFull __is_full, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
+        using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
         const std::size_t __n = __size;
         const std::size_t __remaining_elements = __n - __idx;
         const std::uint8_t __elements_to_process =
-            std::min(static_cast<std::size_t>(__base_t::__preferred_vector_size), __remaining_elements);
+            std::min(static_cast<std::size_t>(_Params::__vector_size), __remaining_elements);
         const std::size_t __output_start = __size - __idx - __elements_to_process;
         // 1. Load vector to reverse
-        _ValueType __rng1_vector[__base_t::__preferred_vector_size];
-        typename __base_t::__vec_load_t{__n}(__is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_load_op{},
-                                             __rng1, __rng1_vector);
+        _ValueType __rng1_vector[_Params::__vector_size];
+        __vec_load_t<_Params::__vector_size>{__n}(
+            __is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_load_op{}, __rng1, __rng1_vector);
         // 2. Reverse in registers
-        typename __base_t::__vec_reverse_t{}(__is_full, __elements_to_process, __rng1_vector);
+        __vec_reverse_t<_Params::__vector_size>{}(__is_full, __elements_to_process, __rng1_vector);
         // 3. Flip the location of the vector in the output buffer
         if constexpr (_IsFull::value)
         {
-            typename __base_t::__vec_store_t{__n}(std::true_type{}, __output_start,
-                                                  oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<
-                                                      oneapi::dpl::__internal::__pstl_assign>{},
-                                                  __rng1_vector, __rng2);
+            __vec_store_t<_Params::__vector_size>{__n}(std::true_type{}, __output_start,
+                                                       oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<
+                                                           oneapi::dpl::__internal::__pstl_assign>{},
+                                                       __rng1_vector, __rng2);
         }
         else
         {
@@ -1256,45 +1185,38 @@ struct __reverse_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
                 __assigner(__rng1_vector[__i], __rng2[__output_start + __i]);
         }
     }
-    template <typename _IsFull>
-    void
-    operator()(_IsFull __is_full, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
-    {
-        if constexpr (__base_t::__can_vectorize)
-            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
-        else
-            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
-    }
 };
 
 //------------------------------------------------------------------------
 // rotate_copy
 //------------------------------------------------------------------------
-template <typename _Size, typename _Range1, typename _Range2>
-struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
+template <typename _Size>
+struct __rotate_copy
 {
   private:
-    using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
-    using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
     _Size __size;
     _Size __shift;
     oneapi::dpl::__internal::__pstl_assign __assigner;
 
   public:
+    constexpr static bool __can_vectorize = true;
+    constexpr static bool __can_process_multiple_iters = true;
     __rotate_copy(_Size __size, _Size __shift) : __size(__size), __shift(__shift) {}
 
-    template <typename _IsFull>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    __vector_path_impl(_IsFull __is_full, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
+        using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
         const std::size_t __shifted_idx = __shift + __idx;
         const std::size_t __wrapped_idx = __shifted_idx % __size;
         const std::size_t __n = __size;
-        _ValueType __rng1_vector[__base_t::__preferred_vector_size];
+        _ValueType __rng1_vector[_Params::__vector_size];
         //1. Vectorize loads only if we know the wrap around point is beyond the current vector elements to process
-        if (__wrapped_idx + __base_t::__preferred_vector_size <= __n)
+        if (__wrapped_idx + _Params::__vector_size <= __n)
         {
-            typename __base_t::__vec_load_t{__n}(
+            __vec_load_t<_Params::__vector_size>{__n}(
                 __is_full, __wrapped_idx, oneapi::dpl::__par_backend_hetero::__scalar_load_op{}, __rng1, __rng1_vector);
         }
         else
@@ -1303,7 +1225,7 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
             // the first before the wraparound point and the second after.
             const std::size_t __remaining_elements = __n - __idx;
             const std::uint8_t __elements_to_process =
-                std::min(std::size_t{__base_t::__preferred_vector_size}, __remaining_elements);
+                std::min(std::size_t{_Params::__vector_size}, __remaining_elements);
             // __n - __wrapped_idx can safely fit into a uint8_t due to the condition check above.
             const std::uint8_t __loop1_elements =
                 std::min(__elements_to_process, static_cast<std::uint8_t>(__n - __wrapped_idx));
@@ -1315,25 +1237,17 @@ struct __rotate_copy : public walk_vector_or_scalar_base<_Range1, _Range2>
                 __assigner(__rng1[__j], __rng1_vector[__i + __j]);
         }
         // 2. Store the rotation
-        typename __base_t::__vec_store_t{__n}(
+        __vec_store_t<_Params::__vector_size>{__n}(
             __is_full, __idx,
             oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<oneapi::dpl::__internal::__pstl_assign>{},
             __rng1_vector, __rng2);
     }
-    template <typename _IsFull>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    __scalar_path_impl(_IsFull, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
         __rng2[__idx] = __rng1[(__shift + __idx) % __size];
-    }
-    template <typename _IsFull>
-    void
-    operator()(_IsFull __is_full, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
-    {
-        if constexpr (__base_t::__can_vectorize)
-            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
-        else
-            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
     }
 };
 
@@ -1407,33 +1321,30 @@ class __brick_set_op
     }
 };
 
-template <typename _ExecutionPolicy, typename _DiffType, typename _Range>
+template <typename _ExecutionPolicy, typename _DiffType>
 struct __brick_shift_left
 {
   private:
-    using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
     // Maximum size supported by compilers to generate vector instructions
     constexpr static std::uint8_t __max_vector_size = 4;
 
   public:
     // Multiple iterations per item are manually processed in the brick with a nd-range strided approach.
-    constexpr static std::uint8_t __preferred_iters_per_item = 1;
-    constexpr static bool __can_vectorize =
-        std::is_fundamental_v<_ValueType> && sizeof(_ValueType) < 4;
-    constexpr static std::uint8_t __preferred_vector_size =
-        __can_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, sizeof(_ValueType)) : 1;
+    constexpr static bool __can_vectorize = true;
+    constexpr static bool __can_process_multiple_iters = false;
 
     _DiffType __size;
     _DiffType __n;
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    __vector_path_impl(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range&& __rng) const
     {
+        using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
         const std::size_t __unsigned_size = __size;
         const _DiffType __i = __idx - __n;
-        oneapi::dpl::__par_backend_hetero::__vector_load<__preferred_vector_size> __vec_load{__unsigned_size};
-        oneapi::dpl::__par_backend_hetero::__vector_store<__preferred_vector_size> __vec_store{__unsigned_size};
+        __vec_load_t<_Params::__vector_size> __vec_load{__unsigned_size};
+        __vec_store_t<_Params::__vector_size> __vec_store{__unsigned_size};
         oneapi::dpl::__par_backend_hetero::__scalar_load_op __load_op;
         oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<oneapi::dpl::__internal::__pstl_assign>
             __store_op;
@@ -1443,9 +1354,9 @@ struct __brick_shift_left
             const _DiffType __write_offset = __k + __i;
             if constexpr (_IsFull::value)
             {
-                if (__read_offset + __preferred_vector_size <= __size)
+                if (__read_offset + _Params::__vector_size <= __size)
                 {
-                    _ValueType __rng_vector[__preferred_vector_size];
+                    _ValueType __rng_vector[_Params::__vector_size];
                     __vec_load(std::true_type{}, __read_offset, __load_op, __rng, __rng_vector);
                     __vec_store(std::true_type{}, __write_offset, __store_op, __rng_vector, __rng);
                 }
@@ -1463,16 +1374,16 @@ struct __brick_shift_left
                 // in branch divergence and masked execution of both vectorized and serial paths for all items in the
                 // sub-group which may worsen performance. Instead, have each item in the sub-group process its work
                 // serially.
-                for (_DiffType __j = 0; __j < std::min(std::size_t{__preferred_vector_size}, __n - __idx); ++__j)
+                for (_DiffType __j = 0; __j < std::min(std::size_t{_Params::__vector_size}, __n - __idx); ++__j)
                     if (__read_offset + __j < __size)
                         __rng[__write_offset + __j] = __rng[__read_offset + __j];
             }
         }
     }
 
-    template <typename _IsFull, typename _ItemId>
+    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    __scalar_path_impl(_IsFull, const _ItemId __idx, _Range __rng) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
         const _DiffType __i = __idx - __n; //loop invariant
         for (_DiffType __k = __n; __k < __size; __k += __n)
@@ -1480,16 +1391,6 @@ struct __brick_shift_left
             if (__k + __idx < __size)
                 __rng[__k + __i] = ::std::move(__rng[__k + __idx]);
         }
-    }
-
-    template <typename _IsFull, typename _ItemId>
-    void
-    operator()(_IsFull __is_full, const _ItemId __idx, _Range __rng) const
-    {
-        if constexpr (__can_vectorize)
-            __vector_path_impl(__is_full, __idx, __rng);
-        else
-            __scalar_path_impl(__is_full, __idx, __rng);
     }
 };
 
@@ -1507,9 +1408,11 @@ struct __brick_assign_key_position
 };
 
 // reduce the values in a segment associated with a key
-template <typename _BinaryOperator, typename _Size, typename _Range>
-struct __brick_reduce_idx : public walk_scalar_base<_Range>
+template <typename _BinaryOperator, typename _Size>
+struct __brick_reduce_idx
 {
+    constexpr static bool __can_vectorize = false;
+    constexpr static bool __can_process_multiple_iters = true;
     __brick_reduce_idx(const _BinaryOperator& __b, const _Size __n_) : __binary_op(__b), __n(__n_) {}
 
     template <typename _Values>
@@ -1523,22 +1426,15 @@ struct __brick_reduce_idx : public walk_scalar_base<_Range>
             __res = __binary_op(__res, __values[__segment_begin]);
         return __res;
     }
-    template <typename _IsFull, typename _ItemId, typename _ReduceIdx, typename _Values, typename _OutValues>
+    template <typename _IsFull, typename _Params, typename _ReduceIdx, typename _Values, typename _OutValues>
     void
-    __scalar_path_impl(_IsFull, const _ItemId __idx, const _ReduceIdx& __segment_starts, const _Values& __values,
-                       _OutValues& __out_values) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, const _ReduceIdx& __segment_starts,
+               const _Values& __values, _OutValues& __out_values) const
     {
         using __value_type = decltype(__segment_starts[__idx]);
         __value_type __segment_end =
             (__idx == __segment_starts.size() - 1) ? __value_type(__n) : __segment_starts[__idx + 1];
         __out_values[__idx] = reduce(__segment_starts[__idx], __segment_end, __values);
-    }
-    template <typename _IsFull, typename _ItemId, typename _ReduceIdx, typename _Values, typename _OutValues>
-    void
-    operator()(_IsFull __is_full, const _ItemId __idx, const _ReduceIdx& __segment_starts, const _Values& __values,
-               _OutValues& __out_values) const
-    {
-        __scalar_path_impl(__is_full, __idx, __segment_starts, __values, __out_values);
     }
 
   private:
@@ -1548,26 +1444,28 @@ struct __brick_reduce_idx : public walk_scalar_base<_Range>
 
 // std::swap_ranges is unique in that both sets of provided ranges will be modified. Due to this,
 // we define a separate functor from __walk2_vectors_or_scalars with a customized vectorization path.
-template <typename _ExecutionPolicy, typename _F, typename _Range1, typename _Range2>
-struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
+template <typename _ExecutionPolicy, typename _F>
+struct __brick_swap
 {
   private:
-    using __base_t = walk_vector_or_scalar_base<_Range1, _Range2>;
     _F __f;
     std::size_t __n;
 
   public:
+    constexpr static bool __can_vectorize = true;
+    constexpr static bool __can_process_multiple_iters = true;
     __brick_swap(_F __f, std::size_t __n) : __f(std::move(__f)), __n(__n) {}
 
-    template <typename _IsFull>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    __vector_path_impl(_IsFull __is_full, const std::size_t __idx, _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
         // Copies are used in the vector path of swap due to the restriction to fundamental types.
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
-        _ValueType __rng_vector[__base_t::__preferred_vector_size];
-        typename __base_t::__vec_load_t __vec_load{__n};
-        typename __base_t::__vec_store_t __vec_store{__n};
+        _ValueType __rng_vector[_Params::__vector_size];
+        __vec_load_t<_Params::__vector_size> __vec_load{__n};
+        __vec_store_t<_Params::__vector_size> __vec_store{__n};
         // 1. Load elements from __rng1.
         __vec_load(__is_full, __idx, oneapi::dpl::__par_backend_hetero::__scalar_load_op{}, __rng1, __rng_vector);
         // 2. Swap the __rng1 elements in the vector with __rng2 elements from global memory. Note the store operation
@@ -1581,21 +1479,12 @@ struct __brick_swap : public walk_vector_or_scalar_base<_Range1, _Range2>
             __rng_vector, __rng1);
     }
 
-    template <typename _IsFull>
+    template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
+              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
     void
-    __scalar_path_impl(_IsFull __is_full, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
         __f(__rng1[__idx], __rng2[__idx]);
-    }
-
-    template <typename _IsFull>
-    void
-    operator()(_IsFull __is_full, const std::size_t __idx, const _Range1 __rng1, _Range2 __rng2) const
-    {
-        if constexpr (__base_t::__can_vectorize)
-            __vector_path_impl(__is_full, __idx, __rng1, __rng2);
-        else
-            __scalar_path_impl(__is_full, __idx, __rng1, __rng2);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -143,7 +143,7 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
 
         auto __init_event = oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__hist_fill_zeros_wrapper>(__exec),
-            unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, decltype(__fill_func), decltype(__bins)>{
+            unseq_backend::walk1_vector_or_scalar<_ExecutionPolicy, decltype(__fill_func)>{
                 __fill_func, static_cast<std::size_t>(__num_bins)},
             __num_bins, __bins);
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -262,9 +262,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
             oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator2>();
         auto __buf2 = __keep2(__d_first, __d_last);
 
-        using _Function =
-            unseq_backend::walk_adjacent_difference<_ExecutionPolicy, decltype(__fn), decltype(__buf1.all_view()),
-                                                    decltype(__buf2.all_view())>;
+        using _Function = unseq_backend::walk_adjacent_difference<_ExecutionPolicy, decltype(__fn)>;
 
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec,
                                                           _Function{__fn, static_cast<std::size_t>(__n)}, __n,

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -46,11 +46,9 @@ test_device_copyable()
                   "constant_iterator_device_copyable is not device copyable");
 
     //__custom_brick
-    static_assert(
-        sycl::is_device_copyable_v<
-            oneapi::dpl::internal::__custom_brick<noop_device_copyable, int_device_copyable, range_device_copyable,
-                                                  oneapi::dpl::internal::search_algorithm::lower_bound>>,
-        "__custom_brick is not device copyable with device copyable types");
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::internal::__custom_brick<
+                      noop_device_copyable, int_device_copyable, oneapi::dpl::internal::search_algorithm::lower_bound>>,
+                  "__custom_brick is not device copyable with device copyable types");
     //replace_if_fun
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::internal::replace_if_fun<int_device_copyable, noop_device_copyable>>,
@@ -79,22 +77,25 @@ test_device_copyable()
                       oneapi::dpl::unseq_backend::walk_n<policy_non_device_copyable, noop_device_copyable>>,
                   "walk_n is not device copyable with device copyable types");
     //walk1_vector_or_scalar
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::unseq_backend::walk1_vector_or_scalar<
-                      policy_non_device_copyable, noop_device_copyable, range_device_copyable>>,
-                  "walk1_vector_or_scalar is not device copyable with device copyable types");
+    static_assert(
+        sycl::is_device_copyable_v<
+            oneapi::dpl::unseq_backend::walk1_vector_or_scalar<policy_non_device_copyable, noop_device_copyable>>,
+        "walk1_vector_or_scalar is not device copyable with device copyable types");
     //walk2_vectors_or_scalars
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::unseq_backend::walk2_vectors_or_scalars<
-                      policy_non_device_copyable, noop_device_copyable, range_device_copyable, range_device_copyable>>,
-                  "walk2_vectors_or_scalars is not device copyable with device copyable types");
+    static_assert(
+        sycl::is_device_copyable_v<
+            oneapi::dpl::unseq_backend::walk2_vectors_or_scalars<policy_non_device_copyable, noop_device_copyable>>,
+        "walk2_vectors_or_scalars is not device copyable with device copyable types");
     //walk3_vectors_or_scalars
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::unseq_backend::walk3_vectors_or_scalars<
-                      policy_non_device_copyable, noop_device_copyable, range_device_copyable, range_device_copyable,
-                      range_device_copyable>>,
-                  "walk3_vectors_or_scalars is not device copyable with device copyable types");
+    static_assert(
+        sycl::is_device_copyable_v<
+            oneapi::dpl::unseq_backend::walk3_vectors_or_scalars<policy_non_device_copyable, noop_device_copyable>>,
+        "walk3_vectors_or_scalars is not device copyable with device copyable types");
     //walk_adjacent_difference
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::unseq_backend::walk_adjacent_difference<
-                      policy_non_device_copyable, noop_device_copyable, range_device_copyable, range_device_copyable>>,
-                  "walk_adjacent_difference is not device copyable with device copyable types");
+    static_assert(
+        sycl::is_device_copyable_v<
+            oneapi::dpl::unseq_backend::walk_adjacent_difference<policy_non_device_copyable, noop_device_copyable>>,
+        "walk_adjacent_difference is not device copyable with device copyable types");
     //transform_reduce
     static_assert(
         sycl::is_device_copyable_v<
@@ -162,8 +163,8 @@ test_device_copyable()
                                                        int_device_copyable, int_device_copyable, std::true_type>>,
         "__brick_set_op is not device copyable with device copyable types");
     // __brick_reduce_idx
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::unseq_backend::__brick_reduce_idx<
-                      noop_device_copyable, int_device_copyable, range_device_copyable>>,
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::unseq_backend::__brick_reduce_idx<noop_device_copyable, int_device_copyable>>,
                   "__brick_reduce_idx is not device copyable with device copyable types");
 
     //__gen_transform_input
@@ -325,10 +326,10 @@ test_non_device_copyable()
     static_assert(!sycl::is_device_copyable_v<range_non_device_copyable>, "range_non_device_copyable is device copyable");
 
     //__custom_brick
-    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::internal::__custom_brick<
-                      noop_device_copyable, int_non_device_copyable, range_non_device_copyable,
-                      oneapi::dpl::internal::search_algorithm::lower_bound>>,
-                  "__custom_brick is device copyable with non device copyable types");
+    static_assert(
+        !sycl::is_device_copyable_v<oneapi::dpl::internal::__custom_brick<
+            noop_device_copyable, int_non_device_copyable, oneapi::dpl::internal::search_algorithm::lower_bound>>,
+        "__custom_brick is device copyable with non device copyable types");
     //replace_if_fun
     static_assert(!sycl::is_device_copyable_v<
                       oneapi::dpl::internal::replace_if_fun<int_device_copyable, noop_non_device_copyable>>,
@@ -358,25 +359,24 @@ test_non_device_copyable()
                       oneapi::dpl::unseq_backend::walk_n<policy_non_device_copyable, noop_non_device_copyable>>,
                   "walk_n is device copyable with non device copyable types");
     //walk1_vector_or_scalar
-    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::unseq_backend::walk1_vector_or_scalar<
-                      policy_non_device_copyable, noop_non_device_copyable, range_non_device_copyable>>,
-                  "walk1_vector_or_scalar is device copyable with non device copyable types");
+    static_assert(
+        !sycl::is_device_copyable_v<
+            oneapi::dpl::unseq_backend::walk1_vector_or_scalar<policy_non_device_copyable, noop_non_device_copyable>>,
+        "walk1_vector_or_scalar is device copyable with non device copyable types");
     //walk2_vectors_or_scalars
     static_assert(
         !sycl::is_device_copyable_v<
-            oneapi::dpl::unseq_backend::walk2_vectors_or_scalars<policy_non_device_copyable, noop_non_device_copyable,
-                                                                 range_non_device_copyable, range_non_device_copyable>>,
+            oneapi::dpl::unseq_backend::walk2_vectors_or_scalars<policy_non_device_copyable, noop_non_device_copyable>>,
         "walk2_vectors_or_scalars is device copyable with non device copyable types");
     //walk3_vectors_or_scalars
-    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::unseq_backend::walk3_vectors_or_scalars<
-                      policy_non_device_copyable, noop_non_device_copyable, range_non_device_copyable,
-                      range_non_device_copyable, range_non_device_copyable>>,
-                  "walk3_vectors_or_scalars is device copyable with non device copyable types");
+    static_assert(
+        !sycl::is_device_copyable_v<
+            oneapi::dpl::unseq_backend::walk3_vectors_or_scalars<policy_non_device_copyable, noop_non_device_copyable>>,
+        "walk3_vectors_or_scalars is device copyable with non device copyable types");
     //walk_adjacent_difference
     static_assert(
         !sycl::is_device_copyable_v<
-            oneapi::dpl::unseq_backend::walk_adjacent_difference<policy_non_device_copyable, noop_non_device_copyable,
-                                                                 range_non_device_copyable, range_non_device_copyable>>,
+            oneapi::dpl::unseq_backend::walk_adjacent_difference<policy_non_device_copyable, noop_non_device_copyable>>,
         "walk_adjacent_difference is device copyable with non device copyable types");
     //transform_reduce
     static_assert(
@@ -445,8 +445,8 @@ test_non_device_copyable()
                                                        int_device_copyable, int_device_copyable, std::true_type>>,
         "__brick_set_op is device copyable with non device copyable types");
     //__brick_reduce_idx
-    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::unseq_backend::__brick_reduce_idx<
-                      noop_device_copyable, int_non_device_copyable, range_non_device_copyable>>,
+    static_assert(!sycl::is_device_copyable_v<
+                      oneapi::dpl::unseq_backend::__brick_reduce_idx<noop_device_copyable, int_non_device_copyable>>,
                   "__brick_reduce_idx is device copyable with non device copyable types");
 
     //__gen_transform_input


### PR DESCRIPTION
This PR addresses https://github.com/uxlfoundation/oneDPL/issues/2023.

In https://github.com/uxlfoundation/oneDPL/pull/1976, parallel-for bricks were redesigned to have an inheritance relationship with a either a scalar or vector tuning base class in order to inherit compile-time tuning constants. This came with a downside of adding the user-provided range types to the class template of parallel-for bricks, complicating usage from the caller side as more templates must be provided when creating a brick.

This PR removes the use of inheritance from parallel-for bricks along with the range class templates with the following approach:

- Each parallel-for brick defines two compile-time boolean constants, `__can_vectorize` and `__can_process_multiple_iters`. `__can_vectorize` defines whether a vectorization path is provided. For some bricks (e.g. `__custom_brick` for binary search) there is no benefit of providing a vectorization path. `__can_process_multiple_iters` specifies whether a single item can safely process multiple strided iterations of input.
- The parallel-for SYCL implementation makes use of a new class `__pfor_params` which queries the brick's static members to define vectorization and iters per item tuning parameters.
- An instance of `__pfor_params` is passed to the brick when invoking the function call operator which includes vector sizes and whether vectorization should be enabled.

Additionally, the `__scalar_path_impl`, `__vector_path_impl`, and dispatch `operator()` design of the bricks have been replaced with two `operator()` definitions using SFINAE to define scalar and vector implementations dependent on whether the provided parameter instance is vectorizable. 