### PR TITLE
Incorrect Kernel name generation for `__parallel_reduce_then_scan_reduce_submitter` and for `__parallel_reduce_then_scan_scan_submitter`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -836,7 +836,17 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         __sub_group_size, __max_inputs_per_item, __inclusive, __is_unique_pattern_v, _ReduceOp, _GenScanInput,
         _ScanInputTransform, _WriteOp, _InitType,
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-            __reduce_then_scan_scan_kernel<_CustomName>>>;
+            __reduce_then_scan_scan_kernel<
+                std::integral_constant<decltype(__sub_group_size), __sub_group_size>,
+                std::integral_constant<decltype(__max_inputs_per_item), __max_inputs_per_item>,
+                _Inclusive,         // for __inclusive state
+                _IsUniquePattern,   // for __is_unique_pattern_v state
+                _ReduceOp,
+                _GenScanInput,
+                _ScanInputTransform,
+                _WriteOp,
+                _InitType,
+                _CustomName>>>;
     _ReduceSubmitter __reduce_submitter{__max_inputs_per_block,
                                         __num_sub_groups_local,
                                         __num_sub_groups_global,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -288,16 +288,12 @@ struct __parallel_reduce_then_scan_reduce_submitter
         using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
         using _KernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            __parallel_reduce_then_scan_reduce_kernel,
-            _CustomName,
-            std::integral_constant<decltype(__sub_group_size),      __sub_group_size>,
+            __parallel_reduce_then_scan_reduce_kernel, _CustomName,
+            std::integral_constant<decltype(__sub_group_size), __sub_group_size>,
             std::integral_constant<decltype(__max_inputs_per_item), __max_inputs_per_item>,
-            std::integral_constant<decltype(__is_inclusive),        __is_inclusive>,
-            std::integral_constant<decltype(__is_unique_pattern_v), __is_unique_pattern_v>,
-            _GenReduceInput,
-            _ReduceOp,
-            _InitType,
-            _InRng, _TmpStorageAcc>;
+            std::integral_constant<decltype(__is_inclusive), __is_inclusive>,
+            std::integral_constant<decltype(__is_unique_pattern_v), __is_unique_pattern_v>, _GenReduceInput, _ReduceOp,
+            _InitType, _InRng, _TmpStorageAcc>;
 
         using _InitValueType = typename _InitType::__value_type;
         return __exec.queue().submit([&, this](sycl::handler& __cgh) {
@@ -306,8 +302,8 @@ struct __parallel_reduce_then_scan_reduce_submitter
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
-            __cgh.parallel_for<_KernelName>(
-                    __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
+            __cgh.parallel_for<_KernelName>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(
+                                                            __sub_group_size)]] {
                 _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 std::size_t __group_id = __ndi.get_group(0);
                 __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
@@ -446,17 +442,12 @@ struct __parallel_reduce_then_scan_scan_submitter
         using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
         using _KernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            __parallel_reduce_then_scan_scan_kernel,
-            _CustomName,
-            std::integral_constant<decltype(__sub_group_size),      __sub_group_size>,
+            __parallel_reduce_then_scan_scan_kernel, _CustomName,
+            std::integral_constant<decltype(__sub_group_size), __sub_group_size>,
             std::integral_constant<decltype(__max_inputs_per_item), __max_inputs_per_item>,
-            std::integral_constant<decltype(__is_inclusive),        __is_inclusive>,
-            std::integral_constant<decltype(__is_unique_pattern_v), __is_unique_pattern_v>,
-            _ReduceOp,
-            _GenScanInput,
-            _ScanInputTransform,
-            _WriteOp, _InitType,
-            _InRng, _OutRng, _TmpStorageAcc>;
+            std::integral_constant<decltype(__is_inclusive), __is_inclusive>,
+            std::integral_constant<decltype(__is_unique_pattern_v), __is_unique_pattern_v>, _ReduceOp, _GenScanInput,
+            _ScanInputTransform, _WriteOp, _InitType, _InRng, _OutRng, _TmpStorageAcc>;
 
         std::uint32_t __inputs_in_block = std::min(__n - __block_num * __max_block_size, std::size_t{__max_block_size});
         std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
@@ -472,8 +463,8 @@ struct __parallel_reduce_then_scan_scan_submitter
             auto __res_acc =
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
-            __cgh.parallel_for<_KernelName>(
-                    __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
+            __cgh.parallel_for<_KernelName>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(
+                                                            __sub_group_size)]] {
                 _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 _InitValueType* __res_ptr =
                     _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __num_sub_groups_global + 2);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -771,8 +771,6 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
                                       _Inclusive, _IsUniquePattern)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-    using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_then_scan_reduce_kernel<_CustomName>>;
     using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
         __reduce_then_scan_scan_kernel<_CustomName>>;
     using _ValueType = typename _InitType::__value_type;
@@ -822,10 +820,11 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
                                                                                     __num_sub_groups_global + 2};
 
     // Reduce and scan step implementations
-    using _ReduceSubmitter =
-        __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inputs_per_item, __inclusive,
-                                                     __is_unique_pattern_v, _GenReduceInput, _ReduceOp, _InitType,
-                                                     _ReduceKernel>;
+    using _ReduceSubmitter = __parallel_reduce_then_scan_reduce_submitter<
+        __sub_group_size, __max_inputs_per_item, __inclusive, __is_unique_pattern_v, _GenReduceInput, _ReduceOp,
+        _InitType,
+        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+            __reduce_then_scan_reduce_kernel<_CustomName>>>;
     using _ScanSubmitter =
         __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs_per_item, __inclusive,
                                                    __is_unique_pattern_v, _ReduceOp, _GenScanInput, _ScanInputTransform,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -775,8 +775,6 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
                                       _ScanInputTransform __scan_input_transform, _WriteOp __write_op, _InitType __init,
                                       _Inclusive, _IsUniquePattern)
 {
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
     using _ValueType = typename _InitType::__value_type;
 
     constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_sg_sz();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -823,7 +823,15 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         __sub_group_size, __max_inputs_per_item, __inclusive, __is_unique_pattern_v, _GenReduceInput, _ReduceOp,
         _InitType,
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-            __reduce_then_scan_reduce_kernel<_CustomName>>>;
+            __reduce_then_scan_reduce_kernel<
+                std::integral_constant<decltype(__sub_group_size), __sub_group_size>,
+                std::integral_constant<decltype(__max_inputs_per_item), __max_inputs_per_item>,
+                _Inclusive,         // for __inclusive state
+                _IsUniquePattern,   // for __is_unique_pattern_v state
+                _GenReduceInput,
+                _ReduceOp,
+                _InitType,
+                _CustomName>>>;
     using _ScanSubmitter = __parallel_reduce_then_scan_scan_submitter<
         __sub_group_size, __max_inputs_per_item, __inclusive, __is_unique_pattern_v, _ReduceOp, _GenScanInput,
         _ScanInputTransform, _WriteOp, _InitType,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -771,8 +771,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
                                       _Inclusive, _IsUniquePattern)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-    using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_then_scan_scan_kernel<_CustomName>>;
+
     using _ValueType = typename _InitType::__value_type;
 
     constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_sg_sz();
@@ -825,10 +824,11 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         _InitType,
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __reduce_then_scan_reduce_kernel<_CustomName>>>;
-    using _ScanSubmitter =
-        __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs_per_item, __inclusive,
-                                                   __is_unique_pattern_v, _ReduceOp, _GenScanInput, _ScanInputTransform,
-                                                   _WriteOp, _InitType, _ScanKernel>;
+    using _ScanSubmitter = __parallel_reduce_then_scan_scan_submitter<
+        __sub_group_size, __max_inputs_per_item, __inclusive, __is_unique_pattern_v, _ReduceOp, _GenScanInput,
+        _ScanInputTransform, _WriteOp, _InitType,
+        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+            __reduce_then_scan_scan_kernel<_CustomName>>>;
     _ReduceSubmitter __reduce_submitter{__max_inputs_per_block,
                                         __num_sub_groups_local,
                                         __num_sub_groups_global,


### PR DESCRIPTION
In this PR we fixing the issue https://github.com/uxlfoundation/oneDPL/issues/2139

Previously we had next Kernel names generation for these structures:
```C++
    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
    using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
        __reduce_then_scan_reduce_kernel<_CustomName>>;
    using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
        __reduce_then_scan_scan_kernel<_CustomName>>;
```
It's not enough to describe all possible instantiations of `struct __parallel_reduce_then_scan_reduce_submitter`, `struct __parallel_reduce_then_scan_scan_submitter` and their `operator()` instantiations.