### PR TITLE
Remove `invoke_if()` function in tests

### DIFF
--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -155,7 +155,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        invoke_if(exec, [&]() { inplace_merge(exec, iter, iter, iter, non_const(::std::less<T>())); });
+        inplace_merge(exec, iter, iter, iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
@@ -209,7 +209,7 @@ struct test_non_const_remove_copy_if
             std::uint32_t i = (std::uint32_t)v;
             return i % 2 == 0;
         };
-        invoke_if(exec, [&]() { remove_copy_if(exec, input_iter, input_iter, out_iter, non_const(is_even)); });
+        remove_copy_if(exec, input_iter, input_iter, out_iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
@@ -70,7 +70,7 @@ struct test_non_const
             std::uint32_t i = (std::uint32_t)v;
             return i % 2 == 0;
         };
-        invoke_if(exec, [&]() { is_partitioned(exec, iter, iter, non_const(is_even)); });
+        is_partitioned(exec, iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -116,9 +116,8 @@ struct test_non_const_partition
             std::uint32_t i = (std::uint32_t)v;
             return i % 2 == 0;
         };
-        invoke_if(exec, [&]() {
-            partition(exec, iter, iter, non_const(is_even));
-        });
+
+        partition(exec, iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -120,9 +120,8 @@ struct test_non_const_stable_partition
             std::uint32_t i = (std::uint32_t)v;
             return i % 2 == 0;
         };
-        invoke_if(exec, [&]() {
-            stable_partition(exec, iter, iter, non_const(is_even));
-        });
+
+        stable_partition(exec, iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
@@ -105,7 +105,7 @@ struct test_non_const
             return i % 2 == 0;
         };
 
-        invoke_if(exec, [&]() { remove_if(exec, iter, iter, non_const(is_even)); });
+        remove_if(exec, iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -155,7 +155,8 @@ struct test_non_const
             std::uint32_t i = (std::uint32_t)v;
             return i % 2 == 0;
         };
-        invoke_if(exec, [&]() { replace_if(exec, iter, iter, non_const(is_even), T(0)); });
+
+        replace_if(exec, iter, iter, non_const(is_even), T(0));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
@@ -109,7 +109,7 @@ struct test_non_const
             return i % 2 == 0;
         };
 
-        invoke_if(exec, [&]() { replace_copy_if(exec, input_iter, input_iter, out_iter, non_const(is_even), T(0)); });
+        replace_copy_if(exec, input_iter, input_iter, out_iter, non_const(is_even), T(0));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -132,10 +132,8 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        invoke_if(exec, [&]() {
-            InputIterator input_iter2 = input_iter;
-            transform(exec, input_iter, input_iter, input_iter2, out_iter, non_const(::std::plus<T>()));
-        });
+        InputIterator input_iter2 = input_iter;
+        transform(exec, input_iter, input_iter, input_iter2, out_iter, non_const(::std::plus<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
@@ -108,7 +108,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        invoke_if(exec, [&]() { transform(exec, input_iter, input_iter, out_iter, non_const(::std::negate<T>())); });
+        transform(exec, input_iter, input_iter, out_iter, non_const(::std::negate<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
@@ -112,7 +112,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        invoke_if(exec, [&]() { unique(exec, iter, iter, non_const(::std::equal_to<T>())); });
+        unique(exec, iter, iter, non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
@@ -139,9 +139,7 @@ struct test_non_const_find_end
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        invoke_if(exec, [&]() {
-            find_end(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
-        });
+        find_end(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
     }
 };
 
@@ -152,9 +150,7 @@ struct test_non_const_search
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        invoke_if(exec, [&]() {
-            search(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
-        });
+        search(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
@@ -108,9 +108,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        invoke_if(exec, [&]() {
-            find_first_of(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
-        });
+        find_first_of(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
@@ -93,9 +93,7 @@ struct test_non_const_find_if
             return i % 2 == 0;
         };
 
-        invoke_if(exec, [&]() {
-            find_if(exec, iter, iter, non_const(is_even));
-        });
+        find_if(exec, iter, iter, non_const(is_even));
     }
 };
 
@@ -110,9 +108,7 @@ struct test_non_const_find_if_not
             return i % 2 == 0;
         };
 
-        invoke_if(exec, [&]() {
-            find_if_not(exec, iter, iter, non_const(is_even));
-        });
+        find_if_not(exec, iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
@@ -106,11 +106,9 @@ struct test_non_const_for_each
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        invoke_if(exec, [&]() {
-            auto f = [](typename ::std::iterator_traits<Iterator>::reference x) { x = x + 1; };
+        auto f = [](typename ::std::iterator_traits<Iterator>::reference x) { x = x + 1; };
 
-            for_each(exec, iter, iter, non_const(f));
-        });
+        for_each(exec, iter, iter, non_const(f));
     }
 };
 
@@ -120,11 +118,9 @@ struct test_non_const_for_each_n
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        invoke_if(exec, [&]() {
-            auto f = [](typename ::std::iterator_traits<Iterator>::reference x) { x = x + 1; };
+        auto f = [](typename ::std::iterator_traits<Iterator>::reference x) { x = x + 1; };
 
-            for_each_n(exec, iter, 0, non_const(f));
-        });
+        for_each_n(exec, iter, 0, non_const(f));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -178,7 +178,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        invoke_if(exec, [&]() { nth_element(exec, iter, iter, iter, non_const(::std::less<T>())); });
+        nth_element(exec, iter, iter, iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
@@ -92,7 +92,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        invoke_if(exec, [&]() { search_n(exec, iter, iter, 0, T(0), non_const(::std::equal_to<T>())); });
+        search_n(exec, iter, iter, 0, T(0), non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -193,9 +193,7 @@ struct test_non_const_is_heap
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        invoke_if(exec, [&]() {
-            is_heap(exec, iter, iter, non_const(::std::less<T>()));
-        });
+        is_heap(exec, iter, iter, non_const(::std::less<T>()));
     }
 };
 
@@ -206,9 +204,7 @@ struct test_non_const_is_heap_until
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        invoke_if(exec, [&]() {
-            is_heap_until(exec, iter, iter, non_const(::std::less<T>()));
-        });
+        is_heap_until(exec, iter, iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
@@ -162,9 +162,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        invoke_if(exec, [&]() {
-            lexicographical_compare(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::less<T>()));
-        });
+        lexicographical_compare(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
@@ -164,9 +164,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        invoke_if(exec, [&]() {
-            partial_sort_copy(exec, input_iter, input_iter, out_iter, out_iter, non_const(::std::less<T>()));
-        });
+        partial_sort_copy(exec, input_iter, input_iter, out_iter, out_iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -760,13 +760,6 @@ test_algo_basic_double(F&& f)
     invoke_on_all_host_policies()(::std::forward<F>(f), in.begin(), out.begin());
 }
 
-template <typename Policy, typename F>
-static void
-invoke_if(Policy&&, F f)
-{
-    f();
-}
-
 template <typename T, typename = bool>
 struct can_use_default_less_operator : ::std::false_type
 {


### PR DESCRIPTION
Remove `invoke_if()` function in tests: this function simple calls their argument and looks like not required:
```C++
template <typename Policy, typename F>
static void
invoke_if(Policy&&, F f)
{
    f();
}
```
In tests we simple replaces their calls with arguments to direct calls:
 - before:
```C++
        invoke_if(exec, [&]() {
            partition(exec, iter, iter, non_const(is_even));
        });
```
 - after:
```C++
        partition(exec, iter, iter, non_const(is_even));
```