### PR TITLE
Remove `ExecutionPolicy` template param from internal oneDPL buffers

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -64,7 +64,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     InputIterator2 last2 = first2 + n;
 
     // compute head flags
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _flags(policy, n);
+    oneapi::dpl::__par_backend::__buffer<FlagType> _flags(n);
     auto flags = _flags.get();
     flags[0] = 1;
 
@@ -72,7 +72,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
-    oneapi::dpl::__par_backend::__buffer<Policy, OutputType> _temp(policy, n);
+    oneapi::dpl::__par_backend::__buffer<OutputType> _temp(n);
     auto temp = _temp.get();
 
     temp[0] = init;
@@ -123,7 +123,7 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
     InputIterator2 last2 = first2 + n;
 
     // compute head flags
-    oneapi::dpl::__par_backend_hetero::__buffer<Policy, FlagType> _flags(policy, n);
+    oneapi::dpl::__par_backend_hetero::__buffer<FlagType> _flags(n);
     {
         auto flag_buf = _flags.get_buffer();
         auto flags = flag_buf.get_host_access(sycl::read_write);
@@ -134,7 +134,7 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
-    oneapi::dpl::__par_backend_hetero::__buffer<Policy, OutputType> _temp(policy, n);
+    oneapi::dpl::__par_backend_hetero::__buffer<OutputType> _temp(n);
     {
         auto temp_buf = _temp.get_buffer();
         auto temp = temp_buf.get_host_access(sycl::read_write);

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -62,7 +62,7 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     typedef unsigned int FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
 
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _mask(policy, n);
+    oneapi::dpl::__par_backend::__buffer<FlagType> _mask(n);
     auto mask = _mask.get();
 
     mask[0] = 1;
@@ -112,7 +112,7 @@ inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
 
     FlagType initial_mask = 1;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<Policy, FlagType> _mask(policy, n);
+    oneapi::dpl::__par_backend_hetero::__buffer<FlagType> _mask(n);
     {
         auto mask_buf = _mask.get_buffer();
         auto mask = mask_buf.get_host_access(sycl::read_write);

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -113,7 +113,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
 
     // buffer that is used to store a flag indicating if the associated key is not equal to
     // the next key, and thus its associated sum should be part of the final result
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _mask(policy, n + 1);
+    oneapi::dpl::__par_backend::__buffer<FlagType> _mask(n + 1);
     auto mask = _mask.get();
     mask[0] = 1;
 
@@ -129,11 +129,11 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     // buffer stores the sums of values associated with a given key. Sums are copied with
     // a shift into result2, and the shift is computed at the same time as the sums, so the
     // sums can't be written to result2 directly.
-    oneapi::dpl::__par_backend::__buffer<Policy, ValueType> _scanned_values(policy, n);
+    oneapi::dpl::__par_backend::__buffer<ValueType> _scanned_values(n);
 
     // Buffer is used to store results of the scan of the mask. Values indicate which position
     // in result2 needs to be written with the scanned_values element.
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _scanned_tail_flags(policy, n);
+    oneapi::dpl::__par_backend::__buffer<FlagType> _scanned_tail_flags(n);
 
     // Compute the sum of the segments. scanned_tail_flags values are not used.
     inclusive_scan(policy, make_zip_iterator(first2, _mask.get()), make_zip_iterator(first2, _mask.get()) + n,

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -148,12 +148,10 @@ struct __sycl_scan_by_segment_impl
 
         ::std::size_t __n_groups = __internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
 
-        auto __partials =
-            oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __val_type>(__exec, __n_groups).get_buffer();
+        auto __partials = oneapi::dpl::__par_backend_hetero::__buffer<__val_type>(__n_groups).get_buffer();
 
         // the number of segment ends found in each work group
-        auto __seg_ends =
-            oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, bool>(__exec, __n_groups).get_buffer();
+        auto __seg_ends = oneapi::dpl::__par_backend_hetero::__buffer<bool>(__n_groups).get_buffer();
 
         // 1. Work group reduction
         auto __wg_scan = __exec.queue().submit([&](sycl::handler& __cgh) {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1327,7 +1327,7 @@ __pattern_copy_if(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(1) < __n)
     {
-        __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        __par_backend::__buffer<bool> __mask_buf(__n);
         return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _DifferenceType __m{};
@@ -1446,7 +1446,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     _DifferenceType __n = __last - __first;
-    __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+    __par_backend::__buffer<bool> __mask_buf(__n);
     // 1. find a first iterator that should be removed
     return __internal::__except_handler([&]() {
         bool* __mask = __mask_buf.get();
@@ -1483,7 +1483,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         __n -= __min;
         __first += __min;
 
-        __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n);
+        __par_backend::__buffer<_Tp> __buf(__n);
         _Tp* __result = __buf.get();
         __mask += __min;
         _DifferenceType __m{};
@@ -1606,7 +1606,7 @@ __pattern_unique_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(2) < __n)
     {
-        __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        __par_backend::__buffer<bool> __mask_buf(__n);
         if (_DifferenceType(2) < __n)
         {
             return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
@@ -1859,7 +1859,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
     auto __m = __middle - __first;
     if (__m <= __n / 2)
     {
-        __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n - __m);
+        __par_backend::__buffer<_Tp> __buf(__n - __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
@@ -1885,7 +1885,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
     }
     else
     {
-        __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __m);
+        __par_backend::__buffer<_Tp> __buf(__m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
@@ -2365,7 +2365,7 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(1) < __n)
     {
-        __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        __par_backend::__buffer<bool> __mask_buf(__n);
         return __internal::__except_handler([&__exec, __n, __first, __out_true, __out_false, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _ReturnType __m{};
@@ -2552,7 +2552,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
         {
             typedef typename ::std::iterator_traits<_RandomAccessIterator1>::value_type _T1;
             typedef typename ::std::iterator_traits<_RandomAccessIterator2>::value_type _T2;
-            __par_backend::__buffer<_ExecutionPolicy, _T1> __buf(__exec, __n1);
+            __par_backend::__buffer<_T1> __buf(__n1);
             _T1* __r = __buf.get();
 
             __par_backend::__parallel_stable_sort(
@@ -3160,7 +3160,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     auto __n = __last - __first;
-    __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n);
+    __par_backend::__buffer<_Tp> __buf(__n);
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
@@ -3291,7 +3291,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     const _DifferenceType __n1 = __last1 - __first1;
     const _DifferenceType __n2 = __last2 - __first2;
 
-    __par_backend::__buffer<_ExecutionPolicy, _T> __buf(__exec, __size_func(__n1, __n2));
+    __par_backend::__buffer<_T> __buf(__size_func(__n1, __n2));
 
     return __internal::__except_handler([&__exec, __n1, __first1, __last1, __first2, __last2, __result, __comp,
                                          __size_func, __set_op, &__buf]() {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1046,7 +1046,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __last - __first);
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __buf(__last - __first);
     auto __copy_first = __buf.get();
 
     auto __copy_last = __pattern_copy_if(__tag, __exec, __first, __last, __copy_first, __not_pred<_Predicate>{__pred});
@@ -1071,7 +1071,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __last - __first);
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __buf(__last - __first);
     auto __copy_first = __buf.get();
     auto __copy_last = __pattern_unique_copy(__tag, __exec, __first, __last, __copy_first, __pred);
 
@@ -1252,7 +1252,7 @@ __pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __ex
     assert(__first < __middle && __middle < __last);
 
     auto __n = __last - __first;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __n);
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __buf(__n);
     auto __copy_first = __buf.get();
     auto __copy_last = __copy_first + __n;
 
@@ -1340,8 +1340,8 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
 
     auto __n = __last - __first;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __true_buf(__exec, __n);
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __false_buf(__exec, __n);
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __true_buf(__n);
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __false_buf(__n);
     auto __true_result = __true_buf.get();
     auto __false_result = __false_buf.get();
 
@@ -1548,7 +1548,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         // - create a temporary buffer and copy all the elements from the input buffer there
         // - run partial sort on the temporary buffer
         // - copy k elements from the temporary buffer to the output buffer.
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __in_size);
+        oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __buf(__in_size);
 
         auto __buf_first = __buf.get();
 
@@ -1672,7 +1672,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
-    auto __temp_buf = oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _Tp>(__exec, __n);
+    auto __temp_buf = oneapi::dpl::__par_backend_hetero::__buffer<_Tp>(__n);
 
     auto __temp_rng_w =
         oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::write>(__temp_buf.get_buffer());
@@ -1858,7 +1858,7 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     // temporary buffer to store intermediate result
     const auto __n2 = __last2 - __first2;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __diff(__exec, __n2);
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff(__n2);
     auto __buf = __diff.get();
 
     //1. Calc difference {2} \ {1}
@@ -1939,10 +1939,10 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
 
     // temporary buffers to store intermediate result
     const auto __n1 = __last1 - __first1;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __diff_1(__exec, __n1);
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff_1(__n1);
     auto __buf_1 = __diff_1.get();
     const auto __n2 = __last2 - __first2;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __diff_2(__exec, __n2);
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff_2(__n2);
     auto __buf_2 = __diff_2.get();
 
     //1. Calc difference {1} \ {2}

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -620,7 +620,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __buf(__rng.size());
     auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
 
     auto __copy_last_id = __ranges::__pattern_copy_if(__tag, __exec, __rng, __copy_rng, __not_pred<_Predicate>{__pred},
@@ -690,7 +690,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __buf(__rng.size());
     auto res_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
     oneapi::dpl::__internal::__difference_t<_Range> res = __ranges::__pattern_unique_copy(
         __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__unique_wrapper>(__exec), __rng, res_rng,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1203,7 +1203,7 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
     _MaskAssigner __add_mask_op;
 
     // temporary buffer to store boolean mask
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n);
+    oneapi::dpl::__par_backend_hetero::__buffer<int32_t> __mask_buf(__n);
 
     return __parallel_transform_scan_base(
         __backend_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -1395,7 +1395,7 @@ __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __
     using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMaskScan, _ScanRangeTransform>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, std::int32_t> __mask_buf(__exec, __rng1.size());
+    oneapi::dpl::__par_backend_hetero::__buffer<std::int32_t> __mask_buf(__rng1.size());
 
     return __parallel_transform_reduce_then_scan(
         __backend_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -1438,7 +1438,7 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
         __comp, __n1, __n2};
 
     // temporary buffer to store boolean mask
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);
+    oneapi::dpl::__par_backend_hetero::__buffer<int32_t> __mask_buf(__n1);
 
     return __par_backend_hetero::__parallel_transform_scan_base(
         __backend_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -2112,7 +2112,7 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
         _Size __n = __rng.size();
         assert(__n > 1);
 
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _Tp> __temp_buf(__exec, __n);
+        oneapi::dpl::__par_backend_hetero::__buffer<_Tp> __temp_buf(__n);
         auto __temp = __temp_buf.get_buffer();
         _PRINT_INFO_IN_DEBUG_MODE(__exec);
 
@@ -2286,11 +2286,11 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     // Round 1: reduce with extra indices added to avoid long segments
     // TODO: At threshold points check if the key is equal to the key at the previous threshold point, indicating a long sequence.
     // Skip a round of copy_if and reduces if there are none.
-    auto __idx = oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n).get_buffer();
+    auto __idx = oneapi::dpl::__par_backend_hetero::__buffer<__diff_type>(__n).get_buffer();
     auto __tmp_out_keys =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __key_type>(__exec, __n).get_buffer();
+        oneapi::dpl::__par_backend_hetero::__buffer<__key_type>(__n).get_buffer();
     auto __tmp_out_values =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __val_type>(__exec, __n).get_buffer();
+        oneapi::dpl::__par_backend_hetero::__buffer<__val_type>(__n).get_buffer();
 
     // Replicating first element of keys view to be able to compare (i-1)-th and (i)-th key with aligned sequences,
     //  dropping the last key for the i-1 sequence.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2287,10 +2287,8 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     // TODO: At threshold points check if the key is equal to the key at the previous threshold point, indicating a long sequence.
     // Skip a round of copy_if and reduces if there are none.
     auto __idx = oneapi::dpl::__par_backend_hetero::__buffer<__diff_type>(__n).get_buffer();
-    auto __tmp_out_keys =
-        oneapi::dpl::__par_backend_hetero::__buffer<__key_type>(__n).get_buffer();
-    auto __tmp_out_values =
-        oneapi::dpl::__par_backend_hetero::__buffer<__val_type>(__n).get_buffer();
+    auto __tmp_out_keys = oneapi::dpl::__par_backend_hetero::__buffer<__key_type>(__n).get_buffer();
+    auto __tmp_out_values = oneapi::dpl::__par_backend_hetero::__buffer<__val_type>(__n).get_buffer();
 
     // Replicating first element of keys view to be able to compare (i-1)-th and (i)-th key with aligned sequences,
     //  dropping the last key for the i-1 sequence.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -429,8 +429,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
 
         auto __private_histograms =
-            oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _bin_type>(__exec, __segments * __num_bins)
-                .get_buffer();
+            oneapi::dpl::__par_backend_hetero::__buffer<_bin_type>(__segments * __num_bins).get_buffer();
 
         return __exec.queue().submit([&](auto& __h) {
             __h.depends_on(__init_event);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -724,7 +724,7 @@ __merge_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _LeafSo
     sycl::event __event_leaf_sort = __merge_sort_leaf_submitter<_LeafSortKernel>()(__q, __rng, __leaf_sorter);
 
     // 2. Merge sorting
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _Tp> __temp(__exec, __rng.size());
+    oneapi::dpl::__par_backend_hetero::__buffer<_Tp> __temp(__rng.size());
     auto __temp_buf = __temp.get_buffer();
     auto [__event_sort, __data_in_temp, __temp_sp_storages] =
         __merge_sort_global_submitter<_IndexT, _DiagonalsKernelName, _GlobalSortKernel1, _GlobalSortKernel2>()(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -847,7 +847,7 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
         sycl::buffer<::std::uint32_t, 1> __tmp_buf{sycl::range<1>(__tmp_buf_size)};
 
         // memory for storing values sorted for an iteration
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueT> __out_buffer_holder{__exec, __n};
+        oneapi::dpl::__par_backend_hetero::__buffer<_ValueT> __out_buffer_holder{__n};
         auto __out_rng = oneapi::dpl::__ranges::all_view<_ValueT, __par_backend_hetero::access_mode::read_write>(
             __out_buffer_holder.get_buffer());
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -147,18 +147,15 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
 
     // intermediate reductions within a workgroup
-    auto __partials =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __val_type>(__exec, __n_groups).get_buffer();
+    auto __partials = oneapi::dpl::__par_backend_hetero::__buffer<__val_type>(__n_groups).get_buffer();
 
-    auto __end_idx = oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, 1).get_buffer();
+    auto __end_idx = oneapi::dpl::__par_backend_hetero::__buffer<__diff_type>(1).get_buffer();
 
     // the number of segment ends found in each work group
-    auto __seg_ends =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n_groups).get_buffer();
+    auto __seg_ends = oneapi::dpl::__par_backend_hetero::__buffer<__diff_type>(__n_groups).get_buffer();
 
     // buffer that stores an exclusive scan of the results
-    auto __seg_ends_scanned =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n_groups).get_buffer();
+    auto __seg_ends_scanned = oneapi::dpl::__par_backend_hetero::__buffer<__diff_type>(__n_groups).get_buffer();
 
     // 1. Count the segment ends in each workgroup
     auto __seg_end_identification = __exec.queue().submit([&](sycl::handler& __cgh) {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -392,9 +392,7 @@ class __buffer_impl
     __container_t __container;
 
   public:
-    __buffer_impl(std::size_t __n_elements) : __container{sycl::range<1>(__n_elements)}
-    {
-    }
+    __buffer_impl(std::size_t __n_elements) : __container{sycl::range<1>(__n_elements)} {}
 
     auto
     get() -> decltype(oneapi::dpl::begin(__container)) const

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -383,7 +383,7 @@ struct __local_buffer<sycl::buffer<::std::tuple<_T...>, __dim, _AllocT>>
 };
 
 // impl for sycl::buffer<...>
-template <typename _ExecutionPolicy, typename _T>
+template <typename _T>
 class __buffer_impl
 {
   private:
@@ -392,7 +392,7 @@ class __buffer_impl
     __container_t __container;
 
   public:
-    __buffer_impl(_ExecutionPolicy /*__exec*/, ::std::size_t __n_elements) : __container{sycl::range<1>(__n_elements)}
+    __buffer_impl(std::size_t __n_elements) : __container{sycl::range<1>(__n_elements)}
     {
     }
 
@@ -456,8 +456,8 @@ struct __memobj_traits<_T*>
 
 } // namespace __internal
 
-template <typename _ExecutionPolicy, typename _T>
-using __buffer = __internal::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _T>;
+template <typename _T>
+using __buffer = __internal::__buffer_impl<_T>;
 
 template <typename T>
 struct __repacked_tuple

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -159,10 +159,9 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
 
         auto __policy =
             __par_backend_hetero::make_wrapped_policy<ExecutionPolicyWrapper>(::std::forward<_ExecutionPolicy>(__exec));
-        using _NewExecutionPolicy = decltype(__policy);
 
         // Create temporary buffer
-        oneapi::dpl::__par_backend_hetero::__buffer<_NewExecutionPolicy, _Type> __tmp_buf(__policy, __n);
+        oneapi::dpl::__par_backend_hetero::__buffer<_Type> __tmp_buf(__n);
         auto __first_tmp = __tmp_buf.get();
         auto __last_tmp = __first_tmp + __n;
         auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -89,7 +89,7 @@ __parallel_strict_scan_body(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial
     const _Index __slack = 4;
     _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
     _Index __m = (__n - 1) / __tilesize;
-    __buffer<_ExecutionPolicy, _Tp> __buf(::std::forward<_ExecutionPolicy>(__exec), __m + 1);
+    __buffer<_Tp> __buf(__m + 1);
     _Tp* __r = __buf.get();
 
     oneapi::dpl::__omp_backend::__upsweep(_Index(0), _Index(__m + 1), __tilesize, __r, __n - __m * __tilesize, __reduce,

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -54,8 +54,8 @@ __cancel_execution(oneapi::dpl::__internal::__omp_backend_tag)
 // raw buffer
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
+template <typename _Tp>
+using __buffer = oneapi::dpl::__utils::__buffer_impl<_Tp, std::allocator>;
 
 // Preliminary size of each chunk: requires further discussion
 constexpr std::size_t __default_chunk_size = 2048;

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -76,8 +76,8 @@ __make_enumerable_tls(Args&&... __args)
     return __detail::__enumerable_thread_local_storage<_ValueType>(std::forward<Args>(__args)...);
 }
 
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
+template <typename _Tp>
+using __buffer = oneapi::dpl::__utils::__buffer_impl<_Tp, std::allocator>;
 
 inline void
 __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -366,7 +366,7 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
             const _Index __slack = 4;
             _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
             _Index __m = (__n - 1) / __tilesize;
-            __tbb_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __m + 1);
+            __tbb_backend::__buffer<_Tp> __buf(__m + 1);
             _Tp* __r = __buf.get();
             __tbb_backend::__upsweep(_Index(0), _Index(__m + 1), __tilesize, __r, __n - __m * __tilesize, __reduce,
                                      __combine);
@@ -1177,7 +1177,7 @@ __parallel_stable_sort(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
         const _DifferenceType __sort_cut_off = _ONEDPL_STABLE_SORT_CUT_OFF;
         if (__n > __sort_cut_off)
         {
-            __tbb_backend::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __n);
+            __tbb_backend::__buffer<_ValueType> __buf(__n);
             __root_task<__stable_sort_func<_RandomAccessIterator, _ValueType*, _Compare, _LeafSort>> __root{
                 __xs, __xe, __buf.get(), true, __comp, __leaf_sort, __nsort, __xs, __buf.get()};
             __task::spawn_root_and_wait(__root);

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -54,8 +54,8 @@ namespace __tbb_backend
 not an initialize array, because initialization/destruction
 would make the span be at least O(N). */
 // tbb::allocator can improve performance in some cases.
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, tbb::tbb_allocator>;
+template <typename _Tp>
+using __buffer = oneapi::dpl::__utils::__buffer_impl<_Tp, tbb::tbb_allocator>;
 
 // Wrapper for tbb::task
 inline void

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -51,10 +51,7 @@ class __buffer_impl
 
   public:
     //! Try to obtain buffer of given size to store objects of _Tp type
-    __buffer_impl(const std::size_t __n)
-        : _M_allocator(), _M_ptr(_M_allocator.allocate(__n)), _M_buf_size(__n)
-    {
-    }
+    __buffer_impl(const std::size_t __n) : _M_allocator(), _M_ptr(_M_allocator.allocate(__n)), _M_buf_size(__n) {}
     //! True if buffer was successfully obtained, zero otherwise.
     operator bool() const { return _M_ptr != nullptr; }
     //! Return pointer to buffer, or nullptr if buffer could not be obtained.

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -38,7 +38,7 @@ namespace __utils
 // raw buffer (with specified _TAllocator)
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Tp, template <typename _T> typename _TAllocator>
+template <typename _Tp, template <typename _T> typename _TAllocator>
 class __buffer_impl
 {
     _TAllocator<_Tp> _M_allocator;
@@ -51,7 +51,7 @@ class __buffer_impl
 
   public:
     //! Try to obtain buffer of given size to store objects of _Tp type
-    __buffer_impl(_ExecutionPolicy /*__exec*/, const ::std::size_t __n)
+    __buffer_impl(const std::size_t __n)
         : _M_allocator(), _M_ptr(_M_allocator.allocate(__n)), _M_buf_size(__n)
     {
     }


### PR DESCRIPTION
In this PR we remove `ExecutionPolicy` template param from internal oneDPL buffers as not required:
- from `__buffer` template aliases;
- from `class __buffer_impl` (both implementations);
- from `__buffer` instances in oneDPL code.