### PR TITLE
[oneDPL][simd] using _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED where it is applicable

### DIFF
--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -259,6 +259,7 @@ __simd_unique_copy(_InputIterator __first, _DifferenceType __n, _OutputIterator 
     _DifferenceType __cnt = 1;
     __result[0] = __first[0];
 
+    _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
     _ONEDPL_PRAGMA_SIMD
     for (_DifferenceType __i = 1; __i < __n; ++__i)
     {
@@ -289,6 +290,7 @@ __simd_copy_if(_InputIterator __first, _DifferenceType __n, _OutputIterator __re
 {
     _DifferenceType __cnt = 0;
 
+    _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
     _ONEDPL_PRAGMA_SIMD
     for (_DifferenceType __i = 0; __i < __n; ++__i)
     {
@@ -338,6 +340,7 @@ __simd_copy_by_mask(_InputIterator __first, _DifferenceType __n, _OutputIterator
                     _Assigner __assigner) noexcept
 {
     _DifferenceType __cnt = 0;
+    _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
     _ONEDPL_PRAGMA_SIMD
     for (_DifferenceType __i = 0; __i < __n; ++__i)
     {
@@ -358,6 +361,7 @@ __simd_partition_by_mask(_InputIterator __first, _DifferenceType __n, _OutputIte
                          _OutputIterator2 __out_false, bool* __mask) noexcept
 {
     _DifferenceType __cnt_true = 0, __cnt_false = 0;
+    _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
     _ONEDPL_PRAGMA_SIMD
     for (_DifferenceType __i = 0; __i < __n; ++__i)
     {
@@ -786,6 +790,7 @@ __simd_partition_copy(_InputIterator __first, _DifferenceType __n, _OutputIterat
 {
     _DifferenceType __cnt_true = 0, __cnt_false = 0;
 
+    _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
     _ONEDPL_PRAGMA_SIMD
     for (_DifferenceType __i = 0; __i < __n; ++__i)
     {
@@ -867,6 +872,7 @@ __simd_remove_if(_RandomAccessIterator __first, _DifferenceType __n, _UnaryPredi
     }
 
     _DifferenceType __cnt = 0;
+    _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
     _ONEDPL_PRAGMA_SIMD
     for (_DifferenceType __i = 1; __i < __n; ++__i)
     {


### PR DESCRIPTION
[oneDPL][simd] using _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED where it is applicable.

"Applicable" means the data is written into global memory and no/almost no computations.