### PR TITLE
[Prototype] Fix scan perf regression and improve set performance

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -783,7 +783,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_sg_sz();
     // Empirically determined maximum. May be less for non-full blocks.
     constexpr std::uint16_t __max_inputs_per_item =
-        std::max(std::uint16_t{1}, std::uint16_t{256 / __bytes_per_work_item_iter});
+        std::max(std::uint16_t{1}, std::uint16_t{512 / __bytes_per_work_item_iter});
     constexpr bool __inclusive = _Inclusive::value;
     constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 


### PR DESCRIPTION
I noticed 5-6% perf regressions affecting scalability of scan. For `__max_inputs_per_item`, we used to process 128 elements (for 4-byte case), but with new approach only 64 are processed.

Bumping the magic constant from 256 to 512 also improves set performance. I observed ~9% improvements for `set_intersection`. 