### PR TITLE
[RNG] Small refactoring of Philox engine implementation and updates in the testing 

### DIFF
--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -134,6 +134,7 @@ class philox_engine
             // all counters are set in reverse order
             state_.X[word_count - __i - 1] = __counter[__i] & in_mask;
         }
+        state_.idx = word_count - 1;
     }
 
     /* Generating functions */
@@ -460,18 +461,15 @@ operator<<(std::basic_ostream<__CharT, __Traits>& __os,
     __CharT __sp = __os.widen(' ');
     __os.fill(__sp);
 
-    for (auto x_elm : __engine.state_.X)
-    {
-        __os << x_elm << __sp;
-    }
     for (auto k_elm : __engine.state_.K)
     {
         __os << k_elm << __sp;
     }
-    for (auto y_elm : __engine.state_.Y)
+    for (auto x_elm : __engine.state_.X)
     {
-        __os << y_elm << __sp;
+        __os << x_elm << __sp;
     }
+
     __os << __engine.state_.idx;
 
     return __os;
@@ -482,18 +480,15 @@ template <typename __UIntType, std::size_t __w, std::size_t __n, std::size_t __r
 const sycl::stream&
 operator<<(const sycl::stream& __os, const philox_engine<__UIntType, __w, __n, __r, __consts...>& __engine)
 {
-    for (auto __x_elm : __engine.state_.X)
-    {
-        __os << __x_elm << ' ';
-    }
     for (auto __k_elm : __engine.state_.K)
     {
         __os << __k_elm << ' ';
     }
-    for (auto __y_elm : __engine.state_.Y)
+    for (auto __x_elm : __engine.state_.X)
     {
-        __os << __y_elm << ' ';
+        __os << __x_elm << ' ';
     }
+
     __os << __engine.state_.idx;
 
     return __os;
@@ -519,13 +514,15 @@ operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType
     if (!__is.fail())
     {
         int __inp_itr = 0;
+        for (std::size_t __i = 0; __i < __n / 2; ++__i, ++__inp_itr)
+        __engine.state_.K[__i] = __tmp_inp[__inp_itr];
         for (std::size_t __i = 0; __i < __n; ++__i, ++__inp_itr)
             __engine.state_.X[__i] = __tmp_inp[__inp_itr];
-        for (std::size_t __i = 0; __i < __n / 2; ++__i, ++__inp_itr)
-            __engine.state_.K[__i] = __tmp_inp[__inp_itr];
-        for (std::size_t __i = 0; __i < __n; ++__i, ++__inp_itr)
-            __engine.state_.Y[__i] = __tmp_inp[__inp_itr];
+
         __engine.state_.idx = __tmp_inp[__inp_itr];
+
+        /* setup Yi */
+        philox_kernel();
     }
 
     return __is;

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -503,10 +503,11 @@ operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType
 
     __is.setf(std::ios_base::dec);
 
-    const std::size_t __state_size = 2 * __n + __n / 2 + 1;
+    /* Size of X, K and idx */
+    const std::size_t __inp_state_size = __n + __n / 2 + 1;
 
-    std::array<oneapi::dpl::internal::element_type_t<__UIntType>, __state_size> __tmp_inp;
-    for (std::size_t __i = 0; __i < __state_size; ++__i)
+    std::array<oneapi::dpl::internal::element_type_t<__UIntType>, __inp_state_size> __tmp_inp;
+    for (std::size_t __i = 0; __i < __inp_state_size; ++__i)
     {
         __is >> __tmp_inp[__i];
     }
@@ -522,7 +523,7 @@ operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType
         __engine.state_.idx = __tmp_inp[__inp_itr];
 
         /* setup Yi */
-        philox_kernel();
+        __engine.philox_kernel();
     }
 
     return __is;

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -10,7 +10,7 @@
 // Abstract:
 //
 // Public header file provides implementation for Philox Engine
-// 
+//
 // The documentation of the Engine: https://en.cppreference.com/w/cpp/numeric/random/philox_engine
 //
 

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -137,6 +137,7 @@ class philox_engine
             // all counters are set in reverse order
             state_.X[word_count - __i - 1] = __counter[__i] & in_mask;
         }
+        state_.idx = word_count - 1;
     }
 
     /* Generating functions */

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -137,7 +137,6 @@ class philox_engine
             // all counters are set in reverse order
             state_.X[word_count - __i - 1] = __counter[__i] & in_mask;
         }
-        state_.idx = word_count - 1;
     }
 
     /* Generating functions */
@@ -464,15 +463,18 @@ operator<<(std::basic_ostream<__CharT, __Traits>& __os,
     __CharT __sp = __os.widen(' ');
     __os.fill(__sp);
 
-    for (auto k_elm : __engine.state_.K)
-    {
-        __os << k_elm << __sp;
-    }
     for (auto x_elm : __engine.state_.X)
     {
         __os << x_elm << __sp;
     }
-
+    for (auto k_elm : __engine.state_.K)
+    {
+        __os << k_elm << __sp;
+    }
+    for (auto y_elm : __engine.state_.Y)
+    {
+        __os << y_elm << __sp;
+    }
     __os << __engine.state_.idx;
 
     return __os;
@@ -483,15 +485,18 @@ template <typename __UIntType, std::size_t __w, std::size_t __n, std::size_t __r
 const sycl::stream&
 operator<<(const sycl::stream& __os, const philox_engine<__UIntType, __w, __n, __r, __consts...>& __engine)
 {
-    for (auto __k_elm : __engine.state_.K)
-    {
-        __os << __k_elm << ' ';
-    }
     for (auto __x_elm : __engine.state_.X)
     {
         __os << __x_elm << ' ';
     }
-
+    for (auto __k_elm : __engine.state_.K)
+    {
+        __os << __k_elm << ' ';
+    }
+    for (auto __y_elm : __engine.state_.Y)
+    {
+        __os << __y_elm << ' ';
+    }
     __os << __engine.state_.idx;
 
     return __os;
@@ -518,15 +523,13 @@ operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType
     if (!__is.fail())
     {
         int __inp_itr = 0;
-        for (std::size_t __i = 0; __i < __n / 2; ++__i, ++__inp_itr)
-        __engine.state_.K[__i] = __tmp_inp[__inp_itr];
         for (std::size_t __i = 0; __i < __n; ++__i, ++__inp_itr)
             __engine.state_.X[__i] = __tmp_inp[__inp_itr];
-
+        for (std::size_t __i = 0; __i < __n / 2; ++__i, ++__inp_itr)
+            __engine.state_.K[__i] = __tmp_inp[__inp_itr];
+        for (std::size_t __i = 0; __i < __n; ++__i, ++__inp_itr)
+            __engine.state_.Y[__i] = __tmp_inp[__inp_itr];
         __engine.state_.idx = __tmp_inp[__inp_itr];
-
-        /* setup Yi */
-        __engine.philox_kernel();
     }
 
     return __is;

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -511,11 +511,10 @@ operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType
 
     __is.setf(std::ios_base::dec);
 
-    /* Size of X, K and idx */
-    const std::size_t __inp_state_size = __n + __n / 2 + 1;
+    const std::size_t __state_size = 2 * __n + __n / 2 + 1;
 
-    std::array<oneapi::dpl::internal::element_type_t<__UIntType>, __inp_state_size> __tmp_inp;
-    for (std::size_t __i = 0; __i < __inp_state_size; ++__i)
+    std::array<oneapi::dpl::internal::element_type_t<__UIntType>, __state_size> __tmp_inp;
+    for (std::size_t __i = 0; __i < __state_size; ++__i)
     {
         __is >> __tmp_inp[__i];
     }

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -512,12 +512,8 @@ operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType
 
     __is.setf(std::ios_base::dec);
 
-    /* Number of elements in X, K and Y */
-    constexpr std::size_t __x_elm_num = __n;
-    constexpr std::size_t __k_elm_num = __n / 2;
-    constexpr std::size_t __y_elm_num = __n;
-
-    constexpr std::size_t __state_size = __x_elm_num + __k_elm_num + __y_elm_num + 1;
+    /* Number of elements in the state (X, K, Y and idx) */
+    constexpr std::size_t __state_size = 2 * __n + __n / 2 + 1;
 
     std::array<oneapi::dpl::internal::element_type_t<__UIntType>, __state_size> __tmp_inp;
     for (std::size_t __i = 0; __i < __state_size; ++__i)
@@ -528,11 +524,11 @@ operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType
     if (!__is.fail())
     {
         int __inp_itr = 0;
-        for (std::size_t __i = 0; __i < __x_elm_num; ++__i, ++__inp_itr)
+        for (std::size_t __i = 0; __i < __n; ++__i, ++__inp_itr)
             __engine.state_.X[__i] = __tmp_inp[__inp_itr];
-        for (std::size_t __i = 0; __i < __k_elm_num; ++__i, ++__inp_itr)
+        for (std::size_t __i = 0; __i < __n / 2; ++__i, ++__inp_itr)
             __engine.state_.K[__i] = __tmp_inp[__inp_itr];
-        for (std::size_t __i = 0; __i < __y_elm_num; ++__i, ++__inp_itr)
+        for (std::size_t __i = 0; __i < __n; ++__i, ++__inp_itr)
             __engine.state_.Y[__i] = __tmp_inp[__inp_itr];
         __engine.state_.idx = __tmp_inp[__inp_itr];
     }

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -10,6 +10,9 @@
 // Abstract:
 //
 // Public header file provides implementation for Philox Engine
+// 
+// The documentation of the Engine: https://en.cppreference.com/w/cpp/numeric/random/philox_engine
+//
 
 #ifndef _ONEDPL_PHILOX_ENGINE_H
 #define _ONEDPL_PHILOX_ENGINE_H

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -511,7 +511,12 @@ operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType
 
     __is.setf(std::ios_base::dec);
 
-    const std::size_t __state_size = 2 * __n + __n / 2 + 1;
+    /* Number of elements in X, K and Y */
+    constexpr std::size_t __x_elm_num = __n;
+    constexpr std::size_t __k_elm_num = __n / 2;
+    constexpr std::size_t __y_elm_num = __n;
+
+    constexpr std::size_t __state_size = __x_elm_num + __k_elm_num + __y_elm_num + 1;
 
     std::array<oneapi::dpl::internal::element_type_t<__UIntType>, __state_size> __tmp_inp;
     for (std::size_t __i = 0; __i < __state_size; ++__i)
@@ -522,11 +527,11 @@ operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType
     if (!__is.fail())
     {
         int __inp_itr = 0;
-        for (std::size_t __i = 0; __i < __n; ++__i, ++__inp_itr)
+        for (std::size_t __i = 0; __i < __x_elm_num; ++__i, ++__inp_itr)
             __engine.state_.X[__i] = __tmp_inp[__inp_itr];
-        for (std::size_t __i = 0; __i < __n / 2; ++__i, ++__inp_itr)
+        for (std::size_t __i = 0; __i < __k_elm_num; ++__i, ++__inp_itr)
             __engine.state_.K[__i] = __tmp_inp[__inp_itr];
-        for (std::size_t __i = 0; __i < __n; ++__i, ++__inp_itr)
+        for (std::size_t __i = 0; __i < __y_elm_num; ++__i, ++__inp_itr)
             __engine.state_.Y[__i] = __tmp_inp[__inp_itr];
         __engine.state_.idx = __tmp_inp[__inp_itr];
     }

--- a/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
@@ -20,6 +20,15 @@
 
 namespace ex = oneapi::dpl::experimental;
 
+using philox2x32 = ex::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x64 = ex::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+
+template <int _N>
+using philox2x32_vec = ex::philox_engine<sycl::vec<uint_fast32_t, _N>, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
+
+template <int _N>
+using philox2x64_vec = ex::philox_engine<sycl::vec<uint_fast64_t, _N>, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+                                     
 int
 main()
 {
@@ -28,9 +37,13 @@ main()
 
     sycl::queue queue = TestUtils::get_test_queue();
 
-    // Reference values
-    std::uint_fast32_t philox4_32_ref = 1955073260;
-    std::uint_fast64_t philox4_64_ref = 3409172418970261260;
+    // Reference values from p2075 paper series
+    std::uint_fast32_t philox4_32_ref = 1955073260U;
+    std::uint_fast64_t philox4_64_ref = 3409172418970261260U;
+    // Reference values, generated using reference implementation from https://github.com/DEShawResearch/random123
+    std::uint_fast32_t philox2_32_ref = 2942762615U;
+    std::uint_fast64_t philox2_64_ref = 14685864013162917916U;
+
     int err = 0;
 
     // Generate 10 000th element for philox4_32
@@ -58,6 +71,32 @@ main()
     err += test<ex::philox4x64_vec<16>, 10000, 16>(queue) != philox4_64_ref;
 #endif // TEST_LONG_RUN
     EXPECT_TRUE(!err, "Test FAILED");
+
+    // Generate 10 000th element for philox2_32
+    err += test<philox2x32, 10000, 1>(queue) != philox2_32_ref;
+    #if TEST_LONG_RUN
+        err += test<philox2x32_vec<1>, 10000, 1>(queue) != philox2_32_ref;
+        err += test<philox2x32_vec<2>, 10000, 2>(queue) != philox2_32_ref;
+        // In case of philox2x32_vec<3> engine generate 10002 values as 10000 % 3 != 0
+        err += test<philox2x32_vec<3>, 10002, 3>(queue) != philox2_32_ref;
+        err += test<philox2x32_vec<4>, 10000, 4>(queue) != philox2_32_ref;
+        err += test<philox2x32_vec<8>, 10000, 8>(queue) != philox2_32_ref;
+        err += test<philox2x32_vec<16>, 10000, 16>(queue) != philox2_32_ref;
+    #endif // TEST_LONG_RUN
+        EXPECT_TRUE(!err, "Test FAILED");
+    
+        // Generate 10 000th element for philox2_64
+        err += test<philox2x64, 10000, 1>(queue) != philox2_64_ref;
+    #if TEST_LONG_RUN
+        err += test<philox2x64_vec<1>, 10000, 1>(queue) != philox2_64_ref;
+        err += test<philox2x64_vec<2>, 10000, 2>(queue) != philox2_64_ref;
+        // In case of philox2x64_vec<3> engine generate 10002 values as 10000 % 3 != 0
+        err += test<philox2x64_vec<3>, 10002, 3>(queue) != philox2_64_ref;
+        err += test<philox2x64_vec<4>, 10000, 4>(queue) != philox2_64_ref;
+        err += test<philox2x64_vec<8>, 10000, 8>(queue) != philox2_64_ref;
+        err += test<philox2x64_vec<16>, 10000, 16>(queue) != philox2_64_ref;
+    #endif // TEST_LONG_RUN
+        EXPECT_TRUE(!err, "Test FAILED");
 
 #endif // TEST_UNNAMED_LAMBDAS
 

--- a/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
@@ -21,14 +21,15 @@
 namespace ex = oneapi::dpl::experimental;
 
 using philox2x32 = ex::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
-using philox2x64 = ex::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64 = ex::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
 
 template <int _N>
 using philox2x32_vec = ex::philox_engine<sycl::vec<uint_fast32_t, _N>, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
 
 template <int _N>
-using philox2x64_vec = ex::philox_engine<sycl::vec<uint_fast64_t, _N>, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
-                                     
+using philox2x64_vec =
+    ex::philox_engine<sycl::vec<uint_fast64_t, _N>, 64, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
+
 int
 main()
 {
@@ -74,29 +75,29 @@ main()
 
     // Generate 10 000th element for philox2_32
     err += test<philox2x32, 10000, 1>(queue) != philox2_32_ref;
-    #if TEST_LONG_RUN
-        err += test<philox2x32_vec<1>, 10000, 1>(queue) != philox2_32_ref;
-        err += test<philox2x32_vec<2>, 10000, 2>(queue) != philox2_32_ref;
-        // In case of philox2x32_vec<3> engine generate 10002 values as 10000 % 3 != 0
-        err += test<philox2x32_vec<3>, 10002, 3>(queue) != philox2_32_ref;
-        err += test<philox2x32_vec<4>, 10000, 4>(queue) != philox2_32_ref;
-        err += test<philox2x32_vec<8>, 10000, 8>(queue) != philox2_32_ref;
-        err += test<philox2x32_vec<16>, 10000, 16>(queue) != philox2_32_ref;
-    #endif // TEST_LONG_RUN
-        EXPECT_TRUE(!err, "Test FAILED");
-    
-        // Generate 10 000th element for philox2_64
-        err += test<philox2x64, 10000, 1>(queue) != philox2_64_ref;
-    #if TEST_LONG_RUN
-        err += test<philox2x64_vec<1>, 10000, 1>(queue) != philox2_64_ref;
-        err += test<philox2x64_vec<2>, 10000, 2>(queue) != philox2_64_ref;
-        // In case of philox2x64_vec<3> engine generate 10002 values as 10000 % 3 != 0
-        err += test<philox2x64_vec<3>, 10002, 3>(queue) != philox2_64_ref;
-        err += test<philox2x64_vec<4>, 10000, 4>(queue) != philox2_64_ref;
-        err += test<philox2x64_vec<8>, 10000, 8>(queue) != philox2_64_ref;
-        err += test<philox2x64_vec<16>, 10000, 16>(queue) != philox2_64_ref;
-    #endif // TEST_LONG_RUN
-        EXPECT_TRUE(!err, "Test FAILED");
+#if TEST_LONG_RUN
+    err += test<philox2x32_vec<1>, 10000, 1>(queue) != philox2_32_ref;
+    err += test<philox2x32_vec<2>, 10000, 2>(queue) != philox2_32_ref;
+    // In case of philox2x32_vec<3> engine generate 10002 values as 10000 % 3 != 0
+    err += test<philox2x32_vec<3>, 10002, 3>(queue) != philox2_32_ref;
+    err += test<philox2x32_vec<4>, 10000, 4>(queue) != philox2_32_ref;
+    err += test<philox2x32_vec<8>, 10000, 8>(queue) != philox2_32_ref;
+    err += test<philox2x32_vec<16>, 10000, 16>(queue) != philox2_32_ref;
+#endif // TEST_LONG_RUN
+    EXPECT_TRUE(!err, "Test FAILED");
+
+    // Generate 10 000th element for philox2_64
+    err += test<philox2x64, 10000, 1>(queue) != philox2_64_ref;
+#if TEST_LONG_RUN
+    err += test<philox2x64_vec<1>, 10000, 1>(queue) != philox2_64_ref;
+    err += test<philox2x64_vec<2>, 10000, 2>(queue) != philox2_64_ref;
+    // In case of philox2x64_vec<3> engine generate 10002 values as 10000 % 3 != 0
+    err += test<philox2x64_vec<3>, 10002, 3>(queue) != philox2_64_ref;
+    err += test<philox2x64_vec<4>, 10000, 4>(queue) != philox2_64_ref;
+    err += test<philox2x64_vec<8>, 10000, 8>(queue) != philox2_64_ref;
+    err += test<philox2x64_vec<16>, 10000, 16>(queue) != philox2_64_ref;
+#endif // TEST_LONG_RUN
+    EXPECT_TRUE(!err, "Test FAILED");
 
 #endif // TEST_UNNAMED_LAMBDAS
 

--- a/test/xpu_api/random/statistics_tests/philox_uniform_real_distr_dp_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/philox_uniform_real_distr_dp_test.pass.cpp
@@ -19,8 +19,8 @@
 
 /* ------   Tested the statistics of different engines   ------ */
 // n = 2
-using philox2x32 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xd256d193, 0x0>;
-using philox2x64 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+using philox2x32 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x64 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
 
 template<typename RealType>
 using Distr = oneapi::dpl::uniform_real_distribution<RealType>;

--- a/test/xpu_api/random/statistics_tests/philox_uniform_real_distr_dp_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/philox_uniform_real_distr_dp_test.pass.cpp
@@ -20,7 +20,8 @@
 /* ------   Tested the statistics of different engines   ------ */
 // n = 2
 using philox2x32 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
-using philox2x64 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64 =
+    oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
 
 template<typename RealType>
 using Distr = oneapi::dpl::uniform_real_distribution<RealType>;

--- a/test/xpu_api/random/statistics_tests/philox_uniform_real_distr_sp_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/philox_uniform_real_distr_sp_test.pass.cpp
@@ -19,20 +19,20 @@
 
 /* ------   Tested the statistics of different engines   ------ */
 // n = 2
-using philox2x32 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xd256d193, 0x0>;
-using philox2x64 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+using philox2x32 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x64 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
 
 // bitsize(result_type) != word_size, test only scalar output
-using philox2x32_w5 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 5, 2, 10, 0xd256d193, 0x0>;
-using philox2x32_w15 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 15, 2, 10, 0xd256d193, 0x0>;
-using philox2x32_w18 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 18, 2, 10, 0xd256d193, 0x0>;
-using philox2x32_w30 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 30, 2, 10, 0xd256d193, 0x0>;
+using philox2x32_w5 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 5, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x32_w15 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 15, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x32_w18 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 18, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x32_w30 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 30, 2, 10, 0xD2511F53, 0x9E3779B9>;
 
-using philox2x64_w5 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 5, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
-using philox2x64_w15 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 15, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
-using philox2x64_w18 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 18, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
-using philox2x64_w25 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 25, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
-using philox2x64_w49 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 49, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+using philox2x64_w5 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 5, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64_w15 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 15, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64_w18 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 18, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64_w25 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 25, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64_w49 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 49, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
 
 using philox4x32_w5 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 5, 4, 10, 0xCD9E8D57, 0x9E3779B9, 0xD2511F53, 0xBB67AE85>;
 using philox4x32_w15 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 15, 4, 10, 0xCD9E8D57, 0x9E3779B9, 0xD2511F53, 0xBB67AE85>;

--- a/test/xpu_api/random/statistics_tests/philox_uniform_real_distr_sp_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/philox_uniform_real_distr_sp_test.pass.cpp
@@ -20,7 +20,8 @@
 /* ------   Tested the statistics of different engines   ------ */
 // n = 2
 using philox2x32 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
-using philox2x64 = oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64 =
+    oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
 
 // bitsize(result_type) != word_size, test only scalar output
 using philox2x32_w5 = oneapi::dpl::experimental::philox_engine<std::uint_fast32_t, 5, 2, 10, 0xD2511F53, 0x9E3779B9>;

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -44,17 +44,17 @@ int
 counter_management_test();
 
 // Philox with word_count = 2
-using philox2x32 = ex::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD256D193, 0x0>;
-using philox2x64 = ex::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
-using philox2x32_w5 = ex::philox_engine<std::uint_fast32_t, 5, 2, 10, 0xD256D193, 0x0>;
-using philox2x32_w15 = ex::philox_engine<std::uint_fast32_t, 15, 2, 10, 0xD256D193, 0x0>;
-using philox2x32_w18 = ex::philox_engine<std::uint_fast32_t, 18, 2, 10, 0xD256D193, 0x0>;
-using philox2x32_w30 = ex::philox_engine<std::uint_fast32_t, 30, 2, 10, 0xD256D193, 0x0>;
-using philox2x64_w5 = ex::philox_engine<std::uint_fast64_t, 5, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
-using philox2x64_w15 = ex::philox_engine<std::uint_fast64_t, 15, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
-using philox2x64_w18 = ex::philox_engine<std::uint_fast64_t, 18, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
-using philox2x64_w25 = ex::philox_engine<std::uint_fast64_t, 25, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
-using philox2x64_w49 = ex::philox_engine<std::uint_fast64_t, 49, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+using philox2x32 = ex::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x64 = ex::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x32_w5 = ex::philox_engine<std::uint_fast32_t, 5, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x32_w15 = ex::philox_engine<std::uint_fast32_t, 15, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x32_w18 = ex::philox_engine<std::uint_fast32_t, 18, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x32_w30 = ex::philox_engine<std::uint_fast32_t, 30, 2, 10, 0xD2511F53, 0x9E3779B9>;
+using philox2x64_w5 = ex::philox_engine<std::uint_fast64_t, 5, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64_w15 = ex::philox_engine<std::uint_fast64_t, 15, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64_w18 = ex::philox_engine<std::uint_fast64_t, 18, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64_w25 = ex::philox_engine<std::uint_fast64_t, 25, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64_w49 = ex::philox_engine<std::uint_fast64_t, 49, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
 
 // Philox with word_count = 4
 using philox4x32_w5 = ex::philox_engine<std::uint_fast32_t, 5, 4, 10, 0xCD9E8D57, 0x9E3779B9, 0xD2511F53, 0xBB67AE85>;

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -45,16 +45,16 @@ counter_management_test();
 
 // Philox with word_count = 2
 using philox2x32 = ex::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD2511F53, 0x9E3779B9>;
-using philox2x64 = ex::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64 = ex::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
 using philox2x32_w5 = ex::philox_engine<std::uint_fast32_t, 5, 2, 10, 0xD2511F53, 0x9E3779B9>;
 using philox2x32_w15 = ex::philox_engine<std::uint_fast32_t, 15, 2, 10, 0xD2511F53, 0x9E3779B9>;
 using philox2x32_w18 = ex::philox_engine<std::uint_fast32_t, 18, 2, 10, 0xD2511F53, 0x9E3779B9>;
 using philox2x32_w30 = ex::philox_engine<std::uint_fast32_t, 30, 2, 10, 0xD2511F53, 0x9E3779B9>;
-using philox2x64_w5 = ex::philox_engine<std::uint_fast64_t, 5, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
-using philox2x64_w15 = ex::philox_engine<std::uint_fast64_t, 15, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
-using philox2x64_w18 = ex::philox_engine<std::uint_fast64_t, 18, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
-using philox2x64_w25 = ex::philox_engine<std::uint_fast64_t, 25, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
-using philox2x64_w49 = ex::philox_engine<std::uint_fast64_t, 49, 2, 10, 0xD2B74407B1CE6E93,0x9E3779B97F4A7C15>;
+using philox2x64_w5 = ex::philox_engine<std::uint_fast64_t, 5, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
+using philox2x64_w15 = ex::philox_engine<std::uint_fast64_t, 15, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
+using philox2x64_w18 = ex::philox_engine<std::uint_fast64_t, 18, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
+using philox2x64_w25 = ex::philox_engine<std::uint_fast64_t, 25, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
+using philox2x64_w49 = ex::philox_engine<std::uint_fast64_t, 49, 2, 10, 0xD2B74407B1CE6E93, 0x9E3779B97F4A7C15>;
 
 // Philox with word_count = 4
 using philox4x32_w5 = ex::philox_engine<std::uint_fast32_t, 5, 4, 10, 0xCD9E8D57, 0x9E3779B9, 0xD2511F53, 0xBB67AE85>;


### PR DESCRIPTION
**The scope of the changes:**
1. [Philox] Corrected `set_counter` API with setting `idx` to `n-1` according to the C++ proposal's wording:
![{70E40BC6-4D83-4B8C-9737-5B9DA35BBF99}](https://github.com/user-attachments/assets/ea1e762d-9fa8-4985-a915-5e856a75d507)
2. [Testing] Generated reference numbers of the 10000th element for Philox with `word_count = 2`  and extended `philox_test.pass`.
3. [Testing] Changed the `philox2x32` and `philox2x64` aliases in the tests.

