### PR TITLE
Adjust biased binary search

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -943,7 +943,7 @@ __find_balanced_path_start_point(const _Rng1& __rng1, const _Rng2& __rng2, const
     _Index __fwd_search_count = std::max(__total_repeats / 2, __rng2_repeats_bck);
     _Index __fwd_search_bound = std::min(__merge_path_rng2 + __fwd_search_count + 1, __rng2.size());
 
-    _Index __rng2_repeat_end = oneapi::dpl::__internal::__biased_upper_bound</*__last_bias=*/false>(
+    _Index __rng2_repeat_end = oneapi::dpl::__internal::__pstl_upper_bound(
         __rng2, __merge_path_rng2, __fwd_search_bound, __ele_val, __comp);
 
     _Index __rng2_eligible_repeats = __rng2_repeat_end - __rng2_repeat_start;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -602,16 +602,17 @@ _Size1
 __biased_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
     auto __n = __last - __first;
-    _Size1 __div = 32;
+    _Size1 __shift_right_div = 10; // divide by 2^10 = 1024
     _Size1 __it = 0;
     _Size1 __cur_idx = 0;
 
-    while (__n > 0 && __div > 2)
+    while (__n > 0 && __shift_right_div > 1)
     {
+        _Size1 __biased_step = (__n >> __shift_right_div);
         if constexpr (__bias_last)
-            __cur_idx = __n - __n / __div - 1;
+            __cur_idx = __n - __biased_step - 1;
         else
-            __cur_idx = __n / __div;
+            __cur_idx = __biased_step;
         __it = __first + __cur_idx;
 
         if (__comp(__acc[__it], __value))
@@ -625,7 +626,7 @@ __biased_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __
             __n = __last - __first;
         }
         // get closer and closer to binary search with more iterations
-        __div >>= 1;
+        __shift_right_div -= 3;
     }
     if (__n > 0)
     {


### PR DESCRIPTION
Adjust biased binary search by removing division, adjusting magic numbers.
Removing biased search forward, as it is likely to be small in size.