### PR TITLE
Enable vectorization of reverse iterators in SYCL backend parallel-for

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -128,7 +128,6 @@ struct walk_vector_or_scalar_base
 
   public:
     constexpr static bool __can_vectorize =
-        (oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Ranges>>::value && ...) &&
         (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
     constexpr static std::uint8_t __preferred_vector_size =
@@ -1428,7 +1427,6 @@ struct __brick_shift_left
     // Multiple iterations per item are manually processed in the brick with a nd-range strided approach.
     constexpr static std::uint8_t __preferred_iters_per_item = 1;
     constexpr static bool __can_vectorize =
-        oneapi::dpl::__ranges::__is_vectorizable_range<std::decay_t<_Range>>::value &&
         std::is_fundamental_v<_ValueType> && sizeof(_ValueType) < 4;
     constexpr static std::uint8_t __preferred_vector_size =
         __can_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, sizeof(_ValueType)) : 1;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -18,12 +18,8 @@
 
 #include <iterator>
 #include <type_traits>
-#if _ONEDPL_CPP20_RANGES_PRESENT && _ONEDPL_CPP20_CONCEPTS_PRESENT
-#include <ranges> // std::ranges::contiguous_range
-#endif
 
 #include "../../utils_ranges.h"
-#include "../../ranges/nanorange.hpp" // contiguous_range from nanorange
 #include "../../iterator_impl.h"
 #include "sycl_iterator.h"
 #include "sycl_defs.h"
@@ -757,55 +753,6 @@ __select_backend(const execution::fpga_policy<_Factor, _KernelName>&, _Ranges&&.
     return {};
 }
 #endif
-
-// TODO: At some point with C++20, we should implement this with concepts to more easily support the less common edge
-// cases (e.g. a pipe over a counting iterator which is non-contiguous). For now, vectorization is primarily based on
-// range contiguity with specialization for internal views and guard views over internal iterators.
-// The following cases enable vectorization for a range:
-// 1. With C++20 concepts, the range satisfies std::ranges::contiguous_range.
-// 2. With C++17 nanoranges, the range satisfies __nanorange::nano::ranges::contiguous_range. Note that a view over
-// a SYCL buffer satisfies this concept along with pipe views that maintain access contiguity.
-// 3. The range is a guard view over an iterator with no global memory access: counting_iterator and discard_iterator
-// 4. The range is one of our internal, vectorizable range types: drop_view_simple, take_view_simple, or
-// transform_view_simple
-
-// Base case: check contiguous range properties
-template <typename _Rng>
-struct __is_vectorizable_range
-{
-    constexpr static bool value =
-#if _ONEDPL_CPP20_RANGES_PRESENT && _ONEDPL_CPP20_CONCEPTS_PRESENT
-        std::ranges::contiguous_range<_Rng> ||
-#endif
-        __nanorange::nano::ranges::contiguous_range<_Rng>;
-};
-
-// Basic guard view specializations - views which are not contiguous but do not interact with global memory
-template <typename _Ip>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<oneapi::dpl::counting_iterator<_Ip>>> : std::true_type
-{
-};
-
-template <>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::guard_view<oneapi::dpl::discard_iterator>> : std::true_type
-{
-};
-
-// Recursive view specializations - internal views which we need to search inwards to identify if it is vectorizable
-template <typename _Rng, typename _F>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::transform_view_simple<_Rng, _F>> : __is_vectorizable_range<_Rng>
-{
-};
-
-template <typename _Rng, typename _Size>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::drop_view_simple<_Rng, _Size>> : __is_vectorizable_range<_Rng>
-{
-};
-
-template <typename _Rng, typename _F>
-struct __is_vectorizable_range<oneapi::dpl::__ranges::take_view_simple<_Rng, _F>> : __is_vectorizable_range<_Rng>
-{
-};
 
 } // namespace __ranges
 } // namespace dpl


### PR DESCRIPTION
The vectorization utilities in https://github.com/uxlfoundation/oneDPL/pull/1976 enforced a requirement that the underlying range / iterator type must be contiguous in order to enable vectorization paths along with other requirements we enforce. While this was not needed for correctness reasons, it was intended to enable good performance for the `reverse_iterator` case. Hardware vector instructions support vector load / stores only on increasing addresses, so in the case where addresses decrease with iterator increments, this is not directly vectorizable.

After further experimentation and study of generated assembly, I see that the oneAPI compiler is able to optimize the loads / stores in the case of `oneapi::dpl::reverse_iterator` to enable the generation of vector instructions / wider loads & stores in parallel-for based algorithms. All experiments I performed on the types we vectorize (single byte and two byte) resulted in better performance when enabling vectorization paths.

Due to this, we can remove the `__is_vectorizable_range` utility in its entirety and always take the vectorization path in fundamental 1 and 2 byte types. This will allow us to vectorize in the contiguous and reverse contiguous case. For types where the access pattern is already poor (e.g. permutation iterator with scattered accesses), the change in access pattern is not a concern here.