### PR TITLE
Remove erroneously const scratch space

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -191,7 +191,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
     operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, const _Size __n,
                const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _TransformOp __transform_op,
-               const __result_and_scratch_storage<_ExecutionPolicy, _Tp>& __scratch_container,
+               __result_and_scratch_storage<_ExecutionPolicy, _Tp>& __scratch_container,
                _Ranges&&... __rngs) const
     {
         auto __transform_pattern =


### PR DESCRIPTION
We pass scratch space as a const lvalue ref, but it's contents are actually modified.
We only call `const` functions `__get_scratch_acc`, but it is incorrect to label this `const`.

Introduced in #1773.