### PR TITLE
Avoid dummy scratch storage with one result

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -227,13 +227,16 @@ struct __parallel_merge_submitter<_OutSizeLimit, _IdType, __internal::__optional
         using __result_and_scratch_storage_t = __result_and_scratch_storage<__val_t, _NResults::value>;
         __result_and_scratch_storage_t* __p_res_storage = nullptr;
 
+        std::shared_ptr<__result_and_scratch_storage_base> __p_result_and_scratch_storage_base;
         if constexpr (_OutSizeLimit{})
+        {
             __p_res_storage = new __result_and_scratch_storage_t(__exec.queue(), 0);
+            __p_result_and_scratch_storage_base = __p_res_storage->__clone_to_result_and_scratch_storage_base_ptr();
+        }
         else
+        {
             assert(__rng3.size() >= __n1 + __n2);
-
-        std::shared_ptr<__result_and_scratch_storage_base> __p_result_and_scratch_storage_base(
-            static_cast<__result_and_scratch_storage_base*>(__p_res_storage));
+        }
 
         auto __event = __exec.queue().submit([&__rng1, &__rng2, &__rng3, __p_res_storage, __comp, __chunk, __steps, __n,
                                               __n1, __n2](sycl::handler& __cgh) {
@@ -448,7 +451,7 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
 
         // Save the raw pointer into a shared_ptr to return it in __future and extend the lifetime of the storage.
         std::shared_ptr<__result_and_scratch_storage_base> __p_result_and_scratch_storage_base(
-            static_cast<__result_and_scratch_storage_base*>(__p_base_diagonals_sp_global_storage));
+            __p_base_diagonals_sp_global_storage->__clone_to_result_and_scratch_storage_base_ptr());
 
         // Find split-points on the base diagonals
         sycl::event __event = eval_split_points_for_groups(__exec, __rng1, __rng2, __n, __comp, __nd_range_params,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -621,8 +621,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
                         new __base_diagonals_sp_storage_t(__exec.queue(), __max_base_diags_count);
 
                     // Save the raw pointer into a shared_ptr to return it in __future and extend the lifetime of the storage.
-                    __p_result_and_scratch_storage_base.reset(
-                        static_cast<__result_and_scratch_storage_base*>(__p_base_diagonals_sp_global_storage));
+                    __p_result_and_scratch_storage_base = __p_base_diagonals_sp_global_storage->__clone_to_result_and_scratch_storage_base_ptr();
                 }
 
                 nd_range_params __nd_range_params_this =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -836,6 +836,20 @@ class __future : private std::tuple<_Args...>
         auto new_tuple = std::tuple_cat(new_val, (std::tuple<_Args...>)*this);
         return __future<_Event, _T, _Args...>(__my_event, new_tuple);
     }
+
+    template <typename _T, std::size_t _NResults>
+    static __future<_Event, std::shared_ptr<__result_and_scratch_storage_base>>
+    __convert_to_future_with_scratch_storage_base_ptr(
+        const __future<_Event, __result_and_scratch_storage<_T, _NResults>>& __f_obj)
+    {
+        using _storage_t = __result_and_scratch_storage<_T, _NResults>;
+        using _tuple_t = std::tuple<_storage_t>;
+
+        const _tuple_t& __tuple = static_cast<const _tuple_t&>(__f_obj);
+        const _storage_t& __storage = std::get<0>(__tuple);
+
+        return {__f_obj.event(), __storage.__clone_to_result_and_scratch_storage_base_ptr()};
+    }
 };
 
 // Invoke a callable and pass a compile-time integer based on a provided run-time integer.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -676,6 +676,18 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
         }
     }
 
+    std::shared_ptr<__result_and_scratch_storage_base>
+    __clone_to_result_and_scratch_storage_base_ptr() const
+    {
+        using _obj_t = std::decay_t<decltype(*this)>;
+        _obj_t* __p_obj = new _obj_t(*this);
+
+        std::shared_ptr<__result_and_scratch_storage_base> __result;
+        __result.reset(static_cast<__result_and_scratch_storage_base*>(__p_obj));
+
+        return __result;
+    }
+
   private:
     bool
     is_USM() const


### PR DESCRIPTION
The goal of this PR - to avoid dummy `__result_and_scratch_storage` instance with one uninitialized result in the `__parallel_transform_scan + oneapi::dpl::__internal::__device_backend_tag`

For merge into https://github.com/uxlfoundation/oneDPL/pull/2167