### PR TITLE
Fix an error in  __one_group_submitter

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -152,7 +152,7 @@ struct __subgroup_radix_sort
     struct __one_group_submitter;
 
     template <typename... _Name>
-    struct __one_group_submitter<__internal::__optional_kernel_name<_Name...>>
+    struct __one_group_submitter<oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
     {
         template <typename _RangeIn, typename _Proj, typename _SLM_tag_val, typename _SLM_counter>
         sycl::event


### PR DESCRIPTION
.... for me the approach from https://github.com/uxlfoundation/oneDPL/pull/709 looks like a little bit strange:
```C++
//The file is an internal file and the code of that file is included by a major file into the following namespaces:
//namespace oneapi
//{
//namespace dpl
//{
//namespace __par_backend_hetero
//{
```

So in someone case I received warning and in this PR I am trying to fix it.

In ideal case probably the approach from https://github.com/uxlfoundation/oneDPL/pull/709 should be reimplemented in we should place this code into normal `oneapi::dpl::__par_backend_hetero` namespace.