### PR TITLE
Resolve C++20 extension warning in histogram_impl_hetero.h

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -101,7 +101,7 @@ __parallel_for(oneapi::dpl::__internal::__fpga_backend_tag, _ExecutionPolicy&& _
 
 // TODO: check if it makes sense to move these wrappers out of backend to a common place
 template <typename _CustomName, typename _Event, typename _Range1, typename _Range2, typename _BinHashMgr>
-auto
+__future<sycl::event>
 __parallel_histogram(oneapi::dpl::__internal::__fpga_backend_tag, sycl::queue& __q, const _Event& __init_event,
                      _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -537,10 +537,10 @@ __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag
     }
 }
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _BinHashMgr>
+template <typename _CustomName, typename _Event, typename _Range1, typename _Range2, typename _BinHashMgr>
 __future<sycl::event>
 __parallel_histogram(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
-                     const sycl::event& __init_event, _Range1&& __input, _Range2&& __bins,
+                     const _Event& __init_event, _Range1&& __input, _Range2&& __bins,
                      const _BinHashMgr& __binhash_manager)
 {
     if (__input.size() < 1048576) // 2^20

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -161,8 +161,8 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
                                                         _RandomAccessIterator1>();
             auto __input_buf = __keep_input(__first, __last);
 
-            __parallel_histogram<_CustomName>(_BackendTag{}, __q_local, __init_event, __input_buf.all_view(),
-                                              std::move(__bins), __binhash_manager)
+            oneapi::dpl::__par_backend_hetero::__parallel_histogram<_CustomName>(
+                _BackendTag{}, __q_local, __init_event, __input_buf.all_view(), std::move(__bins), __binhash_manager)
                 .__deferrable_wait();
         }
         else


### PR DESCRIPTION
The addition of an explicitly provided template parameter in https://github.com/uxlfoundation/oneDPL/pull/2161 when calling `__parallel_histogram` causes a warning in C++17 as this is a C++20 feature when there is no prior declaration. We are trying to call `__parallel_histogram` which is in `oneapi::dpl::__par_backend_hetero` from `oneapi::dpl::__internal`, so adding the full namespace to the call resolves the warning.

Here is the original warning:
```
 warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
  164 |             __parallel_histogram<_CustomName>(_BackendTag{}, __q_local, __init_event, __input_buf.all_view(),
```

I also cherry picked a small commit @SergeyKopienko recommended from his branch.