### PR TITLE
Revert: Removal ExecutionPolicy from submitters and etc. stuff #2161

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -25,7 +25,7 @@ namespace oneapi::dpl::experimental::kt::gpu::esimd
 // TODO: make sure to provide sufficient diagnostic if input does not allow either reading or writing
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _KeysRng>
 std::enable_if_t<!oneapi::dpl::__internal::__is_iterator_type_v<_KeysRng>, sycl::event>
-radix_sort(sycl::queue& __q, _KeysRng&& __keys_rng, _KernelParam __param = {})
+radix_sort(sycl::queue __q, _KeysRng&& __keys_rng, _KernelParam __param = {})
 {
     __impl::__check_esimd_sort_params<__radix_bits, _KernelParam::data_per_workitem, _KernelParam::workgroup_size>();
 
@@ -38,7 +38,7 @@ radix_sort(sycl::queue& __q, _KeysRng&& __keys_rng, _KernelParam __param = {})
 
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _KeysIterator>
 std::enable_if_t<oneapi::dpl::__internal::__is_iterator_type_v<_KeysIterator>, sycl::event>
-radix_sort(sycl::queue& __q, _KeysIterator __keys_first, _KeysIterator __keys_last, _KernelParam __param = {})
+radix_sort(sycl::queue __q, _KeysIterator __keys_first, _KeysIterator __keys_last, _KernelParam __param = {})
 {
     __impl::__check_esimd_sort_params<__radix_bits, _KernelParam::data_per_workitem, _KernelParam::workgroup_size>();
 
@@ -54,7 +54,7 @@ radix_sort(sycl::queue& __q, _KeysIterator __keys_first, _KeysIterator __keys_la
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _KeysRng,
           typename _ValsRng>
 std::enable_if_t<!oneapi::dpl::__internal::__is_iterator_type_v<_KeysRng>, sycl::event>
-radix_sort_by_key(sycl::queue& __q, _KeysRng&& __keys_rng, _ValsRng&& __vals_rng, _KernelParam __param = {})
+radix_sort_by_key(sycl::queue __q, _KeysRng&& __keys_rng, _ValsRng&& __vals_rng, _KernelParam __param = {})
 {
     __impl::__check_esimd_sort_params<__radix_bits, _KernelParam::data_per_workitem, _KernelParam::workgroup_size>();
 
@@ -69,7 +69,7 @@ radix_sort_by_key(sycl::queue& __q, _KeysRng&& __keys_rng, _ValsRng&& __vals_rng
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _KeysIterator,
           typename _ValsIterator>
 std::enable_if_t<oneapi::dpl::__internal::__is_iterator_type_v<_KeysIterator>, sycl::event>
-radix_sort_by_key(sycl::queue& __q, _KeysIterator __keys_first, _KeysIterator __keys_last, _ValsIterator __vals_first,
+radix_sort_by_key(sycl::queue __q, _KeysIterator __keys_first, _KeysIterator __keys_last, _ValsIterator __vals_first,
                   _KernelParam __param = {})
 {
     __impl::__check_esimd_sort_params<__radix_bits, _KernelParam::data_per_workitem, _KernelParam::workgroup_size>();
@@ -89,7 +89,7 @@ radix_sort_by_key(sycl::queue& __q, _KeysIterator __keys_first, _KeysIterator __
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _KeysRng1,
           typename _KeysRng2>
 std::enable_if_t<!oneapi::dpl::__internal::__is_iterator_type_v<_KeysRng1>, sycl::event>
-radix_sort(sycl::queue& __q, _KeysRng1&& __keys_rng, _KeysRng2&& __keys_rng_out, _KernelParam __param = {})
+radix_sort(sycl::queue __q, _KeysRng1&& __keys_rng, _KeysRng2&& __keys_rng_out, _KernelParam __param = {})
 {
     __impl::__check_esimd_sort_params<__radix_bits, _KernelParam::data_per_workitem, _KernelParam::workgroup_size>();
     if (__keys_rng.size() == 0)
@@ -104,7 +104,7 @@ radix_sort(sycl::queue& __q, _KeysRng1&& __keys_rng, _KeysRng2&& __keys_rng_out,
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _KeysIterator1,
           typename _KeysIterator2>
 std::enable_if_t<oneapi::dpl::__internal::__is_iterator_type_v<_KeysIterator1>, sycl::event>
-radix_sort(sycl::queue& __q, _KeysIterator1 __keys_first, _KeysIterator1 __keys_last, _KeysIterator2 __keys_out_first,
+radix_sort(sycl::queue __q, _KeysIterator1 __keys_first, _KeysIterator1 __keys_last, _KeysIterator2 __keys_out_first,
            _KernelParam __param = {})
 {
     __impl::__check_esimd_sort_params<__radix_bits, _KernelParam::data_per_workitem, _KernelParam::workgroup_size>();
@@ -126,7 +126,7 @@ radix_sort(sycl::queue& __q, _KeysIterator1 __keys_first, _KeysIterator1 __keys_
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _KeysRng1,
           typename _ValsRng1, typename _KeysRng2, typename _ValsRng2>
 std::enable_if_t<!oneapi::dpl::__internal::__is_iterator_type_v<_KeysRng1>, sycl::event>
-radix_sort_by_key(sycl::queue& __q, _KeysRng1&& __keys_rng, _ValsRng1&& __vals_rng, _KeysRng2&& __keys_out_rng,
+radix_sort_by_key(sycl::queue __q, _KeysRng1&& __keys_rng, _ValsRng1&& __vals_rng, _KeysRng2&& __keys_out_rng,
                   _ValsRng2&& __vals_out_rng, _KernelParam __param = {})
 {
     __impl::__check_esimd_sort_params<__radix_bits, _KernelParam::data_per_workitem, _KernelParam::workgroup_size>();
@@ -144,9 +144,8 @@ radix_sort_by_key(sycl::queue& __q, _KeysRng1&& __keys_rng, _ValsRng1&& __vals_r
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _KeysIterator1,
           typename _ValsIterator1, typename _KeysIterator2, typename _ValsIterator2>
 std::enable_if_t<oneapi::dpl::__internal::__is_iterator_type_v<_KeysIterator1>, sycl::event>
-radix_sort_by_key(sycl::queue& __q, _KeysIterator1 __keys_first, _KeysIterator1 __keys_last,
-                  _ValsIterator1 __vals_first, _KeysIterator2 __keys_out_first, _ValsIterator2 __vals_out_first,
-                  _KernelParam __param = {})
+radix_sort_by_key(sycl::queue __q, _KeysIterator1 __keys_first, _KeysIterator1 __keys_last, _ValsIterator1 __vals_first,
+                  _KeysIterator2 __keys_out_first, _ValsIterator2 __vals_out_first, _KernelParam __param = {})
 {
     __impl::__check_esimd_sort_params<__radix_bits, _KernelParam::data_per_workitem, _KernelParam::workgroup_size>();
 

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
@@ -51,7 +51,7 @@ class __esimd_radix_sort_onesweep_copyback_by_key;
 template <typename _KernelName, bool __is_ascending, ::std::uint8_t __radix_bits, ::std::uint16_t __data_per_work_item,
           ::std::uint16_t __work_group_size, typename _RngPack>
 sycl::event
-__one_wg(sycl::queue& __q, _RngPack&& __pack, std::size_t __n)
+__one_wg(sycl::queue __q, _RngPack&& __pack, ::std::size_t __n)
 {
     using _KeyT = typename ::std::decay_t<_RngPack>::_KeyT;
     using _EsimRadixSortKernel =
@@ -64,7 +64,7 @@ __one_wg(sycl::queue& __q, _RngPack&& __pack, std::size_t __n)
 template <typename _KernelName, bool __is_ascending, ::std::uint8_t __radix_bits, ::std::uint16_t __data_per_work_item,
           ::std::uint16_t __work_group_size, typename _RngPack1, typename _RngPack2>
 sycl::event
-__one_wg(sycl::queue& __q, _RngPack1&& __pack_in, _RngPack2&& __pack_out, std::size_t __n)
+__one_wg(sycl::queue __q, _RngPack1&& __pack_in, _RngPack2&& __pack_out, ::std::size_t __n)
 {
     using _KeyT = typename ::std::decay_t<_RngPack1>::_KeyT;
     using _EsimRadixSortKernel =

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
@@ -41,7 +41,7 @@ struct __radix_sort_one_wg_submitter<__is_ascending, __radix_bits, __data_per_wo
 {
     template <typename _RngPack1, typename _RngPack2>
     sycl::event
-    operator()(sycl::queue& __q, _RngPack1&& __pack_in, _RngPack2&& __pack_out, std::size_t __n) const
+    operator()(sycl::queue __q, _RngPack1&& __pack_in, _RngPack2&& __pack_out, ::std::size_t __n) const
     {
         sycl::nd_range<1> __nd_range{__work_group_size, __work_group_size};
         return __q.submit([&](sycl::handler& __cgh) {

--- a/include/oneapi/dpl/experimental/kt/single_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/single_pass_scan.h
@@ -145,7 +145,7 @@ struct __lookback_init_submitter<_FlagType, _Type, _BinaryOp,
 {
     template <typename _StatusFlags, typename _PartialValues>
     sycl::event
-    operator()(sycl::queue& __q, _StatusFlags&& __status_flags, _PartialValues&& __partial_values,
+    operator()(sycl::queue __q, _StatusFlags&& __status_flags, _PartialValues&& __partial_values,
                std::size_t __status_flags_size, std::uint16_t __status_flag_padding) const
     {
         return __q.submit([&](sycl::handler& __hdl) {
@@ -276,8 +276,8 @@ struct __lookback_submitter<__data_per_workitem, __workgroup_size, _Type, _FlagT
 
     template <typename _InRng, typename _OutRng, typename _BinaryOp, typename _StatusFlags, typename _StatusValues>
     sycl::event
-    operator()(sycl::queue& __q, sycl::event __prev_event, _InRng&& __in_rng, _OutRng&& __out_rng,
-               _BinaryOp __binary_op, std::size_t __n, _StatusFlags&& __status_flags, std::size_t __status_flags_size,
+    operator()(sycl::queue __q, sycl::event __prev_event, _InRng&& __in_rng, _OutRng&& __out_rng, _BinaryOp __binary_op,
+               std::size_t __n, _StatusFlags&& __status_flags, std::size_t __status_flags_size,
                _StatusValues&& __status_vals_full, _StatusValues&& __status_vals_partial,
                std::size_t __current_num_items) const
     {
@@ -304,7 +304,7 @@ struct __lookback_submitter<__data_per_workitem, __workgroup_size, _Type, _FlagT
 
 template <bool _Inclusive, typename _InRange, typename _OutRange, typename _BinaryOp, typename _KernelParam>
 sycl::event
-__single_pass_scan(sycl::queue& __q, _InRange&& __in_rng, _OutRange&& __out_rng, _BinaryOp __binary_op, _KernelParam)
+__single_pass_scan(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __out_rng, _BinaryOp __binary_op, _KernelParam)
 {
     using _Type = oneapi::dpl::__internal::__value_t<_InRange>;
     using _FlagType = __scan_status_flag<_Type>;
@@ -326,19 +326,19 @@ __single_pass_scan(sycl::queue& __q, _InRange&& __in_rng, _OutRange&& __out_rng,
                   "Only binary operators with known identity values are supported");
 
     assert("This device does not support 64-bit atomics" &&
-           (sizeof(_Type) < 8 || __q.get_device().has(sycl::aspect::atomic64)));
+           (sizeof(_Type) < 8 || __queue.get_device().has(sycl::aspect::atomic64)));
 
     // Next power of 2 greater than or equal to __n
     auto __n_uniform = ::oneapi::dpl::__internal::__dpl_bit_ceil(__n);
 
     // Perform a single-work group scan if the input is small
-    if (oneapi::dpl::__par_backend_hetero::__group_scan_fits_in_slm<_Type>(__q, __n, __n_uniform, /*limit=*/16384))
+    if (oneapi::dpl::__par_backend_hetero::__group_scan_fits_in_slm<_Type>(__queue, __n, __n_uniform, /*limit=*/16384))
     {
-        return oneapi::dpl::__par_backend_hetero::__parallel_transform_scan_single_group<
-            typename _KernelParam::kernel_name>(oneapi::dpl::__internal::__device_backend_tag{}, __q,
-                                                std::forward<_InRange>(__in_rng), std::forward<_OutRange>(__out_rng),
-                                                __n, oneapi::dpl::__internal::__no_op{},
-                                                unseq_backend::__no_init_value<_Type>{}, __binary_op, std::true_type{});
+        return oneapi::dpl::__par_backend_hetero::__parallel_transform_scan_single_group(
+            oneapi::dpl::__internal::__device_backend_tag{},
+            oneapi::dpl::execution::__dpl::make_device_policy<typename _KernelParam::kernel_name>(__queue),
+            std::forward<_InRange>(__in_rng), std::forward<_OutRange>(__out_rng), __n,
+            oneapi::dpl::__internal::__no_op{}, unseq_backend::__no_init_value<_Type>{}, __binary_op, std::true_type{});
     }
 
     constexpr std::size_t __workgroup_size = _KernelParam::workgroup_size;
@@ -358,7 +358,7 @@ __single_pass_scan(sycl::queue& __q, _InRange&& __in_rng, _OutRange&& __out_rng,
     std::size_t __mem_bytes =
         __status_flags_bytes + __status_vals_full_offset_bytes + __status_vals_partial_offset_bytes + __mem_align_pad;
 
-    std::byte* __device_mem = reinterpret_cast<std::byte*>(sycl::malloc_device(__mem_bytes, __q));
+    std::byte* __device_mem = reinterpret_cast<std::byte*>(sycl::malloc_device(__mem_bytes, __queue));
     if (!__device_mem)
         throw std::bad_alloc();
 
@@ -372,14 +372,14 @@ __single_pass_scan(sycl::queue& __q, _InRange&& __in_rng, _OutRange&& __out_rng,
         reinterpret_cast<_Type*>(__status_vals_full + __status_vals_full_offset_bytes / sizeof(_Type));
 
     auto __fill_event = __lookback_init_submitter<_FlagType, _Type, _BinaryOp, _LookbackInitKernel>{}(
-        __q, __status_flags, __status_vals_partial, __status_flags_size, __status_flag_padding);
+        __queue, __status_flags, __status_vals_partial, __status_flags_size, __status_flag_padding);
 
     std::size_t __current_num_wgs = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __elems_in_tile);
     std::size_t __current_num_items = __current_num_wgs * __workgroup_size;
 
     auto __prev_event =
         __lookback_submitter<__data_per_workitem, __workgroup_size, _Type, _FlagType, _LookbackKernel>{}(
-            __q, __fill_event, __in_rng, __out_rng, __binary_op, __n, __status_flags, __status_flags_size,
+            __queue, __fill_event, __in_rng, __out_rng, __binary_op, __n, __status_flags, __status_flags_size,
             __status_vals_full, __status_vals_partial, __current_num_items);
 
     // TODO: Currently, the following portion of code makes this entire function synchronous.
@@ -388,15 +388,15 @@ __single_pass_scan(sycl::queue& __q, _InRange&& __in_rng, _OutRange&& __out_rng,
     // we should replace this code with the asynchronous version below.
     if (0)
     {
-        return __q.submit([=](sycl::handler& __hdl) {
+        return __queue.submit([=](sycl::handler& __hdl) {
             __hdl.depends_on(__prev_event);
-            __hdl.host_task([=]() { sycl::free(__device_mem, __q); });
+            __hdl.host_task([=]() { sycl::free(__device_mem, __queue); });
         });
     }
     else
     {
         __prev_event.wait();
-        sycl::free(__device_mem, __q);
+        sycl::free(__device_mem, __queue);
         return __prev_event;
     }
 }
@@ -405,18 +405,18 @@ __single_pass_scan(sycl::queue& __q, _InRange&& __in_rng, _OutRange&& __out_rng,
 
 template <typename _InRng, typename _OutRng, typename _BinaryOp, typename _KernelParam>
 sycl::event
-inclusive_scan(sycl::queue& __q, _InRng&& __in_rng, _OutRng&& __out_rng, _BinaryOp __binary_op,
+inclusive_scan(sycl::queue __queue, _InRng&& __in_rng, _OutRng&& __out_rng, _BinaryOp __binary_op,
                _KernelParam __param = {})
 {
     auto __in_view = oneapi::dpl::__ranges::views::all(std::forward<_InRng>(__in_rng));
     auto __out_view = oneapi::dpl::__ranges::views::all(std::forward<_OutRng>(__out_rng));
 
-    return __impl::__single_pass_scan<true>(__q, std::move(__in_view), std::move(__out_view), __binary_op, __param);
+    return __impl::__single_pass_scan<true>(__queue, std::move(__in_view), std::move(__out_view), __binary_op, __param);
 }
 
 template <typename _InIterator, typename _OutIterator, typename _BinaryOp, typename _KernelParam>
 sycl::event
-inclusive_scan(sycl::queue& __q, _InIterator __in_begin, _InIterator __in_end, _OutIterator __out_begin,
+inclusive_scan(sycl::queue __queue, _InIterator __in_begin, _InIterator __in_end, _OutIterator __out_begin,
                _BinaryOp __binary_op, _KernelParam __param = {})
 {
     auto __n = __in_end - __in_begin;
@@ -426,7 +426,7 @@ inclusive_scan(sycl::queue& __q, _InIterator __in_begin, _InIterator __in_end, _
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutIterator>();
     auto __buf2 = __keep2(__out_begin, __out_begin + __n);
 
-    return __impl::__single_pass_scan<true>(__q, __buf1.all_view(), __buf2.all_view(), __binary_op, __param);
+    return __impl::__single_pass_scan<true>(__queue, __buf1.all_view(), __buf2.all_view(), __binary_op, __param);
 }
 
 } // namespace gpu

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -140,13 +140,9 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& _
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _RepackedTp,
-                                                                          std::true_type /*is_commutative*/>(
-        _BackendTag{}, __q_local, __binary_op1, _Functor{__binary_op2},
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
+                                                                          ::std::true_type /*is_commutative*/>(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf1.all_view(), __buf2.all_view());
 }
@@ -170,13 +166,9 @@ __pattern_transform_reduce_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& _
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _RepackedTp,
-                                                                          std::true_type /*is_commutative*/>(
-        _BackendTag{}, __q_local, __binary_op, _Functor{__unary_op},
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
+                                                                          ::std::true_type /*is_commutative*/>(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf.all_view());
 }
@@ -212,13 +204,9 @@ __pattern_transform_scan_base_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
     auto __buf2 = __keep2(__result, __result + __n);
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_scan<_CustomName>(
-        _BackendTag{}, __q_local, __buf1.all_view(), __buf2.all_view(), __n, __unary_op, __init, __binary_op,
-        _Inclusive{});
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n, __unary_op,
+        __init, __binary_op, _Inclusive{});
     return __res.__make_future(__result + __n);
 }
 

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -102,12 +102,8 @@ sort_async(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Comp
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
     using __backend_tag = typename decltype(__dispatch_tag)::__backend_tag;
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return __par_backend_hetero::__parallel_stable_sort<_CustomName>(__backend_tag{}, __q_local, __buf.all_view(),
-                                                                     __comp, oneapi::dpl::identity{});
+    return __par_backend_hetero::__parallel_stable_sort(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+                                                        __buf.all_view(), __comp, oneapi::dpl::identity{});
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class... _Events,

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -96,7 +96,7 @@ class __seg_scan_wg_kernel;
 template <bool __is_inclusive, typename... Name>
 class __seg_scan_prefix_kernel;
 
-template <typename _CustomName, bool __is_inclusive>
+template <bool __is_inclusive>
 struct __sycl_scan_by_segment_impl
 {
     template <typename... _Name>
@@ -105,16 +105,20 @@ struct __sycl_scan_by_segment_impl
     template <typename... _Name>
     using _SegScanPrefixPhase = __seg_scan_prefix_kernel<__is_inclusive, _Name...>;
 
-    template <typename _BackendTag, typename _Range1, typename _Range2, typename _Range3, typename _BinaryPredicate,
-              typename _BinaryOperator, typename _T>
+    template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
+              typename _BinaryPredicate, typename _BinaryOperator, typename _T>
     void
-    operator()(_BackendTag, sycl::queue& __q, _Range1&& __keys, _Range2&& __values, _Range3&& __out_values,
+    operator()(_BackendTag, _ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& __values, _Range3&& __out_values,
                _BinaryPredicate __binary_pred, _BinaryOperator __binary_op, _T __init, _T __identity)
     {
+        using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
         using _SegScanWgKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            _SegScanWgPhase, _CustomName, _Range1, _Range2, _Range3, _BinaryPredicate, _BinaryOperator>;
+            _SegScanWgPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _BinaryPredicate,
+            _BinaryOperator>;
         using _SegScanPrefixKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            _SegScanPrefixPhase, _CustomName, _Range1, _Range2, _Range3, _BinaryPredicate, _BinaryOperator>;
+            _SegScanPrefixPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _BinaryPredicate,
+            _BinaryOperator>;
 
         using __val_type = oneapi::dpl::__internal::__value_t<_Range2>;
 
@@ -125,21 +129,21 @@ struct __sycl_scan_by_segment_impl
 
         // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
         // This value exceeds the current practical limit for GPUs, but may need to be re-evaluated in the future.
-        std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__q, (std::size_t)2048);
+        std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec.queue(), (std::size_t)2048);
 
         // We require 2 * sizeof(__val_type) * __wgroup_size of SLM for the work group segmented scan. We add
         // an additional sizeof(__val_type) * __wgroup_size requirement to ensure sufficient SLM for the group algorithms.
-        __wgroup_size =
-            oneapi::dpl::__internal::__slm_adjusted_work_group_size(__q, 3 * sizeof(__val_type), __wgroup_size);
+        __wgroup_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec.queue(), 3 * sizeof(__val_type),
+                                                                                __wgroup_size);
 
 #if _ONEDPL_COMPILE_KERNEL
         auto __seg_scan_wg_kernel =
-            __par_backend_hetero::__internal::__kernel_compiler<_SegScanWgKernel>::__compile(__q);
+            __par_backend_hetero::__internal::__kernel_compiler<_SegScanWgKernel>::__compile(__exec.queue());
         auto __seg_scan_prefix_kernel =
-            __par_backend_hetero::__internal::__kernel_compiler<_SegScanPrefixKernel>::__compile(__q);
-        __wgroup_size =
-            std::min({__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__q, __seg_scan_wg_kernel),
-                      oneapi::dpl::__internal::__kernel_work_group_size(__q, __seg_scan_prefix_kernel)});
+            __par_backend_hetero::__internal::__kernel_compiler<_SegScanPrefixKernel>::__compile(__exec.queue());
+        __wgroup_size = ::std::min(
+            {__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __seg_scan_wg_kernel),
+             oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __seg_scan_prefix_kernel)});
 #endif
 
         ::std::size_t __n_groups = __internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
@@ -150,7 +154,7 @@ struct __sycl_scan_by_segment_impl
         auto __seg_ends = oneapi::dpl::__par_backend_hetero::__buffer<bool>(__n_groups).get_buffer();
 
         // 1. Work group reduction
-        auto __wg_scan = __q.submit([&](sycl::handler& __cgh) {
+        auto __wg_scan = __exec.queue().submit([&](sycl::handler& __cgh) {
             auto __partials_acc = __partials.template get_access<sycl::access_mode::write>(__cgh);
             auto __seg_ends_acc = __seg_ends.template get_access<sycl::access_mode::write>(__cgh);
 
@@ -250,7 +254,8 @@ struct __sycl_scan_by_segment_impl
         });
 
         // 2. Apply work group carry outs, calculate output indices, and load results into correct indices.
-        __q.submit([&](sycl::handler& __cgh) {
+        __exec.queue()
+            .submit([&](sycl::handler& __cgh) {
                 oneapi::dpl::__ranges::__require_access(__cgh, __keys, __out_values);
 
                 auto __partials_acc = __partials.template get_access<sycl::access_mode::read>(__cgh);
@@ -387,14 +392,9 @@ __scan_by_segment_impl_common(__internal::__hetero_tag<_BackendTag>, Policy&& po
 
     constexpr iter_value_t identity = unseq_backend::__known_identity<Operator, iter_value_t>;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<Policy>;
-
-    sycl::queue __q_local = policy.queue();
-
-    __sycl_scan_by_segment_impl<_CustomName, Inclusive::value>{}(_BackendTag{}, __q_local, key_buf.all_view(),
-                                                                 value_buf.all_view(), value_output_buf.all_view(),
-                                                                 binary_pred, binary_op, init, identity);
-
+    __sycl_scan_by_segment_impl<Inclusive::value>()(_BackendTag{}, ::std::forward<Policy>(policy), key_buf.all_view(),
+                                                    value_buf.all_view(), value_output_buf.all_view(), binary_pred,
+                                                    binary_op, init, identity);
     return result + n;
 }
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -78,7 +78,7 @@ for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+    oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                              __f);
 }
 

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -224,7 +224,6 @@ struct __destroy_fn
     void
     operator()(_ReferenceType __val) const
     {
-        static_assert(std::is_reference_v<_ReferenceType>);
         __val.~_ValueType();
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -532,15 +532,11 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    auto __ret_idx =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _ReduceValueType, _Commutative>(
-            _BackendTag{}, __q_local, __reduce_fn, __transform_fn, unseq_backend::__no_init_value{}, // no initial value
-            __buf.all_view())
-            .get();
+    auto __ret_idx = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType, _Commutative>(
+                         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+                         unseq_backend::__no_init_value{}, // no initial value
+                         __buf.all_view())
+                         .get();
 
     return __first + ::std::get<0>(__ret_idx);
 }
@@ -564,7 +560,7 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
 //
 
 template <typename _Compare, typename _ReduceValueType>
-struct __pattern_minmax_element_reduce_fn
+struct __pattern_minmax_element__reduce_fn
 {
     _Compare __comp;
 
@@ -609,7 +605,7 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 
     // This operator doesn't track the lowest found index in case of equal min. values and the highest found index in
     // case of equal max. values. Thus, this operator is not commutative.
-    __pattern_minmax_element_reduce_fn<_Compare, _ReduceValueType> __reduce_fn{__comp};
+    __pattern_minmax_element__reduce_fn<_Compare, _ReduceValueType> __reduce_fn{__comp};
 
     // TODO: Doesn't work with `zip_iterator`.
     //       In that case the first and the second arguments of `_ReduceValueType` will be
@@ -619,16 +615,12 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    auto __ret =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _ReduceValueType,
-                                                                       std::false_type /*is_commutative*/>(
-            _BackendTag{}, __q_local, __reduce_fn, __transform_fn, unseq_backend::__no_init_value{}, // no initial value
-            __buf.all_view())
-            .get();
+    auto __ret = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+                                                                                ::std::false_type /*is_commutative*/>(
+                     _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+                     unseq_backend::__no_init_value{}, // no initial value
+                     __buf.all_view())
+                     .get();
 
     return ::std::make_pair<_Iterator, _Iterator>(__first + ::std::get<0>(__ret), __first + ::std::get<1>(__ret));
 }
@@ -645,8 +637,6 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     if (__last - __first < 2)
         return __last;
 
-    sycl::queue __q_local = __exec.queue();
-
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<adjacent_find_fn<_BinaryPredicate>>;
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
@@ -656,11 +646,9 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    bool result = __par_backend_hetero::__parallel_find_or<_CustomName>(
-        _BackendTag{}, __q_local, _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}},
-        __par_backend_hetero::__parallel_or_tag{},
+    bool result = __par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, __par_backend_hetero::__parallel_or_tag{},
         oneapi::dpl::__ranges::make_zip_view(__buf1.all_view(), __buf2.all_view()));
 
     // inverted conditional because of
@@ -678,19 +666,15 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<adjacent_find_fn<_BinaryPredicate>>;
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    auto __result = __par_backend_hetero::__parallel_find<_CustomName>(
-        _BackendTag{}, __q_local,
+    auto __result = __par_backend_hetero::__parallel_find(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::zip(
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first + 1)),
         __par_backend_hetero::zip(
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last - 1),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last)),
-        _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, std::true_type{});
+        _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, ::std::true_type{});
 
     auto __zip_at_first = __par_backend_hetero::zip(
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
@@ -734,13 +718,9 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _ReduceValueType,
-                                                                          std::true_type /*is_commutative*/>(
-               _BackendTag{}, __q_local, __reduce_fn, __transform_fn,
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+                                                                          ::std::true_type /*is_commutative*/>(
+               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
                unseq_backend::__no_init_value{}, // no initial value
                __buf.all_view())
         .get();
@@ -763,13 +743,11 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or<
-        __par_backend_hetero::__or_policy_wrapper<_CustomName>>(
-        _BackendTag{}, __q_local, _Predicate{__pred}, __par_backend_hetero::__parallel_or_tag{}, __buf.all_view());
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{},
+        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>(
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, __par_backend_hetero::__parallel_or_tag{}, __buf.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -784,8 +762,6 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
     if (__last1 == __first1 || __last2 == __first2 || __last1 - __first1 != __last2 - __first2)
         return false;
 
-    sycl::queue __q_local = __exec.queue();
-
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<equal_predicate<_Pred>>;
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -795,10 +771,9 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return !__par_backend_hetero::__parallel_find_or<_CustomName>(
-        _BackendTag{}, __q_local, _Predicate{equal_predicate<_Pred>{__pred}}, __par_backend_hetero::__parallel_or_tag{},
+    return !__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
+        __par_backend_hetero::__parallel_or_tag{},
         oneapi::dpl::__ranges::make_zip_view(__buf1.all_view(), __buf2.all_view()));
 }
 
@@ -829,15 +804,11 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return __par_backend_hetero::__parallel_find<_CustomName>(
-        _BackendTag{}, __q_local,
+    return __par_backend_hetero::__parallel_find(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__pred},
-        std::true_type{});
+        ::std::true_type{});
 }
 
 //------------------------------------------------------------------------
@@ -862,17 +833,13 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     {
         using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
 
-        sycl::queue __q_local = __exec.queue();
-
-        using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-        return __par_backend_hetero::__parallel_find<_CustomName>(
-            _BackendTag{}, __q_local,
+        return __par_backend_hetero::__parallel_find(
+            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_first),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_last), _Predicate{__pred},
-            std::false_type{});
+            ::std::false_type{});
     }
 }
 
@@ -890,19 +857,15 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
 
     using _Predicate = unseq_backend::first_match_pred<_Pred>;
 
-    sycl::queue __q_local = __exec.queue();
-
     // TODO: To check whether it makes sense to iterate over the second sequence in case of
     // distance(__first, __last) < distance(__s_first, __s_last).
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return __par_backend_hetero::__parallel_find<_CustomName>(
-        _BackendTag{}, __q_local,
+    return __par_backend_hetero::__parallel_find(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_last), _Predicate{__pred},
-        std::true_type{});
+        ::std::true_type{});
 }
 
 //------------------------------------------------------------------------
@@ -934,18 +897,13 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
     }
 
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return __par_backend_hetero::__parallel_find<_CustomName>(
-        _BackendTag{}, __q_local,
+    return __par_backend_hetero::__parallel_find(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_last), _Predicate{__pred},
-        std::true_type{});
+        ::std::true_type{});
 }
 
 //------------------------------------------------------------------------
@@ -987,16 +945,11 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     }
 
     using _Predicate = unseq_backend::n_elem_match_pred<_BinaryPredicate, _Tp, _Size>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return __par_backend_hetero::__parallel_find<_CustomName>(
-        _BackendTag{}, __q_local,
+    return __par_backend_hetero::__parallel_find(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
-        _Predicate{__pred, __value, __count}, std::true_type{});
+        _Predicate{__pred, __value, __count}, ::std::true_type{});
 }
 
 //------------------------------------------------------------------------
@@ -1017,15 +970,9 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
     auto __first_zip = __par_backend_hetero::zip(
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first1),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first2));
-
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    auto __result = __par_backend_hetero::__parallel_find<_CustomName>(
-        _BackendTag{}, __q_local, __first_zip, __first_zip + __n, _Predicate{equal_predicate<_Pred>{__pred}},
-        std::true_type{});
-
+    auto __result = __par_backend_hetero::__parallel_find(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __first_zip, __first_zip + __n,
+        _Predicate{equal_predicate<_Pred>{__pred}}, ::std::true_type{});
     __n = __result - __first_zip;
     return ::std::make_pair(__first1 + __n, __first2 + __n);
 }
@@ -1052,12 +999,8 @@ __pattern_copy_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
     auto __buf2 = __keep2(__result_first, __result_first + __n);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    auto __res = __par_backend_hetero::__parallel_copy_if<_CustomName>(_BackendTag{}, __q_local, __buf1.all_view(),
-                                                                       __buf2.all_view(), __n, __pred);
+    auto __res = __par_backend_hetero::__parallel_copy_if(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+                                                          __buf1.all_view(), __buf2.all_view(), __n, __pred);
 
     ::std::size_t __num_copied = __res.get(); //is a blocking call
     return __result_first + __num_copied;
@@ -1091,12 +1034,8 @@ __pattern_partition_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, decltype(__zipped_res)>();
     auto __buf2 = __keep2(__zipped_res, __zipped_res + __n);
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    auto __result = oneapi::dpl::__par_backend_hetero::__parallel_partition_copy<_CustomName>(
-        _BackendTag{}, __q_local, __buf1.all_view(), __buf2.all_view(), __pred);
+    auto __result = oneapi::dpl::__par_backend_hetero::__parallel_partition_copy(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
 
     _It1DifferenceType __num_true = __result.get(); // blocking call
 
@@ -1133,12 +1072,8 @@ __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
     auto __buf2 = __keep2(__result_first, __result_first + __n);
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    auto __result = oneapi::dpl::__par_backend_hetero::__parallel_unique_copy<_CustomName>(
-        _BackendTag{}, __q_local, __buf1.all_view(), __buf2.all_view(), __pred);
+    auto __result = oneapi::dpl::__par_backend_hetero::__parallel_unique_copy(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
 
     return __result_first + __result.get(); // is a blocking call
 }
@@ -1255,16 +1190,12 @@ __pattern_is_partitioned(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    auto __res =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _ReduceValueType,
-                                                                       std::false_type /*is_commutative*/>(
-            _BackendTag{}, __q_local, __reduce_fn, __transform_fn, unseq_backend::__no_init_value{}, // no initial value
-            __buf.all_view())
-            .get();
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+                                                                                ::std::false_type /*is_commutative*/>(
+                     _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+                     unseq_backend::__no_init_value{}, // no initial value
+                     __buf.all_view())
+                     .get();
 
     return __broken != __reduce_fn(_ReduceValueType{__all_true}, __res);
 }
@@ -1298,15 +1229,11 @@ __pattern_is_heap_until(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred_by_idx<__is_heap_check<_Compare>>;
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return __par_backend_hetero::__parallel_find<_CustomName>(
-        _BackendTag{}, __q_local,
+    return __par_backend_hetero::__parallel_find(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__comp},
-        std::true_type{});
+        ::std::true_type{});
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare>
@@ -1319,12 +1246,8 @@ __pattern_is_heap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomA
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred_by_idx<__is_heap_check<_Compare>>;
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return !__par_backend_hetero::__parallel_or<_CustomName>(
-        _BackendTag{}, __q_local,
+    return !__par_backend_hetero::__parallel_or(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__comp});
 }
@@ -1368,12 +1291,8 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
         auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator3>();
         auto __buf3 = __keep3(__d_first, __d_first + __n);
 
-        using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-        sycl::queue __q_local = __exec.queue();
-
-        __par_backend_hetero::__parallel_merge<_CustomName>(_BackendTag{}, __q_local, __buf1.all_view(),
-                                                            __buf2.all_view(), __buf3.all_view(), __comp)
+        __par_backend_hetero::__parallel_merge(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+                                               __buf1.all_view(), __buf2.all_view(), __buf3.all_view(), __comp)
             .__deferrable_wait();
     }
     return __d_first + __n;
@@ -1430,12 +1349,8 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    __par_backend_hetero::__parallel_stable_sort<_CustomName>(_BackendTag{}, __q_local, __buf.all_view(), __comp,
-                                                              __proj)
+    __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+                                                 __buf.all_view(), __comp, __proj)
         .__deferrable_wait();
 }
 
@@ -1591,14 +1506,11 @@ __pattern_lexicographical_compare(__hetero_tag<_BackendTag>, _ExecutionPolicy&& 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __shared_size);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
     auto __ret_idx =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _ReduceValueType,
-                                                                       std::false_type /*is_commutative*/>(
-            _BackendTag{}, __q_local, __reduce_fn, __transform_fn, unseq_backend::__no_init_value{}, // no initial value
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+                                                                       ::std::false_type /*is_commutative*/>(
+            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+            unseq_backend::__no_init_value{}, // no initial value
             __buf1.all_view(), __buf2.all_view())
             .get();
 
@@ -1624,13 +1536,8 @@ __pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Forwar
     typedef typename ::std::iterator_traits<_ForwardIterator2>::difference_type _Size2;
 
     using __brick_include_type = unseq_backend::__brick_includes<_Compare, _Size1, _Size2>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return !__par_backend_hetero::__parallel_or<_CustomName>(
-        _BackendTag{}, __q_local,
+    return !__par_backend_hetero::__parallel_or(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first2),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last2),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first1),
@@ -1650,12 +1557,8 @@ __pattern_partial_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _It
     if (__last - __first < 2)
         return;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    __par_backend_hetero::__parallel_partial_sort<_CustomName>(
-        _BackendTag{}, __q_local,
+    __par_backend_hetero::__parallel_partial_sort(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__mid),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__last), __comp)
@@ -1750,12 +1653,8 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         // sycl::buffer and sycl accessors. SYCL runtime makes a dependency graph to prevent the races between
         // the patterns: __pattern_walk2, __parallel_partial_sort and __pattern_walk2.
 
-        using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-        sycl::queue __q_local = __exec.queue();
-
-        __par_backend_hetero::__parallel_partial_sort<__partial_sort_2<_CustomName>>(
-            _BackendTag{}, __q_local,
+        __par_backend_hetero::__parallel_partial_sort(
+            _BackendTag{}, __par_backend_hetero::make_wrapped_policy<__partial_sort_2>(__exec),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__buf_first),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__buf_mid),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__buf_last), __comp);
@@ -1918,7 +1817,7 @@ __pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bid
     const auto __shift = __new_first - __first;
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::__rotate_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
                                      decltype(__buf1.all_view()), decltype(__buf2.all_view())>{__n, __shift},
         __n, __buf1.all_view(), __buf2.all_view())
@@ -1948,13 +1847,9 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _F
     auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
     auto __buf3 = __keep3(__result, __result + __n1);
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    auto __result_size = __par_backend_hetero::__parallel_set_op<_CustomName>(
-                             _BackendTag{}, __q_local, __buf1.all_view(), __buf2.all_view(), __buf3.all_view(), __comp,
-                             __is_op_difference)
+    auto __result_size = __par_backend_hetero::__parallel_set_op(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                                                                 __buf1.all_view(), __buf2.all_view(),
+                                                                 __buf3.all_view(), __comp, __is_op_difference)
                              .get();
 
     return __result + __result_size;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -228,16 +228,12 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
     if (__rng1.empty() || __rng2.empty() || __rng1.size() != __rng2.size())
         return false;
 
-    sycl::queue __q_local = __exec.queue();
-
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<equal_predicate<_Pred>>;
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return !oneapi::dpl::__par_backend_hetero::__parallel_find_or<_CustomName>(
-        _BackendTag{}, __q_local, _Predicate{equal_predicate<_Pred>{__pred}},
+    return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
         oneapi::dpl::__par_backend_hetero::__parallel_or_tag{},
         oneapi::dpl::__ranges::zip_view(::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2)));
 }
@@ -269,16 +265,14 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&&
     if (__rng.empty())
         return __rng.size();
 
-    sycl::queue __q_local = __exec.queue();
-
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or<
-        __par_backend_hetero::__find_policy_wrapper<_CustomName>>(_BackendTag{}, __q_local, _Predicate{__pred},
-                                                                  _TagType{}, std::forward<_Range>(__rng));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{},
+        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, _TagType{}, ::std::forward<_Range>(__rng));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -315,17 +309,14 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
         return __res ? 0 : __rng1.size();
     }
 
-    sycl::queue __q_local = __exec.queue();
-
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
     using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_Range1>;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or<
-        __par_backend_hetero::__find_policy_wrapper<_CustomName>>(_BackendTag{}, __q_local, _Predicate{__pred},
-                                                                  _TagType{}, std::forward<_Range1>(__rng1),
-                                                                  std::forward<_Range2>(__rng2));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{},
+        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
 //------------------------------------------------------------------------
@@ -341,18 +332,15 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     if (__rng1.empty() || __rng2.empty())
         return __rng1.size();
 
-    sycl::queue __q_local = __exec.queue();
-
     using _Predicate = unseq_backend::first_match_pred<_Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
     //TODO: To check whether it makes sense to iterate over the second sequence in case of __rng1.size() < __rng2.size()
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or<
-        __par_backend_hetero::__find_policy_wrapper<_CustomName>>(_BackendTag{}, __q_local, _Predicate{__pred},
-                                                                  _TagType{}, std::forward<_Range1>(__rng1),
-                                                                  std::forward<_Range2>(__rng2));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{},
+        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
 //------------------------------------------------------------------------
@@ -366,16 +354,12 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& 
     if (__rng.empty())
         return false;
 
-    sycl::queue __q_local = __exec.queue();
-
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or<
-        oneapi::dpl::__par_backend_hetero::__or_policy_wrapper<_CustomName>>(
-        _BackendTag{}, __q_local, _Predicate{__pred}, oneapi::dpl::__par_backend_hetero::__parallel_or_tag{},
-        std::forward<_Range>(__rng));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{},
+        __par_backend_hetero::make_wrapped_policy<oneapi::dpl::__par_backend_hetero::__or_policy_wrapper>(
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, oneapi::dpl::__par_backend_hetero::__parallel_or_tag{}, ::std::forward<_Range>(__rng));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -421,14 +405,11 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or<
-        oneapi::dpl::__par_backend_hetero::__find_policy_wrapper<_CustomName>>(
-        _BackendTag{}, __q_local, _Predicate{__pred}, _TagType{}, std::forward<_Range1>(__rng1),
-        std::forward<_Range2>(__rng2));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{},
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<
+            oneapi::dpl::__par_backend_hetero::__find_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -527,8 +508,6 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     if (__rng.size() < 2)
         return __rng.size();
 
-    sycl::queue __q_local = __exec.queue();
-
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<adjacent_find_fn<_BinaryPredicate>>;
     using _TagType = ::std::conditional_t<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
                                           oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
@@ -543,10 +522,9 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_or<_CustomName>(
-        _BackendTag{}, __q_local, _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, _TagType{},
+    auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, _TagType{},
         oneapi::dpl::__ranges::zip_view(__rng1, __rng2));
 
     // inverted conditional because of
@@ -613,15 +591,11 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& _
     auto __reduce_fn = ::std::plus<_ReduceValueType>{};
     __pattern_count_transform_fn<_Predicate> __transform_fn{__predicate};
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _ReduceValueType,
-                                                                          std::true_type /*is_commutative*/>(
-               _BackendTag{}, __q_local, __reduce_fn, __transform_fn,
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+                                                                          ::std::true_type /*is_commutative*/>(
+               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
                unseq_backend::__no_init_value{}, // no initial value
-               std::forward<_Range>(__rng))
+               ::std::forward<_Range>(__rng))
         .get();
 }
 
@@ -651,12 +625,9 @@ __pattern_copy_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&
     if (__n == 0)
         return 0;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_copy_if<_CustomName>(
-        _BackendTag{}, __q_local, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2), __n, __pred, __assign);
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_copy_if(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
+        std::forward<_Range2>(__rng2), __n, __pred, __assign);
 
     return __res.get(); //is a blocking call
 }
@@ -742,12 +713,9 @@ __pattern_unique_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
         return 1;
     }
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_unique_copy<_CustomName>(
-        _BackendTag{}, __q_local, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __pred);
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_unique_copy(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
+        std::forward<_Range2>(__result), __pred);
 
     return __res.get(); // is a blocking call
 }
@@ -830,13 +798,9 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ran
         return {__res, 0};
     }
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    auto __res = __par_backend_hetero::__parallel_merge<_CustomName>(
-        _BackendTag{}, __q_local, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-        std::forward<_Range3>(__rng3), __comp, __out_size_limit{});
+    auto __res = __par_backend_hetero::__parallel_merge(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng1),
+        ::std::forward<_Range2>(__rng2), ::std::forward<_Range3>(__rng3), __comp, __out_size_limit{});
 
     auto __val = __res.get();
     return {__val.first, __val.second};
@@ -880,16 +844,10 @@ void
 __pattern_stable_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp,
                       _Proj __proj)
 {
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
     if (__rng.size() >= 2)
-    {
-        sycl::queue __q_local = __exec.queue();
-
-        __par_backend_hetero::__parallel_stable_sort<_CustomName>(_BackendTag{}, __q_local, std::forward<_Range>(__rng),
-                                                                  __comp, __proj)
+        __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+                                                     ::std::forward<_Range>(__rng), __comp, __proj)
             .__deferrable_wait();
-    }
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -957,15 +915,12 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
     __pattern_min_element_reduce_fn<_Compare, _ReduceValueType> __reduce_fn{__comp};
     __pattern_min_element_transform_fn<_ReduceValueType> __transform_fn;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
     auto __ret_idx =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _ReduceValueType,
-                                                                       std::false_type /*is_commutative*/>(
-            _BackendTag{}, __q_local, __reduce_fn, __transform_fn, unseq_backend::__no_init_value{}, // no initial value
-            std::forward<_Range>(__rng))
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+                                                                       ::std::false_type /*is_commutative*/>(
+            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+            unseq_backend::__no_init_value{}, // no initial value
+            ::std::forward<_Range>(__rng))
             .get();
 
     using ::std::get;
@@ -1045,15 +1000,12 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
     //       a `tuple` of `difference_type`, not the `difference_type` itself.
     __pattern_minmax_element_transform_fn<_ReduceValueType> __transform_fn;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
     _ReduceValueType __ret =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _ReduceValueType,
-                                                                       std::false_type /*is_commutative*/>(
-            _BackendTag{}, __q_local, __reduce_fn, __transform_fn, unseq_backend::__no_init_value{}, // no initial value
-            std::forward<_Range>(__rng))
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+                                                                       ::std::false_type /*is_commutative*/>(
+            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+            unseq_backend::__no_init_value{}, // no initial value
+            ::std::forward<_Range>(__rng))
             .get();
 
     using ::std::get;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -232,35 +232,38 @@ struct __parallel_scan_submitter;
 template <typename _CustomName, typename... _PropagateScanName>
 struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name<_PropagateScanName...>>
 {
-    template <typename _Range1, typename _Range2, typename _InitType, typename _LocalScan, typename _GroupScan,
-              typename _GlobalScan>
+    template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _InitType, typename _LocalScan,
+              typename _GroupScan, typename _GlobalScan>
     __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
-    operator()(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _InitType __init, _LocalScan __local_scan,
+    operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _InitType __init, _LocalScan __local_scan,
                _GroupScan __group_scan, _GlobalScan __global_scan) const
     {
         using _Type = typename _InitType::__value_type;
         using _LocalScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            __scan_local_kernel, _CustomName, _Range1, _Range2, _Type, _LocalScan, _GroupScan, _GlobalScan>;
+            __scan_local_kernel, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Type, _LocalScan, _GroupScan,
+            _GlobalScan>;
         using _GroupScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            __scan_group_kernel, _CustomName, _Range1, _Range2, _Type, _LocalScan, _GroupScan, _GlobalScan>;
+            __scan_group_kernel, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Type, _LocalScan, _GroupScan,
+            _GlobalScan>;
         auto __n = __rng1.size();
         assert(__n > 0);
 
-        auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__q);
+        auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec.queue());
         // get the work group size adjusted to the local memory limit
         // TODO: find a way to generalize getting of reliable work-group sizes
-        std::size_t __wgroup_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__q, sizeof(_Type));
+        std::size_t __wgroup_size =
+            oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec.queue(), sizeof(_Type));
         // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
         // This value matches the current practical limit for GPUs, but may need to be re-evaluated in the future.
         __wgroup_size = std::min(__wgroup_size, (std::size_t)1024);
 
 #if _ONEDPL_COMPILE_KERNEL
         //Actually there is one kernel_bundle for the all kernels of the pattern.
-        auto __kernels = __internal::__kernel_compiler<_LocalScanKernel, _GroupScanKernel>::__compile(__q);
+        auto __kernels = __internal::__kernel_compiler<_LocalScanKernel, _GroupScanKernel>::__compile(__exec.queue());
         auto __kernel_1 = __kernels[0];
         auto __kernel_2 = __kernels[1];
-        auto __wgroup_size_kernel_1 = oneapi::dpl::__internal::__kernel_work_group_size(__q, __kernel_1);
-        auto __wgroup_size_kernel_2 = oneapi::dpl::__internal::__kernel_work_group_size(__q, __kernel_2);
+        auto __wgroup_size_kernel_1 = oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __kernel_1);
+        auto __wgroup_size_kernel_2 = oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __kernel_2);
         __wgroup_size = ::std::min({__wgroup_size, __wgroup_size_kernel_1, __wgroup_size_kernel_2});
 #endif
 
@@ -271,12 +274,12 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         // Storage for the results of scan for each workgroup
 
         using __result_and_scratch_storage_t = __result_and_scratch_storage<_Type>;
-        __result_and_scratch_storage_t __result_and_scratch{__q, __n_groups + 1};
+        __result_and_scratch_storage_t __result_and_scratch{__exec.queue(), __n_groups + 1};
 
-        _PRINT_INFO_IN_DEBUG_MODE(__q, __wgroup_size, __max_cu);
+        _PRINT_INFO_IN_DEBUG_MODE(__exec.queue(), __wgroup_size, __max_cu);
 
         // 1. Local scan on each workgroup
-        auto __submit_event = __q.submit([&](sycl::handler& __cgh) {
+        auto __submit_event = __exec.queue().submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2); //get an access to data under SYCL buffer
             auto __temp_acc = __result_and_scratch.template __get_scratch_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
@@ -298,7 +301,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         if (__n_groups > 1)
         {
             auto __iters_per_single_wg = oneapi::dpl::__internal::__dpl_ceiling_div(__n_groups, __wgroup_size);
-            __submit_event = __q.submit([&](sycl::handler& __cgh) {
+            __submit_event = __exec.queue().submit([&](sycl::handler& __cgh) {
                 __cgh.depends_on(__submit_event);
                 auto __temp_acc = __result_and_scratch.template __get_scratch_acc<sycl::access_mode::read_write>(__cgh);
                 __dpl_sycl::__local_accessor<_Type> __local_acc(__wgroup_size, __cgh);
@@ -319,7 +322,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         }
 
         // 3. Final scan for whole range
-        auto __final_event = __q.submit([&](sycl::handler& __cgh) {
+        auto __final_event = __exec.queue().submit([&](sycl::handler& __cgh) {
             __cgh.depends_on(__submit_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2); //get an access to data under SYCL buffer
             auto __temp_acc = __result_and_scratch.template __get_scratch_acc<sycl::access_mode::read>(__cgh);
@@ -368,9 +371,10 @@ template <bool _Inclusive, typename... _ScanKernelName>
 struct __parallel_transform_scan_dynamic_single_group_submitter<_Inclusive,
                                                                 __internal::__optional_kernel_name<_ScanKernelName...>>
 {
-    template <typename _InRng, typename _OutRng, typename _InitType, typename _BinaryOperation, typename _UnaryOp>
+    template <typename _Policy, typename _InRng, typename _OutRng, typename _InitType, typename _BinaryOperation,
+              typename _UnaryOp>
     sycl::event
-    operator()(sycl::queue& __q, _InRng&& __in_rng, _OutRng&& __out_rng, std::size_t __n, _InitType __init,
+    operator()(const _Policy& __policy, _InRng&& __in_rng, _OutRng&& __out_rng, ::std::size_t __n, _InitType __init,
                _BinaryOperation __bin_op, _UnaryOp __unary_op, ::std::uint16_t __wg_size)
     {
         using _ValueType = typename _InitType::__value_type;
@@ -378,7 +382,7 @@ struct __parallel_transform_scan_dynamic_single_group_submitter<_Inclusive,
         const ::std::uint16_t __elems_per_item = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wg_size);
         const ::std::uint16_t __elems_per_wg = __elems_per_item * __wg_size;
 
-        return __q.submit([&](sycl::handler& __hdl) {
+        return __policy.queue().submit([&](sycl::handler& __hdl) {
             oneapi::dpl::__ranges::__require_access(__hdl, __in_rng, __out_rng);
 
             auto __lacc = __dpl_sycl::__local_accessor<_ValueType>(sycl::range<1>{__elems_per_wg}, __hdl);
@@ -422,16 +426,17 @@ template <bool _Inclusive, ::std::uint16_t _ElemsPerItem, ::std::uint16_t _WGSiz
 struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _ElemsPerItem, _WGSize, _IsFullGroup,
                                                                __internal::__optional_kernel_name<_ScanKernelName...>>
 {
-    template <typename _InRng, typename _OutRng, typename _InitType, typename _BinaryOperation, typename _UnaryOp>
+    template <typename _Policy, typename _InRng, typename _OutRng, typename _InitType, typename _BinaryOperation,
+              typename _UnaryOp>
     sycl::event
-    operator()(sycl::queue& __q, _InRng&& __in_rng, _OutRng&& __out_rng, std::size_t __n, _InitType __init,
+    operator()(const _Policy& __policy, _InRng&& __in_rng, _OutRng&& __out_rng, ::std::size_t __n, _InitType __init,
                _BinaryOperation __bin_op, _UnaryOp __unary_op)
     {
         using _ValueType = typename _InitType::__value_type;
 
         constexpr ::uint32_t __elems_per_wg = _ElemsPerItem * _WGSize;
 
-        return __q.submit([&](sycl::handler& __hdl) {
+        return __policy.queue().submit([&](sycl::handler& __hdl) {
             oneapi::dpl::__ranges::__require_access(__hdl, __in_rng, __out_rng);
 
             auto __lacc = __dpl_sycl::__local_accessor<_ValueType>(sycl::range<1>{__elems_per_wg}, __hdl);
@@ -477,10 +482,10 @@ template <typename _Size, ::std::uint16_t _ElemsPerItem, ::std::uint16_t _WGSize
 struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _WGSize, _IsFullGroup,
                                                         __internal::__optional_kernel_name<_ScanKernelName...>>
 {
-    template <typename _InRng, typename _OutRng, typename _InitType, typename _BinaryOperation, typename _UnaryOp,
-              typename _Assign>
+    template <typename _Policy, typename _InRng, typename _OutRng, typename _InitType, typename _BinaryOperation,
+              typename _UnaryOp, typename _Assign>
     __future<sycl::event, __result_and_scratch_storage<_Size>>
-    operator()(sycl::queue& __q, _InRng&& __in_rng, _OutRng&& __out_rng, std::size_t __n, _InitType __init,
+    operator()(_Policy&& __policy, _InRng&& __in_rng, _OutRng&& __out_rng, ::std::size_t __n, _InitType __init,
                _BinaryOperation __bin_op, _UnaryOp __unary_op, _Assign __assign)
     {
         using _ValueType = ::std::uint16_t;
@@ -493,9 +498,9 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
 
         constexpr ::std::uint32_t __elems_per_wg = _ElemsPerItem * _WGSize;
         using __result_and_scratch_storage_t = __result_and_scratch_storage<_Size>;
-        __result_and_scratch_storage_t __result{__q, 0};
+        __result_and_scratch_storage_t __result{__policy.queue(), 0};
 
-        auto __event = __q.submit([&](sycl::handler& __hdl) {
+        auto __event = __policy.queue().submit([&](sycl::handler& __hdl) {
             oneapi::dpl::__ranges::__require_access(__hdl, __in_rng, __out_rng);
 
             // Local memory is split into two parts. The first half stores the result of applying the
@@ -550,15 +555,17 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
     }
 };
 
-template <typename _CustomName, typename _InRng, typename _OutRng, typename _UnaryOperation, typename _InitType,
+template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _UnaryOperation, typename _InitType,
           typename _BinaryOperation, typename _Inclusive>
 sycl::event
-__parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q,
+__parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
                                        _InRng&& __in_rng, _OutRng&& __out_rng, ::std::size_t __n,
                                        _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op,
                                        _Inclusive)
 {
-    std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__q);
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
+    ::std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec.queue());
 
     // Specialization for devices that have a max work-group size of 1024
     constexpr ::std::uint16_t __targeted_wg_size = 1024;
@@ -580,8 +587,8 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
                         ::std::integral_constant<::std::uint16_t, __wg_size>,
                         ::std::integral_constant<::std::uint16_t, __num_elems_per_item>, _BinaryOperation,
                         /* _IsFullGroup= */ std::true_type, _Inclusive, _CustomName>>>()(
-                    __q, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, __init, __binary_op,
-                    __unary_op);
+                    ::std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                    std::forward<_OutRng>(__out_rng), __n, __init, __binary_op, __unary_op);
             else
                 return __parallel_transform_scan_static_single_group_submitter<
                     _Inclusive::value, __num_elems_per_item, __wg_size,
@@ -590,8 +597,8 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
                         ::std::integral_constant<::std::uint16_t, __wg_size>,
                         ::std::integral_constant<::std::uint16_t, __num_elems_per_item>, _BinaryOperation,
                         /* _IsFullGroup= */ ::std::false_type, _Inclusive, _CustomName>>>()(
-                    __q, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, __init, __binary_op,
-                    __unary_op);
+                    ::std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                    std::forward<_OutRng>(__out_rng), __n, __init, __binary_op, __unary_op);
         };
         if (__n <= 16)
             return __single_group_scan_f(std::integral_constant<::std::uint16_t, 16>{});
@@ -622,33 +629,35 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
             __par_backend_hetero::__scan_single_wg_dynamic_kernel<_BinaryOperation, _CustomName>>;
 
         return __parallel_transform_scan_dynamic_single_group_submitter<_Inclusive::value, _DynamicGroupScanKernel>()(
-            __q, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, __init, __binary_op, __unary_op,
-            __max_wg_size);
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng),
+            __n, __init, __binary_op, __unary_op, __max_wg_size);
     }
 }
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _InitType, typename _LocalScan,
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _InitType, typename _LocalScan,
           typename _GroupScan, typename _GlobalScan>
 __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
-__parallel_transform_scan_base(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _Range1&& __in_rng,
-                               _Range2&& __out_rng, _InitType __init, _LocalScan __local_scan, _GroupScan __group_scan,
-                               _GlobalScan __global_scan)
+__parallel_transform_scan_base(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+                               _Range1&& __in_rng, _Range2&& __out_rng, _InitType __init, _LocalScan __local_scan,
+                               _GroupScan __group_scan, _GlobalScan __global_scan)
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
     using _PropagateKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__scan_propagate_kernel<_CustomName>>;
 
-    return __parallel_scan_submitter<_CustomName, _PropagateKernel>()(__q, std::forward<_Range1>(__in_rng),
-                                                                      std::forward<_Range2>(__out_rng), __init,
-                                                                      __local_scan, __group_scan, __global_scan);
+    return __parallel_scan_submitter<_CustomName, _PropagateKernel>()(
+        std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng),
+        __init, __local_scan, __group_scan, __global_scan);
 }
 
 template <typename _Type>
 bool
-__group_scan_fits_in_slm(const sycl::queue& __q, std::size_t __n, std::size_t __n_uniform,
+__group_scan_fits_in_slm(const sycl::queue& __queue, std::size_t __n, std::size_t __n_uniform,
                          std::size_t __single_group_upper_limit)
 {
     // Pessimistically only use half of the memory to take into account memory used by compiled kernel
-    const std::size_t __max_slm_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>() / 2;
+    const std::size_t __max_slm_size = __queue.get_device().template get_info<sycl::info::device::local_mem_size>() / 2;
     const auto __req_slm_size = sizeof(_Type) * __n_uniform;
 
     return (__n <= __single_group_upper_limit && __max_slm_size >= __req_slm_size);
@@ -1029,10 +1038,10 @@ struct __write_to_id_if_else
     _Assign __assign;
 };
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _UnaryOperation, typename _InitType,
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation, typename _InitType,
           typename _BinaryOperation, typename _Inclusive>
 __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
-__parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
+__parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                           _Range1&& __in_rng, _Range2&& __out_rng, std::size_t __n, _UnaryOperation __unary_op,
                           _InitType __init, _BinaryOperation __binary_op, _Inclusive)
 {
@@ -1042,7 +1051,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
     // work-group implementation requires a fundamental type which must also be trivially copyable.
     if constexpr (std::is_trivially_copyable_v<_Type>)
     {
-        bool __use_reduce_then_scan = oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q);
+        bool __use_reduce_then_scan = oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec);
 
         // TODO: Consider re-implementing single group scan to support types without known identities. This could also
         // allow us to use single wg scan for the last block of reduce-then-scan if it is sufficiently small.
@@ -1054,15 +1063,15 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
 
             // Empirically found values for reduce-then-scan and multi pass scan implementation for single wg cutoff
             std::size_t __single_group_upper_limit = __use_reduce_then_scan ? 2048 : 16384;
-            if (__group_scan_fits_in_slm<_Type>(__q, __n, __n_uniform, __single_group_upper_limit))
+            if (__group_scan_fits_in_slm<_Type>(__exec.queue(), __n, __n_uniform, __single_group_upper_limit))
             {
-                auto __event = __parallel_transform_scan_single_group<_CustomName>(
-                    __backend_tag, __q, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __n,
-                    __unary_op, __init, __binary_op, _Inclusive{});
+                auto __event = __parallel_transform_scan_single_group(
+                    __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
+                    std::forward<_Range2>(__out_rng), __n, __unary_op, __init, __binary_op, _Inclusive{});
 
                 // Although we do not actually need result storage in this case, we need to construct
                 // a placeholder here to match the return type of the non-single-work-group implementation
-                __result_and_scratch_storage<_Type> __dummy_result_and_scratch{__q, 0};
+                __result_and_scratch_storage<_Type> __dummy_result_and_scratch{__exec, 0};
 
                 return __future{std::move(__event), std::move(__dummy_result_and_scratch)};
             }
@@ -1075,10 +1084,10 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
 
             _GenInput __gen_transform{__unary_op};
 
-            return __parallel_transform_reduce_then_scan<_CustomName>(
-                __backend_tag, __q, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __gen_transform,
-                __binary_op, __gen_transform, _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
-                /*_IsUniquePattern=*/std::false_type{});
+            return __parallel_transform_reduce_then_scan(
+                __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
+                std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform, _ScanInputTransform{},
+                _WriteOp{}, __init, _Inclusive{}, /*_IsUniquePattern=*/std::false_type{});
         }
     }
 
@@ -1092,8 +1101,9 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
     _NoAssign __no_assign_op;
     _NoOpFunctor __get_data_op;
 
-    return __parallel_transform_scan_base<_CustomName>(
-        __backend_tag, __q, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __init,
+    return __parallel_transform_scan_base(
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
+        std::forward<_Range2>(__out_rng), __init,
         // local scan
         unseq_backend::__scan<_Inclusive, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner, _NoOpFunctor,
                               _InitType>{__binary_op, _UnaryFunctor{__unary_op}, __assign_op, __assign_op,
@@ -1106,22 +1116,23 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
         unseq_backend::__global_scan_functor<_Inclusive, _BinaryOperation, _InitType>{__binary_op, __init});
 }
 
-template <typename _CustomName, typename _SizeType>
+template <typename _SizeType>
 struct __invoke_single_group_copy_if
 {
     // Specialization for devices that have a max work-group size of at least 1024
     static constexpr ::std::uint16_t __targeted_wg_size = 1024;
 
-    template <std::uint16_t _Size, typename _InRng, typename _OutRng, typename _Pred,
+    template <std::uint16_t _Size, typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Pred,
               typename _Assign = oneapi::dpl::__internal::__pstl_assign>
     auto
-    operator()(sycl::queue& __q, std::size_t __n, _InRng&& __in_rng, _OutRng&& __out_rng, _Pred __pred,
+    operator()(_ExecutionPolicy&& __exec, std::size_t __n, _InRng&& __in_rng, _OutRng&& __out_rng, _Pred __pred,
                _Assign __assign)
     {
         constexpr ::std::uint16_t __wg_size = ::std::min(_Size, __targeted_wg_size);
         constexpr ::std::uint16_t __num_elems_per_item = ::oneapi::dpl::__internal::__dpl_ceiling_div(_Size, __wg_size);
         const bool __is_full_group = __n == __wg_size;
 
+        using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
         using _InitType = unseq_backend::__no_init_value<::std::uint16_t>;
         using _ReduceOp = ::std::plus<::std::uint16_t>;
         if (__is_full_group)
@@ -1133,8 +1144,8 @@ struct __invoke_single_group_copy_if
             using _FullKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<_FullKernel>;
             return __par_backend_hetero::__parallel_copy_if_static_single_group_submitter<
                 _SizeType, __num_elems_per_item, __wg_size, true, _FullKernelName>()(
-                __q, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, _InitType{}, _ReduceOp{},
-                __pred, __assign);
+                std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                std::forward<_OutRng>(__out_rng), __n, _InitType{}, _ReduceOp{}, __pred, __assign);
         }
         else
         {
@@ -1146,16 +1157,16 @@ struct __invoke_single_group_copy_if
                 oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<_NonFullKernel>;
             return __par_backend_hetero::__parallel_copy_if_static_single_group_submitter<
                 _SizeType, __num_elems_per_item, __wg_size, false, _NonFullKernelName>()(
-                __q, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, _InitType{}, _ReduceOp{},
-                __pred, __assign);
+                std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                std::forward<_OutRng>(__out_rng), __n, _InitType{}, _ReduceOp{}, __pred, __assign);
         }
     }
 };
 
-template <typename _CustomName, typename _InRng, typename _OutRng, typename _Size, typename _GenMask, typename _WriteOp,
-          typename _IsUniquePattern>
+template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _GenMask,
+          typename _WriteOp, typename _IsUniquePattern>
 __future<sycl::event, __result_and_scratch_storage<_Size>>
-__parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
+__parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                                  _InRng&& __in_rng, _OutRng&& __out_rng, _Size, _GenMask __generate_mask,
                                  _WriteOp __write_op, _IsUniquePattern __is_unique_pattern)
 {
@@ -1164,18 +1175,20 @@ __parallel_reduce_then_scan_copy(oneapi::dpl::__internal::__device_backend_tag _
     using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
-    return __parallel_transform_reduce_then_scan<_CustomName>(
-        __backend_tag, __q, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng),
-        _GenReduceInput{__generate_mask}, _ReduceOp{}, _GenScanInput{__generate_mask, {}}, _ScanInputTransform{},
-        __write_op, oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
-        /*_Inclusive=*/std::true_type{}, __is_unique_pattern);
+    return __parallel_transform_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                                 std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng),
+                                                 _GenReduceInput{__generate_mask}, _ReduceOp{},
+                                                 _GenScanInput{__generate_mask, {}}, _ScanInputTransform{}, __write_op,
+                                                 oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
+                                                 /*_Inclusive=*/std::true_type{}, __is_unique_pattern);
 }
 
-template <typename _CustomName, typename _InRng, typename _OutRng, typename _Size, typename _CreateMaskOp,
+template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _CreateMaskOp,
           typename _CopyByMaskOp>
 __future<sycl::event, __result_and_scratch_storage<_Size>>
-__parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _InRng&& __in_rng,
-                     _OutRng&& __out_rng, _Size __n, _CreateMaskOp __create_mask_op, _CopyByMaskOp __copy_by_mask_op)
+__parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                     _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _CreateMaskOp __create_mask_op,
+                     _CopyByMaskOp __copy_by_mask_op)
 {
     using _ReduceOp = std::plus<_Size>;
     using _Assigner = unseq_backend::__scan_assigner;
@@ -1192,8 +1205,8 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
     // temporary buffer to store boolean mask
     oneapi::dpl::__par_backend_hetero::__buffer<int32_t> __mask_buf(__n);
 
-    return __parallel_transform_scan_base<_CustomName>(
-        __backend_tag, __q,
+    return __parallel_transform_scan_base(
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__ranges::zip_view(
             __in_rng, oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
                           __mask_buf.get_buffer())),
@@ -1209,10 +1222,10 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
         __copy_by_mask_op);
 }
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _BinaryPredicate>
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinaryPredicate>
 __future<sycl::event, __result_and_scratch_storage<oneapi::dpl::__internal::__difference_t<_Range1>>>
-__parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _Range1&& __rng,
-                       _Range2&& __result, _BinaryPredicate __pred)
+__parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                       _Range1&& __rng, _Range2&& __result, _BinaryPredicate __pred)
 {
     using _Assign = oneapi::dpl::__internal::__pstl_assign;
     oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng.size();
@@ -1221,15 +1234,15 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
     // can simply copy the input range to the output.
     assert(__n > 1);
 
-    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q))
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<1, _Assign>;
 
-        return __parallel_reduce_then_scan_copy<_CustomName>(__backend_tag, __q, std::forward<_Range1>(__rng),
-                                                             std::forward<_Range2>(__result), __n, _GenMask{__pred},
-                                                             _WriteOp{_Assign{}},
-                                                             /*_IsUniquePattern=*/std::true_type{});
+        return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                                std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
+                                                _GenMask{__pred}, _WriteOp{_Assign{}},
+                                                /*_IsUniquePattern=*/std::true_type{});
     }
     else
     {
@@ -1240,18 +1253,19 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
                                                                decltype(__n)>;
         using _CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, _Assign, /*inclusive*/ std::true_type, 1>;
 
-        return __parallel_scan_copy<_CustomName>(
-            __backend_tag, __q, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
-            _CreateOp{oneapi::dpl::__internal::__not_pred<_BinaryPredicate>{__pred}}, _CopyOp{_ReduceOp{}, _Assign{}});
+        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
+                                    std::forward<_Range2>(__result), __n,
+                                    _CreateOp{oneapi::dpl::__internal::__not_pred<_BinaryPredicate>{__pred}},
+                                    _CopyOp{_ReduceOp{}, _Assign{}});
     }
 }
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Range4,
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Range4,
           typename _BinaryPredicate, typename _BinaryOperator>
 __future<sycl::event, __result_and_scratch_storage<
                           oneapi::dpl::__internal::tuple<std::size_t, oneapi::dpl::__internal::__value_t<_Range2>>>>
 __parallel_reduce_by_segment_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
-                                              sycl::queue& __q, _Range1&& __keys, _Range2&& __values,
+                                              _ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& __values,
                                               _Range3&& __out_keys, _Range4&& __out_values,
                                               _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
 {
@@ -1269,9 +1283,8 @@ __parallel_reduce_by_segment_reduce_then_scan(oneapi::dpl::__internal::__device_
     std::size_t __n = __keys.size();
     // __gen_red_by_seg_scan_input requires that __n > 1
     assert(__n > 1);
-
-    return __parallel_transform_reduce_then_scan<_CustomName>(
-        __backend_tag, __q,
+    return __parallel_transform_reduce_then_scan(
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__keys), std::forward<_Range2>(__values)),
         oneapi::dpl::__ranges::make_zip_view(std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values)),
         _GenReduceInput{__binary_pred}, _ReduceOp{__binary_op}, _GenScanInput{__binary_pred, __n},
@@ -1280,22 +1293,22 @@ __parallel_reduce_by_segment_reduce_then_scan(oneapi::dpl::__internal::__device_
         /*Inclusive*/ std::true_type{}, /*_IsUniquePattern=*/std::false_type{});
 }
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _UnaryPredicate>
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryPredicate>
 __future<sycl::event, __result_and_scratch_storage<oneapi::dpl::__internal::__difference_t<_Range1>>>
-__parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
+__parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                           _Range1&& __rng, _Range2&& __result, _UnaryPredicate __pred)
 {
     oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng.size();
-    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q))
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
         using _WriteOp =
             oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
 
-        return __parallel_reduce_then_scan_copy<_CustomName>(__backend_tag, __q, std::forward<_Range1>(__rng),
-                                                             std::forward<_Range2>(__result), __n, _GenMask{__pred, {}},
-                                                             _WriteOp{},
-                                                             /*_IsUniquePattern=*/std::false_type{});
+        return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                                std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
+                                                _GenMask{__pred, {}}, _WriteOp{},
+                                                /*_IsUniquePattern=*/std::false_type{});
     }
     else
     {
@@ -1303,32 +1316,32 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
         using _CreateOp = unseq_backend::__create_mask<_UnaryPredicate, decltype(__n)>;
         using _CopyOp = unseq_backend::__partition_by_mask<_ReduceOp, /*inclusive*/ std::true_type>;
 
-        return __parallel_scan_copy<_CustomName>(__backend_tag, __q, std::forward<_Range1>(__rng),
-                                                 std::forward<_Range2>(__result), __n, _CreateOp{__pred},
-                                                 _CopyOp{_ReduceOp{}});
+        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
+                                    std::forward<_Range2>(__result), __n, _CreateOp{__pred}, _CopyOp{_ReduceOp{}});
     }
 }
 
-template <typename _CustomName, typename _InRng, typename _OutRng, typename _Size, typename _Pred,
+template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _Pred,
           typename _Assign = oneapi::dpl::__internal::__pstl_assign>
 __future<sycl::event, __result_and_scratch_storage<_Size>>
-__parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _InRng&& __in_rng,
-                   _OutRng&& __out_rng, _Size __n, _Pred __pred, _Assign __assign = _Assign{})
+__parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                   _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _Pred __pred, _Assign __assign = _Assign{})
 {
-    using _SingleGroupInvoker = __invoke_single_group_copy_if<_CustomName, _Size>;
+    using _SingleGroupInvoker = __invoke_single_group_copy_if<_Size>;
 
     // Next power of 2 greater than or equal to __n
     auto __n_uniform = ::oneapi::dpl::__internal::__dpl_bit_ceil(static_cast<std::make_unsigned_t<_Size>>(__n));
 
     // Pessimistically only use half of the memory to take into account memory used by compiled kernel
-    const std::size_t __max_slm_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>() / 2;
+    const std::size_t __max_slm_size =
+        __exec.queue().get_device().template get_info<sycl::info::device::local_mem_size>() / 2;
 
     // The kernel stores n integers for the predicate and another n integers for the offsets
     const auto __req_slm_size = sizeof(std::uint16_t) * __n_uniform * 2;
 
     constexpr std::uint16_t __single_group_upper_limit = 2048;
 
-    std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__q);
+    std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec.queue());
 
     if (__n <= __single_group_upper_limit && __max_slm_size >= __req_slm_size &&
         __max_wg_size >= _SingleGroupInvoker::__targeted_wg_size)
@@ -1336,18 +1349,18 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
         using _SizeBreakpoints = std::integer_sequence<std::uint16_t, 16, 32, 64, 128, 256, 512, 1024, 2048>;
 
         return __par_backend_hetero::__static_monotonic_dispatcher<_SizeBreakpoints>::__dispatch(
-            _SingleGroupInvoker{}, __n, __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng),
-            __pred, __assign);
+            _SingleGroupInvoker{}, __n, std::forward<_ExecutionPolicy>(__exec), __n, std::forward<_InRng>(__in_rng),
+            std::forward<_OutRng>(__out_rng), __pred, __assign);
     }
-    else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q))
+    else if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
 
-        return __parallel_reduce_then_scan_copy<_CustomName>(__backend_tag, __q, std::forward<_InRng>(__in_rng),
-                                                             std::forward<_OutRng>(__out_rng), __n,
-                                                             _GenMask{__pred, {}}, _WriteOp{__assign},
-                                                             /*_IsUniquePattern=*/std::false_type{});
+        return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                                std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
+                                                _GenMask{__pred, {}}, _WriteOp{__assign},
+                                                /*_IsUniquePattern=*/std::false_type{});
     }
     else
     {
@@ -1356,16 +1369,16 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
         using _CopyOp = unseq_backend::__copy_by_mask<_ReduceOp, _Assign,
                                                       /*inclusive*/ std::true_type, 1>;
 
-        return __parallel_scan_copy<_CustomName>(__backend_tag, __q, std::forward<_InRng>(__in_rng),
-                                                 std::forward<_OutRng>(__out_rng), __n, _CreateOp{__pred},
-                                                 _CopyOp{_ReduceOp{}, __assign});
+        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                    std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
+                                    _CreateOp{__pred}, _CopyOp{_ReduceOp{}, __assign});
     }
 }
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
 __future<sycl::event, __result_and_scratch_storage<oneapi::dpl::__internal::__difference_t<_Range3>>>
-__parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
+__parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                                 _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
                                 _IsOpDifference)
 {
@@ -1385,8 +1398,8 @@ __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __
 
     oneapi::dpl::__par_backend_hetero::__buffer<std::int32_t> __mask_buf(__rng1.size());
 
-    return __parallel_transform_reduce_then_scan<_CustomName>(
-        __backend_tag, __q,
+    return __parallel_transform_reduce_then_scan(
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__ranges::make_zip_view(
             std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
             oneapi::dpl::__ranges::all_view<std::int32_t, __par_backend_hetero::access_mode::read_write>(
@@ -1397,11 +1410,11 @@ __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __
         /*_Inclusive=*/std::true_type{}, /*__is_unique_pattern=*/std::false_type{});
 }
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
 __future<sycl::event, __result_and_scratch_storage<oneapi::dpl::__internal::__difference_t<_Range1>>>
-__parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _Range1&& __rng1,
-                    _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference)
+__parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                    _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference)
 {
     using _Size1 = oneapi::dpl::__internal::__difference_t<_Range1>;
     using _Size2 = oneapi::dpl::__internal::__difference_t<_Range2>;
@@ -1427,8 +1440,8 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
     // temporary buffer to store boolean mask
     oneapi::dpl::__par_backend_hetero::__buffer<int32_t> __mask_buf(__n1);
 
-    return __par_backend_hetero::__parallel_transform_scan_base<_CustomName>(
-        __backend_tag, __q,
+    return __par_backend_hetero::__parallel_transform_scan_base(
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__ranges::make_zip_view(
             std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
             oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
@@ -1445,23 +1458,24 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
         __copy_by_mask_op);
 }
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
 __future<sycl::event, __result_and_scratch_storage<oneapi::dpl::__internal::__difference_t<_Range3>>>
-__parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _Range1&& __rng1,
-                  _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference __is_op_difference)
+__parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                  _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
+                  _IsOpDifference __is_op_difference)
 {
-    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q))
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
     {
-        return __parallel_set_reduce_then_scan<_CustomName>(
-            __backend_tag, __q, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-            std::forward<_Range3>(__result), __comp, __is_op_difference);
+        return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                               std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                                               std::forward<_Range3>(__result), __comp, __is_op_difference);
     }
     else
     {
-        return __parallel_set_scan<_CustomName>(__backend_tag, __q, std::forward<_Range1>(__rng1),
-                                                std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp,
-                                                __is_op_difference);
+        return __parallel_set_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
+                                   std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp,
+                                   __is_op_difference);
     }
 }
 
@@ -1652,20 +1666,22 @@ template <typename Tag>
 struct __parallel_find_or_nd_range_tuner
 {
     // Tune the amount of work-groups and work-group size
+    template <typename _ExecutionPolicy>
     std::tuple<std::size_t, std::size_t>
-    operator()(const sycl::queue& __q, const std::size_t __rng_n) const
+    operator()(const _ExecutionPolicy& __exec, const std::size_t __rng_n) const
     {
         // TODO: find a way to generalize getting of reliable work-group size
         // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
         // This value exceeds the current practical limit for GPUs, but may need to be re-evaluated in the future.
-        const std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__q, (std::size_t)4096);
+        const std::size_t __wgroup_size =
+            oneapi::dpl::__internal::__max_work_group_size(__exec.queue(), (std::size_t)4096);
         std::size_t __n_groups = 1;
         // If no more than 32 data elements per work item, a single work group will be used
         if (__rng_n > __wgroup_size * 32)
         {
             // Compute the number of groups and limit by the number of compute units
             __n_groups = std::min<std::size_t>(oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size),
-                                               oneapi::dpl::__internal::__max_compute_units(__q));
+                                               oneapi::dpl::__internal::__max_compute_units(__exec.queue()));
         }
 
         return {__n_groups, __wgroup_size};
@@ -1678,11 +1694,12 @@ template <>
 struct __parallel_find_or_nd_range_tuner<oneapi::dpl::__internal::__device_backend_tag>
 {
     // Tune the amount of work-groups and work-group size
+    template <typename _ExecutionPolicy>
     std::tuple<std::size_t, std::size_t>
-    operator()(const sycl::queue& __q, const std::size_t __rng_n) const
+    operator()(const _ExecutionPolicy& __exec, const std::size_t __rng_n) const
     {
         // Call common tuning function to get the work-group size
-        auto [__n_groups, __wgroup_size] = __parallel_find_or_nd_range_tuner<int>{}(__q, __rng_n);
+        auto [__n_groups, __wgroup_size] = __parallel_find_or_nd_range_tuner<int>{}(__exec, __rng_n);
 
         if (__n_groups > 1)
         {
@@ -1722,20 +1739,21 @@ struct __parallel_find_or_impl_one_wg;
 template <bool __or_tag_check, typename... KernelName>
 struct __parallel_find_or_impl_one_wg<__or_tag_check, __internal::__optional_kernel_name<KernelName...>>
 {
-    template <typename _BrickTag, typename __FoundStateType, typename _Predicate, typename... _Ranges>
+    template <typename _ExecutionPolicy, typename _BrickTag, typename __FoundStateType, typename _Predicate,
+              typename... _Ranges>
     __FoundStateType
-    operator()(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _BrickTag __brick_tag,
+    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _BrickTag __brick_tag,
                const std::size_t __rng_n, const std::size_t __wgroup_size, const __FoundStateType __init_value,
                _Predicate __pred, _Ranges&&... __rngs)
     {
         using __result_and_scratch_storage_t = __result_and_scratch_storage<__FoundStateType>;
-        __result_and_scratch_storage_t __result_storage{__q, 0};
+        __result_and_scratch_storage_t __result_storage{__exec.queue(), 0};
 
         // Calculate the number of elements to be processed by each work-item.
         const auto __iters_per_work_item = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
 
         // main parallel_for
-        auto __event = __q.submit([&](sycl::handler& __cgh) {
+        auto __event = __exec.queue().submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
             auto __result_acc =
                 __result_storage.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
@@ -1786,9 +1804,10 @@ struct __parallel_find_or_impl_multiple_wgs;
 template <bool __or_tag_check, typename... KernelName>
 struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__optional_kernel_name<KernelName...>>
 {
-    template <typename _BrickTag, typename _AtomicType, typename _Predicate, typename... _Ranges>
+    template <typename _ExecutionPolicy, typename _BrickTag, typename _AtomicType, typename _Predicate,
+              typename... _Ranges>
     _AtomicType
-    operator()(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _BrickTag __brick_tag,
+    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _BrickTag __brick_tag,
                const std::size_t __rng_n, const std::size_t __n_groups, const std::size_t __wgroup_size,
                const _AtomicType __init_value, _Predicate __pred, _Ranges&&... __rngs)
     {
@@ -1803,7 +1822,7 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
             sycl::buffer<_AtomicType, 1> __result_sycl_buf(&__result, 1); // temporary storage for global atomic
 
             // main parallel_for
-            __q.submit([&](sycl::handler& __cgh) {
+            __exec.queue().submit([&](sycl::handler& __cgh) {
                 oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
                 auto __result_sycl_buf_acc = __result_sycl_buf.template get_access<access_mode::read_write>(__cgh);
 
@@ -1852,21 +1871,23 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
 };
 
 // Base pattern for __parallel_or and __parallel_find. The execution depends on tag type _BrickTag.
-template <typename _CustomName, typename _Brick, typename _BrickTag, typename... _Ranges>
+template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 ::std::conditional_t<
     ::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
     oneapi::dpl::__internal::__difference_t<typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>
-__parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _Brick __f, _BrickTag __brick_tag,
-                   _Ranges&&... __rngs)
+__parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
+                   _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
     auto __rng_n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     assert(__rng_n > 0);
 
     // Evaluate the amount of work-groups and work-group size
     const auto [__n_groups, __wgroup_size] =
-        __parallel_find_or_nd_range_tuner<oneapi::dpl::__internal::__device_backend_tag>{}(__q, __rng_n);
+        __parallel_find_or_nd_range_tuner<oneapi::dpl::__internal::__device_backend_tag>{}(__exec, __rng_n);
 
-    _PRINT_INFO_IN_DEBUG_MODE(__q, __wgroup_size);
+    _PRINT_INFO_IN_DEBUG_MODE(__exec.queue(), __wgroup_size);
 
     using _AtomicType = typename _BrickTag::_AtomicType;
     const _AtomicType __init_value = _BrickTag::__init_value(__rng_n);
@@ -1885,21 +1906,21 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& _
 
         // Single WG implementation
         __result = __parallel_find_or_impl_one_wg<__or_tag_check, __find_or_one_wg_kernel_name>()(
-            oneapi::dpl::__internal::__device_backend_tag{}, __q, __brick_tag, __rng_n, __wgroup_size, __init_value,
-            __pred, std::forward<_Ranges>(__rngs)...);
+            oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __brick_tag,
+            __rng_n, __wgroup_size, __init_value, __pred, std::forward<_Ranges>(__rngs)...);
     }
     else
     {
         assert("This device does not support 64-bit atomics" &&
-               (sizeof(_AtomicType) < 8 || __q.get_device().has(sycl::aspect::atomic64)));
+               (sizeof(_AtomicType) < 8 || __exec.queue().get_device().has(sycl::aspect::atomic64)));
 
         using __find_or_kernel_name =
             oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__find_or_kernel<_CustomName>>;
 
         // Multiple WG implementation
         __result = __parallel_find_or_impl_multiple_wgs<__or_tag_check, __find_or_kernel_name>()(
-            oneapi::dpl::__internal::__device_backend_tag{}, __q, __brick_tag, __rng_n, __n_groups, __wgroup_size,
-            __init_value, __pred, std::forward<_Ranges>(__rngs)...);
+            oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __brick_tag,
+            __rng_n, __n_groups, __wgroup_size, __init_value, __pred, std::forward<_Ranges>(__rngs)...);
     }
 
     if constexpr (__or_tag_check)
@@ -1916,33 +1937,37 @@ class __or_policy_wrapper
 {
 };
 
-template <typename _CustomName, typename _Iterator1, typename _Iterator2, typename _Brick>
+template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Brick>
 bool
-__parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _Iterator1 __first,
-              _Iterator1 __last, _Iterator2 __s_first, _Iterator2 __s_last, _Brick __f)
+__parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+              _Iterator1 __first, _Iterator1 __last, _Iterator2 __s_first, _Iterator2 __s_last, _Brick __f)
 {
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf = __keep(__first, __last);
     auto __s_keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
     auto __s_buf = __s_keep(__s_first, __s_last);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or<_CustomName>(
-        __backend_tag, __q, __f, __parallel_or_tag{}, __buf.all_view(), __s_buf.all_view());
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        __backend_tag,
+        __par_backend_hetero::make_wrapped_policy<__or_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)), __f,
+        __parallel_or_tag{}, __buf.all_view(), __s_buf.all_view());
 }
 
 // Special overload for single sequence cases.
 // TODO: check if similar pattern may apply to other algorithms. If so, these overloads should be moved out of
 // backend code.
-template <typename _CustomName, typename _Iterator, typename _Brick>
+template <typename _ExecutionPolicy, typename _Iterator, typename _Brick>
 bool
-__parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _Iterator __first,
+__parallel_or(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec, _Iterator __first,
               _Iterator __last, _Brick __f)
 {
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or<_CustomName>(__backend_tag, __q, __f,
-                                                                              __parallel_or_tag{}, __buf.all_view());
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        __backend_tag,
+        __par_backend_hetero::make_wrapped_policy<__or_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)), __f,
+        __parallel_or_tag{}, __buf.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -1954,10 +1979,10 @@ class __find_policy_wrapper
 {
 };
 
-template <typename _CustomName, typename _Iterator1, typename _Iterator2, typename _Brick, typename _IsFirst>
+template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Brick, typename _IsFirst>
 _Iterator1
-__parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _Iterator1 __first,
-                _Iterator1 __last, _Iterator2 __s_first, _Iterator2 __s_last, _Brick __f, _IsFirst)
+__parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                _Iterator1 __first, _Iterator1 __last, _Iterator2 __s_first, _Iterator2 __s_last, _Brick __f, _IsFirst)
 {
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf = __keep(__first, __last);
@@ -1966,27 +1991,31 @@ __parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, syc
 
     using _TagType = ::std::conditional_t<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
                                           __parallel_find_backward_tag<decltype(__buf.all_view())>>;
-
-    return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or<__find_policy_wrapper<_CustomName>>(
-                         __backend_tag, __q, __f, _TagType{}, __buf.all_view(), __s_buf.all_view());
+    return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+                         __backend_tag,
+                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
+                             ::std::forward<_ExecutionPolicy>(__exec)),
+                         __f, _TagType{}, __buf.all_view(), __s_buf.all_view());
 }
 
 // Special overload for single sequence cases.
 // TODO: check if similar pattern may apply to other algorithms. If so, these overloads should be moved out of
 // backend code.
-template <typename _CustomName, typename _Iterator, typename _Brick, typename _IsFirst>
+template <typename _ExecutionPolicy, typename _Iterator, typename _Brick, typename _IsFirst>
 _Iterator
-__parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _Iterator __first,
-                _Iterator __last, _Brick __f, _IsFirst)
+__parallel_find(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                _Iterator __first, _Iterator __last, _Brick __f, _IsFirst)
 {
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
     using _TagType = ::std::conditional_t<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
                                           __parallel_find_backward_tag<decltype(__buf.all_view())>>;
-
-    return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or<__find_policy_wrapper<_CustomName>>(
-                         __backend_tag, __q, __f, _TagType{}, __buf.all_view());
+    return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+                         __backend_tag,
+                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
+                             ::std::forward<_ExecutionPolicy>(__exec)),
+                         __f, _TagType{}, __buf.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -2074,9 +2103,9 @@ template <typename... _GlobalSortName, typename... _CopyBackName>
 struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_GlobalSortName...>,
                                          __internal::__optional_kernel_name<_CopyBackName...>>
 {
-    template <typename _BackendTag, typename _Range, typename _Merge, typename _Compare>
+    template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Merge, typename _Compare>
     __future<sycl::event>
-    operator()(_BackendTag, sycl::queue& __q, _Range&& __rng, _Merge __merge, _Compare __comp) const
+    operator()(_BackendTag, _ExecutionPolicy&& __exec, _Range&& __rng, _Merge __merge, _Compare __comp) const
     {
         using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
         using _Size = oneapi::dpl::__internal::__difference_t<_Range>;
@@ -2086,14 +2115,14 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
 
         oneapi::dpl::__par_backend_hetero::__buffer<_Tp> __temp_buf(__n);
         auto __temp = __temp_buf.get_buffer();
-        _PRINT_INFO_IN_DEBUG_MODE(__q);
+        _PRINT_INFO_IN_DEBUG_MODE(__exec.queue());
 
         _Size __k = 1;
         bool __data_in_temp = false;
         sycl::event __event1;
         do
         {
-            __event1 = __q.submit([&, __data_in_temp, __k](sycl::handler& __cgh) {
+            __event1 = __exec.queue().submit([&, __data_in_temp, __k](sycl::handler& __cgh) {
                 __cgh.depends_on(__event1);
                 oneapi::dpl::__ranges::__require_access(__cgh, __rng);
                 auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
@@ -2124,7 +2153,7 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
         // if results are in temporary buffer then copy back those
         if (__data_in_temp)
         {
-            __event1 = __q.submit([&](sycl::handler& __cgh) {
+            __event1 = __exec.queue().submit([&](sycl::handler& __cgh) {
                 __cgh.depends_on(__event1);
                 oneapi::dpl::__ranges::__require_access(__cgh, __rng);
                 auto __temp_acc = __temp.template get_access<access_mode::read>(__cgh);
@@ -2142,18 +2171,20 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
 template <typename... _Name>
 class __sort_global_kernel;
 
-template <typename _CustomName, typename _Range, typename _Merge, typename _Compare>
+template <typename _ExecutionPolicy, typename _Range, typename _Merge, typename _Compare>
 __future<sycl::event>
-__parallel_partial_sort_impl(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _Range&& __rng,
+__parallel_partial_sort_impl(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range&& __rng,
                              _Merge __merge, _Compare __comp)
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _GlobalSortKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_global_kernel<_CustomName>>;
     using _CopyBackKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_copy_back_kernel<_CustomName>>;
 
     return __parallel_partial_sort_submitter<_GlobalSortKernel, _CopyBackKernel>()(
-        oneapi::dpl::__internal::__device_backend_tag{}, __q, std::forward<_Range>(__rng), __merge, __comp);
+        oneapi::dpl::__internal::__device_backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        ::std::forward<_Range>(__rng), __merge, __comp);
 }
 
 //------------------------------------------------------------------------
@@ -2175,28 +2206,28 @@ struct __is_radix_sort_usable_for_type
 
 #if _ONEDPL_USE_RADIX_SORT
 template <
-    typename _CustomName, typename _Range, typename _Compare, typename _Proj,
+    typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
     ::std::enable_if_t<
         __is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 __future<sycl::event>
-__parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _Range&& __rng,
-                       _Compare, _Proj __proj)
+__parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                       _Range&& __rng, _Compare, _Proj __proj)
 {
-    return __parallel_radix_sort<_CustomName, __internal::__is_comp_ascending<std::decay_t<_Compare>>::value>(
-        __backend_tag, __q, std::forward<_Range>(__rng), __proj);
+    return __parallel_radix_sort<__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value>(
+        __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __proj);
 }
 #endif // _ONEDPL_USE_RADIX_SORT
 
 template <
-    typename _CustomName, typename _Range, typename _Compare, typename _Proj,
+    typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
     ::std::enable_if_t<
         !__is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
-__parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q, _Range&& __rng,
-                       _Compare __comp, _Proj __proj)
+__parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                       _Range&& __rng, _Compare __comp, _Proj __proj)
 {
-    return __parallel_sort_impl<_CustomName>(__backend_tag, __q, std::forward<_Range>(__rng),
-                                             oneapi::dpl::__internal::__compare<_Compare, _Proj>{__comp, __proj});
+    return __parallel_sort_impl(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
+                                oneapi::dpl::__internal::__compare<_Compare, _Proj>{__comp, __proj});
 }
 
 //------------------------------------------------------------------------
@@ -2206,9 +2237,9 @@ __parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_t
 // TODO: check if it makes sense to move these wrappers out of backend to a common place
 // TODO: consider changing __partial_merge_kernel to make it compatible with
 //       __full_merge_kernel in order to use __parallel_sort_impl routine
-template <typename _CustomName, typename _Iterator, typename _Compare>
+template <typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 __future<sycl::event>
-__parallel_partial_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
+__parallel_partial_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                         _Iterator __first, _Iterator __mid, _Iterator __last, _Compare __comp)
 {
     const auto __mid_idx = __mid - __first;
@@ -2216,8 +2247,8 @@ __parallel_partial_sort(oneapi::dpl::__internal::__device_backend_tag __backend_
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    return __parallel_partial_sort_impl<_CustomName>(__backend_tag, __q, __buf.all_view(),
-                                                     __partial_merge_kernel<decltype(__mid_idx)>{__mid_idx}, __comp);
+    return __parallel_partial_sort_impl(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __buf.all_view(),
+                                        __partial_merge_kernel<decltype(__mid_idx)>{__mid_idx}, __comp);
 }
 
 //------------------------------------------------------------------------
@@ -2288,12 +2319,9 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
                                       _BinaryOperator __binary_op,
                                       /*known_identity=*/std::false_type)
 {
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using __diff_type = oneapi::dpl::__internal::__difference_t<_Range1>;
     using __key_type = oneapi::dpl::__internal::__value_t<_Range1>;
     using __val_type = oneapi::dpl::__internal::__value_t<_Range2>;
-
-    sycl::queue __q_local = __exec.queue();
 
     const auto __n = __keys.size();
     // Round 1: reduce with extra indices added to avoid long segments
@@ -2315,17 +2343,18 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
                                                    oneapi::dpl::__ranges::views::all_write(__idx));
 
     // use work group size adjusted to shared local memory as the maximum segment size.
-    std::size_t __wgroup_size =
-        oneapi::dpl::__internal::__slm_adjusted_work_group_size(__q_local, sizeof(__key_type) + sizeof(__val_type));
+    std::size_t __wgroup_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(
+        __exec.queue(), sizeof(__key_type) + sizeof(__val_type));
 
     // element is copied if it is the 0th element (marks beginning of first segment), is in an index
     // evenly divisible by wg size (ensures segments are not long), or has a key not equal to the
     // adjacent element (marks end of real segments)
     // TODO: replace wgroup size with segment size based on platform specifics.
     auto __intermediate_result_end =
-        oneapi::dpl::__par_backend_hetero::__parallel_copy_if<__assign_key1_wrapper<_CustomName>>(
-            oneapi::dpl::__internal::__device_backend_tag{}, __q_local, __view1, __view2, __n,
-            __internal::__parallel_reduce_by_segment_fallback_fn1<_BinaryPredicate>{__binary_pred, __wgroup_size},
+        oneapi::dpl::__par_backend_hetero::__parallel_copy_if(
+            oneapi::dpl::__internal::__device_backend_tag{},
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key1_wrapper>(__exec), __view1, __view2,
+            __n, __internal::__parallel_reduce_by_segment_fallback_fn1<_BinaryPredicate>{__binary_pred, __wgroup_size},
             unseq_backend::__brick_assign_key_position{})
             .get();
 
@@ -2362,9 +2391,10 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     // element is copied if it is the 0th element (marks beginning of first segment), or has a key not equal to
     // the adjacent element (end of a segment). Artificial segments based on wg size are not created.
     auto __result_end =
-        oneapi::dpl::__par_backend_hetero::__parallel_copy_if<__assign_key2_wrapper<_CustomName>>(
-            oneapi::dpl::__internal::__device_backend_tag{}, __q_local, __view3, __view4, __view3.size(),
-            __internal::__parallel_reduce_by_segment_fallback_fn2<_BinaryPredicate>{__binary_pred},
+        oneapi::dpl::__par_backend_hetero::__parallel_copy_if(
+            oneapi::dpl::__internal::__device_backend_tag{},
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key2_wrapper>(__exec), __view3, __view4,
+            __view3.size(), __internal::__parallel_reduce_by_segment_fallback_fn2<_BinaryPredicate>{__binary_pred},
             unseq_backend::__brick_assign_key_position{})
             .get();
 
@@ -2398,21 +2428,17 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
     //          __out_keys   = { 1, 2, 3, 4, 1, 3, 1, 3, 0 }
     //          __out_values = { 1, 2, 3, 4, 2, 6, 2, 6, 0 }
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
     using __val_type = oneapi::dpl::__internal::__value_t<_Range2>;
     // Prior to icpx 2025.0, the reduce-then-scan path performs poorly and should be avoided.
 #if !defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER >= 20250000
     if constexpr (std::is_trivially_copyable_v<__val_type>)
     {
-        if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
+        if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec))
         {
-            auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan<_CustomName>(
-                oneapi::dpl::__internal::__device_backend_tag{}, __q_local, std::forward<_Range1>(__keys),
-                std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values),
-                __binary_pred, __binary_op);
+            auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan(
+                oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
+                std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys),
+                std::forward<_Range4>(__out_values), __binary_pred, __binary_op);
             // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the
             // past-the-end iterator pair of segmented reduction.
             return std::get<0>(__res.get()) + 1;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -56,13 +56,13 @@ struct __parallel_for_small_submitter;
 template <typename... _Name>
 struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name...>>
 {
-    template <typename _Fp, typename _Index, typename... _Ranges>
+    template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
     __future<sycl::event>
-    operator()(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
+    operator()(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
         assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
-        _PRINT_INFO_IN_DEBUG_MODE(__q);
-        auto __event = __q.submit([__rngs..., __brick, __count](sycl::handler& __cgh) {
+        _PRINT_INFO_IN_DEBUG_MODE(__exec.queue());
+        auto __event = __exec.queue().submit([__rngs..., __brick, __count](sycl::handler& __cgh) {
             //get an access to data under SYCL buffer:
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
@@ -127,25 +127,25 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
 
     // Once there is enough work to launch a group on each compute unit with our chosen __iters_per_item,
     // then we should start using this code path.
-    template <typename _Fp>
+    template <typename _ExecutionPolicy, typename _Fp>
     static std::size_t
-    __estimate_best_start_size(const sycl::queue& __q, _Fp __brick)
+    __estimate_best_start_size(const _ExecutionPolicy& __exec, _Fp __brick)
     {
         const std::size_t __work_group_size =
-            oneapi::dpl::__internal::__max_work_group_size(__q, __max_work_group_size);
-        const std::uint32_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__q);
+            oneapi::dpl::__internal::__max_work_group_size(__exec.queue(), __max_work_group_size);
+        const std::uint32_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec.queue());
         return __work_group_size * _Fp::__preferred_iters_per_item * __max_cu;
     }
 
-    template <typename _Fp, typename _Index, typename... _Ranges>
+    template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
     __future<sycl::event>
-    operator()(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
+    operator()(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
         assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
         const std::size_t __work_group_size =
-            oneapi::dpl::__internal::__max_work_group_size(__q, __max_work_group_size);
-        _PRINT_INFO_IN_DEBUG_MODE(__q);
-        auto __event = __q.submit([__rngs..., __brick, __work_group_size, __count](sycl::handler& __cgh) {
+            oneapi::dpl::__internal::__max_work_group_size(__exec.queue(), __max_work_group_size);
+        _PRINT_INFO_IN_DEBUG_MODE(__exec.queue());
+        auto __event = __exec.queue().submit([__rngs..., __brick, __work_group_size, __count](sycl::handler& __cgh) {
             //get an access to data under SYCL buffer:
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
             constexpr std::uint8_t __iters_per_work_item = _Fp::__preferred_iters_per_item;
@@ -187,8 +187,6 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
     using _ForKernelLarge =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__parallel_for_large_kernel<_CustomName>>;
 
-    sycl::queue __q_local = __exec.queue();
-
     using __small_submitter = __parallel_for_small_submitter<_ForKernelSmall>;
     using __large_submitter = __parallel_for_large_submitter<_ForKernelLarge>;
     // Compile two kernels: one for small-to-medium inputs and a second for large. This avoids runtime checks within a
@@ -196,12 +194,14 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
     // then only compile the basic kernel as the two versions are effectively the same.
     if constexpr (_Fp::__preferred_iters_per_item > 1 || _Fp::__preferred_vector_size > 1)
     {
-        if (__count >= __large_submitter::__estimate_best_start_size(__q_local, __brick))
+        if (__count >= __large_submitter::__estimate_best_start_size(__exec, __brick))
         {
-            return __large_submitter{}(__q_local, __brick, __count, std::forward<_Ranges>(__rngs)...);
+            return __large_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
+                                       std::forward<_Ranges>(__rngs)...);
         }
     }
-    return __small_submitter{}(__q_local, __brick, __count, std::forward<_Ranges>(__rngs)...);
+    return __small_submitter{}(std::forward<_ExecutionPolicy>(__exec), __brick, __count,
+                               std::forward<_Ranges>(__rngs)...);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -55,19 +55,19 @@ struct __parallel_for_fpga_submitter;
 template <typename... _Name>
 struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...>>
 {
-    template <unsigned int unroll_factor, typename _Fp, typename _Index, typename... _Ranges>
+    template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
     __future<sycl::event>
-    operator()(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
+    operator()(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
         assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
 
-        _PRINT_INFO_IN_DEBUG_MODE(__q);
-        auto __event = __q.submit([&__rngs..., &__brick, __count](sycl::handler& __cgh) {
+        _PRINT_INFO_IN_DEBUG_MODE(__exec.queue());
+        auto __event = __exec.queue().submit([&__rngs..., &__brick, __count](sycl::handler& __cgh) {
             //get an access to data under SYCL buffer:
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
             __cgh.single_task<_Name...>([=]() {
-#pragma unroll(unroll_factor)
+#pragma unroll(::std::decay <_ExecutionPolicy>::type::unroll_factor)
                 for (auto __idx = 0; __idx < __count; ++__idx)
                 {
                     __brick.__scalar_path_impl(std::true_type{}, __idx, __rngs...);
@@ -87,12 +87,8 @@ __parallel_for(oneapi::dpl::__internal::__fpga_backend_tag, _ExecutionPolicy&& _
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using __parallel_for_name = __internal::__kernel_name_provider<_CustomName>;
 
-    constexpr unsigned int unroll_factor = std::decay<_ExecutionPolicy>::type::unroll_factor;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return __parallel_for_fpga_submitter<__parallel_for_name>{}.template operator()<unroll_factor>(
-        __q_local, __brick, __count, std::forward<_Ranges>(__rngs)...);
+    return __parallel_for_fpga_submitter<__parallel_for_name>()(std::forward<_ExecutionPolicy>(__exec), __brick,
+                                                                __count, std::forward<_Ranges>(__rngs)...);
 }
 
 //------------------------------------------------------------------------
@@ -100,18 +96,18 @@ __parallel_for(oneapi::dpl::__internal::__fpga_backend_tag, _ExecutionPolicy&& _
 //-----------------------------------------------------------------------
 
 // TODO: check if it makes sense to move these wrappers out of backend to a common place
-template <typename _CustomName, typename _Event, typename _Range1, typename _Range2, typename _BinHashMgr>
+template <typename _ExecutionPolicy, typename _Event, typename _Range1, typename _Range2, typename _BinHashMgr>
 __future<sycl::event>
-__parallel_histogram(oneapi::dpl::__internal::__fpga_backend_tag, sycl::queue& __q, const _Event& __init_event,
+__parallel_histogram(oneapi::dpl::__internal::__fpga_backend_tag, _ExecutionPolicy&& __exec, const _Event& __init_event,
                      _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
     static_assert(sizeof(oneapi::dpl::__internal::__value_t<_Range2>) <= sizeof(::std::uint32_t),
                   "histogram is not supported on FPGA devices with output types greater than 32 bits");
 
     // workaround until we implement more performant version for patterns
-    return oneapi::dpl::__par_backend_hetero::__parallel_histogram<_CustomName>(
-        oneapi::dpl::__internal::__device_backend_tag{}, __q, __init_event, std::forward<_Range1>(__input),
-        std::forward<_Range2>(__bins), __binhash_manager);
+    return oneapi::dpl::__par_backend_hetero::__parallel_histogram(
+        oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __init_event,
+        std::forward<_Range1>(__input), std::forward<_Range2>(__bins), __binhash_manager);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -213,10 +213,10 @@ template <::std::uint16_t __iters_per_work_item, ::std::uint8_t __bins_per_work_
 struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
                                                                __internal::__optional_kernel_name<_KernelName...>>
 {
-    template <typename _Range1, typename _Range2, typename _BinHashMgr>
+    template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
     sycl::event
-    operator()(sycl::queue& __q, const sycl::event& __init_event, std::uint16_t __work_group_size, _Range1&& __input,
-               _Range2&& __bins, const _BinHashMgr& __binhash_manager)
+    operator()(_ExecutionPolicy&& __exec, const sycl::event& __init_event, ::std::uint16_t __work_group_size,
+               _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
     {
         const ::std::size_t __n = __input.size();
         const ::std::uint8_t __num_bins = __bins.size();
@@ -229,7 +229,7 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
         ::std::size_t __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
         ::std::size_t __segments =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
-        return __q.submit([&](auto& __h) {
+        return __exec.queue().submit([&](auto& __h) {
             __h.depends_on(__init_event);
             auto _device_copyable_func = __binhash_manager.prepare_device_binhash(__h);
             oneapi::dpl::__ranges::__require_access(__h, __input, __bins);
@@ -285,13 +285,15 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
     }
 };
 
-template <typename _CustomName, std::uint16_t __iters_per_work_item, std::uint8_t __bins_per_work_item,
+template <::std::uint16_t __iters_per_work_item, ::std::uint8_t __bins_per_work_item, typename _ExecutionPolicy,
           typename _Range1, typename _Range2, typename _BinHashMgr>
 sycl::event
-__histogram_general_registers_local_reduction(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q,
+__histogram_general_registers_local_reduction(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
                                               const sycl::event& __init_event, ::std::uint16_t __work_group_size,
                                               _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
     using _iters_per_work_item_t = ::std::integral_constant<::std::uint16_t, __iters_per_work_item>;
 
     // Required to include _iters_per_work_item_t in kernel name because we compile multiple kernels and decide between
@@ -302,8 +304,8 @@ __histogram_general_registers_local_reduction(oneapi::dpl::__internal::__device_
 
     return __histogram_general_registers_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
                                                                    _RegistersLocalReducName>()(
-        __q, __init_event, __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
-        __binhash_manager);
+        ::std::forward<_ExecutionPolicy>(__exec), __init_event, __work_group_size, ::std::forward<_Range1>(__input),
+        ::std::forward<_Range2>(__bins), __binhash_manager);
 }
 
 template <::std::uint16_t __iters_per_work_item, typename _KernelName>
@@ -313,10 +315,10 @@ template <::std::uint16_t __iters_per_work_item, typename... _KernelName>
 struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                                                    __internal::__optional_kernel_name<_KernelName...>>
 {
-    template <typename _Range1, typename _Range2, typename _BinHashMgr>
+    template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
     sycl::event
-    operator()(sycl::queue& __q, const sycl::event& __init_event, std::uint16_t __work_group_size, _Range1&& __input,
-               _Range2&& __bins, const _BinHashMgr& __binhash_manager)
+    operator()(_ExecutionPolicy&& __exec, const sycl::event& __init_event, ::std::uint16_t __work_group_size,
+               _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
     {
         using _local_histogram_type = ::std::uint32_t;
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
@@ -328,7 +330,7 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
         const ::std::size_t __num_bins = __bins.size();
         ::std::size_t __segments =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
-        return __q.submit([&](auto& __h) {
+        return __exec.queue().submit([&](auto& __h) {
             __h.depends_on(__init_event);
             auto _device_copyable_func = __binhash_manager.prepare_device_binhash(__h);
             oneapi::dpl::__ranges::__require_access(__h, __input, __bins);
@@ -378,13 +380,15 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
     }
 };
 
-template <typename _CustomName, std::uint16_t __iters_per_work_item, typename _Range1, typename _Range2,
+template <::std::uint16_t __iters_per_work_item, typename _ExecutionPolicy, typename _Range1, typename _Range2,
           typename _BinHashMgr>
 sycl::event
-__histogram_general_local_atomics(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q,
+__histogram_general_local_atomics(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
                                   const sycl::event& __init_event, ::std::uint16_t __work_group_size, _Range1&& __input,
                                   _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
     using _iters_per_work_item_t = ::std::integral_constant<::std::uint16_t, __iters_per_work_item>;
 
     // Required to include _iters_per_work_item_t in kernel name because we compile multiple kernels and decide between
@@ -394,8 +398,8 @@ __histogram_general_local_atomics(oneapi::dpl::__internal::__device_backend_tag,
         __histo_kernel_local_atomics<_iters_per_work_item_t, _CustomName>>;
 
     return __histogram_general_local_atomics_submitter<__iters_per_work_item, _local_atomics_name>()(
-        __q, __init_event, __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
-        __binhash_manager);
+        ::std::forward<_ExecutionPolicy>(__exec), __init_event, __work_group_size, ::std::forward<_Range1>(__input),
+        ::std::forward<_Range2>(__bins), __binhash_manager);
 }
 
 template <typename _KernelName>
@@ -404,9 +408,9 @@ struct __histogram_general_private_global_atomics_submitter;
 template <typename... _KernelName>
 struct __histogram_general_private_global_atomics_submitter<__internal::__optional_kernel_name<_KernelName...>>
 {
-    template <typename _BackendTag, typename _Range1, typename _Range2, typename _BinHashMgr>
+    template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
     sycl::event
-    operator()(_BackendTag, sycl::queue& __q, const sycl::event& __init_event,
+    operator()(_BackendTag, _ExecutionPolicy&& __exec, const sycl::event& __init_event,
                ::std::uint16_t __min_iters_per_work_item, ::std::uint16_t __work_group_size, _Range1&& __input,
                _Range2&& __bins, const _BinHashMgr& __binhash_manager)
     {
@@ -415,7 +419,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
         using _histogram_index_type = ::std::int32_t;
 
-        auto __global_mem_size = __q.get_device().template get_info<sycl::info::device::global_mem_size>();
+        auto __global_mem_size = __exec.queue().get_device().template get_info<sycl::info::device::global_mem_size>();
         const ::std::size_t __max_segments =
             ::std::min(__global_mem_size / (__num_bins * sizeof(_bin_type)),
                        oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __min_iters_per_work_item));
@@ -427,7 +431,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
         auto __private_histograms =
             oneapi::dpl::__par_backend_hetero::__buffer<_bin_type>(__segments * __num_bins).get_buffer();
 
-        return __q.submit([&](auto& __h) {
+        return __exec.queue().submit([&](auto& __h) {
             __h.depends_on(__init_event);
             auto _device_copyable_func = __binhash_manager.prepare_device_binhash(__h);
             oneapi::dpl::__ranges::__require_access(__h, __input, __bins);
@@ -474,27 +478,30 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
         });
     }
 };
-template <typename _CustomName, typename _Range1, typename _Range2, typename _BinHashMgr>
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _BinHashMgr>
 sycl::event
-__histogram_general_private_global_atomics(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q,
+__histogram_general_private_global_atomics(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
                                            const sycl::event& __init_event, ::std::uint16_t __min_iters_per_work_item,
                                            ::std::uint16_t __work_group_size, _Range1&& __input, _Range2&& __bins,
                                            const _BinHashMgr& __binhash_manager)
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
     using _global_atomics_name = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
         __histo_kernel_private_glocal_atomics<_CustomName>>;
 
     return __histogram_general_private_global_atomics_submitter<_global_atomics_name>()(
-        oneapi::dpl::__internal::__device_backend_tag{}, __q, __init_event, __min_iters_per_work_item,
-        __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins), __binhash_manager);
+        oneapi::dpl::__internal::__device_backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __init_event,
+        __min_iters_per_work_item, __work_group_size, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins),
+        __binhash_manager);
 }
 
-template <typename _CustomName, std::uint16_t __iters_per_work_item, typename _Range1, typename _Range2,
+template <::std::uint16_t __iters_per_work_item, typename _ExecutionPolicy, typename _Range1, typename _Range2,
           typename _BinHashMgr>
 __future<sycl::event>
-__parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
-                                   const sycl::event& __init_event, _Range1&& __input, _Range2&& __bins,
-                                   const _BinHashMgr& __binhash_manager)
+__parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
+                                   _ExecutionPolicy&& __exec, const sycl::event& __init_event, _Range1&& __input,
+                                   _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
     using _private_histogram_type = ::std::uint16_t;
     using _local_histogram_type = ::std::uint32_t;
@@ -502,27 +509,28 @@ __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag
 
     const auto __num_bins = __bins.size();
     // Limit the maximum work-group size for better performance. Empirically found value.
-    std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, std::uint16_t(1024));
+    std::uint16_t __work_group_size =
+        oneapi::dpl::__internal::__max_work_group_size(__exec.queue(), std::uint16_t(1024));
 
-    auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
+    auto __local_mem_size = __exec.queue().get_device().template get_info<sycl::info::device::local_mem_size>();
     constexpr ::std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
 
     // if bins fit into registers, use register private accumulation
     if (__num_bins <= __max_work_item_private_bins)
     {
-        return __future(__histogram_general_registers_local_reduction<_CustomName, __iters_per_work_item,
-                                                                      __max_work_item_private_bins>(
-            __backend_tag, __q, __init_event, __work_group_size, std::forward<_Range1>(__input),
-            std::forward<_Range2>(__bins), __binhash_manager));
+        return __future(
+            __histogram_general_registers_local_reduction<__iters_per_work_item, __max_work_item_private_bins>(
+                __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, __work_group_size,
+                ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins), __binhash_manager));
     }
     // if bins fit into SLM, use local atomics
     else if (__num_bins * sizeof(_local_histogram_type) +
                  __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type) <
              __local_mem_size)
     {
-        return __future(__histogram_general_local_atomics<_CustomName, __iters_per_work_item>(
-            __backend_tag, __q, __init_event, __work_group_size, std::forward<_Range1>(__input),
-            std::forward<_Range2>(__bins), __binhash_manager));
+        return __future(__histogram_general_local_atomics<__iters_per_work_item>(
+            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, __work_group_size,
+            ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins), __binhash_manager));
     }
     else // otherwise, use global atomics (private copies per workgroup)
     {
@@ -531,29 +539,29 @@ __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag
         // suggestion which but global memory limitations may increase this value to be able to fit the workgroup
         // private copies of the histogram bins in global memory.  No unrolling is taken advantage of here because it
         // is a runtime argument.
-        return __future(__histogram_general_private_global_atomics<_CustomName>(
-            __backend_tag, __q, __init_event, __iters_per_work_item, __work_group_size, std::forward<_Range1>(__input),
-            std::forward<_Range2>(__bins), __binhash_manager));
+        return __future(__histogram_general_private_global_atomics(
+            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, __iters_per_work_item,
+            __work_group_size, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins), __binhash_manager));
     }
 }
 
-template <typename _CustomName, typename _Event, typename _Range1, typename _Range2, typename _BinHashMgr>
+template <typename _ExecutionPolicy, typename _Event, typename _Range1, typename _Range2, typename _BinHashMgr>
 __future<sycl::event>
-__parallel_histogram(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
+__parallel_histogram(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                      const _Event& __init_event, _Range1&& __input, _Range2&& __bins,
                      const _BinHashMgr& __binhash_manager)
 {
     if (__input.size() < 1048576) // 2^20
     {
-        return __parallel_histogram_select_kernel<_CustomName, /*iters_per_workitem = */ 4>(
-            __backend_tag, __q, __init_event, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
-            __binhash_manager);
+        return __parallel_histogram_select_kernel</*iters_per_workitem = */ 4>(
+            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, ::std::forward<_Range1>(__input),
+            ::std::forward<_Range2>(__bins), __binhash_manager);
     }
     else
     {
-        return __parallel_histogram_select_kernel<_CustomName, /*iters_per_workitem = */ 32>(
-            __backend_tag, __q, __init_event, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
-            __binhash_manager);
+        return __parallel_histogram_select_kernel</*iters_per_workitem = */ 32>(
+            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), __init_event, ::std::forward<_Range1>(__input),
+            ::std::forward<_Range2>(__bins), __binhash_manager);
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -204,9 +204,9 @@ struct __parallel_merge_submitter;
 template <typename _OutSizeLimit, typename _IdType, typename... _Name>
 struct __parallel_merge_submitter<_OutSizeLimit, _IdType, __internal::__optional_kernel_name<_Name...>>
 {
-    template <typename _Range1, typename _Range2, typename _Range3, typename _Compare>
+    template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare>
     __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
-    operator()(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
+    operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
     {
         const _IdType __n1 = __rng1.size();
         const _IdType __n2 = __rng2.size();
@@ -214,10 +214,10 @@ struct __parallel_merge_submitter<_OutSizeLimit, _IdType, __internal::__optional
 
         assert(__n1 > 0 || __n2 > 0);
 
-        _PRINT_INFO_IN_DEBUG_MODE(__q);
+        _PRINT_INFO_IN_DEBUG_MODE(__exec.queue());
 
         // Empirical number of values to process per work-item
-        const _IdType __chunk = __q.get_device().is_cpu() ? 128 : 4;
+        const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;
 
         const _IdType __steps = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __chunk);
 
@@ -228,15 +228,15 @@ struct __parallel_merge_submitter<_OutSizeLimit, _IdType, __internal::__optional
         __result_and_scratch_storage_t* __p_res_storage = nullptr;
 
         if constexpr (_OutSizeLimit{})
-            __p_res_storage = new __result_and_scratch_storage_t(__q, 0);
+            __p_res_storage = new __result_and_scratch_storage_t(__exec.queue(), 0);
         else
             assert(__rng3.size() >= __n1 + __n2);
 
         std::shared_ptr<__result_and_scratch_storage_base> __p_result_and_scratch_storage_base(
             static_cast<__result_and_scratch_storage_base*>(__p_res_storage));
 
-        auto __event = __q.submit([&__rng1, &__rng2, &__rng3, __p_res_storage, __comp, __chunk, __steps, __n, __n1,
-                                   __n2](sycl::handler& __cgh) {
+        auto __event = __exec.queue().submit([&__rng1, &__rng2, &__rng3, __p_res_storage, __comp, __chunk, __steps, __n,
+                                              __n1, __n2](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2, __rng3);
             auto __result_acc = __get_acc(__p_res_storage, __cgh);
 
@@ -299,13 +299,13 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
     };
 
     // Calculate nd-range parameters
-    template <typename _Range1, typename _Range2>
+    template <typename _ExecutionPolicy, typename _Range1, typename _Range2>
     nd_range_params
-    eval_nd_range_params(const sycl::queue& __q, const _Range1& __rng1, const _Range2& __rng2,
+    eval_nd_range_params(_ExecutionPolicy&& __exec, const _Range1& __rng1, const _Range2& __rng2,
                          const std::size_t __n) const
     {
         // Empirical number of values to process per work-item
-        const std::uint8_t __chunk = __q.get_device().is_cpu() ? 128 : 4;
+        const std::uint8_t __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;
 
         const _IdType __steps = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __chunk);
         // TODO required to evaluate this value based on available SLM size for each work-group.
@@ -317,10 +317,10 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
     }
 
     // Calculation of split points on each base diagonal
-    template <typename _Range1, typename _Range2, typename _Compare, typename _Storage>
+    template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Compare, typename _Storage>
     sycl::event
-    eval_split_points_for_groups(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _IdType __n, _Compare __comp,
-                                 const nd_range_params& __nd_range_params,
+    eval_split_points_for_groups(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _IdType __n,
+                                 _Compare __comp, const nd_range_params& __nd_range_params,
                                  _Storage& __base_diagonals_sp_global_storage) const
     {
         const _IdType __n1 = __rng1.size();
@@ -328,8 +328,8 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
 
         const _IdType __base_diag_chunk = __nd_range_params.steps_between_two_base_diags * __nd_range_params.chunk;
 
-        return __q.submit([&__rng1, &__rng2, __comp, __nd_range_params, __base_diagonals_sp_global_storage, __n1, __n2,
-                           __n, __base_diag_chunk](sycl::handler& __cgh) {
+        return __exec.queue().submit([&__rng1, &__rng2, __comp, __nd_range_params, __base_diagonals_sp_global_storage,
+                                      __n1, __n2, __n, __base_diag_chunk](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2);
             auto __base_diagonals_sp_global_acc =
                 __base_diagonals_sp_global_storage.template __get_scratch_acc<sycl::access_mode::write>(
@@ -353,9 +353,10 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
     }
 
     // Process parallel merge
-    template <typename _Range1, typename _Range2, typename _Range3, typename _Compare, typename _Storage>
+    template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+              typename _Storage>
     sycl::event
-    run_parallel_merge(const sycl::event& __event, sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2,
+    run_parallel_merge(const sycl::event& __event, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
                        _Range3&& __rng3, _Compare __comp, const nd_range_params& __nd_range_params,
                        const _Storage& __base_diagonals_sp_global_storage) const
     {
@@ -363,8 +364,8 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
         const _IdType __n2 = __rng2.size();
         const _IdType __n = std::min<_IdType>(__n1 + __n2, __rng3.size());
 
-        return __q.submit([&__event, &__rng1, &__rng2, &__rng3, __n, __comp, __nd_range_params,
-                           __base_diagonals_sp_global_storage, __n1, __n2](sycl::handler& __cgh) {
+        return __exec.queue().submit([&__event, &__rng1, &__rng2, &__rng3, __n, __comp, __nd_range_params,
+                                      __base_diagonals_sp_global_storage, __n1, __n2](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2, __rng3);
             auto __base_diagonals_sp_global_acc =
                 __base_diagonals_sp_global_storage.template __get_scratch_acc<sycl::access_mode::read>(__cgh);
@@ -422,9 +423,9 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
     }
 
   public:
-    template <typename _Range1, typename _Range2, typename _Range3, typename _Compare>
+    template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare>
     __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
-    operator()(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
+    operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
     {
         const _IdType __n1 = __rng1.size();
         const _IdType __n2 = __rng2.size();
@@ -432,10 +433,10 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
 
         const _IdType __n = std::min<_IdType>(__n1 + __n2, __rng3.size());
 
-        _PRINT_INFO_IN_DEBUG_MODE(__q);
+        _PRINT_INFO_IN_DEBUG_MODE(__exec.queue());
 
         // Calculate nd-range parameters
-        const nd_range_params __nd_range_params = eval_nd_range_params(__q, __rng1, __rng2, __n);
+        const nd_range_params __nd_range_params = eval_nd_range_params(__exec, __rng1, __rng2, __n);
 
         // Create storage to save split-points on each base diagonal + 1 (for the right base diagonal in the last work-group)
         using __val_t = _split_point_t<_IdType>;
@@ -443,18 +444,18 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
                                              std::integral_constant<std::size_t, 0>>;
         using __result_and_scratch_storage_t = __result_and_scratch_storage<__val_t, _NResults::value>;
         auto __p_base_diagonals_sp_global_storage =
-            new __result_and_scratch_storage_t(__q, __nd_range_params.base_diag_count + 1);
+            new __result_and_scratch_storage_t(__exec, __nd_range_params.base_diag_count + 1);
 
         // Save the raw pointer into a shared_ptr to return it in __future and extend the lifetime of the storage.
         std::shared_ptr<__result_and_scratch_storage_base> __p_result_and_scratch_storage_base(
             static_cast<__result_and_scratch_storage_base*>(__p_base_diagonals_sp_global_storage));
 
         // Find split-points on the base diagonals
-        sycl::event __event = eval_split_points_for_groups(__q, __rng1, __rng2, __n, __comp, __nd_range_params,
+        sycl::event __event = eval_split_points_for_groups(__exec, __rng1, __rng2, __n, __comp, __nd_range_params,
                                                            *__p_base_diagonals_sp_global_storage);
 
         // Merge data using split points on each diagonal
-        __event = run_parallel_merge(__event, __q, __rng1, __rng2, __rng3, __comp, __nd_range_params,
+        __event = run_parallel_merge(__event, __exec, __rng1, __rng2, __rng3, __comp, __nd_range_params,
                                      *__p_base_diagonals_sp_global_storage);
 
         return __future{std::move(__event), std::move(__p_result_and_scratch_storage_base)};
@@ -484,12 +485,14 @@ __get_starting_size_limit_for_large_submitter<int>()
     return 16 * 1'048'576; // 16 MB
 }
 
-template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _OutSizeLimit = std::false_type>
 __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
-__parallel_merge(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2,
-                 _Range3&& __rng3, _Compare __comp, _OutSizeLimit = {})
+__parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range1&& __rng1,
+                 _Range2&& __rng2, _Range3&& __rng3, _Compare __comp, _OutSizeLimit = {})
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
     using __value_type = oneapi::dpl::__internal::__value_t<_Range3>;
 
     const std::size_t __n = std::min<std::size_t>(__rng1.size() + __rng2.size(), __rng3.size());
@@ -501,7 +504,8 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q
         using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __merge_kernel_name<_CustomName, _WiIndex>>;
         return __parallel_merge_submitter<_OutSizeLimit, _WiIndex, _MergeKernelName>()(
-            __q, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2), std::forward<_Range3>(__rng3), __comp);
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+            std::forward<_Range3>(__rng3), __comp);
     }
     else
     {
@@ -513,9 +517,9 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q
             using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
                 __merge_kernel_name_large<_CustomName, _WiIndex>>;
             return __parallel_merge_submitter_large<_OutSizeLimit, _WiIndex, _CustomName, _DiagonalsKernelName,
-                                                    _MergeKernelName>()(__q, std::forward<_Range1>(__rng1),
-                                                                        std::forward<_Range2>(__rng2),
-                                                                        std::forward<_Range3>(__rng3), __comp);
+                                                    _MergeKernelName>()(
+                std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                std::forward<_Range3>(__rng3), __comp);
         }
         else
         {
@@ -525,9 +529,9 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q
             using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
                 __merge_kernel_name_large<_CustomName, _WiIndex>>;
             return __parallel_merge_submitter_large<_OutSizeLimit, _WiIndex, _CustomName, _DiagonalsKernelName,
-                                                    _MergeKernelName>()(__q, std::forward<_Range1>(__rng1),
-                                                                        std::forward<_Range2>(__rng2),
-                                                                        std::forward<_Range3>(__rng3), __comp);
+                                                    _MergeKernelName>()(
+                std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                std::forward<_Range3>(__rng3), __comp);
         }
     }
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -336,24 +336,26 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
     template <typename Rng>
     DropViews(Rng&, const WorkDataArea&) -> DropViews<Rng>;
 
+    template <typename _ExecutionPolicy>
     std::size_t
-    get_max_base_diags_count(const sycl::queue& __q, const _IndexT __chunk, std::size_t __n) const
+    get_max_base_diags_count(const _ExecutionPolicy& __exec, const _IndexT __chunk, std::size_t __n) const
     {
-        const std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__q);
+        const std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec.queue());
         return oneapi::dpl::__internal::__dpl_ceiling_div(__n, __chunk * __max_wg_size);
     }
 
     // Calculate nd-range params
+    template <typename _ExecutionPolicy>
     nd_range_params
-    eval_nd_range_params(const sycl::queue& __q, const std::size_t __rng_size, const _IndexT __n_sorted) const
+    eval_nd_range_params(const _ExecutionPolicy& __exec, const std::size_t __rng_size, const _IndexT __n_sorted) const
     {
-        const bool __is_cpu = __q.get_device().is_cpu();
+        const bool __is_cpu = __exec.queue().get_device().is_cpu();
         // The chunk size must not exceed two sorted sub-sequences to be merged,
         // ensuring that at least one work-item processes them.
         const _IndexT __chunk = std::min<_IndexT>(__is_cpu ? 32 : 4, __n_sorted * 2);
         const _IndexT __steps = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_size, __chunk);
 
-        _IndexT __base_diag_count = get_max_base_diags_count(__q, __chunk, __n_sorted);
+        _IndexT __base_diag_count = get_max_base_diags_count(__exec, __chunk, __n_sorted);
         _IndexT __steps_between_two_base_diags = oneapi::dpl::__internal::__dpl_ceiling_div(__steps, __base_diag_count);
 
         return {__base_diag_count, __steps_between_two_base_diags, __chunk, __steps};
@@ -379,17 +381,18 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
     }
 
     // Calculation of split points on each base diagonal
-    template <typename _Range, typename _TempBuf, typename _Compare, typename _Storage>
+    template <typename _ExecutionPolicy, typename _Range, typename _TempBuf, typename _Compare, typename _Storage>
     sycl::event
     eval_split_points_for_groups(const sycl::event& __event_chain, const _IndexT __n_sorted, const bool __data_in_temp,
-                                 sycl::queue& __q, const _Range& __rng, _TempBuf& __temp_buf, _Compare __comp,
-                                 const nd_range_params& __nd_range_params,
+                                 const _ExecutionPolicy& __exec, const _Range& __rng, _TempBuf& __temp_buf,
+                                 _Compare __comp, const nd_range_params& __nd_range_params,
                                  _Storage& __base_diagonals_sp_global_storage) const
     {
         const _IndexT __n = __rng.size();
 
-        return __q.submit([&__event_chain, __n_sorted, __data_in_temp, &__rng, &__temp_buf, __comp, __nd_range_params,
-                           &__base_diagonals_sp_global_storage, __n](sycl::handler& __cgh) {
+        return __exec.queue().submit([&__event_chain, __n_sorted, __data_in_temp, &__rng, &__temp_buf, __comp,
+                                      __nd_range_params, &__base_diagonals_sp_global_storage,
+                                      __n](sycl::handler& __cgh) {
             __cgh.depends_on(__event_chain);
 
             oneapi::dpl::__ranges::__require_access(__cgh, __rng);
@@ -471,16 +474,16 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
     }
 
     // Process parallel merge
-    template <typename _Range, typename _TempBuf, typename _Compare>
+    template <typename _ExecutionPolicy, typename _Range, typename _TempBuf, typename _Compare>
     sycl::event
     run_parallel_merge(const sycl::event& __event_chain, const _IndexT __n_sorted, const bool __data_in_temp,
-                       sycl::queue& __q, _Range& __rng, _TempBuf& __temp_buf, _Compare __comp,
+                       const _ExecutionPolicy& __exec, _Range& __rng, _TempBuf& __temp_buf, _Compare __comp,
                        const nd_range_params& __nd_range_params) const
     {
         const _IndexT __n = __rng.size();
 
-        return __q.submit([&__event_chain, __n_sorted, __data_in_temp, &__rng, &__temp_buf, __comp, __nd_range_params,
-                           __n](sycl::handler& __cgh) {
+        return __exec.queue().submit([&__event_chain, __n_sorted, __data_in_temp, &__rng, &__temp_buf, __comp,
+                                      __nd_range_params, __n](sycl::handler& __cgh) {
             __cgh.depends_on(__event_chain);
 
             oneapi::dpl::__ranges::__require_access(__cgh, __rng);
@@ -512,17 +515,18 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
     }
 
     // Process parallel merge with usage of split-points on base diagonals
-    template <typename _Range, typename _TempBuf, typename _Compare, typename _Storage>
+    template <typename _ExecutionPolicy, typename _Range, typename _TempBuf, typename _Compare, typename _Storage>
     sycl::event
     run_parallel_merge_from_diagonals(const sycl::event& __event_chain, const _IndexT __n_sorted,
-                                      const bool __data_in_temp, sycl::queue& __q, _Range& __rng, _TempBuf& __temp_buf,
-                                      _Compare __comp, const nd_range_params& __nd_range_params,
+                                      const bool __data_in_temp, const _ExecutionPolicy& __exec, _Range& __rng,
+                                      _TempBuf& __temp_buf, _Compare __comp, const nd_range_params& __nd_range_params,
                                       _Storage& __base_diagonals_sp_global_storage) const
     {
         const _IndexT __n = __rng.size();
 
-        return __q.submit([&__event_chain, __n_sorted, __data_in_temp, &__rng, &__temp_buf, __comp, __nd_range_params,
-                           &__base_diagonals_sp_global_storage, __n](sycl::handler& __cgh) {
+        return __exec.queue().submit([&__event_chain, __n_sorted, __data_in_temp, &__rng, &__temp_buf, __comp,
+                                      __nd_range_params, &__base_diagonals_sp_global_storage,
+                                      __n](sycl::handler& __cgh) {
             __cgh.depends_on(__event_chain);
 
             oneapi::dpl::__ranges::__require_access(__cgh, __rng);
@@ -564,9 +568,9 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
     }
 
   public:
-    template <typename _Range, typename _Compare, typename _TempBuf, typename _LeafSizeT>
+    template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _TempBuf, typename _LeafSizeT>
     std::tuple<sycl::event, bool, std::shared_ptr<__result_and_scratch_storage_base>>
-    operator()(sycl::queue& __q, _Range& __rng, _Compare __comp, _LeafSizeT __leaf_size, _TempBuf& __temp_buf,
+    operator()(_ExecutionPolicy&& __exec, _Range& __rng, _Compare __comp, _LeafSizeT __leaf_size, _TempBuf& __temp_buf,
                sycl::event __event_chain) const
     {
         // 1 final base diagonal for save final sp(0,0)
@@ -580,7 +584,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
         using __value_type = oneapi::dpl::__internal::__value_t<_Range>;
 
         // Calculate nd-range params
-        const nd_range_params __nd_range_params = eval_nd_range_params(__q, __n, __n_sorted);
+        const nd_range_params __nd_range_params = eval_nd_range_params(__exec, __n, __n_sorted);
 
         using __base_diagonals_sp_storage_t = __result_and_scratch_storage<_merge_split_point_t, /* _NResults */ 0>;
 
@@ -597,7 +601,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
 
         // Max amount of base diagonals
         const std::size_t __max_base_diags_count =
-            get_max_base_diags_count(__q, __nd_range_params.chunk, __n) + __1_final_base_diag;
+            get_max_base_diags_count(__exec, __nd_range_params.chunk, __n) + __1_final_base_diag;
 
         for (std::int64_t __i = 0; __i < __n_iter; ++__i)
         {
@@ -605,7 +609,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
             if (2 * __n_sorted < __get_starting_size_limit_for_large_submitter<__value_type>())
             {
                 // Process parallel merge
-                __event_chain = run_parallel_merge(__event_chain, __n_sorted, __data_in_temp, __q, __rng, __temp_buf,
+                __event_chain = run_parallel_merge(__event_chain, __n_sorted, __data_in_temp, __exec, __rng, __temp_buf,
                                                    __comp, __nd_range_params);
             }
             else
@@ -614,7 +618,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
                 {
                     // Create storage to save split-points on each base diagonal + 1 (for the right base diagonal in the last work-group)
                     __p_base_diagonals_sp_global_storage =
-                        new __base_diagonals_sp_storage_t(__q, __max_base_diags_count);
+                        new __base_diagonals_sp_storage_t(__exec.queue(), __max_base_diags_count);
 
                     // Save the raw pointer into a shared_ptr to return it in __future and extend the lifetime of the storage.
                     __p_result_and_scratch_storage_base.reset(
@@ -622,7 +626,7 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
                 }
 
                 nd_range_params __nd_range_params_this =
-                    eval_nd_range_params(__q, std::size_t(2 * __n_sorted), __n_sorted);
+                    eval_nd_range_params(__exec, std::size_t(2 * __n_sorted), __n_sorted);
 
                 // Check that each base diagonal started from beginning of merge matrix
                 assert(0 == (2 * __n_sorted) %
@@ -636,12 +640,12 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
 
                 // Calculation of split-points on each base diagonal
                 __event_chain =
-                    eval_split_points_for_groups(__event_chain, __n_sorted, __data_in_temp, __q, __rng, __temp_buf,
+                    eval_split_points_for_groups(__event_chain, __n_sorted, __data_in_temp, __exec, __rng, __temp_buf,
                                                  __comp, __nd_range_params_this, *__p_base_diagonals_sp_global_storage);
 
                 // Process parallel merge with usage of split-points on base diagonals
-                __event_chain = run_parallel_merge_from_diagonals(__event_chain, __n_sorted, __data_in_temp, __q, __rng,
-                                                                  __temp_buf, __comp, __nd_range_params_this,
+                __event_chain = run_parallel_merge_from_diagonals(__event_chain, __n_sorted, __data_in_temp, __exec,
+                                                                  __rng, __temp_buf, __comp, __nd_range_params_this,
                                                                   *__p_base_diagonals_sp_global_storage);
             }
 
@@ -692,12 +696,13 @@ class __sort_global_kernel2;
 template <typename... _Name>
 class __sort_copy_back_kernel;
 
-template <typename _CustomName, typename _IndexT, typename _Range, typename _Compare, typename _LeafSorter>
+template <typename _IndexT, typename _ExecutionPolicy, typename _Range, typename _Compare, typename _LeafSorter>
 __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
-__merge_sort(sycl::queue& __q, _Range&& __rng, _Compare __comp, _LeafSorter& __leaf_sorter)
+__merge_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _LeafSorter& __leaf_sorter)
 {
     using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
 
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _LeafSortKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_leaf_kernel<_CustomName>>;
     using _DiagonalsKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
@@ -713,6 +718,8 @@ __merge_sort(sycl::queue& __q, _Range&& __rng, _Compare __comp, _LeafSorter& __l
     assert((__leaf_sorter.__process_size & (__leaf_sorter.__process_size - 1)) == 0 &&
            "Leaf size must be a power of 2");
 
+    sycl::queue __q = __exec.queue();
+
     // 1. Perform sorting of the leaves of the merge sort tree
     sycl::event __event_leaf_sort = __merge_sort_leaf_submitter<_LeafSortKernel>()(__q, __rng, __leaf_sorter);
 
@@ -721,7 +728,7 @@ __merge_sort(sycl::queue& __q, _Range&& __rng, _Compare __comp, _LeafSorter& __l
     auto __temp_buf = __temp.get_buffer();
     auto [__event_sort, __data_in_temp, __temp_sp_storages] =
         __merge_sort_global_submitter<_IndexT, _DiagonalsKernelName, _GlobalSortKernel1, _GlobalSortKernel2>()(
-            __q, __rng, __comp, __leaf_sorter.__process_size, __temp_buf, __event_leaf_sort);
+            __exec, __rng, __comp, __leaf_sorter.__process_size, __temp_buf, __event_leaf_sort);
 
     // 3. If the data remained in the temporary buffer then copy it back
     if (__data_in_temp)
@@ -732,15 +739,15 @@ __merge_sort(sycl::queue& __q, _Range&& __rng, _Compare __comp, _LeafSorter& __l
     return __future{std::move(__event_sort), std::move(__temp_sp_storages)};
 }
 
-template <typename _CustomName, typename _IndexT, typename _Range, typename _Compare>
+template <typename _IndexT, typename _ExecutionPolicy, typename _Range, typename _Compare>
 __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
-__submit_selecting_leaf(sycl::queue& __q, _Range&& __rng, _Compare __comp)
+__submit_selecting_leaf(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
 {
     using _Leaf = __leaf_sorter<std::decay_t<_Range>, _Compare>;
     using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
 
     const std::size_t __n = __rng.size();
-    sycl::device __device = __q.get_device();
+    sycl::device __device = __exec.queue().get_device();
 
     const std::size_t __max_wg_size = __device.template get_info<sycl::info::device::max_work_group_size>();
 
@@ -782,20 +789,23 @@ __submit_selecting_leaf(sycl::queue& __q, _Range&& __rng, _Compare __comp)
     __wg_size = oneapi::dpl::__internal::__dpl_bit_floor(__wg_size);
 
     _Leaf __leaf(__rng, __comp, __data_per_workitem, __wg_size);
-    return __merge_sort<_CustomName, _IndexT>(__q, std::forward<_Range>(__rng), __comp, __leaf);
+    return __merge_sort<_IndexT>(std::forward<_ExecutionPolicy>(__exec), std::forward<_Range>(__rng), __comp, __leaf);
 };
 
-template <typename _CustomName, typename _Range, typename _Compare>
+template <typename _ExecutionPolicy, typename _Range, typename _Compare>
 __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
-__parallel_sort_impl(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _Range&& __rng, _Compare __comp)
+__parallel_sort_impl(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range&& __rng,
+                     _Compare __comp)
 {
     if (__rng.size() <= std::numeric_limits<std::uint32_t>::max())
     {
-        return __submit_selecting_leaf<_CustomName, std::uint32_t>(__q, std::forward<_Range>(__rng), __comp);
+        return __submit_selecting_leaf<std::uint32_t>(std::forward<_ExecutionPolicy>(__exec),
+                                                      std::forward<_Range>(__rng), __comp);
     }
     else
     {
-        return __submit_selecting_leaf<_CustomName, std::uint64_t>(__q, std::forward<_Range>(__rng), __comp);
+        return __submit_selecting_leaf<std::uint64_t>(std::forward<_ExecutionPolicy>(__exec),
+                                                      std::forward<_Range>(__rng), __comp);
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -35,7 +35,7 @@ struct __subgroup_radix_sort
 {
     template <typename _RangeIn, typename _Proj>
     sycl::event
-    operator()(sycl::queue& __q, _RangeIn&& __src, _Proj __proj)
+    operator()(sycl::queue __q, _RangeIn&& __src, _Proj __proj)
     {
         using __wg_size_t = ::std::integral_constant<::std::uint16_t, __wg_size>;
         using __block_size_t = ::std::integral_constant<::std::uint16_t, __block_size>;
@@ -127,7 +127,7 @@ struct __subgroup_radix_sort
 
     template <typename _T, typename _Size>
     auto
-    __check_slm_size(const sycl::queue& __q, _Size __n)
+    __check_slm_size(sycl::queue __q, _Size __n)
     {
         assert(__n <= 1 << 16); //the kernel is designed for data size <= 64K
 
@@ -156,7 +156,7 @@ struct __subgroup_radix_sort
     {
         template <typename _RangeIn, typename _Proj, typename _SLM_tag_val, typename _SLM_counter>
         sycl::event
-        operator()(sycl::queue& __q, _RangeIn&& __src, _Proj __proj, _SLM_tag_val, _SLM_counter)
+        operator()(sycl::queue __q, _RangeIn&& __src, _Proj __proj, _SLM_tag_val, _SLM_counter)
         {
             uint16_t __n = __src.size();
             assert(__n <= __block_size * __wg_size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -123,9 +123,10 @@ template <typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename..
 struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
                                                    __internal::__optional_kernel_name<_Name...>>
 {
-    template <typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType, typename... _Ranges>
+    template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
+              typename... _Ranges>
     __future<sycl::event, __result_and_scratch_storage<_Tp>>
-    operator()(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, const _Size __n,
+    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, const _Size __n,
                const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs) const
     {
@@ -136,9 +137,9 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
         using __result_and_scratch_storage_t = __result_and_scratch_storage<_Tp>;
-        __result_and_scratch_storage_t __scratch_container{__q, 0};
+        __result_and_scratch_storage_t __scratch_container{__exec.queue(), 0};
 
-        sycl::event __reduce_event = __q.submit([&, __n](sycl::handler& __cgh) {
+        sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             auto __res_acc =
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
@@ -158,20 +159,21 @@ struct __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize,
     }
 }; // struct __parallel_transform_reduce_small_submitter
 
-template <typename _CustomName, typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename _Size,
+template <typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename _ExecutionPolicy, typename _Size,
           typename _ReduceOp, typename _TransformOp, typename _InitType, typename... _Ranges>
 __future<sycl::event, __result_and_scratch_storage<_Tp>>
-__parallel_transform_reduce_small_impl(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
-                                       const _Size __n, const _Size __work_group_size,
+__parallel_transform_reduce_small_impl(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
+                                       _ExecutionPolicy&& __exec, const _Size __n, const _Size __work_group_size,
                                        const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                                        _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _ReduceKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__reduce_small_kernel<_CustomName>>;
 
     return __parallel_transform_reduce_small_submitter<_Tp, _Commutative, _VecSize, _ReduceKernel>()(
-        __backend_tag, __q, __n, __work_group_size, __iters_per_work_item, __reduce_op, __transform_op, __init,
-        std::forward<_Ranges>(__rngs)...);
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size, __iters_per_work_item,
+        __reduce_op, __transform_op, __init, std::forward<_Ranges>(__rngs)...);
 }
 
 // Submits the first kernel of the parallel_transform_reduce for mid-sized arrays.
@@ -184,9 +186,9 @@ template <typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename..
 struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _VecSize,
                                                            __internal::__optional_kernel_name<_KernelName...>>
 {
-    template <typename _Size, typename _ReduceOp, typename _TransformOp, typename... _Ranges>
+    template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename... _Ranges>
     sycl::event
-    operator()(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, const _Size __n,
+    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, const _Size __n,
                const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
                _TransformOp __transform_op, __result_and_scratch_storage<_Tp>& __scratch_container,
                _Ranges&&... __rngs) const
@@ -202,7 +204,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _V
         const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         const bool __is_full = __n == __size_per_work_group * __n_groups;
 
-        return __q.submit([&, __n](sycl::handler& __cgh) {
+        return __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
@@ -230,11 +232,12 @@ template <typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename..
 struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative, _VecSize,
                                                                __internal::__optional_kernel_name<_KernelName...>>
 {
-    template <typename _Size, typename _ReduceOp, typename _InitType>
+    template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _InitType>
     __future<sycl::event, __result_and_scratch_storage<_Tp>>
-    operator()(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, const sycl::event& __reduce_event,
-               const _Size __n, const _Size __work_group_size, const _Size __iters_per_work_item, _ReduceOp __reduce_op,
-               _InitType __init, __result_and_scratch_storage<_Tp>&& __scratch_container) const
+    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+               const sycl::event& __reduce_event, const _Size __n, const _Size __work_group_size,
+               const _Size __iters_per_work_item, _ReduceOp __reduce_op, _InitType __init,
+               __result_and_scratch_storage<_Tp>&& __scratch_container) const
     {
         using __result_and_scratch_storage_t = __result_and_scratch_storage<_Tp>;
 
@@ -246,7 +249,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
 
         const bool __is_full = __n == __work_group_size * __iters_per_work_item;
 
-        auto __event = __q.submit([&, __n](sycl::handler& __cgh) {
+        auto __event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
 
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::read>(__cgh);
@@ -269,15 +272,16 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative
     }
 }; // struct __parallel_transform_reduce_work_group_kernel_submitter
 
-template <typename _CustomName, typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename _Size,
+template <typename _Tp, typename _Commutative, std::uint8_t _VecSize, typename _ExecutionPolicy, typename _Size,
           typename _ReduceOp, typename _TransformOp, typename _InitType, typename... _Ranges>
 __future<sycl::event, __result_and_scratch_storage<_Tp>>
-__parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
-                                     const _Size __n, const _Size __work_group_size,
+__parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
+                                     _ExecutionPolicy&& __exec, const _Size __n, const _Size __work_group_size,
                                      const _Size __iters_per_work_item_device_kernel,
                                      const _Size __iters_per_work_item_work_group_kernel, _ReduceOp __reduce_op,
                                      _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _ReduceDeviceKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__reduce_mid_device_kernel<_CustomName>>;
     using _ReduceWorkGroupKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
@@ -286,30 +290,32 @@ __parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_t
     // number of buffer elements processed within workgroup
     const _Size __size_per_work_group = __iters_per_work_item_device_kernel * __work_group_size;
     const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
-    __result_and_scratch_storage<_Tp> __scratch_container{__q, __n_groups};
+    __result_and_scratch_storage<_Tp> __scratch_container{__exec.queue(), __n_groups};
 
     sycl::event __reduce_event =
         __parallel_transform_reduce_device_kernel_submitter<_Tp, _Commutative, _VecSize, _ReduceDeviceKernel>()(
-            __backend_tag, __q, __n, __work_group_size, __iters_per_work_item_device_kernel, __reduce_op,
+            __backend_tag, __exec, __n, __work_group_size, __iters_per_work_item_device_kernel, __reduce_op,
             __transform_op, __scratch_container, std::forward<_Ranges>(__rngs)...);
 
     // __n_groups preliminary results from the device kernel.
     return __parallel_transform_reduce_work_group_kernel_submitter<_Tp, _Commutative, _VecSize,
                                                                    _ReduceWorkGroupKernel>()(
-        __backend_tag, __q, __reduce_event, __n_groups, __work_group_size, __iters_per_work_item_work_group_kernel,
-        __reduce_op, __init, std::move(__scratch_container));
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec), __reduce_event, __n_groups, __work_group_size,
+        __iters_per_work_item_work_group_kernel, __reduce_op, __init, std::move(__scratch_container));
 }
 
 // General implementation using a tree reduction
-template <typename _CustomName, typename _Tp, typename _Commutative, std::uint8_t _VecSize>
+template <typename _Tp, typename _Commutative, std::uint8_t _VecSize>
 struct __parallel_transform_reduce_impl
 {
-    template <typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType, typename... _Ranges>
+    template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
+              typename... _Ranges>
     static __future<sycl::event, __result_and_scratch_storage<_Tp>>
-    submit(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _Size __n, _Size __work_group_size,
+    submit(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Size __n, _Size __work_group_size,
            const _Size __iters_per_work_item, _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init,
            _Ranges&&... __rngs)
     {
+        using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
         using _NoOpFunctor = unseq_backend::walk_n<oneapi::dpl::__internal::__no_op>;
         using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             __reduce_kernel, _CustomName, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
@@ -323,8 +329,8 @@ struct __parallel_transform_reduce_impl
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ReduceOp, _Tp>{__reduce_op};
 
 #if _ONEDPL_COMPILE_KERNEL
-        auto __kernel = __internal::__kernel_compiler<_ReduceKernel>::__compile(__q);
-        _Size __adjusted_work_group_size = oneapi::dpl::__internal::__kernel_work_group_size(__q, __kernel);
+        auto __kernel = __internal::__kernel_compiler<_ReduceKernel>::__compile(__exec.queue());
+        _Size __adjusted_work_group_size = oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __kernel);
         __work_group_size = std::min(__work_group_size, __adjusted_work_group_size);
 #endif
 
@@ -335,7 +341,7 @@ struct __parallel_transform_reduce_impl
         // Create temporary global buffers to store temporary values
         const std::size_t __n_scratch = 2 * __n_groups;
         using __result_and_scratch_storage_t = __result_and_scratch_storage<_Tp>;
-        __result_and_scratch_storage_t __scratch_container{__q, __n_scratch};
+        __result_and_scratch_storage_t __scratch_container{__exec.queue(), __n_scratch};
 
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
@@ -349,7 +355,8 @@ struct __parallel_transform_reduce_impl
         sycl::event __reduce_event;
         do
         {
-            __reduce_event = __q.submit([&, __is_first, __offset_1, __offset_2, __n, __n_groups](sycl::handler& __cgh) {
+            __reduce_event = __exec.queue().submit([&, __is_first, __offset_1, __offset_2, __n,
+                                                    __n_groups](sycl::handler& __cgh) {
                 __cgh.depends_on(__reduce_event);
                 auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::read_write>(
                     __cgh, __is_first ? sycl::property_list{__dpl_sycl::__no_init{}} : sycl::property_list{});
@@ -429,10 +436,10 @@ struct __parallel_transform_reduce_impl
 // Mid-sized arrays use two tree reductions with independent __iters_per_work_item.
 // Big arrays are processed with a recursive tree reduction. __work_group_size * __iters_per_work_item elements are
 // reduced in each step.
-template <typename _CustomName, typename _Tp, typename _Commutative, typename _ReduceOp, typename _TransformOp,
+template <typename _Tp, typename _Commutative, typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp,
           typename _InitType, typename... _Ranges>
 __future<sycl::event, __result_and_scratch_storage<_Tp>>
-__parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __backend_tag, sycl::queue& __q,
+__parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                             _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
@@ -450,8 +457,8 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __back
     // Get the work group size adjusted to the local memory limit.
     // Pessimistically double the memory requirement to take into account memory used by compiled kernel.
     // TODO: find a way to generalize getting of reliable work-group size.
-    std::size_t __work_group_size =
-        oneapi::dpl::__internal::__slm_adjusted_work_group_size(__q, static_cast<std::size_t>(sizeof(_Tp) * 2));
+    std::size_t __work_group_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(
+        __exec.queue(), static_cast<std::size_t>(sizeof(_Tp) * 2));
 
     // Limit work-group size to __max_work_group_size for performance on GPUs. Empirically tested.
     __work_group_size = std::min(__work_group_size, __max_work_group_size);
@@ -466,9 +473,9 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __back
         const auto __work_group_size_short = static_cast<std::uint16_t>(__work_group_size);
         std::uint16_t __iters_per_work_item = oneapi::dpl::__internal::__dpl_ceiling_div(__n_short, __work_group_size);
         __iters_per_work_item = __adjust_iters_per_work_item<__vector_size>(__iters_per_work_item);
-        return __parallel_transform_reduce_small_impl<_CustomName, _Tp, _Commutative, __vector_size>(
-            __backend_tag, __q, __n_short, __work_group_size_short, __iters_per_work_item, __reduce_op, __transform_op,
-            __init, std::forward<_Ranges>(__rngs)...);
+        return __parallel_transform_reduce_small_impl<_Tp, _Commutative, __vector_size>(
+            __backend_tag, std::forward<_ExecutionPolicy>(__exec), __n_short, __work_group_size_short,
+            __iters_per_work_item, __reduce_op, __transform_op, __init, std::forward<_Ranges>(__rngs)...);
     }
     // Use two-step tree reduction.
     // First step reduces __work_group_size * __iters_per_work_item_device_kernel elements.
@@ -482,7 +489,7 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __back
         const auto __work_group_size_short = static_cast<std::uint32_t>(__work_group_size);
         // Fully-utilize the device by running a work-group per compute unit.
         // Add a factor more work-groups than compute units to fully utilizes the device and hide latencies.
-        const std::uint32_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__q);
+        const std::uint32_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec.queue());
         std::uint32_t __n_groups = __max_cu * __oversubscription;
         std::uint32_t __iters_per_work_item_device_kernel =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n_short, __n_groups * __work_group_size_short);
@@ -500,16 +507,16 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag __back
             oneapi::dpl::__internal::__dpl_ceiling_div(__n_groups, __work_group_size_short);
         __iters_per_work_item_work_group_kernel =
             __adjust_iters_per_work_item<__vector_size>(__iters_per_work_item_work_group_kernel);
-        return __parallel_transform_reduce_mid_impl<_CustomName, _Tp, _Commutative, __vector_size>(
-            __backend_tag, __q, __n_short, __work_group_size_short, __iters_per_work_item_device_kernel,
-            __iters_per_work_item_work_group_kernel, __reduce_op, __transform_op, __init,
-            std::forward<_Ranges>(__rngs)...);
+        return __parallel_transform_reduce_mid_impl<_Tp, _Commutative, __vector_size>(
+            __backend_tag, std::forward<_ExecutionPolicy>(__exec), __n_short, __work_group_size_short,
+            __iters_per_work_item_device_kernel, __iters_per_work_item_work_group_kernel, __reduce_op, __transform_op,
+            __init, std::forward<_Ranges>(__rngs)...);
     }
     // Otherwise use a recursive tree reduction with __max_iters_per_work_item __iters_per_work_item.
     const auto __work_group_size_long = static_cast<_Size>(__work_group_size);
-    return __parallel_transform_reduce_impl<_CustomName, _Tp, _Commutative, __vector_size>::submit(
-        __backend_tag, __q, __n, __work_group_size_long, __max_iters_per_work_item, __reduce_op, __transform_op, __init,
-        std::forward<_Ranges>(__rngs)...);
+    return __parallel_transform_reduce_impl<_Tp, _Commutative, __vector_size>::submit(
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size_long, __max_iters_per_work_item,
+        __reduce_op, __transform_op, __init, std::forward<_Ranges>(__rngs)...);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -98,15 +98,17 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
     using _SegReduceCountKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        _SegReduceCountPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
+        _SegReduceCountPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate,
+        _BinaryOperator>;
     using _SegReduceOffsetKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        _SegReduceOffsetPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
+        _SegReduceOffsetPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate,
+        _BinaryOperator>;
     using _SegReduceWgKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        _SegReduceWgPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
+        _SegReduceWgPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate,
+        _BinaryOperator>;
     using _SegReducePrefixKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        _SegReducePrefixPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
-
-    sycl::queue __q_local = __exec.queue();
+        _SegReducePrefixPhase, _CustomName, _ExecutionPolicy, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate,
+        _BinaryOperator>;
 
     using __diff_type = oneapi::dpl::__internal::__difference_t<_Range3>;
     using __key_type = oneapi::dpl::__internal::__value_t<_Range1>;
@@ -114,32 +116,32 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
 
     const std::size_t __n = __keys.size();
 
-    // Each work item serially processes 16 items. Best observed performance on gpu
-    constexpr std::uint16_t __vals_per_item = 16;
+    constexpr std::uint16_t __vals_per_item =
+        16; // Each work item serially processes 16 items. Best observed performance on gpu
 
     // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
     // This value exceeds the current practical limit for GPUs, but may need to be re-evaluated in the future.
-    std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__q_local, (std::size_t)2048);
+    std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec.queue(), (std::size_t)2048);
 
     // adjust __wgroup_size according to local memory limit. Double the requirement on __val_type due to sycl group algorithm's use
     // of SLM.
     __wgroup_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(
-        __q_local, sizeof(__key_type) + 2 * sizeof(__val_type), __wgroup_size);
+        __exec.queue(), sizeof(__key_type) + 2 * sizeof(__val_type), __wgroup_size);
 
 #if _ONEDPL_COMPILE_KERNEL
     auto __seg_reduce_count_kernel =
-        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceCountKernel>::__compile(__q_local);
+        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceCountKernel>::__compile(__exec.queue());
     auto __seg_reduce_offset_kernel =
-        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceOffsetKernel>::__compile(__q_local);
+        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceOffsetKernel>::__compile(__exec.queue());
     auto __seg_reduce_wg_kernel =
-        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceWgKernel>::__compile(__q_local);
+        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceWgKernel>::__compile(__exec.queue());
     auto __seg_reduce_prefix_kernel =
-        __par_backend_hetero::__internal::__kernel_compiler<_SegReducePrefixKernel>::__compile(__q_local);
+        __par_backend_hetero::__internal::__kernel_compiler<_SegReducePrefixKernel>::__compile(__exec.queue());
     __wgroup_size = std::min(
-        {__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__q_local, __seg_reduce_count_kernel),
-         oneapi::dpl::__internal::__kernel_work_group_size(__q_local, __seg_reduce_offset_kernel),
-         oneapi::dpl::__internal::__kernel_work_group_size(__q_local, __seg_reduce_wg_kernel),
-         oneapi::dpl::__internal::__kernel_work_group_size(__q_local, __seg_reduce_prefix_kernel)});
+        {__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __seg_reduce_count_kernel),
+         oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __seg_reduce_offset_kernel),
+         oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __seg_reduce_wg_kernel),
+         oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __seg_reduce_prefix_kernel)});
 #endif
 
     std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
@@ -156,7 +158,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     auto __seg_ends_scanned = oneapi::dpl::__par_backend_hetero::__buffer<__diff_type>(__n_groups).get_buffer();
 
     // 1. Count the segment ends in each workgroup
-    auto __seg_end_identification = __q_local.submit([&](sycl::handler& __cgh) {
+    auto __seg_end_identification = __exec.queue().submit([&](sycl::handler& __cgh) {
         oneapi::dpl::__ranges::__require_access(__cgh, __keys);
         auto __seg_ends_acc = __seg_ends.template get_access<sycl::access_mode::write>(__cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT
@@ -193,7 +195,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     });
 
     // 1.5 Small single-group kernel
-    auto __single_group_scan = __q_local.submit([&](sycl::handler& __cgh) {
+    auto __single_group_scan = __exec.queue().submit([&](sycl::handler& __cgh) {
         __cgh.depends_on(__seg_end_identification);
         auto __seg_ends_acc = __seg_ends.template get_access<sycl::access_mode::read>(__cgh);
         auto __seg_ends_scan_acc = __seg_ends_scanned.template get_access<sycl::access_mode::read_write>(__cgh);
@@ -213,7 +215,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     });
 
     // 2. Work group reduction
-    auto __wg_reduce = __q_local.submit([&](sycl::handler& __cgh) {
+    auto __wg_reduce = __exec.queue().submit([&](sycl::handler& __cgh) {
         __cgh.depends_on(__single_group_scan);
         oneapi::dpl::__ranges::__require_access(__cgh, __keys, __out_keys, __out_values, __values);
 
@@ -330,7 +332,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
     });
 
     // 3. Apply inter work-group aggregates
-    __q_local
+    __exec.queue()
         .submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __keys, __out_keys, __out_values);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -344,14 +344,14 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
     static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
     // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
     // input buffer
-    template <typename _InRng, typename _TmpStorageAcc>
+    template <typename _ExecutionPolicy, typename _InRng, typename _TmpStorageAcc>
     sycl::event
-    operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
+    operator()(_ExecutionPolicy&& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         using _InitValueType = typename _InitType::__value_type;
-        return __q.submit([&, this](sycl::handler& __cgh) {
+        return __exec.queue().submit([&, this](sycl::handler& __cgh) {
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
@@ -506,14 +506,14 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
         __tmp_ptr[__num_sub_groups_global + 1 - (__block_num % 2)] = __block_carry_out;
     }
 
-    template <typename _InRng, typename _OutRng, typename _TmpStorageAcc>
+    template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _TmpStorageAcc>
     sycl::event
-    operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
+    operator()(_ExecutionPolicy&& __exec, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         std::uint32_t __inputs_in_block = std::min(__n - __block_num * __max_block_size, std::size_t{__max_block_size});
-        return __q.submit([&, this](sycl::handler& __cgh) {
+        return __exec.queue().submit([&, this](sycl::handler& __cgh) {
             // We need __num_sub_groups_local + 1 temporary SLM locations to store intermediate results:
             //   __num_sub_groups_local for each sub-group partial from the reduce kernel +
             //   1 element for the accumulated block-local carry-in from previous groups in the block
@@ -818,11 +818,12 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 // Enable reduce-then-scan if the device uses the required sub-group size and is ran on a device
 // with fast coordinated subgroup operations. We do not want to run this scan on CPU targets, as they are not
 // performant with this algorithm.
-inline bool
-__is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
+template <typename _ExecutionPolicy>
+bool
+__is_gpu_with_reduce_then_scan_sg_sz(const _ExecutionPolicy& __exec)
 {
-    return (__q.get_device().is_gpu() &&
-            oneapi::dpl::__internal::__supports_sub_group_size(__q, __get_reduce_then_scan_reqd_sg_sz_host()));
+    return (__exec.queue().get_device().is_gpu() &&
+            oneapi::dpl::__internal::__supports_sub_group_size(__exec, __get_reduce_then_scan_reqd_sg_sz_host()));
 }
 
 // General scan-like algorithm helpers
@@ -835,16 +836,17 @@ __is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
 // _ReduceOp - a binary function which is used in the reduction and scan operations
 // _WriteOp - a function which accepts output range, index, and output of `_GenScanInput` applied to the input range
 //            and performs the final write to output operation
-template <typename _CustomName, typename _InRng, typename _OutRng, typename _GenReduceInput, typename _ReduceOp,
+template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _GenReduceInput, typename _ReduceOp,
           typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
           typename _Inclusive, typename _IsUniquePattern>
 __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
-__parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q,
+__parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
                                       _InRng&& __in_rng, _OutRng&& __out_rng, _GenReduceInput __gen_reduce_input,
                                       _ReduceOp __reduce_op, _GenScanInput __gen_scan_input,
                                       _ScanInputTransform __scan_input_transform, _WriteOp __write_op, _InitType __init,
                                       _Inclusive, _IsUniquePattern)
 {
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
         __reduce_then_scan_reduce_kernel<_CustomName>>;
     using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
@@ -859,7 +861,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     constexpr bool __inclusive = _Inclusive::value;
     constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 
-    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 8192);
+    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__exec.queue(), 8192);
     // Round down to nearest multiple of the subgroup size
     const std::uint32_t __work_group_size = (__max_work_group_size / __max_sub_group_size) * __max_sub_group_size;
 
@@ -892,7 +894,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     // We need temporary storage for reductions of each sub-group (__num_sub_groups_global).
     // Additionally, we need two elements for the block carry-out to prevent a race condition
     // between reading and writing the block carry-out within a single kernel.
-    __result_and_scratch_storage<_ValueType> __result_and_scratch{__q, __max_num_sub_groups_global + 2};
+    __result_and_scratch_storage<_ValueType> __result_and_scratch{__exec.queue(), __max_num_sub_groups_global + 2};
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =
@@ -935,10 +937,10 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         auto __local_range = sycl::range<1>(__work_group_size);
         auto __kernel_nd_range = sycl::nd_range<1>(__global_range, __local_range);
         // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
-        __event = __reduce_submitter(__q, __kernel_nd_range, __in_rng, __result_and_scratch, __event,
+        __event = __reduce_submitter(__exec, __kernel_nd_range, __in_rng, __result_and_scratch, __event,
                                      __inputs_remaining, __b);
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.
-        __event = __scan_submitter(__q, __kernel_nd_range, __in_rng, __out_rng, __result_and_scratch, __event,
+        __event = __scan_submitter(__exec, __kernel_nd_range, __in_rng, __out_rng, __result_and_scratch, __event,
                                    __inputs_remaining, __b);
         __inputs_remaining -= std::min(__inputs_remaining, __block_size);
         if (__b + 2 == __num_blocks)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -129,7 +129,7 @@ template <typename _ReduceValueType, typename _Compare>
 struct __pattern_min_element_reduce_fn;
 
 template <typename _Compare, typename _ReduceValueType>
-struct __pattern_minmax_element_reduce_fn;
+struct __pattern_minmax_element__reduce_fn;
 
 template <typename _Predicate>
 struct __pattern_count_transform_fn;
@@ -314,7 +314,7 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 };
 
 template <typename _Compare, typename _ReduceValueType>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__pattern_minmax_element_reduce_fn,
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__pattern_minmax_element__reduce_fn,
                                                        _Compare, _ReduceValueType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Compare, _ReduceValueType>
 {

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -149,10 +149,6 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
 
         if (__n > 0)
         {
-            using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-            sycl::queue __q_local = __exec.queue();
-
             //need __binhash_manager to stay in scope until the kernel completes to keep the buffer alive
             // __make_binhash_manager will call __get_sycl_range for any data which requires it within __func
             auto __binhash_manager = __make_binhash_manager(::std::forward<_BinHash>(__func));
@@ -161,8 +157,8 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
                                                         _RandomAccessIterator1>();
             auto __input_buf = __keep_input(__first, __last);
 
-            oneapi::dpl::__par_backend_hetero::__parallel_histogram<_CustomName>(
-                _BackendTag{}, __q_local, __init_event, __input_buf.all_view(), std::move(__bins), __binhash_manager)
+            oneapi::dpl::__par_backend_hetero::__parallel_histogram(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __init_event,
+                                 __input_buf.all_view(), ::std::move(__bins), __binhash_manager)
                 .__deferrable_wait();
         }
         else

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -157,8 +157,9 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
                                                         _RandomAccessIterator1>();
             auto __input_buf = __keep_input(__first, __last);
 
-            oneapi::dpl::__par_backend_hetero::__parallel_histogram(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __init_event,
-                                 __input_buf.all_view(), ::std::move(__bins), __binhash_manager)
+            oneapi::dpl::__par_backend_hetero::__parallel_histogram(
+                _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __init_event, __input_buf.all_view(),
+                ::std::move(__bins), __binhash_manager)
                 .__deferrable_wait();
         }
         else

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -58,13 +58,9 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _RepackedTp,
-                                                                          std::true_type /*is_commutative*/>(
-               _BackendTag{}, __q_local, __binary_op1, _Functor{__binary_op2},
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
+                                                                          ::std::true_type /*is_commutative*/>(
+               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                __buf1.all_view(), __buf2.all_view())
         .get();
@@ -90,13 +86,9 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _RepackedTp,
-                                                                          std::true_type /*is_commutative*/>(
-               _BackendTag{}, __q_local, __binary_op, _Functor{__unary_op},
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
+                                                                          ::std::true_type /*is_commutative*/>(
+               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
                __buf.all_view())
         .get();
@@ -145,10 +137,6 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
     // This is a temporary workaround for an in-place exclusive scan while the SYCL backend scan pattern is not fixed.
     const bool __is_scan_inplace_exclusive = __n > 1 && !_Inclusive{} && __iterators_possibly_equal(__first, __result);
     if (!__is_scan_inplace_exclusive)
@@ -156,9 +144,9 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
         auto __buf2 = __keep2(__result, __result + __n);
 
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_scan<_CustomName>(
-            _BackendTag{}, __q_local, __buf1.all_view(), __buf2.all_view(), __n, __unary_op, __init, __binary_op,
-            _Inclusive{})
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
+            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n,
+            __unary_op, __init, __binary_op, _Inclusive{})
             .__deferrable_wait();
     }
     else
@@ -180,10 +168,9 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         auto __buf2 = __keep2(__first_tmp, __last_tmp);
 
         // Run main algorithm and save data into temporary buffer
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_scan<
-            oneapi::dpl::__internal::__policy_kernel_name<decltype(__policy)>>(
-            _BackendTag{}, __q_local, __buf1.all_view(), __buf2.all_view(), __n, __unary_op, __init, __binary_op,
-            _Inclusive{})
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(_BackendTag{}, __policy, __buf1.all_view(),
+                                                                     __buf2.all_view(), __n, __unary_op, __init,
+                                                                     __binary_op, _Inclusive{})
             .wait();
 
         // Move data from temporary buffer into results
@@ -290,7 +277,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
         using _Function = unseq_backend::walk_adjacent_difference<decltype(__fn), decltype(__buf1.all_view()),
                                                                   decltype(__buf2.all_view())>;
 
-        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec,
                                                           _Function{__fn, static_cast<std::size_t>(__n)}, __n,
                                                           __buf1.all_view(), __buf2.all_view())
             .__deferrable_wait();

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -51,15 +51,11 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     using _Functor = unseq_backend::walk_n<_BinaryOperation2>;
     using _RepackedTp = oneapi::dpl::__par_backend_hetero::__repacked_tuple_t<_Tp>;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _RepackedTp,
-                                                                          std::true_type /*is_commutative*/>(
-               _BackendTag{}, __q_local, __binary_op1, _Functor{__binary_op2},
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
+                                                                          ::std::true_type /*is_commutative*/>(
+               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-               std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2))
+               ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2))
         .get();
 }
 
@@ -79,15 +75,11 @@ __pattern_transform_reduce(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec,
     using _Functor = unseq_backend::walk_n<_UnaryOperation>;
     using _RepackedTp = oneapi::dpl::__par_backend_hetero::__repacked_tuple_t<_Tp>;
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_CustomName, _RepackedTp,
-                                                                          std::true_type /*is_commutative*/>(
-               _BackendTag{}, __q_local, __binary_op, _Functor{__unary_op},
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
+                                                                          ::std::true_type /*is_commutative*/>(
+               _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
                unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-               std::forward<_Range>(__rng))
+               ::std::forward<_Range>(__rng))
         .get();
 }
 
@@ -105,13 +97,9 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     if (__n == 0)
         return 0;
 
-    sycl::queue __q_local = __exec.queue();
-
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    oneapi::dpl::__par_backend_hetero::__parallel_transform_scan<_CustomName>(
-        _BackendTag{}, __q_local, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2), __n, __unary_op, __init,
-        __binary_op, _Inclusive{})
+    oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
+        std::forward<_Range2>(__rng2), __n, __unary_op, __init, __binary_op, _Inclusive{})
         .__deferrable_wait();
     return __n;
 }


### PR DESCRIPTION
In this PR we revert https://github.com/uxlfoundation/oneDPL/pull/2161

The reason: https://github.com/uxlfoundation/oneDPL/pull/2161#issuecomment-2813669387

Also the change in `kt` namespace (from `sycl::queue` to `sycl::queue&` in params) breaks our experimental API and looks as incorrect.