### PR TITLE
Remove some duplicated structures

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -651,19 +651,6 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     return (__result_iterator == __last - 1) ? __last : __result_iterator;
 }
 
-template <typename _Predicate>
-struct __pattern_count_transform_fn
-{
-    _Predicate __predicate;
-
-    template <typename _TGroupIdx, typename _TAcc>
-    int
-    operator()(_TGroupIdx __gidx, _TAcc __acc) const
-    {
-        return (__predicate(__acc[__gidx]) ? 1 : 0);
-    }
-};
-
 //------------------------------------------------------------------------
 // count, count_if
 //------------------------------------------------------------------------
@@ -681,7 +668,7 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator 
     auto __reduce_fn = ::std::plus<_ReduceValueType>{};
     // int is being implicitly casted to difference_type
     // otherwise we can only pass the difference_type as a functor template parameter
-    __pattern_count_transform_fn<_Predicate> __transform_fn{__predicate};
+    oneapi::dpl::__internal::__pattern_count_transform_fn<_Predicate> __transform_fn{__predicate};
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -499,8 +499,6 @@ struct __pattern_min_element_reduce_fn
     }
 };
 
-
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 _Iterator
 __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -560,7 +560,7 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
 //
 
 template <typename _Compare, typename _ReduceValueType>
-struct __pattern_minmax_element__reduce_fn
+struct __pattern_minmax_element_reduce_fn
 {
     _Compare __comp;
 
@@ -605,7 +605,7 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 
     // This operator doesn't track the lowest found index in case of equal min. values and the highest found index in
     // case of equal max. values. Thus, this operator is not commutative.
-    __pattern_minmax_element__reduce_fn<_Compare, _ReduceValueType> __reduce_fn{__comp};
+    __pattern_minmax_element_reduce_fn<_Compare, _ReduceValueType> __reduce_fn{__comp};
 
     // TODO: Doesn't work with `zip_iterator`.
     //       In that case the first and the second arguments of `_ReduceValueType` will be

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -559,38 +559,6 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
 //   However the solution requires use of custom pattern or substantial redesign of existing parallel_transform_reduce.
 //
 
-template <typename _Compare, typename _ReduceValueType>
-struct __pattern_minmax_element_reduce_fn
-{
-    _Compare __comp;
-
-    _ReduceValueType
-    operator()(_ReduceValueType __a, _ReduceValueType __b) const
-    {
-        using ::std::get;
-        auto __chosen_for_min = __a;
-        auto __chosen_for_max = __b;
-
-        if (__comp(get<2>(__b), get<2>(__a)))
-            __chosen_for_min = ::std::move(__b);
-        if (__comp(get<3>(__b), get<3>(__a)))
-            __chosen_for_max = ::std::move(__a);
-        return _ReduceValueType{get<0>(__chosen_for_min), get<1>(__chosen_for_max), get<2>(__chosen_for_min),
-                                get<3>(__chosen_for_max)};
-    }
-};
-
-template <typename _ReduceValueType>
-struct __pattern_minmax_element_transform_fn
-{
-    template <typename _TGroupIdx, typename _TAcc>
-    _ReduceValueType
-    operator()(_TGroupIdx __gidx, _TAcc __acc) const
-    {
-        return _ReduceValueType{__gidx, __gidx, __acc[__gidx], __acc[__gidx]};
-    }
-};
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 ::std::pair<_Iterator, _Iterator>
 __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
@@ -605,12 +573,12 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 
     // This operator doesn't track the lowest found index in case of equal min. values and the highest found index in
     // case of equal max. values. Thus, this operator is not commutative.
-    __pattern_minmax_element_reduce_fn<_Compare, _ReduceValueType> __reduce_fn{__comp};
+    oneapi::dpl::__internal::__pattern_minmax_element_reduce_fn<_Compare, _ReduceValueType> __reduce_fn{__comp};
 
     // TODO: Doesn't work with `zip_iterator`.
     //       In that case the first and the second arguments of `_ReduceValueType` will be
     //       a `tuple` of `difference_type`, not the `difference_type` itself.
-    __pattern_minmax_element_transform_fn<_ReduceValueType> __transform_fn;
+    oneapi::dpl::__internal::__pattern_minmax_element_transform_fn<_ReduceValueType> __transform_fn;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -499,16 +499,7 @@ struct __pattern_min_element_reduce_fn
     }
 };
 
-template <typename _ReduceValueType>
-struct __pattern_min_element_transform_fn
-{
-    template <typename _TGroupIdx, typename _TAcc>
-    _ReduceValueType
-    operator()(_TGroupIdx __gidx, _TAcc __acc) const
-    {
-        return _ReduceValueType{__gidx, __acc[__gidx]};
-    };
-};
+
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 _Iterator
@@ -527,7 +518,7 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ite
     using _Commutative = oneapi::dpl::__internal::__spirv_target_conditional</*_SpirvT*/ ::std::false_type,
                                                                              /*_NonSpirvT*/ ::std::true_type>;
     __pattern_min_element_reduce_fn<_ReduceValueType, _Compare> __reduce_fn{__comp};
-    __pattern_min_element_transform_fn<_ReduceValueType> __transform_fn;
+    oneapi::dpl::__internal::__pattern_min_element_transform_fn<_ReduceValueType> __transform_fn;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -872,17 +872,6 @@ struct __pattern_min_element_reduce_fn
     }
 };
 
-template <typename _ReduceValueType>
-struct __pattern_min_element_transform_fn
-{
-    template <typename _TGroupIdx, typename _TAcc>
-    _ReduceValueType
-    operator()(_TGroupIdx __gidx, _TAcc __acc) const
-    {
-        return _ReduceValueType{__gidx, __acc[__gidx]};
-    }
-};
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Compare>
 oneapi::dpl::__internal::__difference_t<_Range>
 __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
@@ -898,7 +887,7 @@ __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
     // This operator doesn't track the lowest found index in case of equal min. or max. values. Thus, this operator is
     // not commutative.
     __pattern_min_element_reduce_fn<_Compare, _ReduceValueType> __reduce_fn{__comp};
-    __pattern_min_element_transform_fn<_ReduceValueType> __transform_fn;
+    oneapi::dpl::__internal::__pattern_min_element_transform_fn<_ReduceValueType> __transform_fn;
 
     auto __ret_idx =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -564,21 +564,6 @@ __pattern_is_sorted(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 }
 #endif //_ONEDPL_CPP20_RANGES_PRESENT
 
-template <typename _Predicate>
-struct __pattern_count_transform_fn
-{
-    _Predicate __predicate;
-
-    // int is being implicitly casted to difference_type
-    // otherwise we can only pass the difference_type as a functor template parameter
-    template <typename _TGroupIdx, typename _TAcc>
-    int
-    operator()(_TGroupIdx __gidx, _TAcc __acc) const
-    {
-        return (__predicate(__acc[__gidx]) ? 1 : 0);
-    }
-};
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Predicate>
 oneapi::dpl::__internal::__difference_t<_Range>
 __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __predicate)
@@ -589,7 +574,7 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& _
     using _ReduceValueType = oneapi::dpl::__internal::__difference_t<_Range>;
 
     auto __reduce_fn = ::std::plus<_ReduceValueType>{};
-    __pattern_count_transform_fn<_Predicate> __transform_fn{__predicate};
+    oneapi::dpl::__internal::__pattern_count_transform_fn<_Predicate> __transform_fn{__predicate};
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
                                                                           ::std::true_type /*is_commutative*/>(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -374,31 +374,11 @@ namespace oneapi::dpl::__internal::__ranges
 template <typename _Tp>
 struct __pattern_search_n_fn;
 
-template <typename _Predicate>
-struct __pattern_count_transform_fn;
-
-template <typename _Compare, typename _ReduceValueType>
-struct __pattern_minmax_element_reduce_fn;
-
 } // namespace oneapi::dpl::__internal::__ranges
 
 template <typename _Tp>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__ranges::__pattern_search_n_fn, _Tp)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Tp>
-{
-};
-
-template <typename _Predicate>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__ranges::__pattern_count_transform_fn,
-                                                       _Predicate)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate>
-{
-};
-
-template <typename _Compare, typename _ReduceValueType>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
-    oneapi::dpl::__internal::__ranges::__pattern_minmax_element_reduce_fn, _Compare, _ReduceValueType)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<_Compare, _ReduceValueType>
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -129,7 +129,7 @@ template <typename _ReduceValueType, typename _Compare>
 struct __pattern_min_element_reduce_fn;
 
 template <typename _Compare, typename _ReduceValueType>
-struct __pattern_minmax_element__reduce_fn;
+struct __pattern_minmax_element_reduce_fn;
 
 template <typename _Predicate>
 struct __pattern_count_transform_fn;
@@ -314,7 +314,7 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 };
 
 template <typename _Compare, typename _ReduceValueType>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__pattern_minmax_element__reduce_fn,
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__pattern_minmax_element_reduce_fn,
                                                        _Compare, _ReduceValueType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Compare, _ReduceValueType>
 {

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -125,6 +125,17 @@ struct __pattern_count_transform_fn
     }
 };
 
+template <typename _ReduceValueType>
+struct __pattern_min_element_transform_fn
+{
+    template <typename _TGroupIdx, typename _TAcc>
+    _ReduceValueType
+    operator()(_TGroupIdx __gidx, _TAcc __acc) const
+    {
+        return _ReduceValueType{__gidx, __acc[__gidx]};
+    };
+};
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -77,6 +77,39 @@ struct __create_mask_unique_copy
         return _ValueType{__predicate_result};
     }
 };
+
+template <typename _Compare, typename _ReduceValueType>
+struct __pattern_minmax_element_reduce_fn
+{
+    _Compare __comp;
+
+    _ReduceValueType
+    operator()(_ReduceValueType __a, _ReduceValueType __b) const
+    {
+        using std::get;
+        auto __chosen_for_min = __a;
+        auto __chosen_for_max = __b;
+
+        if (__comp(get<2>(__b), get<2>(__a)))
+            __chosen_for_min = std::move(__b);
+        if (__comp(get<3>(__b), get<3>(__a)))
+            __chosen_for_max = std::move(__a);
+        return _ReduceValueType{get<0>(__chosen_for_min), get<1>(__chosen_for_max), get<2>(__chosen_for_min),
+                                get<3>(__chosen_for_max)};
+    }
+};
+
+template <typename _ReduceValueType>
+struct __pattern_minmax_element_transform_fn
+{
+    template <typename _TGroupIdx, typename _TAcc>
+    _ReduceValueType
+    operator()(_TGroupIdx __gidx, _TAcc __acc) const
+    {
+        return _ReduceValueType{__gidx, __gidx, __acc[__gidx], __acc[__gidx]};
+    }
+};
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -110,6 +110,21 @@ struct __pattern_minmax_element_transform_fn
     }
 };
 
+template <typename _Predicate>
+struct __pattern_count_transform_fn
+{
+    _Predicate __predicate;
+
+    // int is being implicitly casted to difference_type
+    // otherwise we can only pass the difference_type as a functor template parameter
+    template <typename _TGroupIdx, typename _TAcc>
+    int
+    operator()(_TGroupIdx __gidx, _TAcc __acc) const
+    {
+        return (__predicate(__acc[__gidx]) ? 1 : 0);
+    }
+};
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi


### PR DESCRIPTION
In this PR we remove some duplicated structures which were introduces in the PR https://github.com/uxlfoundation/oneDPL/pull/2153

Some structures has duplicated implementations and has been moved into include/oneapi/dpl/pstl/hetero/utils_hetero.h :
- `__pattern_minmax_element__reduce_fn` (renamed to `__pattern_minmax_element_reduce_fn`);
- `__pattern_minmax_element_transform_fn`;
- `__pattern_count_transform_fn`;
- `__pattern_min_element_transform_fn`.

Also `struct __pattern_min_element_reduce_fn` has two different implementations...

Just for note: before https://github.com/uxlfoundation/oneDPL/pull/2153 this code has been duplicated in the `lambda`-form