### PR TITLE
Fix naming and namespaces for scan_by_segment

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -100,10 +100,10 @@ OutputIterator
 __pattern_exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy,
                                          InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                          OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
-                                         ::std::true_type /* has_known_identity*/)
+                                         std::true_type /* has_known_identity*/)
 {
-    return __internal::__pattern_scan_by_segment(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
-                                                 init, binary_pred, binary_op, ::std::false_type{});
+    return __internal::__pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result,
+                                                 init, binary_pred, binary_op, std::false_type{});
 }
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
@@ -112,7 +112,7 @@ OutputIterator
 __pattern_exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
                                          InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
                                          BinaryPredicate binary_pred, Operator binary_op,
-                                         ::std::false_type /* has_known_identity*/)
+                                         std::false_type /* has_known_identity*/)
 {
 
     const auto n = ::std::distance(first1, last1);
@@ -174,9 +174,9 @@ __pattern_exclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag,
                                     BinaryPredicate binary_pred, Operator binary_op)
 {
     return __internal::__pattern_exclusive_scan_by_segment_impl(
-        __tag, ::std::forward<Policy>(policy), first1, last1, first2, result, init, binary_pred, binary_op,
+        __tag, std::forward<Policy>(policy), first1, last1, first2, result, init, binary_pred, binary_op,
         typename unseq_backend::__has_known_identity<
-            Operator, typename ::std::iterator_traits<InputIterator2>::value_type>::type{});
+            Operator, typename std::iterator_traits<InputIterator2>::value_type>::type{});
 }
 
 #endif
@@ -190,8 +190,8 @@ exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, first1, first2, result);
 
-    return __internal::__pattern_exclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1,
-                                                           last1, first2, result, init, binary_pred, binary_op);
+    return __internal::__pattern_exclusive_scan_by_segment(__dispatch_tag, std::forward<Policy>(policy), first1, last1,
+                                                           first2, result, init, binary_pred, binary_op);
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -29,7 +29,7 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace internal
+namespace __internal
 {
 
 template <typename Name>
@@ -102,8 +102,8 @@ __pattern_exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> _
                                          OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
                                          ::std::true_type /* has_known_identity*/)
 {
-    return internal::__pattern_scan_by_segment(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
-                                               init, binary_pred, binary_op, ::std::false_type{});
+    return __internal::__pattern_scan_by_segment(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
+                                                 init, binary_pred, binary_op, ::std::false_type{});
 }
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
@@ -173,14 +173,14 @@ __pattern_exclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag,
                                     InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
                                     BinaryPredicate binary_pred, Operator binary_op)
 {
-    return internal::__pattern_exclusive_scan_by_segment_impl(
+    return __internal::__pattern_exclusive_scan_by_segment_impl(
         __tag, ::std::forward<Policy>(policy), first1, last1, first2, result, init, binary_pred, binary_op,
         typename unseq_backend::__has_known_identity<
             Operator, typename ::std::iterator_traits<InputIterator2>::value_type>::type{});
 }
 
 #endif
-} // namespace internal
+} // namespace __internal
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
@@ -190,8 +190,8 @@ exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, first1, first2, result);
 
-    return internal::__pattern_exclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1, last1,
-                                                         first2, result, init, binary_pred, binary_op);
+    return __internal::__pattern_exclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1,
+                                                           last1, first2, result, init, binary_pred, binary_op);
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -40,9 +40,9 @@ class ExclusiveScan2;
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename T, typename BinaryPredicate, typename Operator>
 OutputIterator
-pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, InputIterator1 last1,
-                                  InputIterator2 first2, OutputIterator result, T init, BinaryPredicate binary_pred,
-                                  Operator binary_op)
+__pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, InputIterator1 last1,
+                                    InputIterator2 first2, OutputIterator result, T init, BinaryPredicate binary_pred,
+                                    Operator binary_op)
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
@@ -97,22 +97,22 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator>
 OutputIterator
-exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
-                               InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
-                               BinaryPredicate binary_pred, Operator binary_op,
-                               ::std::true_type /* has_known_identity*/)
+__pattern_exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy,
+                                         InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
+                                         OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
+                                         ::std::true_type /* has_known_identity*/)
 {
-    return internal::__scan_by_segment_impl_common(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
-                                                   init, binary_pred, binary_op, ::std::false_type{});
+    return internal::__pattern_scan_by_segment(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
+                                               init, binary_pred, binary_op, ::std::false_type{});
 }
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator>
 OutputIterator
-exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
-                               InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
-                               BinaryPredicate binary_pred, Operator binary_op,
-                               ::std::false_type /* has_known_identity*/)
+__pattern_exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
+                                         InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
+                                         BinaryPredicate binary_pred, Operator binary_op,
+                                         ::std::false_type /* has_known_identity*/)
 {
 
     const auto n = ::std::distance(first1, last1);
@@ -169,11 +169,11 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator>
 OutputIterator
-pattern_exclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
-                                  InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
-                                  BinaryPredicate binary_pred, Operator binary_op)
+__pattern_exclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
+                                    InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
+                                    BinaryPredicate binary_pred, Operator binary_op)
 {
-    return internal::exclusive_scan_by_segment_impl(
+    return internal::__pattern_exclusive_scan_by_segment_impl(
         __tag, ::std::forward<Policy>(policy), first1, last1, first2, result, init, binary_pred, binary_op,
         typename unseq_backend::__has_known_identity<
             Operator, typename ::std::iterator_traits<InputIterator2>::value_type>::type{});
@@ -190,8 +190,8 @@ exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, first1, first2, result);
 
-    return internal::pattern_exclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1, last1,
-                                                       first2, result, init, binary_pred, binary_op);
+    return internal::__pattern_exclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1, last1,
+                                                         first2, result, init, binary_pred, binary_op);
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -33,7 +33,7 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace internal
+namespace __internal
 {
 
 template <typename Name>
@@ -88,8 +88,8 @@ __pattern_inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> _
 {
     using iter_value_t = typename ::std::iterator_traits<InputIterator2>::value_type;
     iter_value_t identity = unseq_backend::__known_identity<BinaryOperator, iter_value_t>;
-    return internal::__pattern_scan_by_segment(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
-                                               identity, binary_pred, binary_op, ::std::true_type{});
+    return __internal::__pattern_scan_by_segment(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
+                                                 identity, binary_pred, binary_op, ::std::true_type{});
 }
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
@@ -138,14 +138,14 @@ __pattern_inclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag,
                                     InputIterator1 last1, InputIterator2 first2, OutputIterator result,
                                     BinaryPredicate binary_pred, BinaryOperator binary_op)
 {
-    return internal::__pattern_inclusive_scan_by_segment_impl(
+    return __internal::__pattern_inclusive_scan_by_segment_impl(
         __tag, ::std::forward<Policy>(policy), first1, last1, first2, result, binary_pred, binary_op,
         typename unseq_backend::__has_known_identity<
             BinaryOperator, typename ::std::iterator_traits<InputIterator2>::value_type>::type{});
 }
 
 #endif
-} // namespace internal
+} // namespace __internal
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
@@ -155,8 +155,8 @@ inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, first1, first2, result);
 
-    return internal::__pattern_inclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1, last1,
-                                                         first2, result, binary_pred, binary_op);
+    return __internal::__pattern_inclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1,
+                                                           last1, first2, result, binary_pred, binary_op);
 }
 
 template <typename Policy, typename InputIter1, typename InputIter2, typename OutputIter, typename BinaryPredicate>

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -42,9 +42,9 @@ class InclusiveScan1;
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
 OutputIterator
-pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, InputIterator1 last1,
-                                  InputIterator2 first2, OutputIterator result, BinaryPredicate binary_pred,
-                                  BinaryOperator binary_op)
+__pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, InputIterator1 last1,
+                                    InputIterator2 first2, OutputIterator result, BinaryPredicate binary_pred,
+                                    BinaryOperator binary_op)
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
@@ -81,24 +81,24 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename BinaryPredicate, typename BinaryOperator>
 OutputIterator
-inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
-                               InputIterator1 last1, InputIterator2 first2, OutputIterator result,
-                               BinaryPredicate binary_pred, BinaryOperator binary_op,
-                               ::std::true_type /* has_known_identity */)
+__pattern_inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy,
+                                         InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
+                                         OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op,
+                                         ::std::true_type /* has_known_identity */)
 {
     using iter_value_t = typename ::std::iterator_traits<InputIterator2>::value_type;
     iter_value_t identity = unseq_backend::__known_identity<BinaryOperator, iter_value_t>;
-    return internal::__scan_by_segment_impl_common(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
-                                                   identity, binary_pred, binary_op, ::std::true_type{});
+    return internal::__pattern_scan_by_segment(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
+                                               identity, binary_pred, binary_op, ::std::true_type{});
 }
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename BinaryPredicate, typename BinaryOperator>
 OutputIterator
-inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
-                               InputIterator1 last1, InputIterator2 first2, OutputIterator result,
-                               BinaryPredicate binary_pred, BinaryOperator binary_op,
-                               ::std::false_type /* has_known_identity */)
+__pattern_inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
+                                         InputIterator1 last1, InputIterator2 first2, OutputIterator result,
+                                         BinaryPredicate binary_pred, BinaryOperator binary_op,
+                                         ::std::false_type /* has_known_identity */)
 {
 
     typedef unsigned int FlagType;
@@ -134,11 +134,11 @@ inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename BinaryPredicate, typename BinaryOperator>
 OutputIterator
-pattern_inclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
-                                  InputIterator1 last1, InputIterator2 first2, OutputIterator result,
-                                  BinaryPredicate binary_pred, BinaryOperator binary_op)
+__pattern_inclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
+                                    InputIterator1 last1, InputIterator2 first2, OutputIterator result,
+                                    BinaryPredicate binary_pred, BinaryOperator binary_op)
 {
-    return internal::inclusive_scan_by_segment_impl(
+    return internal::__pattern_inclusive_scan_by_segment_impl(
         __tag, ::std::forward<Policy>(policy), first1, last1, first2, result, binary_pred, binary_op,
         typename unseq_backend::__has_known_identity<
             BinaryOperator, typename ::std::iterator_traits<InputIterator2>::value_type>::type{});
@@ -155,8 +155,8 @@ inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, first1, first2, result);
 
-    return internal::pattern_inclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1, last1,
-                                                       first2, result, binary_pred, binary_op);
+    return internal::__pattern_inclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1, last1,
+                                                         first2, result, binary_pred, binary_op);
 }
 
 template <typename Policy, typename InputIter1, typename InputIter2, typename OutputIter, typename BinaryPredicate>

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -84,12 +84,12 @@ OutputIterator
 __pattern_inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy,
                                          InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                          OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op,
-                                         ::std::true_type /* has_known_identity */)
+                                         std::true_type /* has_known_identity */)
 {
     using iter_value_t = typename ::std::iterator_traits<InputIterator2>::value_type;
     iter_value_t identity = unseq_backend::__known_identity<BinaryOperator, iter_value_t>;
-    return __internal::__pattern_scan_by_segment(__tag, ::std::forward<Policy>(policy), first1, last1, first2, result,
-                                                 identity, binary_pred, binary_op, ::std::true_type{});
+    return __internal::__pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result,
+                                                 identity, binary_pred, binary_op, std::true_type{});
 }
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
@@ -98,7 +98,7 @@ OutputIterator
 __pattern_inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
                                          InputIterator1 last1, InputIterator2 first2, OutputIterator result,
                                          BinaryPredicate binary_pred, BinaryOperator binary_op,
-                                         ::std::false_type /* has_known_identity */)
+                                         std::false_type /* has_known_identity */)
 {
 
     typedef unsigned int FlagType;
@@ -155,8 +155,8 @@ inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(policy, first1, first2, result);
 
-    return __internal::__pattern_inclusive_scan_by_segment(__dispatch_tag, ::std::forward<Policy>(policy), first1,
-                                                           last1, first2, result, binary_pred, binary_op);
+    return __internal::__pattern_inclusive_scan_by_segment(__dispatch_tag, std::forward<Policy>(policy), first1, last1,
+                                                           first2, result, binary_pred, binary_op);
 }
 
 template <typename Policy, typename InputIter1, typename InputIter2, typename OutputIter, typename BinaryPredicate>

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -378,8 +378,8 @@ __parallel_scan_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Execu
         ::std::forward<_Range1>(__keys), ::std::forward<_Range2>(__values), ::std::forward<_Range3>(__out_values),
         __binary_pred, __binary_op, __init, __identity);
 }
-
 } //namespace __par_backend_hetero
+
 namespace internal
 {
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -52,7 +52,7 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace internal
+namespace __par_backend_hetero
 {
 
 // This function is responsible for performing an exclusive segmented scan between work items in shared local memory.
@@ -146,7 +146,7 @@ struct __sycl_scan_by_segment_impl
              oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __seg_scan_prefix_kernel)});
 #endif
 
-        ::std::size_t __n_groups = __internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
+        ::std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
 
         auto __partials = oneapi::dpl::__par_backend_hetero::__buffer<__val_type>(__n_groups).get_buffer();
 
@@ -366,12 +366,28 @@ struct __sycl_scan_by_segment_impl
     }
 };
 
+template <bool __is_inclusive, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
+          typename _BinaryPredicate, typename _BinaryOperator, typename _T>
+void
+__parallel_scan_by_segment(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range1&& __keys,
+                           _Range2&& __values, _Range3&& __out_values, _BinaryPredicate __binary_pred,
+                           _BinaryOperator __binary_op, _T __init, _T __identity)
+{
+    __sycl_scan_by_segment_impl<__is_inclusive>()(
+        oneapi::dpl::__internal::__device_backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        ::std::forward<_Range1>(__keys), ::std::forward<_Range2>(__values), ::std::forward<_Range3>(__out_values),
+        __binary_pred, __binary_op, __init, __identity);
+}
+
+} //namespace __par_backend_hetero
+namespace internal
+{
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator, typename Inclusive>
 OutputIterator
-__scan_by_segment_impl_common(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
-                              InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
-                              BinaryPredicate binary_pred, Operator binary_op, Inclusive)
+__pattern_scan_by_segment(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
+                          InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
+                          BinaryPredicate binary_pred, Operator binary_op, Inclusive)
 {
     const auto n = ::std::distance(first1, last1);
 
@@ -392,9 +408,9 @@ __scan_by_segment_impl_common(__internal::__hetero_tag<_BackendTag>, Policy&& po
 
     constexpr iter_value_t identity = unseq_backend::__known_identity<Operator, iter_value_t>;
 
-    __sycl_scan_by_segment_impl<Inclusive::value>()(_BackendTag{}, ::std::forward<Policy>(policy), key_buf.all_view(),
-                                                    value_buf.all_view(), value_output_buf.all_view(), binary_pred,
-                                                    binary_op, init, identity);
+    __bknd::__parallel_scan_by_segment<Inclusive::value>(
+        _BackendTag{}, ::std::forward<Policy>(policy), key_buf.all_view(), value_buf.all_view(),
+        value_output_buf.all_view(), binary_pred, binary_op, init, identity);
     return result + n;
 }
 

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -380,7 +380,7 @@ __parallel_scan_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Execu
 }
 } //namespace __par_backend_hetero
 
-namespace internal
+namespace __internal
 {
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator, typename Inclusive>
@@ -414,7 +414,7 @@ __pattern_scan_by_segment(__internal::__hetero_tag<_BackendTag>, Policy&& policy
     return result + n;
 }
 
-} // namespace internal
+} // namespace __internal
 } // namespace dpl
 } // namespace oneapi
 #endif

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -146,7 +146,7 @@ struct __sycl_scan_by_segment_impl
              oneapi::dpl::__internal::__kernel_work_group_size(__exec.queue(), __seg_scan_prefix_kernel)});
 #endif
 
-        ::std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
+        std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
 
         auto __partials = oneapi::dpl::__par_backend_hetero::__buffer<__val_type>(__n_groups).get_buffer();
 
@@ -373,10 +373,10 @@ __parallel_scan_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Execu
                            _Range2&& __values, _Range3&& __out_values, _BinaryPredicate __binary_pred,
                            _BinaryOperator __binary_op, _T __init, _T __identity)
 {
-    __sycl_scan_by_segment_impl<__is_inclusive>()(
-        oneapi::dpl::__internal::__device_backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        ::std::forward<_Range1>(__keys), ::std::forward<_Range2>(__values), ::std::forward<_Range3>(__out_values),
-        __binary_pred, __binary_op, __init, __identity);
+    __sycl_scan_by_segment_impl<__is_inclusive>()(oneapi::dpl::__internal::__device_backend_tag{},
+                                                  std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__keys),
+                                                  std::forward<_Range2>(__values), std::forward<_Range3>(__out_values),
+                                                  __binary_pred, __binary_op, __init, __identity);
 }
 } //namespace __par_backend_hetero
 
@@ -409,7 +409,7 @@ __pattern_scan_by_segment(__internal::__hetero_tag<_BackendTag>, Policy&& policy
     constexpr iter_value_t identity = unseq_backend::__known_identity<Operator, iter_value_t>;
 
     __bknd::__parallel_scan_by_segment<Inclusive::value>(
-        _BackendTag{}, ::std::forward<Policy>(policy), key_buf.all_view(), value_buf.all_view(),
+        _BackendTag{}, std::forward<Policy>(policy), key_buf.all_view(), value_buf.all_view(),
         value_output_buf.all_view(), binary_pred, binary_op, init, identity);
     return result + n;
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -272,7 +272,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
                     __group, __max_end, __dpl_sycl::__maximum<std::size_t>());
 
                 // __wg_segmented_scan is a derivative work and responsible for the third header copyright
-                __val_type __carry_in = oneapi::dpl::internal::__wg_segmented_scan(
+                __val_type __carry_in = oneapi::dpl::__par_backend_hetero::__wg_segmented_scan(
                     __item, __loc_acc, __local_id, __local_id - __closest_seg_id, __accumulator, __identity,
                     __binary_op, __wgroup_size);
 


### PR DESCRIPTION
As described https://github.com/uxlfoundation/oneDPL/pull/2198#discussion_r2050818264
This fix provides better naming and namespace structure for `*_scan_by_segment`.  

It makes more clear the divide between hetero and device backend, and provides an entry point above the submitter within the device backend to transition from Policy to sycl queue and KernelName.  It also puts things in the correct namespaces.


I'm considering moving stuff between files, and changing the file structure out of the scope of this PR, but this should also be done at some point...

Should be applied before #2198 (as it provides the appropriate place to transition from policy to queue)