### PR TITLE
Remove duplicate `__pattern_min_element_reduce_fn` implementations

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -457,43 +457,6 @@ struct __brick_fill_n<__hetero_tag<_BackendTag>, _SourceT>
 // min_element, max_element
 //------------------------------------------------------------------------
 
-template <typename _ReduceValueType, typename _Compare>
-struct __pattern_min_element_reduce_fn
-{
-    _Compare __comp;
-
-    _ReduceValueType
-    operator()(_ReduceValueType __a, _ReduceValueType __b) const
-    {
-        using ::std::get;
-        // TODO: Consider removing the non-commutative operator for SPIR-V targets when we see improved performance with the
-        // non-sequential load path in transform_reduce.
-        if constexpr (oneapi::dpl::__internal::__is_spirv_target_v)
-        {
-            // This operator doesn't track the lowest found index in case of equal min. or max. values. Thus, this operator is
-            // not commutative.
-            if (__comp(get<1>(__b), get<1>(__a)))
-            {
-                return __b;
-            }
-            return __a;
-        }
-        else
-        {
-            // This operator keeps track of the lowest found index in case of equal min. or max. values. Thus, this operator is
-            // commutative.
-            bool _is_a_lt_b = __comp(get<1>(__a), get<1>(__b));
-            bool _is_b_lt_a = __comp(get<1>(__b), get<1>(__a));
-
-            if (_is_b_lt_a || (!_is_a_lt_b && get<0>(__b) < get<0>(__a)))
-            {
-                return __b;
-            }
-            return __a;
-        }
-    }
-};
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 _Iterator
 __pattern_min_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -924,23 +924,6 @@ __pattern_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 // min_element
 //------------------------------------------------------------------------
 
-template <typename _Compare, typename _ReduceValueType>
-struct __pattern_min_element_reduce_fn
-{
-    _Compare __comp;
-
-    _ReduceValueType
-    operator()(_ReduceValueType __a, _ReduceValueType __b) const
-    {
-        using ::std::get;
-        if (__comp(get<1>(__b), get<1>(__a)))
-        {
-            return __b;
-        }
-        return __a;
-    }
-};
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Compare>
 std::pair<oneapi::dpl::__internal::__difference_t<_Range>, oneapi::dpl::__internal::__value_t<_Range>>
 __pattern_min_element_impl(_BackendTag __tag, _ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
@@ -953,7 +936,7 @@ __pattern_min_element_impl(_BackendTag __tag, _ExecutionPolicy&& __exec, _Range&
 
     // This operator doesn't track the lowest found index in case of equal min. or max. values. Thus, this operator is
     // not commutative.
-    __pattern_min_element_reduce_fn<_Compare, _ReduceValueType> __reduce_fn{__comp};
+    __pattern_min_element_reduce_fn<_ReduceValueType, _Compare> __reduce_fn{__comp};
     oneapi::dpl::__internal::__pattern_min_element_transform_fn<_ReduceValueType> __transform_fn;
 
     [[maybe_unused]] auto [__idx, __val] =

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -107,7 +107,7 @@ struct __pattern_min_element_reduce_fn
     _ReduceValueType
     operator()(_ReduceValueType __a, _ReduceValueType __b) const
     {
-        using ::std::get;
+        using std::get;
         // TODO: Consider removing the non-commutative operator for SPIR-V targets when we see improved performance with the
         // non-sequential load path in transform_reduce.
         if constexpr (oneapi::dpl::__internal::__is_spirv_target_v)

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -21,6 +21,9 @@
 #ifndef _ONEDPL_UTILS_HETERO_H
 #define _ONEDPL_UTILS_HETERO_H
 
+#include "../utils.h"
+#include <tuple>
+
 namespace oneapi
 {
 namespace dpl


### PR DESCRIPTION
This PR is a follow-up to https://github.com/uxlfoundation/oneDPL/pull/2200 and addresses https://github.com/uxlfoundation/oneDPL/issues/2204. We remove the duplicate definitions of `__pattern_min_element_reduce_fn` and place the implementation in the `utils_hetero.h` header.

The two existing implementations are slightly different. The version of the functor that differentiates between SPIR-V and non SPIR-V target backends is chosen to keep as it continue to show the best performance across assessed platforms.

I do not think this is considered a feature but am okay with holding off on merging until after the milestone's completion if we wish.