### PR TITLE
Resolve ambiguous return in `__red_by_seg_op` in SYCL backend

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -806,6 +806,7 @@ struct __red_by_seg_op
     operator()(const _Tup1& __lhs_tup, const _Tup2& __rhs_tup) const
     {
         using std::get;
+        using _OpOutType = decltype(__binary_op(get<1>(__lhs_tup), get<1>(__rhs_tup)));
         // The left-hand side has processed elements from the same segment, so update the reduction value.
         if (get<0>(__rhs_tup) == 0)
         {
@@ -813,7 +814,7 @@ struct __red_by_seg_op
                                                        __binary_op(get<1>(__lhs_tup), get<1>(__rhs_tup)));
         }
         // We are looking at elements from a previous segment so just update the output index.
-        return oneapi::dpl::__internal::make_tuple(get<0>(__lhs_tup) + get<0>(__rhs_tup), get<1>(__rhs_tup));
+        return oneapi::dpl::__internal::make_tuple(get<0>(__lhs_tup) + get<0>(__rhs_tup), _OpOutType{get<1>(__rhs_tup)});
     }
     _BinaryOp __binary_op;
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -806,7 +806,7 @@ struct __red_by_seg_op
     operator()(const _Tup1& __lhs_tup, const _Tup2& __rhs_tup) const
     {
         using std::get;
-        using _OpOutType = decltype(__binary_op(get<1>(__lhs_tup), get<1>(__rhs_tup)));
+        using _OpReturnType = decltype(__binary_op(get<1>(__lhs_tup), get<1>(__rhs_tup)));
         // The left-hand side has processed elements from the same segment, so update the reduction value.
         if (get<0>(__rhs_tup) == 0)
         {
@@ -815,7 +815,7 @@ struct __red_by_seg_op
         }
         // We are looking at elements from a previous segment so just update the output index.
         return oneapi::dpl::__internal::make_tuple(get<0>(__lhs_tup) + get<0>(__rhs_tup),
-                                                   _OpOutType{get<1>(__rhs_tup)});
+                                                   _OpReturnType{get<1>(__rhs_tup)});
     }
     _BinaryOp __binary_op;
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -814,7 +814,8 @@ struct __red_by_seg_op
                                                        __binary_op(get<1>(__lhs_tup), get<1>(__rhs_tup)));
         }
         // We are looking at elements from a previous segment so just update the output index.
-        return oneapi::dpl::__internal::make_tuple(get<0>(__lhs_tup) + get<0>(__rhs_tup), _OpOutType{get<1>(__rhs_tup)});
+        return oneapi::dpl::__internal::make_tuple(get<0>(__lhs_tup) + get<0>(__rhs_tup),
+                                                   _OpOutType{get<1>(__rhs_tup)});
     }
     _BinaryOp __binary_op;
 };

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -861,7 +861,7 @@ struct MaxAbsFunctor<MatrixPoint<_Tp>>
     }
 };
 
-struct TupleAddFunctor
+struct TupleAddFunctor1
 {
     template <typename Tup1, typename Tup2>
     auto
@@ -869,6 +869,22 @@ struct TupleAddFunctor
     {
         using ::std::get;
         Tup1 tup_sum = ::std::make_tuple(get<0>(lhs) + get<0>(rhs), get<1>(lhs) + get<1>(rhs));
+        return tup_sum;
+    }
+};
+
+// Exercise an explicit return of std::tuple to check for issues related to ambiguous return types between
+// oneapi::dpl::__internal::tuple and std::tuple
+struct TupleAddFunctor2
+{
+    template <typename Tup1, typename Tup2>
+    auto
+    operator()(const Tup1& lhs, const Tup2& rhs) const
+    {
+        using std::get;
+        using return_t =
+            std::tuple<decltype(get<0>(lhs) + get<0>(rhs)), decltype(get<1>(lhs) + get<1>(rhs))>;
+        return_t tup_sum{get<0>(lhs) + get<0>(rhs), get<1>(lhs) + get<1>(rhs)};
         return tup_sum;
     }
 };


### PR DESCRIPTION
`__red_by_seg_op` has a potential ambiguous return when the return type of `__binary_op` differs from the input segment's underlying value type. To resolve this issue, we can ensure the second element in the tuple returned by `__red_by_seg_op` matches the return type of `__binary_op` through a conversion.

In practice, this issue was encountered when performing a `reduce_by_segment` operation over zip iterators where a `std::tuple` is explicitly returned by the reduction operator. I have added a test case which catches this issue in `reduce_by_segment_zip.pass`