### PR TITLE
Adding definition of DPLROOT variable to make the library consistent with other oneAPI libraries

### DIFF
--- a/integration/env/vars.bat
+++ b/integration/env/vars.bat
@@ -18,6 +18,7 @@ REM
 set "VARSDIR=%~dp0"
 
 if not defined DPL_ROOT for /f "delims=" %%F in ("%VARSDIR%..") do set "DPL_ROOT=%%~fF"
+if not defined DPLROOT for /f "delims=" %%F in ("%VARSDIR%..") do set "DPLROOT=%%~fF"
 
 set "CPLUS_INCLUDE_PATH=%DPL_ROOT%\include;%CPLUS_INCLUDE_PATH%"
 set "PKG_CONFIG_PATH=%DPL_ROOT%\lib\pkgconfig;%PKG_CONFIG_PATH%"

--- a/integration/env/vars.sh
+++ b/integration/env/vars.sh
@@ -176,6 +176,7 @@ fi
 
 _onedpl_scrip_path=$(dirname -- "$(rreadlink "${vars_script_name:-}")")
 DPL_ROOT=$(dirname -- "${_onedpl_scrip_path}") ; export DPL_ROOT
+DPLROOT=$(dirname -- "${_onedpl_scrip_path}") ; export DPLROOT
 CPLUS_INCLUDE_PATH=$(prepend_path "${DPL_ROOT}/include" "${CPLUS_INCLUDE_PATH:-}") ; export CPLUS_INCLUDE_PATH
 PKG_CONFIG_PATH=$(prepend_path "${DPL_ROOT}/lib/pkgconfig" "${PKG_CONFIG_PATH:-}") ; export PKG_CONFIG_PATH
 CMAKE_PREFIX_PATH=$(prepend_path "${DPL_ROOT}/lib/cmake/oneDPL" "${CMAKE_PREFIX_PATH:-}") ; export CMAKE_PREFIX_PATH

--- a/integration/etc/vars.bat
+++ b/integration/etc/vars.bat
@@ -34,3 +34,4 @@ if not defined ONEAPI_ROOT (
 rem ############################################################################
 
 set "DPL_ROOT=%ONEAPI_ROOT%"
+set "DPLROOT=%ONEAPI_ROOT%"

--- a/integration/etc/vars.sh
+++ b/integration/etc/vars.sh
@@ -34,3 +34,4 @@ fi
 # ############################################################################
 
 DPL_ROOT=${ONEAPI_ROOT} ; export DPL_ROOT
+DPLROOT=${ONEAPI_ROOT} ; export DPLROOT

--- a/integration/modulefiles/dpl
+++ b/integration/modulefiles/dpl
@@ -58,6 +58,7 @@ proc ModulesHelp { } {
 
 set dpl_root "$componentroot"
 setenv DPL_ROOT "$dpl_root"
+setenv DPLROOT "$dpl_root"
 prepend-path CPLUS_INCLUDE_PATH "$dpl_root/include"
 prepend-path CMAKE_PREFIX_PATH "$dpl_root/lib/cmake/oneDPL"
 prepend-path PKG_CONFIG_PATH "$dpl_root/lib/pkgconfig"


### PR DESCRIPTION
Installations of oneDPL include an environment activation scripts which define environment variables as needed for DPL to work.

In particular, it defines an environment variable with name 'DPL_ROOT', which points at the path where the DPL installation is to be found.

The name "DPL_ROOT" with an underscore is inconsistent with the rest of oneAPI products, which define similar variables without underscores in their names.

For example:

MKLROOT
TBBROOT
IPPROOT
DALROOT

This PR introduces `DPLROOT` to make the library consistent with other oneAPI libraries to improve the user experience. It mirrors `DPL_ROOT` so no invasive changes to the library are immediately necessary and a plan to deprecate `DPL_ROOT` can be implemented.