### PR TITLE
Fix segmented scans: remove extra template parameter

### DIFF
--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -105,7 +105,7 @@ struct __sycl_scan_by_segment_impl
     template <typename... _Name>
     using _SegScanPrefixPhase = __seg_scan_prefix_kernel<__is_inclusive, _Name...>;
 
-    template <typename _BackendTag, typename _Range1, typename _Range2, typename _Range3, typename _BinaryPredicate,
+    template <typename _Range1, typename _Range2, typename _Range3, typename _BinaryPredicate,
               typename _BinaryOperator, typename _T>
     void
     operator()(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _Range1&& __keys, _Range2&& __values,

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -105,8 +105,8 @@ struct __sycl_scan_by_segment_impl
     template <typename... _Name>
     using _SegScanPrefixPhase = __seg_scan_prefix_kernel<__is_inclusive, _Name...>;
 
-    template <typename _Range1, typename _Range2, typename _Range3, typename _BinaryPredicate,
-              typename _BinaryOperator, typename _T>
+    template <typename _Range1, typename _Range2, typename _Range3, typename _BinaryPredicate, typename _BinaryOperator,
+              typename _T>
     void
     operator()(oneapi::dpl::__internal::__device_backend_tag, sycl::queue& __q, _Range1&& __keys, _Range2&& __values,
                _Range3&& __out_values, _BinaryPredicate __binary_pred, _BinaryOperator __binary_op, _T __init,


### PR DESCRIPTION
It fixes an error:
> scan_by_segment_impl.h(376,5): error: no matching function for call to object of type '__sycl_scan_by_segment_impl<_CustomName, true>'
...
note: candidate template ignored: couldn't infer template argument '_BackendTag'

This issue has been introduced by @SergeyKopienko in the PR https://github.com/uxlfoundation/oneDPL/pull/2198