### PR TITLE
Update the ONEDPL_VERSION number for the coming release

### DIFF
--- a/documentation/library_guide/conf.py
+++ b/documentation/library_guide/conf.py
@@ -37,7 +37,7 @@ copyright = 'Intel Corporation'
 author = 'Intel'
 
 # The full version, including alpha/beta/rc tags
-release = '2022.8.0'
+release = '2022.9.0'
 
 rst_epilog = """
 .. include:: /variables.txt

--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -12,7 +12,7 @@
 
 // The library version
 #define ONEDPL_VERSION_MAJOR 2022
-#define ONEDPL_VERSION_MINOR 8
+#define ONEDPL_VERSION_MINOR 9
 #define ONEDPL_VERSION_PATCH 0
 
 // The oneAPI Specification version this implementation is compliant with

--- a/test/general/version.pass.cpp
+++ b/test/general/version.pass.cpp
@@ -25,7 +25,7 @@ static_assert(_PSTL_VERSION_PATCH == 0);
 #endif
 
 static_assert(ONEDPL_VERSION_MAJOR == 2022);
-static_assert(ONEDPL_VERSION_MINOR == 8);
+static_assert(ONEDPL_VERSION_MINOR == 9);
 static_assert(ONEDPL_VERSION_PATCH == 0);
 
 #include "support/utils.h"


### PR DESCRIPTION
The PR updates the oneDPL version macro and test verifying it.

According to https://github.com/uxlfoundation/oneAPI-spec/blob/4f3aad16ec26780b98fe5135ac4de9b8f27f8dd8/roadmap.rst a new version of the oneAPI specification is not expected at this time, so the ONEAPI_SPEC_VERSION macro is not updated in this PR.

This PR should not be merged until code freeze for the coming release.