### PR TITLE
Fix a compile error with mismatching types in std::min

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -415,10 +415,11 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
         using _histogram_index_type = ::std::int32_t;
 
-        auto __global_mem_size = __q.get_device().template get_info<sycl::info::device::global_mem_size>();
-        const ::std::size_t __max_segments =
-            ::std::min(__global_mem_size / (__num_bins * sizeof(_bin_type)),
-                       oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __min_iters_per_work_item));
+        const std::uint64_t __global_mem_size = __q.get_device().get_info<sycl::info::device::global_mem_size>();
+        const auto __max_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __min_iters_per_work_item);
+        const std::size_t __max_segments = std::min<std::common_type_t<std::uint64_t, decltype(__max_groups)>>(
+            __global_mem_size / (__num_bins * sizeof(_bin_type)), __max_groups);
+
         const ::std::size_t __iters_per_work_item =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __max_segments * __work_group_size);
         ::std::size_t __segments =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -418,7 +418,8 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
         const std::uint64_t __global_mem_size = __q.get_device().get_info<sycl::info::device::global_mem_size>();
         const std::uint64_t __max_groups =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __min_iters_per_work_item);
-        const std::uint64_t __max_segments = std::min(__global_mem_size / (__num_bins * sizeof(_bin_type)), __max_groups);
+        const std::uint64_t __max_segments =
+            std::min(__global_mem_size / (__num_bins * sizeof(_bin_type)), __max_groups);
 
         const std::uint64_t __iters_per_work_item =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __max_segments * __work_group_size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -416,7 +416,8 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
         using _histogram_index_type = ::std::int32_t;
 
         const std::uint64_t __global_mem_size = __q.get_device().get_info<sycl::info::device::global_mem_size>();
-        const auto __max_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __min_iters_per_work_item);
+        const auto __max_groups =
+            oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __min_iters_per_work_item);
         const std::size_t __max_segments = std::min<std::common_type_t<std::uint64_t, decltype(__max_groups)>>(
             __global_mem_size / (__num_bins * sizeof(_bin_type)), __max_groups);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -421,9 +421,9 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
         const std::uint64_t __max_segments =
             std::min(__global_mem_size / (__num_bins * sizeof(_bin_type)), __max_groups);
 
-        const std::uint64_t __iters_per_work_item =
+        const std::size_t __iters_per_work_item =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __max_segments * __work_group_size);
-        const std::uint64_t __segments =
+        const std::size_t __segments =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
 
         auto __private_histograms =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -416,14 +416,13 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
         using _histogram_index_type = ::std::int32_t;
 
         const std::uint64_t __global_mem_size = __q.get_device().get_info<sycl::info::device::global_mem_size>();
-        const auto __max_groups =
+        const std::uint64_t __max_groups =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __min_iters_per_work_item);
-        const std::size_t __max_segments = std::min<std::common_type_t<std::uint64_t, decltype(__max_groups)>>(
-            __global_mem_size / (__num_bins * sizeof(_bin_type)), __max_groups);
+        const std::uint64_t __max_segments = std::min(__global_mem_size / (__num_bins * sizeof(_bin_type)), __max_groups);
 
-        const ::std::size_t __iters_per_work_item =
+        const std::uint64_t __iters_per_work_item =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __max_segments * __work_group_size);
-        ::std::size_t __segments =
+        const std::uint64_t __segments =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
 
         auto __private_histograms =


### PR DESCRIPTION
The PR fixes an error:

```
include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h:420:13: error: no matching function for call to 'min'
  420 |             ::std::min(__global_mem_size / (__num_bins * sizeof(_bin_type)),
      |             ^~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/algorithmfwd.h:420:5: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('typename info::device::global_mem_size::return_type' (aka 'unsigned long long') vs. 'unsigned long')
```

It happens with AdaptiveCPP based on clang++18.