### PR TITLE
[test] Update usages of `TupleAddFunctor` to `TupleAddFunctor1`

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_zip.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_zip.pass.cpp
@@ -68,8 +68,8 @@ test_with_usm()
     //run exclusive_scan_by_segment algorithm 
     oneapi::dpl::exclusive_scan_by_segment(
         TestUtils::make_device_policy<KernelName>(q), begin_keys_in,
-        end_keys_in, begin_vals_in, begin_vals_out, ::std::make_tuple(int(1), int(1)),
-        ::std::equal_to<>(), TestUtils::TupleAddFunctor());
+        end_keys_in, begin_vals_in, begin_vals_out, std::make_tuple(int(1), int(1)),
+        std::equal_to<>(), TestUtils::TupleAddFunctor1());
 
     //retrieve result on the host and check the result
     dt_helper5.retrieve_data(output_values1);

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment_zip.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment_zip.pass.cpp
@@ -69,7 +69,7 @@ test_with_usm()
     oneapi::dpl::inclusive_scan_by_segment(
         TestUtils::make_device_policy<KernelName>(q), begin_keys_in,
         end_keys_in, begin_vals_in, begin_vals_out,
-        ::std::equal_to<>(), TestUtils::TupleAddFunctor());
+        std::equal_to<>(), TestUtils::TupleAddFunctor1());
 
     //retrieve result on the host and check the result
     dt_helper5.retrieve_data(output_values1);


### PR DESCRIPTION
In https://github.com/uxlfoundation/oneDPL/pull/2206, the test utility `TupleAddFunctor` was renamed to `TupleAddFunctor1`. In addition to being used in `reduce_by_segment_zip.pass`, it is also used in the zip inclusive and exclusive scan by segment tests.

I've verified all instances in testing have now been updated and that the tests run:
```
~/repos/oneDPL/test$ grep -r "TupleAddFunctor" .
./support/utils.h:struct TupleAddFunctor1
./support/utils.h:struct TupleAddFunctor2
./parallel_api/numeric/numeric.ops/reduce_by_segment_zip.pass.cpp:    run_test_with_op(TestUtils::TupleAddFunctor1{});
./parallel_api/numeric/numeric.ops/reduce_by_segment_zip.pass.cpp:    run_test_with_op(TestUtils::TupleAddFunctor2{});
./parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_zip.pass.cpp:        std::equal_to<>(), TestUtils::TupleAddFunctor1());
./parallel_api/numeric/numeric.ops/inclusive_scan_by_segment_zip.pass.cpp:        std::equal_to<>(), TestUtils::TupleAddFunctor1());

```