### PR TITLE
Fix early memory deallocation in algorithm implementations

### DIFF
--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -212,7 +212,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
         __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::lower_bound>{
             comp, size, use_32bit_indexing},
         value_size, zip_vw)
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
     return result + value_size;
 }
 
@@ -245,7 +245,7 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
         __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::upper_bound>{
             comp, size, use_32bit_indexing},
         value_size, zip_vw)
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
     return result + value_size;
 }
 
@@ -278,7 +278,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
         __custom_brick<StrictWeakOrdering, decltype(size), decltype(zip_vw), search_algorithm::binary_search>{
             comp, size, use_32bit_indexing},
         value_size, zip_vw)
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
     return result + value_size;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1237,7 +1237,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
 
         __par_backend_hetero::__parallel_merge(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                __buf1.all_view(), __buf2.all_view(), __buf3.all_view(), __comp)
-            .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+            .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
     }
     return __d_first + __n;
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1237,7 +1237,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
 
         __par_backend_hetero::__parallel_merge(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                __buf1.all_view(), __buf2.all_view(), __buf3.all_view(), __comp)
-            .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
+            .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
     }
     return __d_first + __n;
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1237,7 +1237,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
 
         __par_backend_hetero::__parallel_merge(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                __buf1.all_view(), __buf2.all_view(), __buf3.all_view(), __comp)
-            .__checked_deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+            .__checked_deferrable_wait();
     }
     return __d_first + __n;
 }
@@ -1295,7 +1295,7 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 
     __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                  __buf.all_view(), __comp, __proj)
-        .__checked_deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+        .__checked_deferrable_wait();
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1295,7 +1295,7 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 
     __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                  __buf.all_view(), __comp, __proj)
-        .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
+        .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -61,7 +61,7 @@ __pattern_walk1(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
         unseq_backend::walk1_vector_or_scalar<_Function, decltype(__buf.all_view())>{__f,
                                                                                      static_cast<std::size_t>(__n)},
         __n, __buf.all_view())
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
 }
 
 //------------------------------------------------------------------------
@@ -201,7 +201,7 @@ __pattern_walk3(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
         unseq_backend::walk3_vectors_or_scalars<_Function, decltype(__buf1.all_view()), decltype(__buf2.all_view()),
                                                 decltype(__buf3.all_view())>{__f, static_cast<std::size_t>(__n)},
         __n, __buf1.all_view(), __buf2.all_view(), __buf3.all_view())
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
 
     return __first3 + __n;
 }
@@ -1237,7 +1237,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
 
         __par_backend_hetero::__parallel_merge(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                __buf1.all_view(), __buf2.all_view(), __buf3.all_view(), __comp)
-            .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+            .__checked_deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
     }
     return __d_first + __n;
 }
@@ -1295,7 +1295,7 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 
     __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                  __buf.all_view(), __comp, __proj)
-        .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+        .__checked_deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare,
@@ -1506,7 +1506,7 @@ __pattern_partial_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _It
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__mid),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__last), __comp)
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
 }
 
 //------------------------------------------------------------------------
@@ -1649,7 +1649,7 @@ __pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
         unseq_backend::__reverse_functor<typename std::iterator_traits<_Iterator>::difference_type,
                                          decltype(__buf.all_view())>{__n},
         __n / 2, __buf.all_view())
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
 }
 
 //------------------------------------------------------------------------
@@ -1676,7 +1676,7 @@ __pattern_reverse_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bi
         unseq_backend::__reverse_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
                                       decltype(__buf1.all_view()), decltype(__buf2.all_view())>{__n},
         __n, __buf1.all_view(), __buf2.all_view())
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
 
     return __result + __n;
 }
@@ -1730,7 +1730,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
             _Function{}, static_cast<std::size_t>(__n)};
     oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __brick,
                                                       __n, __temp_rng_rw, __buf.all_view())
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
 
     // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
     // we must call __parallel_for with wait() to provide the blocking synchronization for this pattern.
@@ -1765,7 +1765,7 @@ __pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bid
         unseq_backend::__rotate_copy<typename std::iterator_traits<_BidirectionalIterator>::difference_type,
                                      decltype(__buf1.all_view()), decltype(__buf2.all_view())>{__n, __shift},
         __n, __buf1.all_view(), __buf2.all_view())
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
 
     return __result + __n;
 }
@@ -2026,7 +2026,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
 
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                           __brick, __size_res, __src, __dst)
-            .__deferrable_wait();
+            .__checked_deferrable_wait();
     }
     else //2. n < size/2; 'n' parallel copying
     {
@@ -2036,7 +2036,7 @@ __pattern_shift_left(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rang
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__shift_left_right>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __brick, __n, __rng)
-            .__deferrable_wait();
+            .__checked_deferrable_wait();
     }
 
     return __size_res;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1295,7 +1295,7 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 
     __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                  __buf.all_view(), __comp, __proj)
-        .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+        .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1237,7 +1237,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ite
 
         __par_backend_hetero::__parallel_merge(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                __buf1.all_view(), __buf2.all_view(), __buf3.all_view(), __comp)
-            .__deferrable_wait();
+            .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
     }
     return __d_first + __n;
 }
@@ -1295,7 +1295,7 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 
     __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                  __buf.all_view(), __comp, __proj)
-        .__deferrable_wait();
+        .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -928,7 +928,7 @@ __pattern_stable_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
     if (__rng.size() >= 2)
         __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                      ::std::forward<_Range>(__rng), __comp, __proj)
-            .__deferrable_wait();
+            .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -928,7 +928,7 @@ __pattern_stable_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
     if (__rng.size() >= 2)
         __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                      ::std::forward<_Range>(__rng), __comp, __proj)
-            .__checked_deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+            .__checked_deferrable_wait();
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -928,7 +928,7 @@ __pattern_stable_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
     if (__rng.size() >= 2)
         __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                      ::std::forward<_Range>(__rng), __comp, __proj)
-            .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+            .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -928,7 +928,7 @@ __pattern_stable_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
     if (__rng.size() >= 2)
         __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                      ::std::forward<_Range>(__rng), __comp, __proj)
-            .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
+            .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -67,7 +67,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
                 unseq_backend::walk1_vector_or_scalar<_Function, std::decay_t<_Ranges>...>{
                     __f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
-                .__deferrable_wait();
+                .__checked_deferrable_wait();
         }
         else if constexpr (__num_ranges == 2)
         {
@@ -76,7 +76,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
                 unseq_backend::walk2_vectors_or_scalars<_Function, std::decay_t<_Ranges>...>{
                     __f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
-                .__deferrable_wait();
+                .__checked_deferrable_wait();
         }
         else
         {
@@ -85,7 +85,7 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
                 unseq_backend::walk3_vectors_or_scalars<_Function, std::decay_t<_Ranges>...>{
                     __f, static_cast<std::size_t>(__n)},
                 __n, std::forward<_Ranges>(__rngs)...)
-                .__deferrable_wait();
+                .__checked_deferrable_wait();
         }
     }
     return __n;
@@ -217,7 +217,7 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& _
                 std::forward<_ExecutionPolicy>(__exec)),
             unseq_backend::__brick_swap<_Function, std::decay_t<_Range1>, std::decay_t<_Range2>>{__f, __n}, __n, __rng1,
             __rng2)
-            .__deferrable_wait();
+            .__checked_deferrable_wait();
         return __n;
     }
     const std::size_t __n = __rng2.size();
@@ -226,7 +226,7 @@ __pattern_swap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& _
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(std::forward<_ExecutionPolicy>(__exec)),
         unseq_backend::__brick_swap<_Function, std::decay_t<_Range2>, std::decay_t<_Range1>>{__f, __n}, __n, __rng2,
         __rng1)
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
     return __n;
 }
 
@@ -928,7 +928,7 @@ __pattern_stable_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Ran
     if (__rng.size() >= 2)
         __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                                      ::std::forward<_Range>(__rng), __comp, __proj)
-            .__deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+            .__checked_deferrable_wait(); // __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2467,7 +2467,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
         __result_end,
         oneapi::dpl::__ranges::take_view_simple(oneapi::dpl::__ranges::views::all_read(__idx), __result_end),
         oneapi::dpl::__ranges::views::all_read(__tmp_out_values), std::forward<_Range4>(__out_values))
-        .__deferrable_wait();
+        .__checked_deferrable_wait();
     return __result_end;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -803,7 +803,7 @@ class __future : private std::tuple<_Args...>
         constexpr std::size_t __size_of_tuple = std::tuple_size_v<decltype(*this)>;
 
         // __result_and_scratch_storage is the last element of the tuple if it exist
-        if constexpr (__size_of_tuple > 1)
+        if constexpr (__size_of_tuple > 0)
         {
             using __temporary_data_t = std::shared_ptr<__result_and_scratch_storage_base>;
             using __last_element_t = std::decay_t<std::tuple_element_t<__size_of_tuple - 1, decltype(*this)>>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -809,6 +809,7 @@ class __future : private std::tuple<_Args...>
             using __last_element_t = std::decay_t<std::tuple_element_t<__size_of_tuple - 1, decltype(*this)>>;
             if constexpr (std::is_same_v<__last_element_t, __temporary_data_t>)
             {
+                // We should have this wait() call to ensure that the temporary data is not destroyed before the kernel code finished
                 wait();
             }
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -799,6 +799,19 @@ class __future : private std::tuple<_Args...>
     {
 #if !ONEDPL_ALLOW_DEFERRED_WAITING
         wait();
+#else
+        constexpr std::size_t __size_of_tuple = std::tuple_size_v<decltype(*this)>;
+
+        // __result_and_scratch_storage is the last element of the tuple if it exist
+        if constexpr (__size_of_tuple > 1)
+        {
+            using __temporary_data_t = std::shared_ptr<__result_and_scratch_storage_base>;
+            using __last_element_t = std::decay_t<std::tuple_element_t<__size_of_tuple - 1, decltype(*this)>>;
+            if (std::is_same_v<__last_element_t, __temporary_data_t>)
+            {
+                wait();
+            }
+        }
 #endif
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -807,7 +807,7 @@ class __future : private std::tuple<_Args...>
         {
             using __temporary_data_t = std::shared_ptr<__result_and_scratch_storage_base>;
             using __last_element_t = std::decay_t<std::tuple_element_t<__size_of_tuple - 1, decltype(*this)>>;
-            if (std::is_same_v<__last_element_t, __temporary_data_t>)
+            if constexpr (std::is_same_v<__last_element_t, __temporary_data_t>)
             {
                 wait();
             }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -791,11 +791,11 @@ class __future : private std::tuple<_Args...>
         if constexpr (std::is_same_v<_WaitModeTag, __sync_mode>)
             wait();
         else if constexpr (std::is_same_v<_WaitModeTag, __deferrable_mode>)
-            __deferrable_wait();
+            __checked_deferrable_wait();
     }
 
     void
-    __deferrable_wait()
+    __checked_deferrable_wait()
     {
 #if !ONEDPL_ALLOW_DEFERRED_WAITING
         wait();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -800,18 +800,10 @@ class __future : private std::tuple<_Args...>
 #if !ONEDPL_ALLOW_DEFERRED_WAITING
         wait();
 #else
-        constexpr std::size_t __size_of_tuple = std::tuple_size_v<decltype(*this)>;
-
-        // __result_and_scratch_storage is the last element of the tuple if it exist
-        if constexpr (__size_of_tuple > 0)
+        if constexpr (sizeof...(_Args) > 0)
         {
-            using __temporary_data_t = std::shared_ptr<__result_and_scratch_storage_base>;
-            using __last_element_t = std::decay_t<std::tuple_element_t<__size_of_tuple - 1, decltype(*this)>>;
-            if constexpr (std::is_same_v<__last_element_t, __temporary_data_t>)
-            {
-                // We should have this wait() call to ensure that the temporary data is not destroyed before the kernel code finished
-                wait();
-            }
+            // We should have this wait() call to ensure that the temporary data is not destroyed before the kernel code finished
+            wait();
         }
 #endif
     }

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -160,7 +160,7 @@ __pattern_histogram(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Rando
             oneapi::dpl::__par_backend_hetero::__parallel_histogram(
                 _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __init_event, __input_buf.all_view(),
                 ::std::move(__bins), __binhash_manager)
-                .__deferrable_wait();
+                .__checked_deferrable_wait();
         }
         else
         {

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -147,7 +147,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
             _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n,
             __unary_op, __init, __binary_op, _Inclusive{})
-            .__deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
+            .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -147,7 +147,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
             _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n,
             __unary_op, __init, __binary_op, _Inclusive{})
-            .__deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
+            .__checked_deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
     }
     else
     {
@@ -280,7 +280,7 @@ __pattern_adjacent_difference(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec,
                                                           _Function{__fn, static_cast<std::size_t>(__n)}, __n,
                                                           __buf1.all_view(), __buf2.all_view())
-            .__deferrable_wait();
+            .__checked_deferrable_wait();
     }
 
     return __d_last;

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -147,7 +147,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
             _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n,
             __unary_op, __init, __binary_op, _Inclusive{})
-            .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
+            .__deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -147,7 +147,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
             _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n,
             __unary_op, __init, __binary_op, _Inclusive{})
-            .__checked_deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
+            .__checked_deferrable_wait();
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -147,7 +147,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
             _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __n,
             __unary_op, __init, __binary_op, _Inclusive{})
-            .__deferrable_wait();
+            .__deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -100,7 +100,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
         std::forward<_Range2>(__rng2), __n, __unary_op, __init, __binary_op, _Inclusive{})
-        .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
+        .__deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
     return __n;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -100,7 +100,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
         std::forward<_Range2>(__rng2), __n, __unary_op, __init, __binary_op, _Inclusive{})
-        .__deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
+        .wait(); // Calls wait() here because we should extend the life-time of temporary data inside __future instance
     return __n;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -100,7 +100,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
         std::forward<_Range2>(__rng2), __n, __unary_op, __init, __binary_op, _Inclusive{})
-        .__deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
+        .__checked_deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
     return __n;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -100,7 +100,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
         std::forward<_Range2>(__rng2), __n, __unary_op, __init, __binary_op, _Inclusive{})
-        .__checked_deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
+        .__checked_deferrable_wait();
     return __n;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -100,7 +100,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
         std::forward<_Range2>(__rng2), __n, __unary_op, __init, __binary_op, _Inclusive{})
-        .__deferrable_wait();
+        .__deferrable_wait(); // __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
     return __n;
 }
 


### PR DESCRIPTION
In this PR we fix early memory deallocation in algorithm implementations.

# The problem statement.
Typically in oneDPL algorithms we have the code like:
```C++
    __par_backend_hetero::__parallel_partial_sort(
        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__first),
        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__mid),
        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__last), __comp)
        .__deferrable_wait();
```

where `__parallel_partial_sort` return the instance of `__future<sycl::event>`.
So in this case the is no memory management inside and so on.

But in the some cases we have another calls, for example:
```C++
        __par_backend_hetero::__parallel_merge(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
                                               __buf1.all_view(), __buf2.all_view(), __buf3.all_view(), __comp)
            .__deferrable_wait();
```

where we returns `__future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>`
As we may see, some management of temporary objects has place here.

This mean, that after `__deferrable_wait()` call, implemented as
```C++
    void
    __deferrable_wait()
    {
#if !ONEDPL_ALLOW_DEFERRED_WAITING
        wait();
#endif
    }
```
all temporary objects, saved in the `__future` instance, will be destroyed.

But if  `ONEDPL_ALLOW_DEFERRED_WAITING` is defined, the kernel code may still works after exit from `__deferrable_wait()` call and we will work with deallocated memory and so on.

# Solution
Options:
1) change implementation of `__deferrable_wait()` : if `__future` instance contains inside some `std::shared_ptr<__result_and_scratch_storage_base>` data type. then call `wait()` independently from the state if `ONEDPL_ALLOW_DEFERRED_WAITING` macros.
2) call `wait()` in problem cases instead of `__deferrable_wait()` 

I prefer option (1), because we have two implementations of `__parallel_stable_sort` for `oneapi::dpl::__internal::__device_backend_tag` : one of them returns `__future<sycl::event>` and another returns `__future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>`. Which implementation will be used depends on the state of `_ONEDPL_USE_RADIX_SORT` macros.

## Proposed implementation of `__deferrable_wait()` :
I renamed `__deferrable_wait()` to `__checked_deferrable_wait()` and implement it by this way:
```C++
void
__checked_deferrable_wait()
{
#if !ONEDPL_ALLOW_DEFERRED_WAITING
    wait();
#else
    if constexpr (sizeof...(_Args) > 0)
    {
        // We should have this wait() call to ensure that the temporary data is not destroyed before the kernel code finished
        wait();
    }
#endif
}
```