### PR TITLE
Remove use of `std::array` in `reduce_by_segment`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -48,7 +48,6 @@
 #include <type_traits>
 #include <utility>
 #include <algorithm>
-#include <array>
 
 #include "sycl_defs.h"
 #include "parallel_backend_sycl_utils.h"
@@ -228,7 +227,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
             __seg_reduce_wg_kernel,
 #endif
             sycl::nd_range<1>{__n_groups * __wgroup_size, __wgroup_size}, [=](sycl::nd_item<1> __item) {
-                std::array<__val_type, __vals_per_item> __loc_partials;
+                __val_type __loc_partials[__vals_per_item];
 
                 auto __group = __item.get_group();
                 std::size_t __group_id = __item.get_group(0);


### PR DESCRIPTION
MSVC's `std::array` implementation is not compatible with SYCL kernels in debug builds. Previously, the `icpx` and intel open-source compilers had a workaround for this that enabled `std::array` to work in kernels in this case. However, due to some changes in the MSVC STL implementation, this workaround has been removed, and we cannot safely use `std::array` within kernels.

In `reduce_by_segment`, there is a single use of `std::array` that can be replaced with a standard C++ array.