### PR TITLE
Declare return type in the function `__future::__wait_and_get_value(...)`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -817,8 +817,8 @@ class __future : private std::tuple<_Args...>
             auto& __val = std::get<0>(*this);
             return __wait_and_get_value(__val);
         }
-        else
-            wait();
+
+        wait();
     }
 
     //The internal API. There are cases where the implementation specifies return value  "higher" than SYCL backend,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -817,8 +817,8 @@ class __future : private std::tuple<_Args...>
             auto& __val = std::get<0>(*this);
             return __wait_and_get_value(__val);
         }
-
-        wait();
+        else
+            wait();
     }
 
     //The internal API. There are cases where the implementation specifies return value  "higher" than SYCL backend,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -738,7 +738,7 @@ class __future : private std::tuple<_Args...>
     _Event __my_event;
 
     template <typename _T>
-    constexpr _T
+    _T
     __wait_and_get_value(const sycl::buffer<_T>& __buf)
     {
         //according to a contract, returned value is one-element sycl::buffer
@@ -746,13 +746,13 @@ class __future : private std::tuple<_Args...>
     }
 
     template <typename _T, std::size_t _NResults>
-    constexpr _T
+    _T
     __wait_and_get_value(const __result_and_scratch_storage<_T, _NResults>& __storage)
     {
         return __storage.__wait_and_get_value(__my_event);
     }
 
-    constexpr std::pair<std::size_t, std::size_t>
+    std::pair<std::size_t, std::size_t>
     __wait_and_get_value(const std::shared_ptr<__result_and_scratch_storage_base>& __p_storage)
     {
         std::size_t __buf[2] = {0, 0};
@@ -763,7 +763,7 @@ class __future : private std::tuple<_Args...>
     }
 
     template <typename _T>
-    constexpr _T
+    _T
     __wait_and_get_value(const _T& __val)
     {
         wait();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -824,7 +824,7 @@ class __future : private std::tuple<_Args...>
     //The internal API. There are cases where the implementation specifies return value  "higher" than SYCL backend,
     //where a future is created.
     template <typename _T>
-    auto
+    __future<_Event, _T, _Args...>
     __make_future(_T __t) const
     {
         auto new_val = std::tuple<_T>(__t);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -746,7 +746,7 @@ class __future : private std::tuple<_Args...>
     }
 
     template <typename _T, std::size_t _NResults>
-    constexpr auto
+    constexpr _T
     __wait_and_get_value(const __result_and_scratch_storage<_T, _NResults>& __storage)
     {
         return __storage.__wait_and_get_value(__my_event);


### PR DESCRIPTION
In this PR we declare return type in the function `__future::__wait_and_get_value(...)` instead of `auto`.

The goal - to improve readability.