### PR TITLE
Fix nanorange with gcc 15

### DIFF
--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -8006,22 +8006,16 @@ class counted_iterator
     template <typename II = I, ::std::enable_if_t<input_iterator<II>, int> = 0>
 #                    endif
     friend constexpr iter_rvalue_reference_t<I>
-#                   ifndef _MSC_VER
-    // GCC 15 and later cannot find i.current_ outside of immediate context
-    iter_move(const counted_iterator<II>& i)
-#                   else
-    iter_move(const counted_iterator& i)
-#                   endif
-        noexcept(noexcept(ranges::iter_move(i.current_)))
+    iter_move(const counted_iterator& i) noexcept(noexcept(ranges::iter_move(i.current_)))
     {
         return ranges::iter_move(i.current_);
     }
 
-    template <typename I2, typename II = I>
+    template <typename I2>
     friend constexpr auto
-    iter_swap(const counted_iterator<II>& x,
+    iter_swap(const counted_iterator<I>& x,
               const counted_iterator<I2>& y) noexcept(noexcept(ranges::iter_swap(x.current_, y.current_)))
-        -> ::std::enable_if_t<indirectly_swappable<I2, II>>
+        -> ::std::enable_if_t<indirectly_swappable<I2, I>>
     {
         ranges::iter_swap(x.current_, y.current_);
     }
@@ -8484,18 +8478,17 @@ class move_iterator
         return iter_move(current_ + n);
     }
 
-    template<typename II = I>
-    friend constexpr iter_rvalue_reference_t<II>
-    iter_move(const move_iterator<II>& i) noexcept(noexcept(ranges::iter_move(i.current_)))
+    friend constexpr iter_rvalue_reference_t<I>
+    iter_move(const move_iterator& i) noexcept(noexcept(ranges::iter_move(i.current_)))
     {
         return ranges::iter_move(i.current_);
     }
 
-    template <typename I2, typename II = I>
+    template <typename I2>
     friend constexpr auto
-    iter_swap(const move_iterator<II>& x,
+    iter_swap(const move_iterator& x,
               const move_iterator<I2>& y) noexcept(noexcept(ranges::iter_swap(x.current_, y.current_)))
-        -> ::std::enable_if_t<indirectly_swappable<I2, II>>
+        -> ::std::enable_if_t<indirectly_swappable<I2, I>>
     {
         ranges::iter_swap(x.current_, y.current_);
     }
@@ -17049,7 +17042,7 @@ struct iota_view : view_interface<iota_view<W, Bound>>
                 }
                 else
                 {
-                    return (y.value_ > x.value_) ? D(-D(y.value_ - x.value_)) : D(x.value_ - y.value_);
+                    return (y.value_ > x.value) ? D(-D(y.value_ - x.value_)) : D(x.value_ - y.value_);
                 }
             }
             else

--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -8003,16 +8003,15 @@ class counted_iterator
 #                    ifndef _MSC_VER
     // FIXME MSVC: If this is a template, MSVC can't find it via ADL for some reason
     // Making it a non-template doesn't lose much other than the InputIterator guard
-    template <typename II = I, ::std::enable_if_t<input_iterator<II>, int> = 0>
-#                    endif
-    friend constexpr iter_rvalue_reference_t<I>
-#                   ifndef _MSC_VER
+    //
     // GCC 15 and later cannot find i.current_ outside of immediate context
-    iter_move(const counted_iterator<II>& i)
-#                   else
-    iter_move(const counted_iterator& i)
-#                   endif
-        noexcept(noexcept(ranges::iter_move(i.current_)))
+    template <typename II = I, ::std::enable_if_t<input_iterator<II>, int> = 0>
+    friend constexpr iter_rvalue_reference_t<II>
+    iter_move(const counted_iterator<II>& i) noexcept(noexcept(ranges::iter_move(i.current_)))
+#                    else
+    friend constexpr iter_rvalue_reference_t<I>
+    iter_move(const counted_iterator& i) noexcept(noexcept(ranges::iter_move(i.current_)))
+#                    endif // _MSC_VER
     {
         return ranges::iter_move(i.current_);
     }

--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -7771,15 +7771,20 @@ namespace counted_iterator_
 template <typename I>
 class counted_iterator
 {
+  public:
+    using iterator = I;
+    using difference_type = iter_difference_t<I>;
+
+  private:
+    I current_{};
+    iter_difference_t<I> cnt_{0};
+
     static_assert(input_or_output_iterator<I>, "");
 
     template <typename I2>
     friend class counted_iterator;
 
   public:
-    using iterator = I;
-    using difference_type = iter_difference_t<I>;
-
     constexpr counted_iterator() = default;
 
     constexpr counted_iterator(I x, iter_difference_t<I> n) : current_(x), cnt_(n) {}
@@ -8019,10 +8024,6 @@ class counted_iterator
     {
         ranges::iter_swap(x.current_, y.current_);
     }
-
-  private:
-    I current_{};
-    iter_difference_t<I> cnt_{0};
 };
 
 } // namespace counted_iterator_
@@ -8363,12 +8364,6 @@ namespace move_iterator_
 template <typename I>
 class move_iterator
 {
-
-    static_assert(input_iterator<I>, "Template argument to move_iterator must model InputIterator");
-
-    template <typename I2>
-    friend class move_iterator;
-
   public:
     using iterator_type = I;
     using difference_type = iter_difference_t<I>;
@@ -8376,6 +8371,15 @@ class move_iterator
     using iterator_category = input_iterator_tag;
     using reference = iter_rvalue_reference_t<I>;
 
+  private:
+    I current_{};
+
+    static_assert(input_iterator<I>, "Template argument to move_iterator must model InputIterator");
+
+    template <typename I2>
+    friend class move_iterator;
+
+  public:
     constexpr move_iterator() = default;
 
     explicit constexpr move_iterator(I i) : current_(::std::move(i)) {}
@@ -8492,9 +8496,6 @@ class move_iterator
     {
         ranges::iter_swap(x.current_, y.current_);
     }
-
-  private:
-    I current_{};
 };
 
 template <typename I1, typename I2>
@@ -17042,7 +17043,7 @@ struct iota_view : view_interface<iota_view<W, Bound>>
                 }
                 else
                 {
-                    return (y.value_ > x.value) ? D(-D(y.value_ - x.value_)) : D(x.value_ - y.value_);
+                    return (y.value_ > x.value_) ? D(-D(y.value_ - x.value_)) : D(x.value_ - y.value_);
                 }
             }
             else

--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -8003,15 +8003,16 @@ class counted_iterator
 #                    ifndef _MSC_VER
     // FIXME MSVC: If this is a template, MSVC can't find it via ADL for some reason
     // Making it a non-template doesn't lose much other than the InputIterator guard
-    //
-    // GCC 15 and later cannot find i.current_ outside of immediate context
     template <typename II = I, ::std::enable_if_t<input_iterator<II>, int> = 0>
-    friend constexpr iter_rvalue_reference_t<II>
-    iter_move(const counted_iterator<II>& i) noexcept(noexcept(ranges::iter_move(i.current_)))
-#                    else
+#                    endif
     friend constexpr iter_rvalue_reference_t<I>
-    iter_move(const counted_iterator& i) noexcept(noexcept(ranges::iter_move(i.current_)))
-#                    endif // _MSC_VER
+#                   ifndef _MSC_VER
+    // GCC 15 and later cannot find i.current_ outside of immediate context
+    iter_move(const counted_iterator<II>& i)
+#                   else
+    iter_move(const counted_iterator& i)
+#                   endif
+        noexcept(noexcept(ranges::iter_move(i.current_)))
     {
         return ranges::iter_move(i.current_);
     }


### PR DESCRIPTION
When compiling with g++ (GCC) 15.1.1 20250425 (available in Fedora 42), there are the following issues:

```c++
nanorange.hpp:8009:80: error: ‘const class __nanorange::nano::ranges::counted_iterator_::counted_iterator<I>’ has no member named ‘current_’ [-Wtemplate-body]
// 3 more locations

nanorange.hpp:17045:42: error: ‘const struct __nanorange::nano::ranges::iota_view<W, Bound>::iterator’ has no member named ‘value’; did you mean ‘value_’?
```

Minimal reproducer: https://godbolt.org/z/zGM6zPbb4
```c++
// error: 'const struct S<T>' has no member named 'x' [-Wtemplate-body]
template <typename T>
struct S
{
    friend void f(const S& s) noexcept(noexcept(s.x)) {}
    T x;
};
int main() {}
```