### PR TITLE
Fix warnings related to <ciso646> deprecation

### DIFF
--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -80,7 +80,11 @@
 #                            ifndef NANORANGE_DETAIL_MACROS_HPP_INCLUDED
 #                                define NANORANGE_DETAIL_MACROS_HPP_INCLUDED
 
-#                                include <ciso646>
+#                                if __has_include(<version>)
+#                                   include <version>
+#                                else
+#                                    include <ciso646>
+#                                endif
 
 #                                ifdef NANORANGE_NO_DEPRECATION_WARNINGS
 #                                    define NANO_DEPRECATED

--- a/test/support/test_macros.h
+++ b/test/support/test_macros.h
@@ -26,10 +26,11 @@
 # endif
 #endif
 #ifndef TEST_IMP_INCLUDED_HEADER
-#if __has_include(<version>)
-# include <version>
-#else
-# include <ciso646>
+#  if __has_include(<version>)
+#   include <version>
+#  else
+#   include <ciso646>
+#  endif
 #endif
 
 #define TEST_STRINGIZE_IMPL(x) #x

--- a/test/support/test_macros.h
+++ b/test/support/test_macros.h
@@ -26,7 +26,10 @@
 # endif
 #endif
 #ifndef TEST_IMP_INCLUDED_HEADER
-#include <ciso646>
+#if __has_include(<version>)
+# include <version>
+#else
+# include <ciso646>
 #endif
 
 #define TEST_STRINGIZE_IMPL(x) #x


### PR DESCRIPTION
The PR fixes a warning, which is triggered with g++15:
> /usr/include/c++/15/ciso646:46:4: warning: #warning "\<ciso646\> is deprecated in C++17, use \<version\> to detect implementation-specific macros" [-Wcpp]

There is also an important note on [cppreference](https://en.cppreference.com/w/cpp/header/ciso646):

> \<ciso646\> is removed in C++20

However, I have not seen this error to trigger in practice. 