### PR TITLE
Resolving g++ warnings with `is_onedpl_indirectly_device_accessible`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -125,7 +125,8 @@ struct sycl_iterator
 
     // While sycl_iterator cannot be "passed directly" because it is not device_copyable or a random access iterator,
     // it does represent indirectly device accessible data.
-    friend std::true_type is_onedpl_indirectly_device_accessible(sycl_iterator)
+    friend std::true_type
+    is_onedpl_indirectly_device_accessible(sycl_iterator)
     {
         return {}; //minimal body provided to avoid warnings of non-template-friend in g++
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -125,7 +125,10 @@ struct sycl_iterator
 
     // While sycl_iterator cannot be "passed directly" because it is not device_copyable or a random access iterator,
     // it does represent indirectly device accessible data.
-    friend std::true_type is_onedpl_indirectly_device_accessible(sycl_iterator);
+    friend std::true_type is_onedpl_indirectly_device_accessible(sycl_iterator)
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 };
 
 // map access_mode tag to access_mode value

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -314,7 +314,8 @@ class counting_iterator
         return !(*this < __it);
     }
 
-    friend std::true_type is_onedpl_indirectly_device_accessible(counting_iterator)
+    friend std::true_type
+    is_onedpl_indirectly_device_accessible(counting_iterator)
     {
         return {}; //minimal body provided to avoid warnings of non-template-friend in g++
     }
@@ -451,7 +452,8 @@ class zip_iterator
         return !(*this < __it);
     }
 
-    friend auto is_onedpl_indirectly_device_accessible(zip_iterator)
+    friend auto
+    is_onedpl_indirectly_device_accessible(zip_iterator)
         -> std::conjunction<oneapi::dpl::is_indirectly_device_accessible<_Types>...>
     {
         return {}; //minimal body provided to avoid warnings of non-template-friend in g++
@@ -633,8 +635,8 @@ class transform_iterator
     {
         return __my_unary_func_;
     }
-    friend auto is_onedpl_indirectly_device_accessible(transform_iterator)
-        -> oneapi::dpl::is_indirectly_device_accessible<_Iter>
+    friend auto
+    is_onedpl_indirectly_device_accessible(transform_iterator) -> oneapi::dpl::is_indirectly_device_accessible<_Iter>
     {
         return {}; //minimal body provided to avoid warnings of non-template-friend in g++
     }
@@ -829,7 +831,8 @@ class permutation_iterator
         return !(*this < it);
     }
 
-    friend auto is_onedpl_indirectly_device_accessible(permutation_iterator)
+    friend auto
+    is_onedpl_indirectly_device_accessible(permutation_iterator)
         -> std::conjunction<oneapi::dpl::is_indirectly_device_accessible<SourceIterator>,
                             oneapi::dpl::is_indirectly_device_accessible<permutation_iterator::IndexMap>>
     {
@@ -998,7 +1001,8 @@ class discard_iterator
         return !(*this < __it);
     }
 
-    friend std::true_type is_onedpl_indirectly_device_accessible(discard_iterator)
+    friend std::true_type
+    is_onedpl_indirectly_device_accessible(discard_iterator)
     {
         return {}; //minimal body provided to avoid warnings of non-template-friend in g++
     }

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -314,7 +314,10 @@ class counting_iterator
         return !(*this < __it);
     }
 
-    friend std::true_type is_onedpl_indirectly_device_accessible(counting_iterator);
+    friend std::true_type is_onedpl_indirectly_device_accessible(counting_iterator)
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 
   private:
     _Ip __my_counter_;
@@ -449,7 +452,10 @@ class zip_iterator
     }
 
     friend auto is_onedpl_indirectly_device_accessible(zip_iterator)
-        -> std::conjunction<oneapi::dpl::is_indirectly_device_accessible<_Types>...>;
+        -> std::conjunction<oneapi::dpl::is_indirectly_device_accessible<_Types>...>
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 
   private:
     __it_types __my_it_;
@@ -628,7 +634,10 @@ class transform_iterator
         return __my_unary_func_;
     }
     friend auto is_onedpl_indirectly_device_accessible(transform_iterator)
-        -> oneapi::dpl::is_indirectly_device_accessible<_Iter>;
+        -> oneapi::dpl::is_indirectly_device_accessible<_Iter>
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 };
 
 template <typename _Iter, typename _UnaryFunc>
@@ -822,7 +831,10 @@ class permutation_iterator
 
     friend auto is_onedpl_indirectly_device_accessible(permutation_iterator)
         -> std::conjunction<oneapi::dpl::is_indirectly_device_accessible<SourceIterator>,
-                            oneapi::dpl::is_indirectly_device_accessible<permutation_iterator::IndexMap>>;
+                            oneapi::dpl::is_indirectly_device_accessible<permutation_iterator::IndexMap>>
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 
   private:
     SourceIterator my_source_it;
@@ -986,7 +998,10 @@ class discard_iterator
         return !(*this < __it);
     }
 
-    friend std::true_type is_onedpl_indirectly_device_accessible(discard_iterator);
+    friend std::true_type is_onedpl_indirectly_device_accessible(discard_iterator)
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 
   private:
     difference_type __my_position_;


### PR DESCRIPTION
g++ has a warning: "friend declaration declares a non-template function [-Wnon-template-friend]"

This is to flag a common error [(as described here)](https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Making_New_Friends) where one declares but does not define a non-template `friend` function in a class with the intention of having a one-to-one mapping of the class instance and the friend.  However, without a forward declaration of a template function, and some other adjustments this is not possible.

The warning in our case is a false one as far as I can understand.  Our intention is to never define a body for this function declaration, since it is only used to communicate a return type, so we have no such problem .  

However, the warning is of course undesirable, and its best to not have what looks like a common error in our code.  To workaround the warning and perception of this error, lets include a minimal function body `{ return {};}` which successfully defines the function only for the instances of the template class which are instantiated.  

This removes the warnings and perceptions of error.