### PR TITLE
Resolving g++ warnings with `is_onedpl_indirectly_device_accessible` (#2241)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -125,7 +125,11 @@ struct sycl_iterator
 
     // While sycl_iterator cannot be "passed directly" because it is not device_copyable or a random access iterator,
     // it does represent indirectly device accessible data.
-    friend std::true_type is_onedpl_indirectly_device_accessible(sycl_iterator);
+    friend std::true_type
+    is_onedpl_indirectly_device_accessible(sycl_iterator)
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 };
 
 // map access_mode tag to access_mode value

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -314,7 +314,11 @@ class counting_iterator
         return !(*this < __it);
     }
 
-    friend std::true_type is_onedpl_indirectly_device_accessible(counting_iterator);
+    friend std::true_type
+    is_onedpl_indirectly_device_accessible(counting_iterator)
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 
   private:
     _Ip __my_counter_;
@@ -448,8 +452,12 @@ class zip_iterator
         return !(*this < __it);
     }
 
-    friend auto is_onedpl_indirectly_device_accessible(zip_iterator)
-        -> std::conjunction<oneapi::dpl::is_indirectly_device_accessible<_Types>...>;
+    friend auto
+    is_onedpl_indirectly_device_accessible(zip_iterator)
+        -> std::conjunction<oneapi::dpl::is_indirectly_device_accessible<_Types>...>
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 
   private:
     __it_types __my_it_;
@@ -627,8 +635,11 @@ class transform_iterator
     {
         return __my_unary_func_;
     }
-    friend auto is_onedpl_indirectly_device_accessible(transform_iterator)
-        -> oneapi::dpl::is_indirectly_device_accessible<_Iter>;
+    friend auto
+    is_onedpl_indirectly_device_accessible(transform_iterator) -> oneapi::dpl::is_indirectly_device_accessible<_Iter>
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 };
 
 template <typename _Iter, typename _UnaryFunc>
@@ -820,9 +831,13 @@ class permutation_iterator
         return !(*this < it);
     }
 
-    friend auto is_onedpl_indirectly_device_accessible(permutation_iterator)
+    friend auto
+    is_onedpl_indirectly_device_accessible(permutation_iterator)
         -> std::conjunction<oneapi::dpl::is_indirectly_device_accessible<SourceIterator>,
-                            oneapi::dpl::is_indirectly_device_accessible<permutation_iterator::IndexMap>>;
+                            oneapi::dpl::is_indirectly_device_accessible<permutation_iterator::IndexMap>>
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 
   private:
     SourceIterator my_source_it;
@@ -986,7 +1001,11 @@ class discard_iterator
         return !(*this < __it);
     }
 
-    friend std::true_type is_onedpl_indirectly_device_accessible(discard_iterator);
+    friend std::true_type
+    is_onedpl_indirectly_device_accessible(discard_iterator)
+    {
+        return {}; //minimal body provided to avoid warnings of non-template-friend in g++
+    }
 
   private:
     difference_type __my_position_;


### PR DESCRIPTION
Cherry picking #2241 on to the 2022.9 release branch at the suggestion of @akukanov .