### PR TITLE
Fix unused-parameter warnings (device backend)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -157,7 +157,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     // then we should start using this code path.
     template <typename _Fp, typename... _Ranges>
     static std::size_t
-    __estimate_best_start_size(const sycl::queue& __q, _Fp __brick)
+    __estimate_best_start_size(const sycl::queue& __q)
     {
         using __params_t = __pfor_params<true /*__enable_tuning*/, _Fp, _Ranges...>;
         const std::size_t __work_group_size =
@@ -255,7 +255,7 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
     // then only compile the basic kernel as the two versions are effectively the same.
     if constexpr (__params_t::__iters_per_item > 1 || __params_t::__vector_size > 1)
     {
-        if (__count >= __large_submitter::template __estimate_best_start_size<_Fp, _Ranges...>(__q_local, __brick))
+        if (__count >= __large_submitter::template __estimate_best_start_size<_Fp, _Ranges...>(__q_local))
         {
             return __large_submitter{}(__q_local, __brick, __count, std::forward<_Ranges>(__rngs)...);
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -301,8 +301,7 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
     // Calculate nd-range parameters
     template <typename _Range1, typename _Range2>
     nd_range_params
-    eval_nd_range_params(const sycl::queue& __q, const _Range1& __rng1, const _Range2& __rng2,
-                         const std::size_t __n) const
+    eval_nd_range_params(const sycl::queue& __q, const std::size_t __n) const
     {
         // Empirical number of values to process per work-item
         const std::uint8_t __chunk = __q.get_device().is_cpu() ? 128 : 4;
@@ -435,7 +434,7 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
         _PRINT_INFO_IN_DEBUG_MODE(__q);
 
         // Calculate nd-range parameters
-        const nd_range_params __nd_range_params = eval_nd_range_params(__q, __rng1, __rng2, __n);
+        const nd_range_params __nd_range_params = eval_nd_range_params(__q, __n);
 
         // Create storage to save split-points on each base diagonal + 1 (for the right base diagonal in the last work-group)
         using __val_t = _split_point_t<_IdType>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -299,7 +299,6 @@ struct __parallel_merge_submitter_large<_OutSizeLimit, _IdType, _CustomName,
     };
 
     // Calculate nd-range parameters
-    template <typename _Range1, typename _Range2>
     nd_range_params
     eval_nd_range_params(const sycl::queue& __q, const std::size_t __n) const
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -62,7 +62,7 @@ struct __group_merge_path_sorter
 {
     template <typename _StorageAcc, typename _Compare>
     bool
-    sort(const sycl::nd_item<1>& __item, const _StorageAcc& __storage_acc, _Compare __comp, std::uint32_t __start,
+    sort(const sycl::nd_item<1>& __item, const _StorageAcc& __storage_acc, _Compare __comp,
          std::uint32_t __end, std::uint32_t __sorted, std::uint32_t __data_per_workitem,
          std::uint32_t __workgroup_size) const
     {
@@ -178,7 +178,7 @@ struct __leaf_sorter
 
         // 3. Sort on work-group level
         bool __data_in_temp =
-            __group_sorter.sort(__item, __storage_acc, __comp, std::uint32_t{0}, __adjusted_process_size,
+            __group_sorter.sort(__item, __storage_acc, __comp, __adjusted_process_size,
                                 /*sorted per sub-group*/ __data_per_workitem, __data_per_workitem, __workgroup_size);
         // barrier is not needed here because of the barrier inside the sort method
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -62,9 +62,8 @@ struct __group_merge_path_sorter
 {
     template <typename _StorageAcc, typename _Compare>
     bool
-    sort(const sycl::nd_item<1>& __item, const _StorageAcc& __storage_acc, _Compare __comp,
-         std::uint32_t __end, std::uint32_t __sorted, std::uint32_t __data_per_workitem,
-         std::uint32_t __workgroup_size) const
+    sort(const sycl::nd_item<1>& __item, const _StorageAcc& __storage_acc, _Compare __comp, std::uint32_t __end,
+         std::uint32_t __sorted, std::uint32_t __data_per_workitem, std::uint32_t __workgroup_size) const
     {
         const std::uint32_t __sorted_final = __data_per_workitem * __workgroup_size;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -472,8 +472,8 @@ struct __peer_prefix_helper<__radix_states, _OffsetT, __peer_prefix_algo::subgro
 
 template <typename _InRange, typename _OutRange>
 void
-__copy_kernel_for_radix_sort(const std::size_t __elem_per_segment, std::size_t __sg_size,
-                         sycl::nd_item<1> __self_item, _InRange& __input_rng, _OutRange& __output_rng)
+__copy_kernel_for_radix_sort(const std::size_t __elem_per_segment, std::size_t __sg_size, sycl::nd_item<1> __self_item,
+                             _InRange& __input_rng, _OutRange& __output_rng)
 {
     // item info
     const ::std::size_t __self_lidx = __self_item.get_local_id(0);
@@ -557,8 +557,7 @@ __radix_sort_reorder_submit(sycl::queue& __q, std::size_t __segments, std::size_
                 auto& __no_op_flag = __offset_rng[__no_op_flag_idx];
                 if (__no_op_flag)
                 {
-                    __copy_kernel_for_radix_sort(__elem_per_segment, __sg_size, __self_item, __input_rng,
-                                                 __output_rng);
+                    __copy_kernel_for_radix_sort(__elem_per_segment, __sg_size, __self_item, __input_rng, __output_rng);
                     return;
                 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -472,7 +472,7 @@ struct __peer_prefix_helper<__radix_states, _OffsetT, __peer_prefix_algo::subgro
 
 template <typename _InRange, typename _OutRange>
 void
-__copy_kernel_for_radix_sort(::std::size_t __segments, const ::std::size_t __elem_per_segment, ::std::size_t __sg_size,
+__copy_kernel_for_radix_sort(const std::size_t __elem_per_segment, std::size_t __sg_size,
                          sycl::nd_item<1> __self_item, _InRange& __input_rng, _OutRange& __output_rng)
 {
     // item info
@@ -557,7 +557,7 @@ __radix_sort_reorder_submit(sycl::queue& __q, std::size_t __segments, std::size_
                 auto& __no_op_flag = __offset_rng[__no_op_flag_idx];
                 if (__no_op_flag)
                 {
-                    __copy_kernel_for_radix_sort(__segments, __elem_per_segment, __sg_size, __self_item, __input_rng,
+                    __copy_kernel_for_radix_sort(__elem_per_segment, __sg_size, __self_item, __input_rng,
                                                  __output_rng);
                     return;
                 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1320,7 +1320,7 @@ struct __brick_shift_left
 
     template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__b_vectorize, int> = 0>
     void
-    operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range&& __rng) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
         const std::size_t __unsigned_size = __size;
@@ -1410,7 +1410,7 @@ struct __brick_reduce_idx
     }
     template <typename _IsFull, typename _Params, typename _ReduceIdx, typename _Values, typename _OutValues>
     void
-    operator()(_IsFull __is_full, const std::size_t __idx, _Params, const _ReduceIdx& __segment_starts,
+    operator()(_IsFull, const std::size_t __idx, _Params, const _ReduceIdx& __segment_starts,
                const _Values& __values, _OutValues& __out_values) const
     {
         using __value_type = decltype(__segment_starts[__idx]);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1410,8 +1410,8 @@ struct __brick_reduce_idx
     }
     template <typename _IsFull, typename _Params, typename _ReduceIdx, typename _Values, typename _OutValues>
     void
-    operator()(_IsFull, const std::size_t __idx, _Params, const _ReduceIdx& __segment_starts,
-               const _Values& __values, _OutValues& __out_values) const
+    operator()(_IsFull, const std::size_t __idx, _Params, const _ReduceIdx& __segment_starts, const _Values& __values,
+               _OutValues& __out_values) const
     {
         using __value_type = decltype(__segment_starts[__idx]);
         __value_type __segment_end =


### PR DESCRIPTION
The PR fixes warnings like:

> parallel_backend_sycl_merge.h(304,65): warning: unused parameter '__rng1' [-Wunused-parameter]

> parallel_backend_sycl_for.h(160,60): warning: unused parameter '__brick' [-Wunused-parameter]

> unseq_backend_sycl.h(1323,24): warning: unused parameter '__is_full' [-Wunused-parameter]

The warnings occur with icx and -W4 flag in Windows. 