### PR TITLE
Fix macro-redefined warning, fix enablement of PSTL_USE_NONTEMPORAL_STORES

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -378,7 +378,7 @@ jobs:
           export OpenMP_ROOT=$(brew --prefix)/opt/libomp
           mkdir build && cd build
 
-          warning_flags="-Wall -Werror -Wno-error=unused-parameter -Wno-error=sign-compare -Wno-error=deprecated-copy -Wno-error=unused-but-set-variable -Wno-error=deprecated-copy-with-user-provided-copy -Wno-error=pass-failed -Wno-error=macro-redefined"
+          warning_flags="-Wall -Werror -Wno-error=unused-parameter -Wno-error=sign-compare -Wno-error=deprecated-copy -Wno-error=unused-but-set-variable -Wno-error=deprecated-copy-with-user-provided-copy -Wno-error=pass-failed"
 
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_CXX_FLAGS="${warning_flags}" ..

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -378,7 +378,7 @@ jobs:
           export OpenMP_ROOT=$(brew --prefix)/opt/libomp
           mkdir build && cd build
 
-          warning_flags="-Wall -Werror -Wno-error=unused-parameter -Wno-error=sign-compare -Wno-error=deprecated-copy -Wno-error=unused-but-set-variable -Wno-error=deprecated-copy-with-user-provided-copy -Wno-error=pass-failed"
+          warning_flags="-Wall -Werror -Wno-error=unused-parameter -Wno-error=sign-compare -Wno-error=deprecated-copy -Wno-error=unused-but-set-variable -Wno-error=deprecated-copy-with-user-provided-copy -Wno-error=pass-failed -Wno-error=macro-redefined"
 
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_CXX_FLAGS="${warning_flags}" ..

--- a/include/oneapi/dpl/pstl/omp/parallel_for.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for.h
@@ -35,7 +35,7 @@ __parallel_for_body(_Index __first, _Index __last, _Fp __f, std::size_t __grains
     auto __policy = oneapi::dpl::__omp_backend::__chunk_partitioner(__first, __last, __grainsize);
 
     // To avoid over-subscription we use taskloop for the nested parallelism
-    _PSTL_PRAGMA(omp taskloop untied mergeable)
+    _ONEDPL_PRAGMA(omp taskloop untied mergeable)
     for (std::size_t __chunk = 0; __chunk < __policy.__n_chunks; ++__chunk)
     {
         oneapi::dpl::__omp_backend::__process_chunk(__policy, __first, __chunk, __f);
@@ -62,8 +62,8 @@ __parallel_for(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _
     {
         // in any case (nested or non-nested) one parallel region is created and
         // only one thread creates a set of tasks
-        _PSTL_PRAGMA(omp parallel)
-        _PSTL_PRAGMA(omp single nowait)
+        _ONEDPL_PRAGMA(omp parallel)
+        _ONEDPL_PRAGMA(omp single nowait)
         {
             oneapi::dpl::__omp_backend::__parallel_for_body(__first, __last, __f, __grainsize);
         }

--- a/include/oneapi/dpl/pstl/omp/parallel_for_each.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for_each.h
@@ -33,7 +33,7 @@ __parallel_for_each_body(_ForwardIterator __first, _ForwardIterator __last, _Fp 
     // TODO: Think of an approach to remove the std::distance call
     auto __size = std::distance(__first, __last);
 
-    _PSTL_PRAGMA(omp taskloop untied mergeable)
+    _ONEDPL_PRAGMA(omp taskloop untied mergeable)
     for (DifferenceType __index = 0; __index < __size; ++__index)
     {
         // TODO: Think of an approach to remove the increment here each time.
@@ -57,8 +57,8 @@ __parallel_for_each(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy
     {
         // in any case (nested or non-nested) one parallel region is created and
         // only one thread creates a set of tasks
-        _PSTL_PRAGMA(omp parallel)
-        _PSTL_PRAGMA(omp single nowait) { oneapi::dpl::__omp_backend::__parallel_for_each_body(__first, __last, __f); }
+        _ONEDPL_PRAGMA(omp parallel)
+        _ONEDPL_PRAGMA(omp single nowait) { oneapi::dpl::__omp_backend::__parallel_for_each_body(__first, __last, __f); }
     }
 }
 

--- a/include/oneapi/dpl/pstl/omp/parallel_invoke.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_invoke.h
@@ -29,10 +29,10 @@ template <typename _F1, typename _F2>
 void
 __parallel_invoke_body(_F1&& __f1, _F2&& __f2)
 {
-    _PSTL_PRAGMA(omp taskgroup)
+    _ONEDPL_PRAGMA(omp taskgroup)
     {
-        _PSTL_PRAGMA(omp task untied mergeable) { std::forward<_F1>(__f1)(); }
-        _PSTL_PRAGMA(omp task untied mergeable) { std::forward<_F2>(__f2)(); }
+        _ONEDPL_PRAGMA(omp task untied mergeable) { std::forward<_F1>(__f1)(); }
+        _ONEDPL_PRAGMA(omp task untied mergeable) { std::forward<_F2>(__f2)(); }
     }
 }
 
@@ -46,8 +46,8 @@ __parallel_invoke(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&
     }
     else
     {
-        _PSTL_PRAGMA(omp parallel)
-        _PSTL_PRAGMA(omp single nowait)
+        _ONEDPL_PRAGMA(omp parallel)
+        _ONEDPL_PRAGMA(omp single nowait)
         oneapi::dpl::__omp_backend::__parallel_invoke_body(std::forward<_F1>(__f1), std::forward<_F2>(__f2));
     }
 }

--- a/include/oneapi/dpl/pstl/omp/parallel_merge.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_merge.h
@@ -55,17 +55,17 @@ __parallel_merge_body(std::size_t __size_x, std::size_t __size_y, _RandomAccessI
 
     auto __zm = __zs + (__xm - __xs) + (__ym - __ys);
 
-    _PSTL_PRAGMA(omp task untied mergeable default(none)
+    _ONEDPL_PRAGMA(omp task untied mergeable default(none)
                      firstprivate(__xs, __xm, __ys, __ym, __zs, __comp, __leaf_merge))
     oneapi::dpl::__omp_backend::__parallel_merge_body(__xm - __xs, __ym - __ys, __xs, __xm, __ys, __ym, __zs, __comp,
                                                       __leaf_merge);
 
-    _PSTL_PRAGMA(omp task untied mergeable default(none)
+    _ONEDPL_PRAGMA(omp task untied mergeable default(none)
                      firstprivate(__xm, __xe, __ym, __ye, __zm, __comp, __leaf_merge))
     oneapi::dpl::__omp_backend::__parallel_merge_body(__xe - __xm, __ye - __ym, __xm, __xe, __ym, __ye, __zm, __comp,
                                                       __leaf_merge);
 
-    _PSTL_PRAGMA(omp taskwait)
+    _ONEDPL_PRAGMA(omp taskwait)
 }
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
@@ -90,9 +90,9 @@ __parallel_merge(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&& 
     }
     else
     {
-        _PSTL_PRAGMA(omp parallel)
+        _ONEDPL_PRAGMA(omp parallel)
         {
-            _PSTL_PRAGMA(omp single nowait)
+            _ONEDPL_PRAGMA(omp single nowait)
             oneapi::dpl::__omp_backend::__parallel_merge_body(__size_x, __size_y, __xs, __xe, __ys, __ye, __zs, __comp,
                                                               __leaf_merge);
         }

--- a/include/oneapi/dpl/pstl/omp/parallel_reduce.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_reduce.h
@@ -67,8 +67,8 @@ __parallel_reduce(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&
     // one thread creates a set of tasks.
     _Value __res = __identity;
 
-    _PSTL_PRAGMA(omp parallel)
-    _PSTL_PRAGMA(omp single nowait)
+    _ONEDPL_PRAGMA(omp parallel)
+    _ONEDPL_PRAGMA(omp single nowait)
     {
         __res =
             oneapi::dpl::__omp_backend::__parallel_reduce_body(__first, __last, __identity, __real_body, __reduction);

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -131,8 +131,8 @@ __parallel_strict_scan(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPol
     }
     else
     {
-        _PSTL_PRAGMA(omp parallel)
-        _PSTL_PRAGMA(omp single nowait)
+        _ONEDPL_PRAGMA(omp parallel)
+        _ONEDPL_PRAGMA(omp single nowait)
         {
             oneapi::dpl::__omp_backend::__parallel_strict_scan_body(__n, __initial, __reduce, __combine, __scan,
                                                                     __apex);

--- a/include/oneapi/dpl/pstl/omp/parallel_stable_sort.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_stable_sort.h
@@ -54,7 +54,7 @@ __parallel_move_range(_RandomAccessIterator __first1, _RandomAccessIterator __la
     // Perform parallel moving of larger chunks
     auto __policy = oneapi::dpl::__omp_backend::__chunk_partitioner(__first1, __last1);
 
-    _PSTL_PRAGMA(omp taskloop)
+    _ONEDPL_PRAGMA(omp taskloop)
     for (std::size_t __chunk = 0; __chunk < __policy.__n_chunks; ++__chunk)
     {
         oneapi::dpl::__omp_backend::__process_chunk(__policy, __first1, __chunk,
@@ -150,8 +150,8 @@ __parallel_stable_sort(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPol
     }
     else
     {
-        _PSTL_PRAGMA(omp parallel)
-        _PSTL_PRAGMA(omp single nowait)
+        _ONEDPL_PRAGMA(omp parallel)
+        _ONEDPL_PRAGMA(omp single nowait)
         if (__count <= __nsort)
         {
             oneapi::dpl::__omp_backend::__parallel_stable_sort_body(__xs, __xe, __comp, __leaf_sort);

--- a/include/oneapi/dpl/pstl/omp/parallel_transform_reduce.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_transform_reduce.h
@@ -64,7 +64,7 @@ __transform_reduce_body(_RandomAccessIterator __first, _RandomAccessIterator __l
     }
 
     // main loop
-    _PSTL_PRAGMA(omp taskloop shared(__accums))
+    _ONEDPL_PRAGMA(omp taskloop shared(__accums))
     for (std::size_t __chunk = 0; __chunk < __policy.__n_chunks; ++__chunk)
     {
         oneapi::dpl::__omp_backend::__process_chunk(
@@ -102,8 +102,8 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__omp_backend_tag, _Executi
     {
         // Create a parallel region, and a single thread will create tasks
         // for the region.
-        _PSTL_PRAGMA(omp parallel)
-        _PSTL_PRAGMA(omp single nowait)
+        _ONEDPL_PRAGMA(omp parallel)
+        _ONEDPL_PRAGMA(omp single nowait)
         {
             __result = oneapi::dpl::__omp_backend::__transform_reduce_body(__first, __last, __unary_op, __init,
                                                                            __combiner, __reduction);

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -27,13 +27,6 @@
 #include "../unseq_backend_simd.h"
 #include "../utils.h"
 
-// Portability "#pragma" definition
-#ifdef _MSC_VER
-#    define _PSTL_PRAGMA(x) __pragma(x)
-#else
-#    define _PSTL_PRAGMA(x) _Pragma(#    x)
-#endif
-
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -229,7 +229,7 @@
 // Check the user-defined macro to use non-temporal stores
 #ifndef _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
 #    if defined(PSTL_USE_NONTEMPORAL_STORES) && (__INTEL_LLVM_COMPILER || __INTEL_COMPILER >= 1600)
-#        define _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED _PSTL_PRAGMA(vector nontemporal)
+#        define _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED _ONEDPL_PRAGMA(vector nontemporal)
 #    else
 #        define _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
 #    endif


### PR DESCRIPTION
Let's use `_ONEDPL_PRAGMA` in oneDPL instead of `_PSTL_PRAGMA`. 

It will fix this warning, which I suppose happens if Parallel STL is already present on a system (e.g. as a part of libstdc++):
> oneDPL/include/oneapi/dpl/pstl/./omp/util.h:34:13: warning: '_PSTL_PRAGMA' macro redefined [-Wmacro-redefined]

It also fixes a bug with the enablement of `PSTL_USE_NONTEMPORAL_STORES` mode, which used non-defined `_PSTL_PRAGMA`, hence expanding to nothing and having no effect.
