### PR TITLE
[oneDPL][hetero] adjacent_find pattern perf potential fix (based on refactoring paralle_find_or hetero pattern)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -544,7 +544,8 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 // adjacent_find
 //------------------------------------------------------------------------
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _BinaryPredicate, typename _OrFirstTag>
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _BinaryPredicate,
+          typename _OrFirstTag>
 _Iterator
 __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
                         _BinaryPredicate __pred, _OrFirstTag __is_or_semantic)
@@ -571,8 +572,9 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    auto result = __par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, _TagType{}, __size_calc{}, __view1, __view2);
+    auto result =
+        __par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                                                 _Predicate{__pred}, _TagType{}, __size_calc{}, __view1, __view2);
 
     // inverted conditional because of
     // reorder_predicate in glue_algorithm_impl.h
@@ -631,8 +633,9 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
 
     using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, __par_backend_hetero::__parallel_or_tag{}, __size_calc{}, __buf.all_view());
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred},
+        __par_backend_hetero::__parallel_or_tag{}, __size_calc{}, __buf.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -646,8 +649,8 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
 {
     if (__last1 - __first1 != __last2 - __first2)
         return false;
-   
-    if(__last1 == __first1)
+
+    if (__last1 == __first1)
         return true; //both sequences are empty
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<_Pred>>;
@@ -662,9 +665,10 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    return !__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{oneapi::dpl::__internal::__not_pred<_Pred>{__pred}},
-        __par_backend_hetero::__parallel_or_tag{}, size_calc{}, __buf1.all_view(), __buf2.all_view());
+    return !__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                                                     _Predicate{oneapi::dpl::__internal::__not_pred<_Pred>{__pred}},
+                                                     __par_backend_hetero::__parallel_or_tag{}, size_calc{},
+                                                     __buf1.all_view(), __buf2.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -700,8 +704,9 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf = __keep(__first, __last);
 
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, _TagType{}, __size_calc{}, __buf.all_view());
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{},
+        __buf.all_view());
 
     return __first + __res;
 }
@@ -735,8 +740,9 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
         auto __buf1 = __keep(__first, __last);
         auto __buf2 = __keep(__s_first, __s_last);
 
-        auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-            _Predicate{__pred}, _TagType{}, __size_calc{}, __buf1.all_view(), __buf2.all_view());
+        auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{},
+            __buf1.all_view(), __buf2.all_view());
 
         return __first + __res;
     }
@@ -766,8 +772,9 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     auto __buf1 = __keep(__first, __last);
     auto __buf2 = __keep(__s_first, __s_last);
 
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, _TagType{}, __size_calc{}, __buf1.all_view(), __buf2.all_view());
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{},
+        __buf1.all_view(), __buf2.all_view());
 
     return __first + __res;
 }
@@ -809,9 +816,10 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
     auto __buf1 = __keep(__first, __last);
     auto __buf2 = __keep(__s_first, __s_last);
 
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, _TagType{}, __size_calc{}, __buf1.all_view(), __buf2.all_view());
-        
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{},
+        __buf1.all_view(), __buf2.all_view());
+
     return __first + __res;
 }
 
@@ -861,8 +869,9 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf = __keep(__first, __last);
 
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred, __value, __count}, _TagType{}, __size_calc{}, __buf.all_view());
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred, __value, __count}, _TagType{},
+        __size_calc{}, __buf.all_view());
 
     return __first + __res;
 }
@@ -891,8 +900,10 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
     auto __buf1 = __keep(__first1, __last1);
     auto __buf2 = __keep(__first2, __last2);
 
-    __n = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{oneapi::dpl::__internal::__not_pred<_Pred>{__pred}}, _TagType{}, __size_calc{}, __buf1.all_view(), __buf2.all_view());
+    __n = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{oneapi::dpl::__internal::__not_pred<_Pred>{__pred}}, _TagType{}, __size_calc{}, __buf1.all_view(),
+        __buf2.all_view());
 
     return std::make_pair(__first1 + __n, __first2 + __n);
 }
@@ -1155,8 +1166,9 @@ __pattern_is_heap_until(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf = __keep(__first, __last);
 
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__comp}, _TagType{}, __size_calc{}, __buf.all_view());
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__comp}, _TagType{}, __size_calc{},
+        __buf.all_view());
 
     return __first + __res;
 }
@@ -1177,7 +1189,8 @@ __pattern_is_heap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomA
     auto __buf = __keep(__first, __last);
 
     return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__comp}, _TagType{}, __size_calc{}, __buf.all_view());
+                                                                  _Predicate{__comp}, _TagType{}, __size_calc{},
+                                                                  __buf.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -1471,7 +1484,8 @@ __pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Forwar
     auto __buf2 = __keep(__first2, __last2);
 
     return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        __brick_include_type{__comp, __n1, __n2}, _TagType{}, __size_calc{}, __buf2.all_view(), __buf1.all_view());
+                                                                  __brick_include_type{__comp, __n1, __n2}, _TagType{},
+                                                                  __size_calc{}, __buf2.all_view(), __buf1.all_view());
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -562,7 +562,7 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     auto __view1 = oneapi::dpl::__ranges::take_view_simple(__view, __view.size() - 1);
     auto __view2 = oneapi::dpl::__ranges::drop_view_simple(__view, 1);
 
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
     using _IndexType = std::make_unsigned_t<typename std::iterator_traits<_Iterator>::difference_type>;
     using _TagType = std::conditional_t<__is_or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
                                         oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>>;
@@ -627,7 +627,7 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         _Predicate{__pred}, __par_backend_hetero::__parallel_or_tag{}, __size_calc{}, __buf.all_view());
@@ -651,7 +651,7 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
     auto __buf1 = __keep(__first1, __last1);
     auto __buf2 = __keep(__first2, __last2);
 
-    using size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+    using size_calc = oneapi::dpl::__ranges::__min_size_calc;
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
@@ -688,7 +688,7 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
     using _IndexType = std::make_unsigned_t<typename std::iterator_traits<_Iterator>::difference_type>;
     using _TagType = __par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf = __keep(__first, __last);
@@ -722,7 +722,7 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
         using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
         using _IndexType = typename std::iterator_traits<_Iterator1>::difference_type;
         using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_IndexType>;
-        using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+        using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
         auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
         auto __buf1 = __keep(__first, __last);
@@ -750,7 +750,7 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     using _Predicate = unseq_backend::first_match_pred<_Pred>;
     using _IndexType = std::make_unsigned_t<typename std::iterator_traits<_Iterator1>::difference_type>;
     using _TagType = __par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     // TODO: To check whether it makes sense to iterate over the second sequence in case of
     // distance(__first, __last) < distance(__s_first, __s_last).
@@ -796,7 +796,7 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
     using _IndexType = std::make_unsigned_t<typename std::iterator_traits<_Iterator1>::difference_type>;
     using _TagType = __par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf1 = __keep(__first, __last);
@@ -849,7 +849,7 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     using _Predicate = unseq_backend::n_elem_match_pred<_BinaryPredicate, _Tp, _Size>;
     using _IndexType = std::make_unsigned_t<typename std::iterator_traits<_Iterator>::difference_type>;
     using _TagType = __par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf = __keep(__first, __last);
@@ -878,7 +878,7 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
         std::make_unsigned_t<std::common_type_t<typename std::iterator_traits<_Iterator1>::difference_type,
                                                 typename std::iterator_traits<_Iterator2>::difference_type>>;
     using _TagType = __par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf1 = __keep(__first1, __last1);
@@ -1143,7 +1143,7 @@ __pattern_is_heap_until(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred_by_idx<__is_heap_check<_Compare>>;
     using _IndexType = std::make_unsigned_t<typename std::iterator_traits<_RandomAccessIterator>::difference_type>;
     using _TagType = __par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf = __keep(__first, __last);
@@ -1164,7 +1164,7 @@ __pattern_is_heap(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _RandomA
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred_by_idx<__is_heap_check<_Compare>>;
     using _TagType = __par_backend_hetero::__parallel_or_tag;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf = __keep(__first, __last);
@@ -1457,7 +1457,7 @@ __pattern_includes(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Forwar
 
     using __brick_include_type = unseq_backend::__brick_includes<_Compare, decltype(__n1), decltype(__n2)>;
     using _TagType = __par_backend_hetero::__parallel_or_tag;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf1 = __keep(__first1, __last1);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -570,8 +570,6 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     using _TagType = std::conditional_t<__is_or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
                                         oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>>;
 
-    // TODO: in case of conflicting names
-    // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
     auto result =
         __par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                                                  _Predicate{__pred}, _TagType{}, __size_calc{}, __view1, __view2);
@@ -663,8 +661,6 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
 
     using size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
-    // TODO: in case of conflicting names
-    // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
     return !__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                                                      _Predicate{oneapi::dpl::__internal::__not_pred<_Pred>{__pred}},
                                                      __par_backend_hetero::__parallel_or_tag{}, size_calc{},

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -562,7 +562,9 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     auto __view1 = oneapi::dpl::__ranges::take_view_simple(__view, __view.size() - 1);
     auto __view2 = oneapi::dpl::__ranges::drop_view_simple(__view, 1);
 
-    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
+    assert(__view1.size() = __view2.size());
+
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
     using _IndexType = std::make_unsigned_t<typename std::iterator_traits<_Iterator>::difference_type>;
     using _TagType = std::conditional_t<__is_or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
                                         oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>>;
@@ -642,8 +644,11 @@ bool
 __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __last1,
                 _Iterator2 __first2, _Iterator2 __last2, _Pred __pred)
 {
-    if (__last1 == __first1 || __last2 == __first2 || __last1 - __first1 != __last2 - __first2)
+    if (__last1 - __first1 != __last2 - __first2)
         return false;
+   
+    if(__last1 == __first1)
+        return true; //both sequences are empty
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<_Pred>>;
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -562,7 +562,7 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
     auto __view1 = oneapi::dpl::__ranges::take_view_simple(__view, __view.size() - 1);
     auto __view2 = oneapi::dpl::__ranges::drop_view_simple(__view, 1);
 
-    assert(__view1.size() = __view2.size());
+    assert(__view1.size() == __view2.size());
 
     using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
     using _IndexType = std::make_unsigned_t<typename std::iterator_traits<_Iterator>::difference_type>;
@@ -656,7 +656,9 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
     auto __buf1 = __keep(__first1, __last1);
     auto __buf2 = __keep(__first2, __last2);
 
-    using size_calc = oneapi::dpl::__ranges::__min_size_calc;
+    assert(__last1 - __first1 == __last2 - __first2);
+
+    using size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
@@ -693,7 +695,7 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
     using _IndexType = std::make_unsigned_t<typename std::iterator_traits<_Iterator>::difference_type>;
     using _TagType = __par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
     auto __buf = __keep(__first, __last);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -647,17 +647,16 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<_Pred>>;
 
-    auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
-    auto __buf1 = __keep1(__first1, __last1);
-    auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
-    auto __buf2 = __keep2(__first2, __last2);
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
+    auto __buf1 = __keep(__first1, __last1);
+    auto __buf2 = __keep(__first2, __last2);
 
     using size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
     return !__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred},
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred},
         __par_backend_hetero::__parallel_or_tag{}, size_calc{}, __buf1.all_view(), __buf2.all_view());
 }
 
@@ -687,12 +686,16 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
         return __last;
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
+    using _TagType = __par_backend_hetero::__parallel_find_forward_tag;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
 
-    return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__pred},
-        ::std::true_type{});
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
+    auto __buf = __keep(__first, __last);
+
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__pred}, _TagType{}, __size_calc{}, __buf.all_view());
+
+    return __first + __res;
 }
 
 //------------------------------------------------------------------------
@@ -716,14 +719,17 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     else
     {
         using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
+        using _TagType = __par_backend_hetero::__parallel_find_backward_tag;
+        using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
-        return __par_backend_hetero::__parallel_find(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-            __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
-            __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
-            __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_first),
-            __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_last), _Predicate{__pred},
-            ::std::false_type{});
+        auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
+        auto __buf1 = __keep(__first, __last);
+        auto __buf2 = __keep(__s_first, __s_last);
+
+        auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+            _Predicate{__pred}, _TagType{}, __size_calc{}, __buf.all_view());
+
+        return __first + __res;
     }
 }
 
@@ -740,16 +746,20 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
         return __last;
 
     using _Predicate = unseq_backend::first_match_pred<_Pred>;
+    using _TagType = __par_backend_hetero::__parallel_find_forward_tag;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
     // TODO: To check whether it makes sense to iterate over the second sequence in case of
     // distance(__first, __last) < distance(__s_first, __s_last).
-    return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_last), _Predicate{__pred},
-        ::std::true_type{});
+
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
+    auto __buf1 = __keep(__first, __last);
+    auto __buf2 = __keep(__s_first, __s_last);
+
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__pred}, _TagType{}, __size_calc{}, __buf1.all_view(), __buf2.all_view());
+
+    return __first + __res;
 }
 
 //------------------------------------------------------------------------
@@ -781,13 +791,17 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
     }
 
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
-    return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__s_last), _Predicate{__pred},
-        ::std::true_type{});
+    using _TagType = __par_backend_hetero::__parallel_find_forward_tag;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
+    auto __buf1 = __keep(__first, __last);
+    auto __buf2 = __keep(__s_first, __s_last);
+
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__pred}, _TagType{}, __size_calc{}, __buf1.all_view(), __buf2.all_view());
+        
+    return __first + __res;
 }
 
 //------------------------------------------------------------------------
@@ -829,11 +843,16 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     }
 
     using _Predicate = unseq_backend::n_elem_match_pred<_BinaryPredicate, _Tp, _Size>;
-    return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
-        _Predicate{__pred, __value, __count}, ::std::true_type{});
+    using _TagType = __par_backend_hetero::__parallel_find_forward_tag;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
+    auto __buf = __keep(__first, __last);
+
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__pred, __value, __count}, _TagType{}, __size_calc{}, __buf.all_view());
+
+    return __first + __res;
 }
 
 //------------------------------------------------------------------------
@@ -850,12 +869,17 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
         return std::make_pair(__first1, __first2);
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<_Pred>>;
+    using _TagType = __par_backend_hetero::__parallel_find_forward_tag;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
 
-    auto __result = __par_backend_hetero::__parallel_find(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        __first1, __last1, __first2, __last2, _Predicate{__pred}, std::true_type{});
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
+    auto __buf1 = __keep(__first1, __last1);
+    auto __buf2 = __keep(__first2, __last2);
 
-    __n = __result - __first_zip;
-    return ::std::make_pair(__first1 + __n, __first2 + __n);
+    __n = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__pred}, _TagType{}, __size_calc{}, __buf1.all_view(), __buf2.all_view());
+
+    return std::make_pair(__first1 + __n, __first2 + __n);
 }
 
 //------------------------------------------------------------------------
@@ -1109,12 +1133,16 @@ __pattern_is_heap_until(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
         return __last;
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred_by_idx<__is_heap_check<_Compare>>;
+    using _TagType = __par_backend_hetero::__parallel_find_forward_tag;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
-    return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__comp},
-        ::std::true_type{});
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read>();
+    auto __buf = __keep(__first, __last);
+
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__comp}, _TagType{}, __size_calc{}, __buf.all_view());
+
+    return __first + __res;
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -204,7 +204,7 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<_Pred>>;
     using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
@@ -243,7 +243,7 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&&
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
     using _IndexType = std::make_unsigned_t<oneapi::dpl::__internal::__difference_t<_Range>>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range>(__rng));
@@ -286,7 +286,7 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
     using _IndexType = oneapi::dpl::__internal::__difference_t<_Range1>;
     using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
@@ -327,7 +327,7 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     using _Predicate = unseq_backend::first_match_pred<_Pred>;
     using _IndexType = std::make_unsigned_t<oneapi::dpl::__internal::__difference_t<_Range1>>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     //TODO: To check whether it makes sense to iterate over the second sequence in case of __rng1.size() < __rng2.size()
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
@@ -363,7 +363,7 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& 
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
     using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
     
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         _Predicate{__pred}, __or_tag{}, __size_calc{}, std::forward<_Range>(__rng));
@@ -412,7 +412,7 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
     using _IndexType = std::make_unsigned_t<oneapi::dpl::__internal::__difference_t<_Range1>>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
@@ -529,7 +529,7 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     auto __rng1 = oneapi::dpl::__ranges::take_view_simple(__rng, __rng.size() - 1);
     auto __rng2 = oneapi::dpl::__ranges::drop_view_simple(__rng, 1);
 
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
@@ -1070,7 +1070,7 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R1&& _
                                                                oneapi::dpl::__internal::__difference_t<_R2>>>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<__bin_pred_type>>;
-    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
 
     auto __idx = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{},
         std::forward<_ExecutionPolicy>(__exec), _Predicate{oneapi::dpl::__internal::__not_pred<__bin_pred_type>(__bin_pred)}, _TagType{},

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -210,9 +210,10 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{},
-        std::forward<_ExecutionPolicy>(__exec), _Predicate{oneapi::dpl::__internal::__not_pred<_Pred>{__pred}},
-        __or_tag{}, __size_calc{}, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
+    return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{oneapi::dpl::__internal::__not_pred<_Pred>{__pred}}, __or_tag{}, __size_calc{},
+        std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -248,7 +249,8 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&&
     using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range>(__rng));
+                                                                 _Predicate{__pred}, _TagType{}, __size_calc{},
+                                                                 std::forward<_Range>(__rng));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -290,8 +292,9 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_IndexType>;
     using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{},
+        std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -332,8 +335,9 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
     //TODO: To check whether it makes sense to iterate over the second sequence in case of __rng1.size() < __rng2.size()
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{},
+        std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -366,9 +370,10 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
     using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag;
     using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
-    
+
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, __or_tag{}, __size_calc{}, std::forward<_Range>(__rng));
+                                                                 _Predicate{__pred}, __or_tag{}, __size_calc{},
+                                                                 std::forward<_Range>(__rng));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -416,8 +421,9 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
     using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{},
+        std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -510,8 +516,8 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _BinaryPredicate,
           typename _OrFirstTag>
 oneapi::dpl::__internal::__difference_t<_Range>
-__pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng,
-                        _BinaryPredicate __pred, _OrFirstTag __is_or_semantic)
+__pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredicate __pred,
+                        _OrFirstTag __is_or_semantic)
 {
     if (__rng.size() < 2)
         return __rng.size();
@@ -537,8 +543,9 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{},
-        std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{}, __rng1, __rng2);
+    auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{}, __rng1,
+        __rng2);
 
     // inverted conditional because of
     // reorder_predicate in glue_algorithm_impl.h
@@ -1070,15 +1077,16 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R1&& _
     oneapi::dpl::__internal::__binary_op<_Pred, _Proj1, _Proj2> __bin_pred{__pred, __proj1, __proj2};
 
     using __bin_pred_type = decltype(__bin_pred);
-    using _IndexType = std::make_unsigned_t<std::common_type_t<oneapi::dpl::__internal::__difference_t<_R1>,
-                                                               oneapi::dpl::__internal::__difference_t<_R2>>>;
+    using _IndexType = std::make_unsigned_t<
+        std::common_type_t<oneapi::dpl::__internal::__difference_t<_R1>, oneapi::dpl::__internal::__difference_t<_R2>>>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<__bin_pred_type>>;
     using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
 
-    auto __idx = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{},
-        std::forward<_ExecutionPolicy>(__exec), _Predicate{oneapi::dpl::__internal::__not_pred<__bin_pred_type>(__bin_pred)}, _TagType{},
-        __size_calc{}, oneapi::dpl::__ranges::views::all_read(__r1), oneapi::dpl::__ranges::views::all_read(__r2));
+    auto __idx = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{oneapi::dpl::__internal::__not_pred<__bin_pred_type>(__bin_pred)}, _TagType{}, __size_calc{},
+        oneapi::dpl::__ranges::views::all_read(__r1), oneapi::dpl::__ranges::views::all_read(__r2));
 
     return {std::ranges::begin(__r1) + __idx, std::ranges::begin(__r2) + __idx};
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -208,8 +208,6 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
 
     assert(__rng1.size() == __rng2.size());
 
-    // TODO: in case of conflicting names
-    // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
     return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         _Predicate{oneapi::dpl::__internal::__not_pred<_Pred>{__pred}}, __or_tag{}, __size_calc{},
@@ -541,8 +539,6 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
 
     assert(__rng1.size() == __rng2.size());
 
-    // TODO: in case of conflicting names
-    // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
     auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{}, __rng1,
         __rng2);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -203,14 +203,14 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
         return true; //both sequences are empty
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<_Pred>>;
-    using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag{};
+    using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag;
     using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, __or_tag{}, __size_calc{},
-        std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
+    return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{},
+        std::forward<_ExecutionPolicy>(__exec), _Predicate{oneapi::dpl::__internal::__not_pred<_Pred>{__pred}},
+        __or_tag{}, __size_calc{}, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -241,14 +241,12 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&&
         return __rng.size();
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
-    using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>;
+    using _IndexType = std::make_unsigned_t<oneapi::dpl::__internal::__difference_t<_Range>>;
+    using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
     using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
-        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
-            std::forward<_ExecutionPolicy>(__exec)), _Predicate{__pred}, _TagType{}, __size_calc{},
-            std::forward<_Range>(__rng));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range>(__rng));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -286,14 +284,12 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     }
 
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
-    using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_Range1>;
+    using _IndexType = oneapi::dpl::__internal::__difference_t<_Range1>;
+    using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_IndexType>;
     using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
-        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
-            std::forward<_ExecutionPolicy>(__exec)), _Predicate{__pred}, _TagType{}, __size_calc{},
-            std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -329,15 +325,13 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
         return __rng1.size();
 
     using _Predicate = unseq_backend::first_match_pred<_Pred>;
-    using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
+    using _IndexType = std::make_unsigned_t<oneapi::dpl::__internal::__difference_t<_Range1>>;
+    using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
     using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
     //TODO: To check whether it makes sense to iterate over the second sequence in case of __rng1.size() < __rng2.size()
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
-        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
-            std::forward<_ExecutionPolicy>(__exec)), _Predicate{__pred}, _TagType{}, __size_calc{},
-            std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -371,11 +365,8 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& 
     using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag;
     using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
     
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
-        __par_backend_hetero::make_wrapped_policy<oneapi::dpl::__par_backend_hetero::__or_policy_wrapper>(
-            std::forward<_ExecutionPolicy>(__exec)), _Predicate{__pred}, __or_tag{}, __size_calc{},
-            std::forward<_Range>(__rng));
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{__pred}, __or_tag{}, __size_calc{}, std::forward<_Range>(__rng));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -419,12 +410,11 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     }
 
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
-    using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
+    using _IndexType = std::make_unsigned_t<oneapi::dpl::__internal::__difference_t<_Range1>>;
+    using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
     using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{},
-        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<
-            oneapi::dpl::__par_backend_hetero::__find_policy_wrapper>(std::forward<_ExecutionPolicy>(__exec)),
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
@@ -525,8 +515,9 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
         return __rng.size();
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_BinaryPredicate>;
+    using _IndexType = std::make_unsigned_t<oneapi::dpl::__internal::__difference_t<_Range>>;
     using _TagType = std::conditional_t<__is_or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
-                                        oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
+                                        oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>>;
 
     //ATTENTION!!! oneDPL supports SYCL buffer via a placeholder accessor; a 'subrange' cannot be used here because
     //getting an iterator for the placeholder accessor is incorrect on the host; so, oneDPL uses lazy-access views
@@ -1075,7 +1066,9 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R1&& _
     oneapi::dpl::__internal::__binary_op<_Pred, _Proj1, _Proj2> __bin_pred{__pred, __proj1, __proj2};
 
     using __bin_pred_type = decltype(__bin_pred);
-    using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_R1, _R2>;
+    using _IndexType = std::make_unsigned_t<std::common_type_t<oneapi::dpl::__internal::__difference_t<_R1>,
+                                                               oneapi::dpl::__internal::__difference_t<_R2>>>;
+    using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_IndexType>;
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<__bin_pred_type>>;
     using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -202,14 +202,15 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
     if (__rng1.empty())
         return true; //both sequences are empty
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<equal_predicate<_Pred>>;
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<_Pred>>;
+    using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag{};
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
     return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
-        oneapi::dpl::__par_backend_hetero::__parallel_or_tag{},
-        oneapi::dpl::__ranges::zip_view(::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2)));
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, __or_tag{}, __size_calc{},
+        std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -241,12 +242,13 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&&
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, _TagType{}, ::std::forward<_Range>(__rng));
+            std::forward<_ExecutionPolicy>(__exec)), _Predicate{__pred}, _TagType{}, __size_calc{},
+            std::forward<_Range>(__rng));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -285,12 +287,13 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
 
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
     using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_Range1>;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
+            std::forward<_ExecutionPolicy>(__exec)), _Predicate{__pred}, _TagType{}, __size_calc{},
+            std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -327,13 +330,14 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
 
     using _Predicate = unseq_backend::first_match_pred<_Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
     //TODO: To check whether it makes sense to iterate over the second sequence in case of __rng1.size() < __rng2.size()
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
+            std::forward<_ExecutionPolicy>(__exec)), _Predicate{__pred}, _TagType{}, __size_calc{},
+            std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -364,11 +368,14 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& 
         return false;
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
+    using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+    
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<oneapi::dpl::__par_backend_hetero::__or_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, oneapi::dpl::__par_backend_hetero::__parallel_or_tag{}, ::std::forward<_Range>(__rng));
+            std::forward<_ExecutionPolicy>(__exec)), _Predicate{__pred}, __or_tag{}, __size_calc{},
+            std::forward<_Range>(__rng));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -413,12 +420,12 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
 
     using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__first_size_calc;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{},
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<
-            oneapi::dpl::__par_backend_hetero::__find_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
+            oneapi::dpl::__par_backend_hetero::__find_policy_wrapper>(std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, _TagType{}, __size_calc{}, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
@@ -511,15 +518,15 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _BinaryPredicate,
           typename _OrFirstTag>
 oneapi::dpl::__internal::__difference_t<_Range>
-__pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredicate __pred,
-                        _OrFirstTag __is__or_semantic)
+__pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng,
+                        _BinaryPredicate __pred, _OrFirstTag __is_or_semantic)
 {
     if (__rng.size() < 2)
         return __rng.size();
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_BinaryPredicate>;
-    using _TagType = ::std::conditional_t<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
-                                          oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
+    using _TagType = std::conditional_t<__is_or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
+                                        oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
 
     //ATTENTION!!! oneDPL supports SYCL buffer via a placeholder accessor; a 'subrange' cannot be used here because
     //getting an iterator for the placeholder accessor is incorrect on the host; so, oneDPL uses lazy-access views
@@ -531,14 +538,16 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     auto __rng1 = oneapi::dpl::__ranges::take_view_simple(__rng, __rng.size() - 1);
     auto __rng2 = oneapi::dpl::__ranges::drop_view_simple(__rng, 1);
 
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
+
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __rng1, __rng2);
+    auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{},
+        std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{}, __rng1, __rng2);
 
     // inverted conditional because of
     // reorder_predicate in glue_algorithm_impl.h
-    if constexpr (__is__or_semantic())
+    if constexpr (__is_or_semantic())
         return result ? 0 : __rng.size();
     else
         return result == __rng.size() - 1 ? __rng.size() : result;
@@ -1068,10 +1077,11 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R1&& _
     using __bin_pred_type = decltype(__bin_pred);
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_R1, _R2>;
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<__bin_pred_type>>;
+    using __size_calc = oneapi::dpl::__par_backend_hetero::__min_size_calc;
 
-    auto __idx = oneapi::dpl::__par_backend_hetero::__parallel_find_or_min_size(_BackendTag{},
+    auto __idx = oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{},
         std::forward<_ExecutionPolicy>(__exec), _Predicate{oneapi::dpl::__internal::__not_pred<__bin_pred_type>(__bin_pred)}, _TagType{},
-        oneapi::dpl::__ranges::views::all_read(__r1), oneapi::dpl::__ranges::views::all_read(__r2));
+        __size_calc{}, oneapi::dpl::__ranges::views::all_read(__r1), oneapi::dpl::__ranges::views::all_read(__r2));
 
     return {std::ranges::begin(__r1) + __idx, std::ranges::begin(__r2) + __idx};
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -204,7 +204,9 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<oneapi::dpl::__internal::__not_pred<_Pred>>;
     using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag;
-    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
+
+    assert(__rng1.size() == __rng2.size());
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
@@ -363,7 +365,7 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& 
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_Pred>;
     using __or_tag = oneapi::dpl::__par_backend_hetero::__parallel_or_tag;
-    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
     
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         _Predicate{__pred}, __or_tag{}, __size_calc{}, std::forward<_Range>(__rng));
@@ -529,7 +531,9 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     auto __rng1 = oneapi::dpl::__ranges::take_view_simple(__rng, __rng.size() - 1);
     auto __rng2 = oneapi::dpl::__ranges::drop_view_simple(__rng, 1);
 
-    using __size_calc = oneapi::dpl::__ranges::__min_size_calc;
+    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;
+
+    assert(__rng1.size() == __rng2.size());
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2289,9 +2289,10 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
     }
 };
 
-template <typename... _Ranges>
 struct __first_size_calc
 {
+
+    template <typename... _Ranges>
     auto
     operator()(const _Ranges&... __rngs) const
     {
@@ -2299,9 +2300,9 @@ struct __first_size_calc
     }
 };
 
-template <typename... _Ranges>
 struct __min_size_calc
 {
+    template <typename... _Ranges>
     auto
     operator()(const _Ranges&... __rngs) const
     {
@@ -2315,7 +2316,7 @@ template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typena
 std::conditional_t<
     ::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
     oneapi::dpl::__internal::__difference_t<typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>
-__parallel_find_or_impl(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
+__parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
                         _BrickTag __brick_tag, _SizeCalc __sz_calc, _Ranges&&... __rngs)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
@@ -2369,119 +2370,6 @@ __parallel_find_or_impl(oneapi::dpl::__internal::__device_backend_tag, _Executio
         return __result != __init_value;
     else
         return __result != __init_value ? __result : __rng_n;
-}
-
-template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
-std::conditional_t<
-    ::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
-    oneapi::dpl::__internal::__difference_t<typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>
-__parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
-                   _BrickTag __brick_tag, _Ranges&&... __rngs)
-{
-    return __parallel_find_or_impl(oneapi::dpl::__internal::__device_backend_tag{},
-                                   std::forward<_ExecutionPolicy>(__exec), __f, __brick_tag,
-                                   __first_size_calc<_Ranges...>{}, std::forward<_Ranges>(__rngs)...);
-}
-
-template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
-std::conditional_t<
-    ::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
-    oneapi::dpl::__internal::__difference_t<typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>
-__parallel_find_or_min_size(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
-                            _BrickTag __brick_tag, _Ranges&&... __rngs)
-{
-    return __parallel_find_or_impl(oneapi::dpl::__internal::__device_backend_tag{},
-                                   std::forward<_ExecutionPolicy>(__exec), __f, __brick_tag,
-                                   __min_size_calc<_Ranges...>{}, std::forward<_Ranges>(__rngs)...);
-}
-
-// parallel_or - sync pattern
-//------------------------------------------------------------------------
-
-template <typename Name>
-class __or_policy_wrapper
-{
-};
-
-template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Brick>
-bool
-__parallel_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Iterator1 __first,
-              _Iterator1 __last, _Iterator2 __s_first, _Iterator2 __s_last, _Brick __f)
-{
-    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
-    auto __buf = __keep(__first, __last);
-    auto __s_keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
-    auto __s_buf = __s_keep(__s_first, __s_last);
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        oneapi::dpl::__internal::__device_backend_tag{},
-        __par_backend_hetero::make_wrapped_policy<__or_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)), __f,
-        __parallel_or_tag{}, __buf.all_view(), __s_buf.all_view());
-}
-
-// Special overload for single sequence cases.
-// TODO: check if similar pattern may apply to other algorithms. If so, these overloads should be moved out of
-// backend code.
-template <typename _ExecutionPolicy, typename _Iterator, typename _Brick>
-bool
-__parallel_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Iterator __first,
-              _Iterator __last, _Brick __f)
-{
-    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
-    auto __buf = __keep(__first, __last);
-
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        oneapi::dpl::__internal::__device_backend_tag{},
-        __par_backend_hetero::make_wrapped_policy<__or_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)), __f,
-        __parallel_or_tag{}, __buf.all_view());
-}
-
-//------------------------------------------------------------------------
-// parallel_find - sync pattern
-//-----------------------------------------------------------------------
-
-template <typename Name>
-class __find_policy_wrapper
-{
-};
-
-template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Brick, typename _IsFirst>
-_Iterator1
-__parallel_find(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Iterator1 __first,
-                _Iterator1 __last, _Iterator2 __s_first, _Iterator2 __s_last, _Brick __f, _IsFirst)
-{
-    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
-    auto __buf = __keep(__first, __last);
-    auto __s_keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
-    auto __s_buf = __s_keep(__s_first, __s_last);
-
-    using _TagType = ::std::conditional_t<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
-                                          __parallel_find_backward_tag<decltype(__buf.all_view())>>;
-    return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-                         oneapi::dpl::__internal::__device_backend_tag{},
-                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
-                             ::std::forward<_ExecutionPolicy>(__exec)),
-                         __f, _TagType{}, __buf.all_view(), __s_buf.all_view());
-}
-
-// Special overload for single sequence cases.
-// TODO: check if similar pattern may apply to other algorithms. If so, these overloads should be moved out of
-// backend code.
-template <typename _ExecutionPolicy, typename _Iterator, typename _Brick, typename _IsFirst>
-_Iterator
-__parallel_find(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Iterator __first,
-                _Iterator __last, _Brick __f, _IsFirst)
-{
-    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
-    auto __buf = __keep(__first, __last);
-
-    using _TagType = ::std::conditional_t<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
-                                          __parallel_find_backward_tag<decltype(__buf.all_view())>>;
-    return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-                         oneapi::dpl::__internal::__device_backend_tag{},
-                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
-                             ::std::forward<_ExecutionPolicy>(__exec)),
-                         __f, _TagType{}, __buf.all_view());
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2289,33 +2289,9 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
     }
 };
 
-struct __first_size_calc
-{
-
-    template <typename... _Ranges>
-    auto
-    operator()(const _Ranges&... __rngs) const
-    {
-        return oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
-    }
-};
-
-struct __min_size_calc
-{
-    template <typename... _Ranges>
-    auto
-    operator()(const _Ranges&... __rngs) const
-    {
-        using _Size = std::make_unsigned_t<std::common_type_t<oneapi::dpl::__internal::__difference_t<_Ranges>...>>;
-        return std::min({_Size(__rngs.size())...});
-    }
-};
-
 // Base pattern for __parallel_or and __parallel_find. The execution depends on tag type _BrickTag.
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename _SizeCalc, typename... _Ranges>
-std::conditional_t<
-    ::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
-    oneapi::dpl::__internal::__difference_t<typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>
+auto
 __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
                         _BrickTag __brick_tag, _SizeCalc __sz_calc, _Ranges&&... __rngs)
 {
@@ -2367,9 +2343,9 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     }
 
     if constexpr (__or_tag_check)
-        return __result != __init_value;
+        return __result != __init_value; //return a bool type
     else
-        return __result != __init_value ? __result : __rng_n;
+        return __result != __init_value ? decltype(__rng_n)(__result) : __rng_n; //return a decltype(__rng_n)
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1910,14 +1910,14 @@ __can_set_op_write_from_set_b(oneapi::dpl::__internal::__device_backend_tag, _Ex
 //------------------------------------------------------------------------
 
 // Tag for __parallel_find_or to find the first element that satisfies predicate
-template <typename... _Ranges>
+template <typename _IndexType>
 struct __parallel_find_forward_tag
 {
 // FPGA devices don't support 64-bit atomics
 #if _ONEDPL_FPGA_DEVICE
     using _AtomicType = uint32_t;
 #else
-    using _AtomicType = std::make_unsigned_t<std::common_type_t<oneapi::dpl::__internal::__difference_t<_Ranges>...>>;
+    using _AtomicType = _IndexType;
 #endif
 
     using _LocalResultsReduceOp = __dpl_sycl::__minimum<_AtomicType>;
@@ -1949,14 +1949,14 @@ struct __parallel_find_forward_tag
 };
 
 // Tag for __parallel_find_or to find the last element that satisfies predicate
-template <typename _RangeType>
+template <typename _IndexType>
 struct __parallel_find_backward_tag
 {
 // FPGA devices don't support 64-bit atomics
 #if _ONEDPL_FPGA_DEVICE
     using _AtomicType = int32_t;
 #else
-    using _AtomicType = oneapi::dpl::__internal::__difference_t<_RangeType>;
+    using _AtomicType = _IndexType;
 #endif
 
     using _LocalResultsReduceOp = __dpl_sycl::__maximum<_AtomicType>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2293,7 +2293,7 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename _SizeCalc, typename... _Ranges>
 auto
 __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
-                        _BrickTag __brick_tag, _SizeCalc __sz_calc, _Ranges&&... __rngs)
+                   _BrickTag __brick_tag, _SizeCalc __sz_calc, _Ranges&&... __rngs)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -171,7 +171,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     operator()(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
         using __params_t = __pfor_params<true /*__enable_tuning*/, _Fp, _Ranges...>;
-        assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
+        assert(oneapi::dpl::__ranges::__first_size_calc{}(__rngs...) > 0);
         const std::size_t __work_group_size =
             oneapi::dpl::__internal::__max_work_group_size(__q, __max_work_group_size);
         _PRINT_INFO_IN_DEBUG_MODE(__q);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -434,7 +434,7 @@ __parallel_transform_reduce(oneapi::dpl::__internal::__device_backend_tag, _Exec
 
     sycl::queue __q_local = __exec.queue();
 
-    auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
+    auto __n = oneapi::dpl::__ranges::__first_size_calc{}(__rngs...);
     assert(__n > 0);
     using _Size = decltype(__n);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -95,14 +95,8 @@ struct fill_functor;
 template <typename _Generator>
 struct generate_functor;
 
-template <typename _Pred>
-struct equal_predicate;
-
 template <typename _Tp, typename _Pred>
 struct __search_n_unary_predicate;
-
-template <typename _Predicate>
-struct adjacent_find_fn;
 
 template <class _Comp>
 struct __is_heap_check;
@@ -271,18 +265,6 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 template <class _Comp>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__is_heap_check, _Comp)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Comp>
-{
-};
-
-template <typename _Pred>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::equal_predicate, _Pred)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<_Pred>
-{
-};
-
-template <typename _Predicate>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::adjacent_find_fn, _Predicate)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate>
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -370,7 +370,7 @@ struct __range_holder
     }
 };
 
-template <sycl::access::mode AccMode, typename _Iterator>
+template <sycl::access::mode AccMode, typename _Iterator = void> //TODO: _Iterator is not used and should be removed
 struct __get_sycl_range
 {
     __get_sycl_range()

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -251,19 +251,6 @@ using val_t = typename ::std::iterator_traits<_Iter>::value_type;
 
 //range/zip_view/all_view/ variadic utilities
 
-template <typename _Range, typename... _Ranges>
-struct __get_first_range_type
-{
-    using type = _Range;
-};
-
-template <typename _Range, typename... _Ranges>
-constexpr auto
-__get_first_range_size(const _Range& __rng, const _Ranges&...) -> decltype(__rng.size())
-{
-    return __rng.size();
-}
-
 //forward declaration required for _require_access_args
 template <typename _Range, typename... _Ranges>
 void

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -31,36 +31,6 @@ namespace dpl
 namespace __internal
 {
 
-template <typename _Pred>
-struct equal_predicate
-{
-    _Pred __pred;
-
-    template <typename _Value>
-    bool
-    operator()(const _Value& __val) const
-    {
-        using ::std::get;
-        return !__pred(get<0>(__val), get<1>(__val));
-    }
-};
-
-template <typename _Predicate>
-struct adjacent_find_fn
-{
-    _Predicate __predicate;
-
-    // the functor is being used instead of a lambda because
-    // at this level we don't know what type we get during zip_iterator unpack
-    template <typename _Pack>
-    bool
-    operator()(const _Pack& __packed_neighbor_values) const
-    {
-        using ::std::get;
-        return __predicate(get<0>(__packed_neighbor_values), get<1>(__packed_neighbor_values));
-    }
-};
-
 template <typename _Predicate, typename _ValueType>
 struct __create_mask_unique_copy
 {

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -129,6 +129,35 @@ using projected_value_t = std::remove_cvref_t<std::invoke_result_t<Proj&, std::i
 namespace __ranges
 {
 
+struct __first_size_calc
+{
+    template <typename _Range, typename... _Ranges>
+    auto
+    operator()(const _Range& __rng, const _Ranges&...) const
+    {
+#if _ONEDPL_CPP20_RANGES_PRESENT
+        return std::ranges::size(__rng);
+#else
+        return __rng.size();
+#endif
+    }
+};
+
+struct __min_size_calc
+{
+    template <typename... _Ranges>
+    auto
+    operator()(const _Ranges&... __rngs) const
+    {
+        using _Size = std::make_unsigned_t<std::common_type_t<oneapi::dpl::__internal::__difference_t<_Ranges>...>>;
+#if _ONEDPL_CPP20_RANGES_PRESENT
+        return std::min({_Size(std::ranges::size(__rngs))...});
+#else
+        return std::min({_Size(__rngs.size())...});
+#endif
+    }
+};
+
 // helpers to check implement "has_base"
 template <typename U>
 auto

--- a/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
@@ -678,7 +678,7 @@ DEFINE_TEST(test_equal)
         ::std::fill(host_vals.get() + new_start, host_vals.get() + new_end, value);
         update_data(host_keys, host_vals);
 
-        auto expected  = new_end - new_start > 0;
+        auto expected  = new_end - new_start >= 0;
         auto result = ::std::equal(make_new_policy<new_kernel_name<Policy, 0>>(exec), first1 + new_start,
                                    first1 + new_end, first2 + new_start);
         wait_and_throw(exec);

--- a/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
@@ -145,18 +145,20 @@ test(size_t bits, Compare comp)
     Sequence<T> in(max_size, [bits](size_t k) { return T(2 * HashBits(k, bits - 1) ^ 1); });
     Sequence<T> inCopy(in);
 
-    for (size_t n = 1; n <= max_size; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= max_size; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        invoke_on_all_policies<0>()(test_with_3_iters<T>(), in.begin(), in.begin() + n, inCopy.begin(), comp, true);
-        invoke_on_all_policies<1>()(test_with_3_iters<T>(), in.cbegin(), in.cbegin() + n, inCopy.cbegin(), true);
-        invoke_on_all_policies<2>()(test_with_4_iters<T>(), in.begin(), in.begin() + n, inCopy.begin(), inCopy.begin() + n, comp, true);
+	const bool ex_res_true = true;
+        invoke_on_all_policies<0>()(test_with_3_iters<T>(), in.begin(), in.begin() + n, inCopy.begin(), comp, ex_res_true);
+        invoke_on_all_policies<1>()(test_with_3_iters<T>(), in.cbegin(), in.cbegin() + n, inCopy.cbegin(), ex_res_true);
+        invoke_on_all_policies<2>()(test_with_4_iters<T>(), in.begin(), in.begin() + n, inCopy.begin(), inCopy.begin() + n, comp, ex_res_true);
 
         // testing bool !equal()
         T original = inCopy[0];
         inCopy[0] = !original;
-        invoke_on_all_policies<3>()(test_with_4_iters<T>(), in.begin(), in.begin() + n, inCopy.begin(), inCopy.begin() + n, false);
-        invoke_on_all_policies<4>()(test_with_4_iters<T>(), in.cbegin(), in.cbegin() + n, inCopy.cbegin(), inCopy.cbegin() + n, comp, false);
-        invoke_on_all_policies<5>()(test_with_3_iters<T>(), in.cbegin(), in.cbegin() + n, inCopy.cbegin(), false);
+        const bool ex_res_false = false || n == 0; //In case of the both sequences are empty, result is true.
+        invoke_on_all_policies<3>()(test_with_4_iters<T>(), in.begin(), in.begin() + n, inCopy.begin(), inCopy.begin() + n, ex_res_false);
+        invoke_on_all_policies<4>()(test_with_4_iters<T>(), in.cbegin(), in.cbegin() + n, inCopy.cbegin(), inCopy.cbegin() + n, comp, ex_res_false);
+        invoke_on_all_policies<5>()(test_with_3_iters<T>(), in.cbegin(), in.cbegin() + n, inCopy.cbegin(), ex_res_false);
         inCopy[0] = original;
     }
     // check different sized sequences

--- a/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
@@ -147,7 +147,7 @@ test(size_t bits, Compare comp)
 
     for (size_t n = 0; n <= max_size; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-	const bool ex_res_true = true;
+        const bool ex_res_true = true;
         invoke_on_all_policies<0>()(test_with_3_iters<T>(), in.begin(), in.begin() + n, inCopy.begin(), comp, ex_res_true);
         invoke_on_all_policies<1>()(test_with_3_iters<T>(), in.cbegin(), in.cbegin() + n, inCopy.cbegin(), ex_res_true);
         invoke_on_all_policies<2>()(test_with_4_iters<T>(), in.begin(), in.begin() + n, inCopy.begin(), inCopy.begin() + n, comp, ex_res_true);


### PR DESCRIPTION
[oneDPL][hetero] adjacent_find pattern perf potential fix (based on refactoring paralle_find_or hetero pattern).

1) Used directly data access (ranges access for several middle layer algorithm patterns) instead of "indirectly access via zip_iterator and _zip_view). 
2) Reduced number of versions of paralle_find_(or ) hetero patterns, because to have just one is absolutely enough.  
3) Extended test coverage for "equal" algorithm
4) At the same time  - a fix for `__pattern_equal` iterator based pattern (trivial sequences case).