### PR TITLE
Fix __dpl_signbit to prevent double support requirement

### DIFF
--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -572,8 +572,9 @@ template <typename _T>
 std::enable_if_t<!std::is_floating_point_v<_T>, bool>
 __dpl_signbit(const _T& __x)
 {
-    using unsigned_type = std::make_unsigned_t<_T>;
-    constexpr unsigned_type __mask = (unsigned_type{1} << (sizeof(_T) * 8 - 1));
+    using __unsigned_type = std::make_unsigned_t<_T>;
+    static_assert(std::is_signed_v<_T>, "Only signed types do not have a signbit.");
+    constexpr __unsigned_type __mask = (__unsigned_type{1} << (sizeof(_T) * 8 - 1));
     return (__x & __mask) != 0;
 }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -573,7 +573,7 @@ std::enable_if_t<!std::is_floating_point_v<_T>, bool>
 __dpl_signbit(const _T& __x)
 {
     using __unsigned_type = std::make_unsigned_t<_T>;
-    static_assert(std::is_signed_v<_T>, "Only signed types do not have a signbit.");
+    static_assert(std::is_signed_v<_T>, "Only signed types have a signbit.");
     constexpr __unsigned_type __mask = (__unsigned_type{1} << (sizeof(_T) * 8 - 1));
     return (__x & __mask) != 0;
 }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -573,7 +573,7 @@ std::enable_if_t<!std::is_floating_point_v<_T>, bool>
 __dpl_signbit(const _T& __x)
 {
     using unsigned_type = std::make_unsigned_t<_T>;
-    unsigned_type __mask = (unsigned_type{1} << (sizeof(_T) * 8 - 1));
+    constexpr unsigned_type __mask = (unsigned_type{1} << (sizeof(_T) * 8 - 1));
     return (__x & __mask) != 0;
 }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -567,12 +567,14 @@ __dpl_signbit(const _T& __x)
     return std::signbit(__x);
 }
 
-//This is required to resolve some possible ambiguity for some STL implementations
+// This prevents ambiguity with std::signbit for integral types on MSVC without requiring double support
 template <typename _T>
 std::enable_if_t<!std::is_floating_point_v<_T>, bool>
 __dpl_signbit(const _T& __x)
 {
-    return std::signbit(static_cast<double>(__x));
+    using unsigned_type = std::make_unsigned_t<_T>;
+    unsigned_type __mask = (unsigned_type{1} << (sizeof(_T) * 8 - 1));
+    return (__x & __mask) != 0;
 }
 
 template <typename _Acc, typename _Size1, typename _Value, typename _Compare>


### PR DESCRIPTION
This PR removes double support requirements when calling `__dpl_signbit` with integral types.  `__dpl_signbit` exists to resolve an ambiguity (build error) in MSVC STL for integral types. The previous strategy was to convert to `double`, as this is the semantic requirement for functionality from the spec for integral overloads.  
However, this requires double support, which is unexpected for callers not using double input types to the algorithms, and also this likely incurs some performance penalty in the static case vs a more direct mask approach.
