### PR TITLE
Fix warnings in esimd KT

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
@@ -211,7 +211,6 @@ __onesweep_impl(sycl::queue __q, _RngPack1&& __input_pack, _RngPack2&& __virt_pa
                 const _MemHolder& __mem_holder, ::std::size_t __n)
 {
     using _KeyT = typename ::std::decay_t<_RngPack1>::_KeyT;
-    using _ValT = typename ::std::decay_t<_RngPack1>::_ValT;
     constexpr bool __has_values = ::std::decay_t<_RngPack1>::__has_values;
 
     using _EsimdRadixSortHistogram = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
@@ -258,7 +257,7 @@ __onesweep_impl(sycl::queue __q, _RngPack1&& __input_pack, _RngPack2&& __virt_pa
         __q, __input_pack.__keys_rng(), __mem_holder.__global_hist_ptr(), __n, __event_chain);
 
     __event_chain = __radix_sort_onesweep_scan_submitter<__stage_count, __bin_count, _EsimdRadixSortScan>()(
-        __q, __mem_holder.__global_hist_ptr(), __n, __event_chain);
+        __q, __mem_holder.__global_hist_ptr(), __event_chain);
 
     __event_chain = __radix_sort_onesweep_submitter<__is_ascending, __radix_bits, __data_per_work_item,
                                                     __work_group_size, _EsimdRadixSortSweepInitial>()(
@@ -372,7 +371,7 @@ __onesweep(sycl::queue __q, _RngPack1&& __pack, _RngPack2&& __pack_out, ::std::s
 template <bool __is_ascending, ::std::uint8_t __radix_bits, bool __in_place, typename _RngPack1, typename _RngPack2,
           typename _KernelParam>
 sycl::event
-__radix_sort(sycl::queue __q, _RngPack1&& __pack_in, _RngPack2&& __pack_out, _KernelParam __param)
+__radix_sort(sycl::queue __q, _RngPack1&& __pack_in, _RngPack2&& __pack_out, _KernelParam)
 {
     const auto __n = __pack_in.__keys_rng().size();
     assert(__n > 0);

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
@@ -90,8 +90,7 @@ struct __radix_sort_onesweep_scan_submitter<
 {
     template <typename _GlobalOffsetData>
     sycl::event
-    operator()(sycl::queue& __q, const _GlobalOffsetData& __global_offset_data, ::std::size_t __n,
-               const sycl::event& __e) const
+    operator()(sycl::queue& __q, const _GlobalOffsetData& __global_offset_data, const sycl::event& __e) const
     {
         sycl::nd_range<1> __nd_range(__stage_count * __bin_count, __bin_count);
         return __q.submit([&](sycl::handler& __cgh) {

--- a/test/general/sycl_iterator/sycl_iterator_sort.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_sort.pass.cpp
@@ -291,7 +291,7 @@ DEFINE_TEST(test_nth_element)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 /*first2*/, Iterator2 /* last2 */, Size n)
     {
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
         TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);


### PR DESCRIPTION
The PR fixes `unused-variable`, `unused-parameter` and `unused-local-typedefs` warnings.

It's been cherry-picked from #2249 for easier review. 