### PR TITLE
Fix warnings in the statistics tests

### DIFF
--- a/test/xpu_api/random/statistics_tests/common_for_distributions.hpp
+++ b/test/xpu_api/random/statistics_tests/common_for_distributions.hpp
@@ -416,8 +416,6 @@ template <class Distr, class UIntType>
 std::enable_if_t<std::is_same_v<Distr, oneapi::dpl::geometric_distribution<typename Distr::result_type>>, int>
 tests_set_portion(sycl::queue& queue, std::int32_t nsamples, unsigned int part)
 {
-    using real_type = typename Distr::result_type;
-
     constexpr int nparams = 2;
 
     double p_array[nparams] = {0.2, 0.9};

--- a/test/xpu_api/random/statistics_tests/lognormal_distr_dp_portion_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/lognormal_distr_dp_portion_test.pass.cpp
@@ -27,7 +27,6 @@ int main() {
 
     sycl::queue queue = TestUtils::get_test_queue();
 
-    constexpr int nsamples = 100;
     int err = 0;
 
     // Skip tests if DP is not supported

--- a/test/xpu_api/random/statistics_tests/normal_distr_dp_portion_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/normal_distr_dp_portion_test.pass.cpp
@@ -27,7 +27,6 @@ int main() {
 
     sycl::queue queue = TestUtils::get_test_queue();
 
-    constexpr int nsamples = 100;
     int err = 0;
 
     // Skip tests if DP is not supported

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -115,7 +115,7 @@ main()
     err += skip_test<ex::philox4x32>();
     std::cout << "void skip_test() [Engine = philox4x64]";
     err += skip_test<ex::philox4x64>();
-    
+
     std::cout << "void counter_overflow_test() [Engine = philox2x32]";
     err += counter_overflow_test<philox2x32>();
     std::cout << "void counter_overflow_test() [Engine = philox2x64]";
@@ -246,7 +246,7 @@ main()
     err += counter_management_test<philox2x64_w25>();
     std::cout << "void counter_management_test() [Engine = philox2x64_w49]";
     err += counter_management_test<philox2x64_w49>();
-    
+
     // `counter_management_test` philox4x*
     std::cout << "void counter_management_test() [Engine = philox4x32_w5]";
     err += counter_management_test<philox4x32_w5>();
@@ -473,7 +473,6 @@ discard_overflow_test()
     int ret_sts = 0;
 
     using T = typename Engine::result_type;
-    using scalar_type = typename Engine::scalar_type;
 
     // Iterate through the counter's position being overflown
     for (int overflown_position = 0; overflown_position < Engine::word_count - 1; ++overflown_position)


### PR DESCRIPTION
The PR fixes `unused-local-typedef` and `unused-variable` warnings in the statistics tests.

It's been cherry-picked from https://github.com/uxlfoundation/oneDPL/pull/2249 for easier review.