### PR TITLE
Fix warnings in XPU tests

### DIFF
--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -128,8 +128,8 @@ namespace TestUtils
     // Run test in Kernel as single task
     template <typename TFncDoubleHasSupportInRuntime, typename TFncDoubleHasntSupportInRuntime>
     void
-    run_test_in_kernel(TFncDoubleHasSupportInRuntime fncDoubleHasSupportInRuntime,
-                       TFncDoubleHasntSupportInRuntime fncDoubleHasntSupportInRuntime)
+    run_test_in_kernel([[maybe_unused]] TFncDoubleHasSupportInRuntime fncDoubleHasSupportInRuntime,
+                       [[maybe_unused]] TFncDoubleHasntSupportInRuntime fncDoubleHasntSupportInRuntime)
     {
 #if TEST_DPCPP_BACKEND_PRESENT
         try

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/binary.search/partitioned_g1.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/binary.search/partitioned_g1.pass.cpp
@@ -50,7 +50,7 @@ kernel_test()
 {
     // Test with range that is partitioned, but not sorted.
     sycl::queue deviceQueue = TestUtils::get_test_queue();
-    X seq[] = {1, 3, 5, 7, 1, 6, 4};
+    X seq[] = {{1}, {3}, {5}, {7}, {1}, {6}, {4}};
     auto tmp = seq;
     bool ret = false;
     bool check = false;
@@ -67,7 +67,7 @@ kernel_test()
                 auto check_access = buffer2.get_access<sycl::access::mode::write>(cgh);
                 auto access = buffer3.get_access<sycl::access::mode::write>(cgh);
                 cgh.single_task<class KernelTest>([=]() {
-                    X tmp[] = {1, 3, 5, 7, 1, 6, 4};
+                    X tmp[] = {{1}, {3}, {5}, {7}, {1}, {6}, {4}};
                     // check if there is change after data transfer
                     check_access[0] = TestUtils::check_data(&access[0], &tmp[0], N);
 

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/lower.bound/partitioned_g2.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/lower.bound/partitioned_g2.pass.cpp
@@ -49,7 +49,7 @@ bool
 kernel_test1(sycl::queue& deviceQueue)
 {
     // Test with range that is partitioned, but not sorted.
-    X seq[] = {1, 3, 5, 7, 1, 6, 4, 2};
+    X seq[] = {{1}, {3}, {5}, {7}, {1}, {6}, {4}}
     auto tmp = seq;
     const int N = sizeof(seq) / sizeof(seq[0]);
     bool ret = false;
@@ -67,7 +67,7 @@ kernel_test1(sycl::queue& deviceQueue)
                 auto check_access = buffer2.get_access<sycl::access::mode::write>(cgh);
                 auto access = buffer3.get_access<sycl::access::mode::write>(cgh);
                 cgh.single_task<class KernelTest1>([=]() {
-                    X arr[] = {1, 3, 5, 7, 1, 6, 4, 2};
+                    X arr[] = {{1}, {3}, {5}, {7}, {1}, {6}, {4}};
                     // check if there is change after data transfer
                     check_access[0] = TestUtils::check_data(&access[0], arr, N);
                     if (check_access[0])
@@ -120,7 +120,7 @@ struct Y
 bool
 kernel_test2(sycl::queue& deviceQueue)
 {
-    Y seq[] = {-0.1, 1.2, 5.0, 5.2, 5.1, 5.9, 5.5, 6.0};
+    Y seq[] = {{-0.1}, {1.2}, {5.0}, {5.2}, {5.1}, {5.9}, {5.5}, {6.0}};
     auto tmp = seq;
     const int N = sizeof(seq) / sizeof(seq[0]);
     bool ret = false;
@@ -137,7 +137,7 @@ kernel_test2(sycl::queue& deviceQueue)
                 auto check_access = buffer2.get_access<sycl::access::mode::write>(cgh);
                 auto access = buffer3.get_access<sycl::access::mode::write>(cgh);
                 cgh.single_task<class KernelTest2>([=]() {
-                    Y arr[] = {-0.1, 1.2, 5.0, 5.2, 5.1, 5.9, 5.5, 6.0};
+                    Y arr[] = {{-0.1}, {1.2}, {5.0}, {5.2}, {5.1}, {5.9}, {5.5}, {6.0}};
                     // check if there is change after data transfer
                     check_access[0] = TestUtils::check_data(&access[0], arr, N);
                     if (check_access[0])

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/lower.bound/partitioned_g2.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/lower.bound/partitioned_g2.pass.cpp
@@ -49,7 +49,7 @@ bool
 kernel_test1(sycl::queue& deviceQueue)
 {
     // Test with range that is partitioned, but not sorted.
-    X seq[] = {{1}, {3}, {5}, {7}, {1}, {6}, {4}}
+    X seq[] = {{1}, {3}, {5}, {7}, {1}, {6}, {4}};
     auto tmp = seq;
     const int N = sizeof(seq) / sizeof(seq[0]);
     bool ret = false;

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/upper.bound/partitioned_g.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/upper.bound/partitioned_g.pass.cpp
@@ -49,7 +49,7 @@ bool
 kernel_test1(sycl::queue& deviceQueue)
 {
     // Test with range that is partitioned, but not sorted.
-    X seq[] = {1, 3, 5, 7, 1, 6, 4, 2};
+    X seq[] = {{1}, {3}, {5}, {7}, {1}, {6}, {4}, {2}};
     auto tmp = seq;
     const int N = sizeof(seq) / sizeof(seq[0]);
     bool ret = false;
@@ -67,7 +67,7 @@ kernel_test1(sycl::queue& deviceQueue)
                 auto check_access = buffer2.get_access<sycl::access::mode::write>(cgh);
                 auto access = buffer3.get_access<sycl::access::mode::write>(cgh);
                 cgh.single_task<class KernelTest1>([=]() {
-                    X arr[] = {1, 3, 5, 7, 1, 6, 4, 2};
+                    X arr[] = {{1}, {3}, {5}, {7}, {1}, {6}, {4}, {2}};
                     // check if there is change after data transfer
                     check_access[0] = TestUtils::check_data(&access[0], arr, N);
                     if (check_access[0])
@@ -120,7 +120,7 @@ kernel_test2(sycl::queue& deviceQueue)
 {
     bool ret = false;
     bool check = false;
-    Y seq[] = {-0.1, 1.2, 5.0, 5.2, 5.1, 5.9, 5.5, 6.0};
+    Y seq[] = {{-0.1}, {1.2}, {5.0}, {5.2}, {5.1}, {5.9}, {5.5}, {6.0}};
     auto tmp = seq;
     const int N = sizeof(seq) / sizeof(seq[0]);
     sycl::range<1> item1{1};
@@ -135,7 +135,7 @@ kernel_test2(sycl::queue& deviceQueue)
                 auto check_access = buffer2.get_access<sycl::access::mode::write>(cgh);
                 auto access = buffer3.get_access<sycl::access::mode::write>(cgh);
                 cgh.single_task<class KernelTest2>([=]() {
-                    Y arr[] = {-0.1, 1.2, 5.0, 5.2, 5.1, 5.9, 5.5, 6.0};
+                    Y arr[] = {{-0.1}, {1.2}, {5.0}, {5.2}, {5.1}, {5.9}, {5.5}, {6.0}};
                     // check if there is change after data transfer
                     check_access[0] = TestUtils::check_data(&access[0], arr, N);
                     if (check_access[0])

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/upper.bound/upper_bound1_g.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/upper.bound/upper_bound1_g.pass.cpp
@@ -47,7 +47,6 @@ kernel_test()
                     int arr[] = {0, 0, 0, 0, 1, 1, 1, 1};
                     // check if there is change after data transfer
                     check_access[0] = TestUtils::check_data(&access[0], arr, N);
-                    auto ret = true;
                     if (check_access[0])
                     {
                         auto ret = true;

--- a/test/xpu_api/containers/sequences/array/array.data/data.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.data/data.pass.cpp
@@ -55,7 +55,7 @@ main()
                     typedef float T;
                     typedef dpl::array<T, 0> C;
                     C c = {};
-                    T* p = c.data();
+                    [[maybe_unused]] T* p = c.data();
                 }
                 {
                     typedef float T;
@@ -68,7 +68,7 @@ main()
                     typedef NoDefault T;
                     typedef dpl::array<T, 0> C;
                     C c = {};
-                    T* p = c.data();
+                    [[maybe_unused]] T* p = c.data();
                 }
             });
         });

--- a/test/xpu_api/containers/sequences/array/array.data/data.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.data/data.pass.cpp
@@ -61,7 +61,7 @@ main()
                     typedef float T;
                     typedef dpl::array<const T, 0> C;
                     C c = {{}};
-                    const T* p = c.data();
+                    [[maybe_unused]] const T* p = c.data();
                     static_assert(dpl::is_same<decltype(c.data()), const T*>::value);
                 }
                 {

--- a/test/xpu_api/containers/sequences/array/array.data/data_const.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.data/data_const.pass.cpp
@@ -62,6 +62,7 @@ main()
                     typedef dpl::array<T, 0> C;
                     const C c = {};
                     const T* p = c.data();
+                    (void)p;
                 }
             });
         });

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_complex.pass.cpp
@@ -42,7 +42,7 @@ void test_edges()
         for (unsigned j = 0; j < N; ++j)
         {
             dpl::complex<double> r = dpl::pow(testcases[i], testcases[j]);
-            dpl::complex<double> z = dpl::exp(testcases[j] * dpl::log(testcases[i]));
+            [[maybe_unused]] dpl::complex<double> z = dpl::exp(testcases[j] * dpl::log(testcases[i]));
             if (std::isnan(dpl::real(r)))
             {
 #if !_PSTL_ICC_TEST_COMPLEX_POW_COMPLEX_COMPLEX_PASS_BROKEN_TEST_EDGES   // testcases[0], testcases[13]

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
@@ -42,7 +42,7 @@ void test_edges()
         for (unsigned j = 0; j < N; ++j)
         {
             dpl::complex<double> r = dpl::pow(testcases[i], dpl::real(testcases[j]));
-            dpl::complex<double> z = dpl::exp(dpl::complex<double>(dpl::real(testcases[j])) * dpl::log(testcases[i]));
+            [[maybe_unused]] dpl::complex<double> z = dpl::exp(dpl::complex<double>(dpl::real(testcases[j])) * dpl::log(testcases[i]));
             if (std::isnan(dpl::real(r)))
             {
 #if !_PSTL_ICC_TEST_COMPLEX_POW_COMPLEX_SCALAR_PASS_BROKEN_TEST_EDGES       // testcases[0], testcases[33]

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
@@ -42,7 +42,7 @@ void test_edges()
         for (unsigned j = 0; j < N; ++j)
         {
             dpl::complex<double> r = dpl::pow(dpl::real(testcases[i]), testcases[j]);
-            dpl::complex<double> z = dpl::exp(testcases[j] * dpl::log(dpl::complex<double>(dpl::real(testcases[i]))));
+            [[maybe_unused]] dpl::complex<double> z = dpl::exp(testcases[j] * dpl::log(dpl::complex<double>(dpl::real(testcases[i]))));
             if (std::isnan(dpl::real(r)))
             {
 #if !_PSTL_ICC_TEST_COMPLEX_POW_SCALAR_COMPLEX_PASS_BROKEN_TEST_EDGES       // testcases[1], testcases[13]

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
@@ -31,17 +31,21 @@ template <class InIter, class OutIter, class Test> void test() {
   sycl::queue deviceQueue = TestUtils::get_test_queue();
   int input[5] = {1, 2, 3, 4, 5};
   int output[5] = {0};
+  int result_distance[1] = {0};
   sycl::range<1> numOfItems1{5};
 
   {
     sycl::buffer<int, 1> buffer1(input, numOfItems1);
     sycl::buffer<int, 1> buffer2(output, numOfItems1);
+    sycl::buffer<int, 1> buffer3(result_distance, sycl::range<1>(1));
     deviceQueue.submit([&](sycl::handler &cgh) {
       auto in = buffer1.get_access<sycl::access::mode::read>(cgh);
       auto out = buffer2.get_access<sycl::access::mode::write>(cgh);
+      auto res = buffer3.get_access<sycl::access::mode::write>(cgh);
       cgh.single_task<Test>([=]() {
         OutIter r = oneapi::dpl::partial_sum(InIter(&in[0]), InIter(&in[0] + 5),
                                              OutIter(&out[0]));
+        res[0] = std::distance(OutIter(&out[0]), r);
       });
     });
   }
@@ -49,6 +53,7 @@ template <class InIter, class OutIter, class Test> void test() {
   for (int i = 0; i < 5; ++i) {
     ASSERT_EQUAL(ref[i], output[i]);
   }
+  ASSERT_EQUAL(5, result_distance[0]);
 }
 
 class KernelTest1;

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
@@ -38,7 +38,7 @@ template <class InIter, class OutIter, class Test> void test() {
   {
     sycl::buffer<int, 1> buffer1(input, numOfItems1);
     sycl::buffer<int, 1> buffer2(output, numOfItems1);
-    sycl::buffer<int, 1> buffer3(&result_distance, sycl::range<1>(1));
+    sycl::buffer<int, 1> buffer3(result_distance, sycl::range<1>(1));
     deviceQueue.submit([&](sycl::handler &cgh) {
       auto in = buffer1.get_access<sycl::access::mode::read>(cgh);
       auto out = buffer2.get_access<sycl::access::mode::write>(cgh);
@@ -55,7 +55,7 @@ template <class InIter, class OutIter, class Test> void test() {
   for (int i = 0; i < 5; ++i) {
     ASSERT_EQUAL(ref[i], output[i]);
   }
-  ASSERT_EQUAL(5, result_distance);
+  ASSERT_EQUAL(5, result_distance[0]);
 }
 
 class KernelTest1;

--- a/test/xpu_api/tuple/tuple.tuple/tuple.cons/tuple_cons.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.cons/tuple_cons.pass.cpp
@@ -38,7 +38,7 @@ kernel_test1()
 
                 // Test empty constructor
                 [[maybe_unused]] dpl::tuple<> ta;
-                dpl::tuple<int, int> tb;
+                [[maybe_unused]] dpl::tuple<int, int> tb;
                 // Test construction from values
                 dpl::tuple<int, int> tc(x1, x2);
                 dpl::tuple<int, int&> td(x1, x2);
@@ -48,22 +48,22 @@ kernel_test1()
                 ret_access[0] = (get<0>(td) == 0 && get<1>(td) == 1 && get<0>(t1) == 1);
 
                 // Test identical dpl::tuple copy constructor
-                dpl::tuple<int, int> tf(tc);
+                [[maybe_unused]] dpl::tuple<int, int> tf(tc);
                 dpl::tuple<int, int> tg(td);
-                dpl::tuple<const int&> th(t1);
+                [[maybe_unused]] dpl::tuple<const int&> th(t1);
                 // Test different dpl::tuple copy constructor
-                dpl::tuple<int, float> ti(tc);
-                dpl::tuple<int, float> tj(td);
+                [[maybe_unused]] dpl::tuple<int, float> ti(tc);
+                [[maybe_unused]] dpl::tuple<int, float> tj(td);
                 // dpl::tuple<int&, int&> tk(tc);
                 dpl::tuple<const int&, const int&> tl(tc);
-                dpl::tuple<const int&, const int&> tm(tl);
+                [[maybe_unused]] dpl::tuple<const int&, const int&> tm(tl);
                 // Test constructing from a pair
                 pair<int, int> pair1(1, 1);
                 const pair<int, int> pair2(pair1);
-                dpl::tuple<int, int> tn(pair1);
-                dpl::tuple<int, const int&> to(pair1);
-                dpl::tuple<int, int> tp(pair2);
-                dpl::tuple<int, const int&> tq(pair2);
+                [[maybe_unused]] dpl::tuple<int, int> tn(pair1);
+                [[maybe_unused]] dpl::tuple<int, const int&> to(pair1);
+                [[maybe_unused]] dpl::tuple<int, int> tp(pair2);
+                [[maybe_unused]] dpl::tuple<int, const int&> tq(pair2);
             });
         });
     }

--- a/test/xpu_api/tuple/tuple.tuple/tuple.cons/tuple_cons_constexpr.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.cons/tuple_cons_constexpr.pass.cpp
@@ -57,17 +57,17 @@ kernel_test()
 
                 // 03: element move ctor, single element
                 const int i1(415);
-                constexpr tuple_type t2{44, dpl::move(i1)};
+                [[maybe_unused]] constexpr tuple_type t2{44, dpl::move(i1)};
 
                 // 04: element move ctor, two element
                 const int i2(510);
                 const int i3(408);
-                constexpr tuple_type t4{dpl::move(i2), dpl::move(i3)};
+                [[maybe_unused]] constexpr tuple_type t4{dpl::move(i2), dpl::move(i3)};
 
                 // 05: value-type conversion constructor
                 const int i4(650);
                 const int i5(310);
-                constexpr tuple_type t8(i4, i5);
+                [[maybe_unused]] constexpr tuple_type t8(i4, i5);
 
                 // 06: pair conversion ctor
                 test_constexpr_single_val_ctor<tuple_type, dpl::pair<int, int>>();

--- a/test/xpu_api/tuple/tuple.tuple/tuple.creation/tuple_cat1.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.creation/tuple_cat1.pass.cpp
@@ -76,17 +76,17 @@ kernel_test1(sycl::queue& deviceQueue)
             }
 
             {
-                constexpr dpl::tuple<> t = dpl::tuple_cat();
+                [[maybe_unused]] constexpr dpl::tuple<> t = dpl::tuple_cat();
             }
 
             {
                 constexpr dpl::tuple<> t1;
-                constexpr dpl::tuple<> t2 = dpl::tuple_cat(t1);
+                [[maybe_unused]] constexpr dpl::tuple<> t2 = dpl::tuple_cat(t1);
             }
 
             {
                 constexpr dpl::array<int, 0> empty_array = {};
-                constexpr dpl::tuple<> t = dpl::tuple_cat(empty_array);
+                [[maybe_unused]] constexpr dpl::tuple<> t = dpl::tuple_cat(empty_array);
             }
 
             {

--- a/test/xpu_api/utilities/optional/optional.object/optional.object.ctor/initializer_list_in_place.pass.cpp
+++ b/test/xpu_api/utilities/optional/optional.object/optional.object.ctor/initializer_list_in_place.pass.cpp
@@ -65,17 +65,12 @@ class Y
     }
 };
 
-bool
+void
 kernel_test()
 {
     sycl::queue q = TestUtils::get_test_queue();
-    bool ret = true;
-    sycl::range<1> numOfItems1{1};
     {
-        sycl::buffer<bool, 1> buffer1(&ret, numOfItems1);
-
         q.submit([&](sycl::handler& cgh) {
-            auto ret_access = buffer1.get_access<sycl::access::mode::write>(cgh);
             cgh.single_task<class KernelTest>([=]() {
                 {
                     static_assert(!dpl::is_constructible<X, std::initializer_list<int>&>::value);
@@ -98,14 +93,11 @@ kernel_test()
             });
         });
     }
-    return ret;
 }
 
 int
 main()
 {
-    auto ret = kernel_test();
-    EXPECT_TRUE(ret, "Wrong result of constexpr dpl::optional and initialization list check");
-
+    kernel_test();
     return TestUtils::done();
 }


### PR DESCRIPTION
The PR fixes these types of warnings:

- `unused-parameter`
- `unused-variable`
- `missing-braces` (a weird one, probably a clang bug, but is easy to silence).

It's been cherry-picked from https://github.com/uxlfoundation/oneDPL/pull/2249 for easier review.