### PR TITLE
Fix warnings in additional algorithms

### DIFF
--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -401,7 +401,6 @@ __pattern_scan_by_segment(__internal::__hetero_tag<_BackendTag>, Policy&& policy
     auto value_buf = keep_values(first2, first2 + n);
     auto keep_value_outputs = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::write, OutputIterator>();
     auto value_output_buf = keep_value_outputs(result, result + n);
-    auto buf_view = key_buf.all_view();
     using iter_value_t = typename ::std::iterator_traits<InputIterator2>::value_type;
 
     constexpr iter_value_t identity = unseq_backend::__known_identity<Operator, iter_value_t>;

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -59,7 +59,7 @@ DEFINE_TEST(test_binary_search)
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
-               Iterator3 result_first, Iterator3 result_last, Size n)
+               Iterator3 result_first, Iterator3 /*result_last*/, Size n)
     {
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
         TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);
@@ -100,7 +100,7 @@ DEFINE_TEST(test_binary_search)
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
-               Iterator3 result_first, Iterator3 result_last, Size n)
+               Iterator3 result_first, Iterator3 /*result_last*/, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type ValueT;
 
@@ -121,8 +121,7 @@ DEFINE_TEST(test_binary_search)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
-               Iterator3 result_first, Iterator3 result_last, Size n)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2, Iterator3, Iterator3, Size)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -54,7 +54,7 @@ DEFINE_TEST(test_lower_bound)
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
-               Iterator3 result_first, Iterator3 result_last, Size n)
+               Iterator3 result_first, Iterator3 /*result_last*/, Size n)
     {
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
         TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);
@@ -95,7 +95,7 @@ DEFINE_TEST(test_lower_bound)
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
-               Iterator3 result_first, Iterator3 result_last, Size n)
+               Iterator3 result_first, Iterator3 /*result_last*/, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type ValueT;
         // call algorithm with no optional arguments
@@ -115,8 +115,7 @@ DEFINE_TEST(test_lower_bound)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
-               Iterator3 result_first, Iterator3 result_last, Size n)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2, Iterator3, Iterator3, Size)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -61,7 +61,7 @@ DEFINE_TEST(test_upper_bound)
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
-               Iterator3 result_first, Iterator3 result_last, Size n)
+               Iterator3 result_first, Iterator3 /*result_last*/, Size n)
     {
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
         TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);
@@ -102,7 +102,7 @@ DEFINE_TEST(test_upper_bound)
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
-               Iterator3 result_first, Iterator3 result_last, Size n)
+               Iterator3 result_first, Iterator3 /*result_last*/, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type ValueT;
         // call algorithm with no optional arguments
@@ -122,8 +122,7 @@ DEFINE_TEST(test_upper_bound)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
-               Iterator3 result_first, Iterator3 result_last, Size n)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2, Iterator3, Iterator3, Size)
     {
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -112,8 +112,8 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
-               Iterator3 val_res_first, Iterator3 val_res_last, Size n)
+    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 /*vals_last*/,
+               Iterator3 val_res_first, Iterator3 /*val_res_last*/, Size n)
     {
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
         TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);
@@ -155,7 +155,6 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
         initialize_data(host_keys.get(), host_vals.get(), host_val_res.get(), n);
         update_data(host_keys, host_vals, host_val_res);
 
-        auto binary_op = [](ValT first, ValT second) { return first + second; };
         auto new_policy3 = make_new_policy<new_kernel_name<Policy, 2>>(exec);
         auto res3 = oneapi::dpl::exclusive_scan_by_segment(new_policy3, keys_first, keys_last, vals_first,
                                                            val_res_first, init, BinaryPredicate());
@@ -188,8 +187,8 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
         !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
 #endif // TEST_DPCPP_BACKEND_PRESENT
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
-               Iterator3 val_res_first, Iterator3 val_res_last, Size n)
+    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 /*vals_last*/,
+               Iterator3 val_res_first, Iterator3 /*val_res_last*/, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator2>::value_type ValT;
 
@@ -227,8 +226,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
-               Iterator3 val_res_first, Iterator3 val_res_last, Size n)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2, Iterator3, Iterator3, Size)
     {
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/histogram.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/histogram.pass.cpp
@@ -30,7 +30,7 @@ struct test_histogram_even_bins
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
     std::enable_if_t<TestUtils::is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 expected_bin_first,
-               Iterator2 expected_bin_last, Iterator3 bin_first, Iterator3 bin_last, Size n, T bin_min, T bin_max,
+               Iterator2 /*expected_bin_last*/, Iterator3 bin_first, Iterator3 bin_last, Size /*n*/, T bin_min, T bin_max,
                Size trash)
     {
         const Size bin_size = bin_last - bin_first;
@@ -43,9 +43,7 @@ struct test_histogram_even_bins
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
     std::enable_if_t<!TestUtils::is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 expected_bin_first,
-               Iterator2 expected_bin_last, Iterator3 bin_first, Iterator3 bin_last, Size n, T bin_min, T bin_max,
-               Size trash)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2, Iterator3, Iterator3, Size, T, T, Size)
     {
     }
 };
@@ -70,9 +68,7 @@ struct test_histogram_range_bins
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
     std::enable_if_t<!TestUtils::is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 boundary_first, Iterator2 boundary_last,
-               Iterator3 expected_bin_first, Iterator3 /* expected_bin_last */, Iterator4 bin_first, Iterator4 bin_last,
-               Size trash)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2, Iterator3, Iterator3, Iterator4, Iterator4, Size)
     {
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/histogram.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/histogram.pass.cpp
@@ -79,12 +79,12 @@ test_range_and_even_histogram(Size n, T min_boundary, T max_boundary, T overflow
                               Size trash)
 {
     //possibly spill over by overflow/2 on each side of range
-    Sequence<T> in(n, [&](size_t k) {
+    Sequence<T> in(n, [&](size_t /*index*/) {
         return T(std::rand() % Size(max_boundary - min_boundary + overflow)) + min_boundary - overflow / T(2);
     });
 
-    Sequence<Size> expected(num_bins, [](size_t k) { return 0; });
-    Sequence<Size> out(num_bins, [&](size_t k) { return trash; });
+    Sequence<Size> expected(num_bins, [](size_t /*index*/) { return 0; });
+    Sequence<Size> out(num_bins, [&](size_t /*index*/) { return trash; });
 
     invoke_on_all_policies<CallNumber * 4>()(test_histogram_even_bins(), in.begin(), in.end(), expected.begin(),
                                                     expected.end(), out.begin(), out.end(), Size(in.size()),

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -112,8 +112,8 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
-               Iterator3 val_res_first, Iterator3 val_res_last, Size n)
+    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 /*vals_last*/,
+               Iterator3 val_res_first, Iterator3 /*val_res_last*/, Size n)
     {
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
         TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);
@@ -169,8 +169,8 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
         !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
-               Iterator3 val_res_first, Iterator3 val_res_last, Size n)
+    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 /*vals_last*/,
+               Iterator3 val_res_first, Iterator3 /*val_res_last*/, Size n)
     {
         // call algorithm with no optional arguments
         initialize_data(keys_first, vals_first, val_res_first, n);
@@ -196,8 +196,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
-               Iterator3 val_res_first, Iterator3 val_res_last, Size n)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2, Iterator3, Iterator3, Size)
     {
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -119,8 +119,6 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
         TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);
         TestDataTransfer<UDTKind::eRes, Size> host_res(*this, n);
 
-        typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
-
         // call algorithm with no optional arguments
         initialize_data(host_keys.get(), host_vals.get(), host_res.get(), n);
         update_data(host_keys, host_vals, host_res);

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -258,8 +258,8 @@ test_flag_pred()
     T key_res_head_on_host[n] = {};
     T val_res_head_on_host[n] = {};
 
-    prepare_data(n, key_head_on_host, val_head_on_host, key_res_head_on_host, val_res_head_on_host);
-    auto flag_pred = [](const auto& a, const auto& b) {
+    prepare_data(n, key_head_on_host, val_head_on_host);
+    auto flag_pred = [](const auto&, const auto& b) {
         using KeyT = ::std::decay_t<decltype(b)>;
         return b != KeyT(1);
     };

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -194,7 +194,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
         typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
         typedef typename ::std::iterator_traits<Iterator2>::value_type ValT;
 
-        initialize_data(keys_first, vals_first, key_res_first, val_res_first, n);
+        initialize_data(keys_first, vals_first, val_res_first, n);
 
         std::pair<Iterator3, Iterator4> res;
         if constexpr (std::is_same_v<std::equal_to<KeyT>, std::decay_t<BinaryPredicate>> &&

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -49,8 +49,8 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
 {
     DEFINE_TEST_CONSTRUCTOR(test_reduce_by_segment, 1.0f, 1.0f)
 
-    template <typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Size>
-    void initialize_data(Iterator1 host_keys, Iterator2 host_vals, Iterator3 host_key_res, Iterator4 host_val_res,
+    template <typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
+    void initialize_data(Iterator1 host_keys, Iterator2 host_vals, Iterator3 host_val_res,
                          Size n)
     {
         // T keys[n] = { 1, 2, 3, 4, 1, 1, 2, 2, 3, 3, 4, 4, 1, 1, 1, ...};
@@ -139,8 +139,8 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator4>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
-               Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
+    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 /*vals_last*/,
+               Iterator3 key_res_first, Iterator3 /*key_res_last*/, Iterator4 val_res_first, Iterator4 /*val_res_last*/, Size n)
     {
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
         TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);
@@ -150,7 +150,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
         typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
         typedef typename ::std::iterator_traits<Iterator2>::value_type ValT;
 
-        initialize_data(host_keys.get(), host_vals.get(), host_res_keys.get(), host_res.get(), n);
+        initialize_data(host_keys.get(), host_vals.get(), host_res.get(), n);
         update_data(host_keys, host_vals, host_res_keys, host_res);
 
         std::pair<Iterator3, Iterator4> res;
@@ -188,8 +188,8 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3> &&
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator4>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
-               Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
+    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 /*vals_last*/,
+               Iterator3 key_res_first, Iterator3 /*key_res_last*/, Iterator4 val_res_first, Iterator4 /*val_res_last*/, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
         typedef typename ::std::iterator_traits<Iterator2>::value_type ValT;
@@ -224,8 +224,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
               typename Size>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3> ||
                            !is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator4>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
-               Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2, Iterator3, Iterator3, Iterator4, Iterator4, Size)
     {
     }
 };
@@ -244,7 +243,7 @@ test_flag_pred()
     // keys_result = {1, 1, 1};
     // vals_result = {11, 12, 10};
 
-    auto prepare_data = [](int n, T* key_head, T* val_head, T* key_res_head, T* val_res_head)
+    auto prepare_data = [](int n, T* key_head, T* val_head)
         {
             for (int i = 0; i < n; ++i)
             {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment_zip.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment_zip.pass.cpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <iostream>
 #include <tuple>
+#include <iterator>
 
 #if TEST_DPCPP_BACKEND_PRESENT
 #include "support/sycl_alloc_utils.h"
@@ -74,7 +75,7 @@ test_with_usm(BinaryOp binary_op)
     auto begin_vals_out= oneapi::dpl::make_zip_iterator(d_output_values1, d_output_values2);
     auto policy = TestUtils::make_device_policy<
         TestUtils::unique_kernel_name<BinaryOp, KernelIdx>>(q);
-    //run reduce_by_segment algorithm 
+    //run reduce_by_segment algorithm
     auto new_last = oneapi::dpl::reduce_by_segment(
         policy, begin_keys_in,
         end_keys_in, begin_vals_in, begin_keys_out, begin_vals_out,
@@ -109,6 +110,8 @@ test_with_usm(BinaryOp binary_op)
     EXPECT_EQ_N(exp_keys2, output_keys2, n, "wrong keys2 from reduce_by_segment");
     EXPECT_EQ_N(exp_values1, output_values1, n, "wrong values1 from reduce_by_segment");
     EXPECT_EQ_N(exp_values2, output_values2, n, "wrong values2 from reduce_by_segment");
+    EXPECT_EQ(std::distance(begin_keys_out, new_last.first), 6, "wrong number of keys from reduce_by_segment");
+    EXPECT_EQ(std::distance(begin_vals_out, new_last.second), 6, "wrong number of values from reduce_by_segment");
 }
 
 template <std::size_t KernelIdx, typename BinaryOp>
@@ -164,6 +167,8 @@ test_zip_with_discard(BinaryOp binary_op)
     const int exp_values[n] = {4, 4, 2};
     EXPECT_EQ_N(exp_keys, output_keys, n, "wrong keys from reduce_by_segment");
     EXPECT_EQ_N(exp_values, output_values, n, "wrong values from reduce_by_segment");
+    EXPECT_EQ(std::distance(begin_keys_out, new_last.first), 3, "wrong number of keys from reduce_by_segment");
+    EXPECT_EQ(std::distance(begin_vals_out, new_last.second), 3, "wrong number of values from reduce_by_segment");
 }
 #endif
 


### PR DESCRIPTION
The PR fixes warnings like:
 - `unused-variable`
 - `unused-parameter`

There are additional checks in `reduce_by_segment_zip.pass.cpp` to avoid `unused-variable` for `new_last`.

It's been cherry-picked from https://github.com/uxlfoundation/oneDPL/pull/2249 for easier review.