### PR TITLE
Fix deprecated-copy warning in the library

### DIFF
--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -49,6 +49,8 @@ class __induction_object
   public:
     __induction_object(__value_type __var, _Sp __stride) : __var_(__var), __stride_(__stride) {}
 
+    __induction_object(const __induction_object& __other) = default;
+
     __induction_object&
     operator=(const __induction_object& __other)
     {
@@ -87,6 +89,8 @@ class __induction_object<_Tp, void>
 
   public:
     __induction_object(__value_type __var) : __var_(__var) {}
+
+    __induction_object(const __induction_object& __other) = default;
 
     __induction_object&
     operator=(const __induction_object& __other)

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -545,13 +545,8 @@ struct _Combiner
     // "initializer(omp_priv = omp_orig). That solution was done just for UDR simd bricks, when an identity
     // value unknown and it assumes getting an identity by _Tp value initialization - _Tp{}.
     _Combiner(const _Combiner& __obj) : __value{}, __bin_op(__obj.__bin_op) {}
-    _Combiner&
-    operator=(const _Combiner& __obj)
-    {
-        __value = _Tp{};
-        __bin_op = __obj.__bin_op;
-        return *this;
-    }
+
+    _Combiner& operator=(const _Combiner& __obj) = default;
 
     void
     operator()(const _Combiner& __obj)

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -545,7 +545,13 @@ struct _Combiner
     // "initializer(omp_priv = omp_orig). That solution was done just for UDR simd bricks, when an identity
     // value unknown and it assumes getting an identity by _Tp value initialization - _Tp{}.
     _Combiner(const _Combiner& __obj) : __value{}, __bin_op(__obj.__bin_op) {}
-    _Combiner& operator=(const _Combiner& __obj) = delete; // avoid warning: definition of implicit copy assignment operator
+    _Combiner&
+    operator=(const _Combiner& __obj)
+    {
+        __value{};
+        __bin_op = __obj.__bin_op;
+        return *this;
+    }
 
     void
     operator()(const _Combiner& __obj)

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -546,7 +546,8 @@ struct _Combiner
     // value unknown and it assumes getting an identity by _Tp value initialization - _Tp{}.
     _Combiner(const _Combiner& __obj) : __value{}, __bin_op(__obj.__bin_op) {}
 
-    _Combiner& operator=(const _Combiner& __obj) = default;
+    _Combiner&
+    operator=(const _Combiner& __obj) = default;
 
     void
     operator()(const _Combiner& __obj)

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -546,6 +546,9 @@ struct _Combiner
     // value unknown and it assumes getting an identity by _Tp value initialization - _Tp{}.
     _Combiner(const _Combiner& __obj) : __value{}, __bin_op(__obj.__bin_op) {}
 
+    // This assignment operator copies the reduced value back to the caller
+    // It does not participate in the creation of an initial value,
+    // hence its behaviour is different from the copy constructor above
     _Combiner&
     operator=(const _Combiner& __obj) = default;
 

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -545,6 +545,7 @@ struct _Combiner
     // "initializer(omp_priv = omp_orig). That solution was done just for UDR simd bricks, when an identity
     // value unknown and it assumes getting an identity by _Tp value initialization - _Tp{}.
     _Combiner(const _Combiner& __obj) : __value{}, __bin_op(__obj.__bin_op) {}
+    _Combiner& operator=(const _Combiner& __obj) = delete; // avoid warning: definition of implicit copy assignment operator
 
     void
     operator()(const _Combiner& __obj)

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -548,7 +548,7 @@ struct _Combiner
     _Combiner&
     operator=(const _Combiner& __obj)
     {
-        __value{};
+        __value = _Tp{};
         __bin_op = __obj.__bin_op;
         return *this;
     }


### PR DESCRIPTION
Examples of the warnings:

> induction_impl.h:53:5: error: definition of implicit copy constructor for '__induction_object<int, unsigned long>' is deprecated because it has a user-provided copy assignment operator

> unseq_backend_simd.h:547:5: error: definition of implicit copy assignment operator for '_Combiner<oneapi::dpl::__internal::tuple<unsigned long, unsigned int>, oneapi::dpl::internal::segmented_scan_fun<unsigned long, unsigned int, std::plus<unsigned long>>>' is deprecated because it has a user-provided copy constructor

---
Note that `_Combiner` has `_Combiner(const _Combiner& __obj) : __value{}, __bin_op(__obj.__bin_op) {}` constructor, which behavior is unusual. However, if a corresponding copy assignment operator also default initializes `__value`, several tests produce wrong results.

It's been cherry-picked from https://github.com/uxlfoundation/oneDPL/pull/2249 for easier review.