### PR TITLE
Fix warning in tests: declaration of <x> hides global declaration

### DIFF
--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
@@ -39,11 +39,10 @@ template <typename T, typename Predicate>
 void
 test(Predicate pred)
 {
+    const std::size_t max_size = 1000000;
+    Sequence<T> in(max_size, [](std::size_t k) { return T(k); });
 
-    const ::std::size_t max_n = 1000000;
-    Sequence<T> in(max_n, [](::std::size_t k) { return T(k); });
-
-    for (::std::size_t n1 = 0; n1 <= max_n; n1 = n1 <= 16 ? n1 + 1 : ::std::size_t(3.1415 * n1))
+    for (std::size_t n1 = 0; n1 <= max_size; n1 = n1 <= 16 ? n1 + 1 : std::size_t(3.1415 * n1))
     {
         invoke_on_all_policies<0>()(test_is_partitioned<T>(), in.begin(), in.begin() + n1, pred);
         ::std::partition(in.begin(), in.begin() + n1, pred);

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -101,7 +101,7 @@ test(Predicate pred, _IteratorAdapter adap = {})
     // very slow code leading to test timeouts.
 
     const auto test_sizes = TestUtils::get_pattern_for_test_sizes();
-    size_t max_n =
+    size_t max_size =
 #if PSTL_USE_DEBUG && ONEDPL_USE_OPENMP_BACKEND
         10000;
 #else
@@ -109,7 +109,7 @@ test(Predicate pred, _IteratorAdapter adap = {})
 #endif
     for (size_t n : test_sizes)
     {
-        if (n <= max_n)
+        if (n <= max_size)
         {
             Sequence<In1> in1(n, [](size_t k) { return k % 5 != 1 ? In1(3 * k + 7) : 0; });
             Sequence<In2> in2(n, [](size_t k) { return k % 7 != 2 ? In2(5 * k + 5) : 0; });

--- a/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
@@ -53,29 +53,29 @@ void
 test(Predicate pred)
 {
 
-    const ::std::size_t max_n = 1000000;
-    Sequence<T1> in1(max_n, [](::std::size_t k) { return T1(k); });
-    Sequence<T2> in2(2 * max_n, [](::std::size_t k) { return T2(k); });
+    const ::std::size_t max_size = 1000000;
+    Sequence<T1> in1(max_size, [](::std::size_t k) { return T1(k); });
+    Sequence<T2> in2(2 * max_size, [](::std::size_t k) { return T2(k); });
 
     ::std::size_t n2;
 
     // Test case: Call algorithm's version without predicate.
-    invoke_on_all_policies<0>()(test_one_policy<T1>(), in1.cbegin(), in1.cbegin() + max_n,
-                                in2.cbegin() + 3 * max_n / 10, in2.cbegin() + 5 * max_n / 10);
+    invoke_on_all_policies<0>()(test_one_policy<T1>(), in1.cbegin(), in1.cbegin() + max_size,
+                                in2.cbegin() + 3 * max_size / 10, in2.cbegin() + 5 * max_size / 10);
 
     // Test case: If one range is a prefix of another, the shorter range is lexicographically less than the other.
-    ::std::size_t max_n2 = max_n / 10;
-    invoke_on_all_policies<1>()(test_one_policy<T1>(), in1.begin(), in1.begin() + max_n, in2.cbegin(),
-                                in2.cbegin() + max_n2, pred);
-    invoke_on_all_policies<2>()(test_one_policy<T1>(), in1.begin(), in1.begin() + max_n, in2.begin() + max_n2,
-                                in2.begin() + 3 * max_n2, pred);
+    ::std::size_t max_size2 = max_size / 10;
+    invoke_on_all_policies<1>()(test_one_policy<T1>(), in1.begin(), in1.begin() + max_size, in2.cbegin(),
+                                in2.cbegin() + max_size2, pred);
+    invoke_on_all_policies<2>()(test_one_policy<T1>(), in1.begin(), in1.begin() + max_size, in2.begin() + max_size2,
+                                in2.begin() + 3 * max_size2, pred);
 
     // Test case: If one range is a prefix of another, the shorter range is lexicographically less than the other.
-    max_n2 = 2 * max_n;
-    invoke_on_all_policies<3>()(test_one_policy<T1>(), in1.cbegin(), in1.cbegin() + max_n, in2.begin(),
-                                in2.begin() + max_n2, pred);
+    max_size2 = 2 * max_size;
+    invoke_on_all_policies<3>()(test_one_policy<T1>(), in1.cbegin(), in1.cbegin() + max_size, in2.begin(),
+                                in2.begin() + max_size2, pred);
 
-    for (::std::size_t n1 = 0; n1 <= max_n; n1 = n1 <= 16 ? n1 + 1 : ::std::size_t(3.1415 * n1))
+    for (::std::size_t n1 = 0; n1 <= max_size; n1 = n1 <= 16 ? n1 + 1 : ::std::size_t(3.1415 * n1))
     {
         // Test case: If two ranges have equivalent elements and are of the same length, then the ranges are lexicographically equal.
         n2 = n1;
@@ -103,16 +103,15 @@ template <typename Predicate>
 void
 test_string(Predicate pred)
 {
-
-    const ::std::size_t max_n = 1000000;
+    const std::size_t max_size = 1000000;
     ::std::string in1 = "";
     ::std::string in2 = "";
-    for (::std::size_t n1 = 0; n1 <= max_n; ++n1)
+    for (::std::size_t n1 = 0; n1 <= max_size; ++n1)
     {
         in1 += n1;
     }
 
-    for (::std::size_t n1 = 0; n1 <= 2 * max_n; ++n1)
+    for (std::size_t n1 = 0; n1 <= 2 * max_size; ++n1)
     {
         in2 += n1;
     }
@@ -137,8 +136,8 @@ test_string(Predicate pred)
         invoke_on_all_policies<9>()(test_one_policy<Predicate>(), in1.begin(), in1.begin() + n1, in2.cbegin(),
                                     in2.cbegin() + n2, pred);
     }
-    invoke_on_all_policies<10>()(test_one_policy<Predicate>(), in1.cbegin(), in1.cbegin() + max_n,
-                                 in2.cbegin() + 3 * max_n / 10, in2.cbegin() + 5 * max_n / 10);
+    invoke_on_all_policies<10>()(test_one_policy<Predicate>(), in1.cbegin(), in1.cbegin() + max_size,
+                                 in2.cbegin() + 3 * max_size / 10, in2.cbegin() + 5 * max_size / 10);
 }
 
 template <typename T>

--- a/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
@@ -97,9 +97,9 @@ template <typename T>
 void
 test_is_sorted_by_type()
 {
-    const ::std::size_t max_n = 1000000;
+    const ::std::size_t max_size = 1000000;
 
-    for (::std::size_t n1 = 1; n1 <= max_n; n1 = n1 <= 16 ? n1 + 1 : ::std::size_t(3.1415 * n1))
+    for (::std::size_t n1 = 1; n1 <= max_size; n1 = n1 <= 16 ? n1 + 1 : ::std::size_t(3.1415 * n1))
     {
         Sequence<T> in(n1, [](::std::size_t v) -> T { return T(v); }); //fill 0..n
 #ifdef _PSTL_TEST_IS_SORTED

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -176,8 +176,8 @@ main()
 #if TEST_DPCPP_BACKEND_PRESENT
     test_copyable();
 
-    size_t max_n = 10000;
-    for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    size_t max_size = 10000;
+    for (size_t n = 1; n <= max_size; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         test_simple_copy(n);
         test_ignore_copy(n);

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -39,7 +39,6 @@ main()
         sycl::buffer<int> B1(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B2(data2, sycl::range<1>(max_n));
 
-        using namespace TestUtils;
         using namespace oneapi::dpl::experimental;
 
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
@@ -47,9 +46,10 @@ main()
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 
         ranges::exclusive_scan(exec, A, view_res1, 100);
-        ranges::exclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, 100, ::std::plus<int>());
+        ranges::exclusive_scan(exec2, view, B2, 100, ::std::plus<int>());
     }
 
     //check result

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -40,7 +40,6 @@ main()
         sycl::buffer<int> B2(data2, sycl::range<1>(max_n));
         sycl::buffer<int> B3(data3, sycl::range<1>(max_n));
 
-        using namespace TestUtils;
         using namespace oneapi::dpl::experimental;
 
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
@@ -49,10 +48,12 @@ main()
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
+        auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
 
         ranges::inclusive_scan(exec, A, view_res1);
-        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, ::std::plus<int>());
-        ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 1>>(exec), view, view_res3, ::std::plus<int>(), 100);
+        ranges::inclusive_scan(exec2, view, B2, ::std::plus<int>());
+        ranges::inclusive_scan(exec3, view, view_res3, ::std::plus<int>(), 100);
     }
 
     //check result

--- a/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
@@ -36,7 +36,6 @@ main()
     bool res1 = false;
     bool res2 = false;
     bool res3 = false;
-    using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
     {
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
@@ -44,10 +43,12 @@ main()
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
+        auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
 
         res1 = is_sorted(exec, all_view(A));
-        res2 = is_sorted(make_new_policy<new_kernel_name<Policy, 0>>(exec), B);
-        res3 = is_sorted(make_new_policy<new_kernel_name<Policy, 1>>(exec), A, [](auto a, auto b) { return a > b;});
+        res2 = is_sorted(exec2, B);
+        res3 = is_sorted(exec3, A, [](auto a, auto b) { return a > b;});
     }
 
     //check result

--- a/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
@@ -36,7 +36,6 @@ main()
     data[idx] = 0;
 
     int res1 = -1, res2 = - 1;
-    using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
@@ -45,9 +44,10 @@ main()
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 
         res1 = is_sorted_until(exec, view);
-        res2 = is_sorted_until(make_new_policy<new_kernel_name<Policy, 0>>(exec), A, [](auto a, auto b) { return a < b; });
+        res2 = is_sorted_until(exec2, A, [](auto a, auto b) { return a < b; });
     }
 
     //check result

--- a/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
@@ -40,7 +40,7 @@ main()
     int res1 = -1, res2 = - 1, res3 = -1, res4 = -1, res5 = -1;
     ::std::pair<int, int> res_minmax1(-1, -1);
     ::std::pair<int, int> res_minmax2(-1, -1);
-    using namespace TestUtils;
+
     using namespace oneapi::dpl::experimental::ranges;
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
@@ -49,18 +49,25 @@ main()
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
+        auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
+        auto exec4 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 4>>(exec);
+        auto exec5 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 5>>(exec);
+        auto exec6 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 6>>(exec);
+        auto exec7 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 7>>(exec);
 
         //min element
         res1 = min_element(exec, A);
-        res2 = min_element(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, ::std::less<int>());
-        res3 = min_element(make_new_policy<new_kernel_name<Policy, 1>>(exec), view | views::take(1));
+        res2 = min_element(exec2, view, ::std::less<int>());
+        res3 = min_element(exec3, view | views::take(1));
 
         //max_element
-        res4 = max_element(make_new_policy<new_kernel_name<Policy, 2>>(exec), A);
-        res5 = max_element(make_new_policy<new_kernel_name<Policy, 3>>(exec), view, ::std::less<int>());
+        res4 = max_element(exec4, A);
+        res5 = max_element(exec5, view, ::std::less<int>());
 
-        res_minmax1 = minmax_element(make_new_policy<new_kernel_name<Policy, 4>>(exec), A);
-        res_minmax2 = minmax_element(make_new_policy<new_kernel_name<Policy, 5>>(exec), view, ::std::less<int>());
+        //minmax_element
+        res_minmax1 = minmax_element(exec6, A);
+        res_minmax2 = minmax_element(exec7, view, ::std::less<int>());
     }
 
     //check result

--- a/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
@@ -32,7 +32,6 @@ main()
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
     auto res1 = -1, res2 = -1, res3 = -1;
     {
@@ -42,10 +41,12 @@ main()
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
+        auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
 
         res1 = reduce(exec, A);
-        res2 = reduce(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, 100);
-        res3 = reduce(make_new_policy<new_kernel_name<Policy, 1>>(exec), view, 100, ::std::plus<int>());
+        res2 = reduce(exec2, view, 100);
+        res3 = reduce(exec3, view, 100, ::std::plus<int>());
     }
 
     //check result

--- a/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
@@ -33,7 +33,6 @@ main()
     int data1[max_n] = {0, 1, 2, -1, 4, 5, 6, 7, 8, 9};
     int data2[max_n] = {0, 1, 2, -1, 4, 5, -6, 7, 8, 9};
 
-    using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
     {
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
@@ -41,10 +40,10 @@ main()
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 
         stable_sort(exec, A); //check passing sycl buffer directly
-        stable_sort(make_new_policy<new_kernel_name<Policy, 0>>(exec), all_view<int, sycl::access::mode::read_write>(B),
-            ::std::greater<int>());
+        stable_sort(exec2, all_view<int, sycl::access::mode::read_write>(B), std::greater<int>());
     }
 
     //check result

--- a/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
@@ -41,7 +41,6 @@ main()
         sycl::buffer<int> B1(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B2(data2, sycl::range<1>(max_n));
 
-        using namespace TestUtils;
         using namespace oneapi::dpl::experimental;
 
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
@@ -49,9 +48,10 @@ main()
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 
         ranges::transform_inclusive_scan(exec, A, view_res1, ::std::plus<int>(), lambda);
-        ranges::transform_inclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, ::std::plus<int>(), lambda, init);
+        ranges::transform_inclusive_scan(exec2, view, B2, ::std::plus<int>(), lambda, init);
     }
 
     //check result

--- a/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
@@ -38,16 +38,16 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
 
-        using namespace TestUtils;
-
         auto view = oneapi::dpl::experimental::ranges::all_view<int, sycl::access::mode::read>(A);
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
+        auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
 
         res1 = oneapi::dpl::experimental::ranges::transform_reduce(exec, A, view, 0);
-        res2 = oneapi::dpl::experimental::ranges::transform_reduce(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, A, 0, ::std::plus<int>(), ::std::multiplies<int>());
-        res3 = oneapi::dpl::experimental::ranges::transform_reduce(make_new_policy<new_kernel_name<Policy, 1>>(exec), view, 0, ::std::plus<int>(), lambda1);
+        res2 = oneapi::dpl::experimental::ranges::transform_reduce(exec2, view, A, 0, ::std::plus<int>(), ::std::multiplies<int>());
+        res3 = oneapi::dpl::experimental::ranges::transform_reduce(exec3, view, 0, ::std::plus<int>(), lambda1);
     }
 
     //check result

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1024,13 +1024,13 @@ generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
 }
 
 // Utility that models __estimate_best_start_size in the SYCL backend parallel_for to ensure large enough inputs are
-// used to test the large submitter path. A multiplier to the max n is added to ensure we get a few separate test inputs
-// for this path. For debug testing, only test with a single large n to avoid timeouts. Returns a monotonically increasing
+// used to test the large submitter path. A multiplier to the max size is added to ensure we get a few separate test inputs
+// for this path. For debug testing, only test with a single large size to avoid timeouts. Returns a monotonically increasing
 // sequence for use in testing.
 inline std::vector<std::size_t>
 get_pattern_for_test_sizes()
 {
-    std::size_t max_n = 0;
+    std::size_t max_size = 0;
     // We do not enable large input size testing for FPGA devices as __parallel_for_submitter_fpga only has a single
     // implementation with the standard input sizes providing full coverage, and testing large inputs is slow with the
     // FPGA emulator.
@@ -1045,18 +1045,18 @@ get_pattern_for_test_sizes()
 #endif
 #if TEST_DPCPP_BACKEND_PRESENT && !PSTL_USE_DEBUG && !ONEDPL_FPGA_DEVICE
     std::size_t cap = 10000000;
-    max_n = multiplier * large_submitter_limit;
-    // Ensure that TestUtils::max_n <= max_n <= cap
-    max_n = std::max(TestUtils::max_n, std::min(cap, max_n));
+    max_size = multiplier * large_submitter_limit;
+    // Ensure that TestUtils::max_n <= max <= cap
+    max_size = std::max(TestUtils::max_n, std::min(cap, max_size));
 #else
-    max_n = TestUtils::max_n;
+    max_size = TestUtils::max_n;
 #endif
     // Generate the sequence of test input sizes
     std::vector<std::size_t> sizes;
-    for (std::size_t n = 0; n <= max_n; n = n <= 16 ? n + 1 : std::size_t(3.1415 * n))
+    for (std::size_t n = 0; n <= max_size; n = n <= 16 ? n + 1 : std::size_t(3.1415 * n))
         sizes.push_back(n);
 #if TEST_DPCPP_BACKEND_PRESENT && PSTL_USE_DEBUG && !ONEDPL_FPGA_DEVICE
-    if (max_n < large_submitter_limit)
+    if (max_size < large_submitter_limit)
         sizes.push_back(large_submitter_limit);
 #endif
     return sizes;


### PR DESCRIPTION
The PR fixes a warning:

> test\support/utils.h(1033): warning C4459: declaration of 'max_n' hides global declaration

It renames local `max_n` to `max_size` to avoid a conflict with `TestUtils::max_n` or removes `using namespace TestUtils;`, whatever is simpler. 