### PR TITLE
Fix various warnings in tests

### DIFF
--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -172,7 +172,7 @@ struct shift_right_algo
     //skip the test for non-bidirectional iterator (forward iterator, etc)
     template <typename Policy, typename It>
     ::std::enable_if_t<!TestUtils::is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, It>, It>
-    operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
+    operator()(Policy&&, It first, It, typename ::std::iterator_traits<It>::difference_type)
     {
         return first;
     }
@@ -199,8 +199,8 @@ struct shift_right_algo
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
     ::std::enable_if_t<!TestUtils::is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, It>>
-    check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
-        typename ::std::iterator_traits<It>::difference_type n)
+    check(It, It, typename ::std::iterator_traits<It>::difference_type, ItExp,
+        typename ::std::iterator_traits<It>::difference_type)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
@@ -56,7 +56,7 @@ struct Parity
     bool
     operator()(T value) const
     {
-        return (size_t(value) ^ parity) % 2 == 0;
+        return (size_t(value) ^ size_t(parity)) % 2 == 0;
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -42,7 +42,7 @@ DEFINE_TEST(test_binary_search)
         {
             if (i == 0)
             {
-                EXPECT_TRUE(result[i] == true, "wrong effect from binary_search");
+                EXPECT_TRUE(static_cast<bool>(result[i]) == true, "wrong effect from binary_search");
             }
             else
             {

--- a/test/parallel_api/algorithm/alg.sorting/alg.sort/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.sort/sort.pass.cpp
@@ -34,7 +34,7 @@ int main()
     test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device"}, sizes, Device<0>{},
                                     Converter<TestUtils::float32_t>{});
 
-    auto sycl_half_convert = [](size_t k, size_t val) {
+    auto sycl_half_convert = [](size_t /*index*/, size_t val) {
         constexpr std::uint16_t mask = 0xFFFFu;
         std::uint16_t raw = std::uint16_t(val & mask);
         // Avoid NaN values, because they need a custom comparator due to: (x < NaN = false) and (NaN < x = false).

--- a/test/parallel_api/iterator/input_data_sweep.h
+++ b/test/parallel_api/iterator/input_data_sweep.h
@@ -54,6 +54,7 @@ wrap_recurse(Policy&& exec, InputIterator1 first, InputIterator1 last, InputIter
 
     //Run the tests
     auto get_expect = [n](auto exp) {
+        (void)n; // avoid unused-lambda-capture, bug https://bugs.llvm.org/show_bug.cgi?id=35450
         if constexpr (__reverses % 2 == 0)
         {
             return exp;

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -349,9 +349,9 @@ struct test_permutation_iterator
 
 struct test_discard_iterator
 {
-    template <typename T1, typename T2>
+    template <typename T1>
     void
-    operator()(::std::vector<T1>& in1, ::std::vector<T2>& in2)
+    operator()(std::vector<T1>& in1)
     {
         ::std::iota(in1.begin(), in1.end(), T1(0));
 
@@ -380,7 +380,7 @@ void test_iterator_by_type(IntType n) {
     test_zip_iterator()(in, in2);
     test_transform_iterator()(in, in2);
     test_permutation_iterator()(in, in2);
-    test_discard_iterator()(in, in2);
+    test_discard_iterator()(in);
 }
 
 int main() {

--- a/test/parallel_api/iterator/permutation_iterator_common.h
+++ b/test/parallel_api/iterator/permutation_iterator_common.h
@@ -51,7 +51,7 @@ using namespace TestUtils;
 
 template <typename ExecutionPolicy>
 void
-wait_and_throw(ExecutionPolicy&& exec)
+wait_and_throw([[maybe_unused]] ExecutionPolicy&& exec)
 {
 #if TEST_DPCPP_BACKEND_PRESENT
     if constexpr (oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<ExecutionPolicy>>::value)

--- a/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
@@ -30,7 +30,7 @@ DEFINE_TEST_PERM_IT(test_find, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /*last1*/, Size n)
     {
         assert(n > 0);
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -47,7 +47,7 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /*last1*/, Iterator2 first2, Iterator2 /*last2*/, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -30,7 +30,10 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3, Iterator3 last3, Size n)
+    operator()(Policy&& exec,
+               Iterator1 first1, [[maybe_unused]] Iterator1 last1,
+               Iterator2 first2, [[maybe_unused]] Iterator2 last2,
+               Iterator3 first3, Iterator3 last3, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {

--- a/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
@@ -30,7 +30,7 @@ DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /*last1*/, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -40,7 +40,7 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /*last1*/, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {

--- a/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
@@ -40,7 +40,7 @@ DEFINE_TEST_PERM_IT(test_sort, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /*last1*/, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
@@ -31,7 +31,7 @@ DEFINE_TEST_PERM_IT(test_transform_reduce, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /*last1*/, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
@@ -33,7 +33,7 @@ DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /*last1*/, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {

--- a/test/parallel_api/iterator/transform_iterator_constructible.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator_constructible.pass.cpp
@@ -61,6 +61,9 @@ struct stateful_functor_no_copy_assign
 
     stateful_functor_no_copy_assign&
     operator=(const stateful_functor_no_copy_assign&) = delete;
+
+    stateful_functor_no_copy_assign(const stateful_functor_no_copy_assign&) = default;
+    
     int
     operator()(int a) const
     {

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -70,16 +70,16 @@ compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Functio
     if (first == last)
         return true;
 
-    T2 temp(*first);
-    if (!compare(temp, *d_first))
+    T2 temp1(*first);
+    if (!compare(temp1, *d_first))
         return false;
     Iterator1 second = ::std::next(first);
 
     ++d_first;
     for (; second != last; ++first, ++second, ++d_first)
     {
-        T2 temp(f(*second, *first));
-        if (!compare(temp, *d_first))
+        T2 temp2(f(*second, *first));
+        if (!compare(temp2, *d_first))
             return false;
     }
 

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -119,7 +119,6 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
         TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);
         TestDataTransfer<UDTKind::eRes, Size> host_val_res(*this, n);
 
-        typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
         typedef typename ::std::iterator_traits<Iterator2>::value_type ValT;
 
         const ValT zero = 0;

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -259,7 +259,7 @@ test_with_multiplies()
         Sequence<T> out(n, [&](size_t) { return trash; });
         Sequence<T> expected(n, [&](size_t) { return trash; });
 
-        Sequence<T> in(n, [](size_t k) { return 1; });
+        Sequence<T> in(n, [](size_t /*index*/) { return 1; });
         std::size_t counter = 0;
         std::generate_n(in.begin(), custom_item_count, [&counter]() { return (counter++) % 3 + 2; } );
         std::default_random_engine gen{42};

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -151,7 +151,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
-               Iterator2 vals_first, Iterator2 vals_last,
+               Iterator2 vals_first, Iterator2 /*vals_last*/,
                Size n)
     {
         using ValT = typename ::std::iterator_traits<Iterator2>::value_type;
@@ -198,7 +198,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
-               Iterator2 vals_first, Iterator2 vals_last,
+               Iterator2 vals_first, Iterator2 /*vals_last*/,
                Size n)
     {
         using ValT = typename ::std::iterator_traits<Iterator2>::value_type;
@@ -218,10 +218,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
-    operator()(Policy&& exec,
-               Iterator1 keys_first, Iterator1 keys_last,
-               Iterator2 vals_first, Iterator2 vals_last,
-               Size n)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2, Size)
     {
     }
 };
@@ -287,7 +284,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Size>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
-    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
+    operator()(Policy&&, Iterator1, Iterator1, Size)
     {
     }
 };

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -173,7 +173,7 @@ template<typename>
 constexpr int calc_res_size(int n, int) { return n; }
 
 auto data_gen2_default = [](auto i) { return i % 5 ? i : 0;};
-auto data_gen_zero = [](auto i) { return 0;};
+auto data_gen_zero = [](auto) { return 0;};
 
 template<typename DataType, typename Container, TestDataMode test_mode = data_in, typename DataGen1 = std::identity,
          typename DataGen2 = decltype(data_gen2_default)>
@@ -210,7 +210,7 @@ private:
 
         typename Container::type& A = cont_in();
         decltype(auto) r_in = tr_in(A);
-        auto res = algo(exec, r_in, args...);        
+        auto res = algo(exec, r_in, args...);
 
         //check result
         static_assert(std::is_same_v<decltype(res), decltype(checker(r_in, args...))>, "Wrong return type");

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -779,7 +779,7 @@ template <typename _Tp>
 struct UserBinaryPredicate
 {
     bool
-    operator()(const _Tp& __x, const _Tp& __y) const
+    operator()(const _Tp&, const _Tp& __y) const
     {
         using KeyT = ::std::decay_t<_Tp>;
         return __y != KeyT(1);

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -260,8 +260,7 @@ bool check_by_predicate(T t1, T t2)
 
 template <typename InputIterator, typename OutputIterator1, typename OutputIterator2, typename Size>
 void
-copy_data(InputIterator first, OutputIterator1 expected_first, OutputIterator1 expected_last, OutputIterator2 tmp_first,
-          Size n)
+copy_data(InputIterator first, OutputIterator1 expected_first, OutputIterator2 tmp_first, Size n)
 {
     std::copy_n(first, n, expected_first);
     std::copy_n(first, n, tmp_first);
@@ -332,7 +331,7 @@ run_test(SortTestConfig config,
          OutputIterator2 expected_last, InputIterator first, InputIterator /*last*/, Size n, Compare ...compare)
 {
     // Prepare data for sort algorithm
-    copy_data(first, expected_first, expected_last, tmp_first, n);
+    copy_data(first, expected_first, tmp_first, n);
     call_reference_sort(config.is_stable, expected_first + 1, expected_last - 1, compare...);
 
     // Call sort algorithm on prepared data
@@ -354,7 +353,7 @@ test_usm(SortTestConfig config,
          OutputIterator2 expected_last, InputIterator first, InputIterator /* last */, Size n, Compare... compare)
 {
     // Prepare data for sort algorithm
-    copy_data(first, expected_first, expected_last, tmp_first, n);
+    copy_data(first, expected_first, tmp_first, n);
     call_reference_sort(config.is_stable, expected_first + 1, expected_last - 1, compare...);
 
     using ValueType = typename std::iterator_traits<OutputIterator>::value_type;


### PR DESCRIPTION
The PR fixes warnings like:

> all_of.pass.cpp(59): warning C4805: '^': unsafe mix of type 'size_t' and type 'const bool' in operation

> adjacent_difference.pass.cpp(81): warning C4456: declaration of 'temp' hides previous local declaration

`stateful_functor_no_copy_assign(const stateful_functor_no_copy_assign&) = default;` is added to avoid [-Wdeprecated-copy-with-user-provided-copy](https://clang.llvm.org/docs/DiagnosticsReference.html#id258).

There rest are either `unused-lambda-capture` or `unused-parameter`.