### PR TITLE
Fix warning: unary minus operator applied to unsigned type

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -79,12 +79,8 @@ __pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1
 
     // TODO : add stencil form of replace_copy_if to oneDPL if the
     // transform call here is difficult to understand and maintain.
-#if 1
     transform(policy, first2, last2 - 1, _flags.get() + 1, _temp.get() + 1,
-              internal::replace_if_fun<T, ::std::negate<FlagType>>(::std::negate<FlagType>(), init));
-#else
-    replace_copy_if(policy1, first2, last2 - 1, _flags.get() + 1, _temp.get() + 1, ::std::negate<FlagType>(), init);
-#endif
+              internal::replace_by_flag<T>(init));
 
     // scan key-flag tuples
     inclusive_scan(::std::forward<Policy>(policy), make_zip_iterator(_temp.get(), _flags.get()),
@@ -146,13 +142,8 @@ __pattern_exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, 
 
     // TODO : add stencil form of replace_copy_if to oneDPL if the
     // transform call here is difficult to understand and maintain.
-#    if 1
     transform(::std::move(policy1), first2, last2 - 1, _flags.get() + 1, _temp.get() + 1,
-              internal::replace_if_fun<T, ::std::negate<FlagType>>(::std::negate<FlagType>(), init));
-#    else
-    replace_copy_if(::std::move(policy1), first2, last2 - 1, _flags.get() + 1, _temp.get() + 1,
-                    ::std::negate<FlagType>(), init);
-#    endif
+              internal::replace_by_flag<T>(init));
 
     auto policy2 =
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<ExclusiveScan2>(::std::forward<Policy>(policy));

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -17,6 +17,8 @@
 #define _ONEDPL_INTERNAL_FUNCTION_H
 
 #include <utility>
+#include <iostream>
+
 #if _ONEDPL_BACKEND_SYCL
 #    include "../pstl/hetero/dpcpp/parallel_backend_sycl_utils.h"
 #endif
@@ -44,22 +46,21 @@ struct is_discard_iterator<Iter, ::std::enable_if_t<Iter::is_discard::value>> : 
 
 // Used by: exclusive_scan_by_key
 // Lambda: [pred, &new_value](Ref1 a, Ref2 s) {return pred(s) ? new_value : a; });
-template <typename T, typename Predicate>
-struct replace_if_fun
+template <typename T>
+struct replace_by_flag
 {
     using result_of = T;
 
-    replace_if_fun(Predicate _pred, T _new_value) : pred(_pred), new_value(_new_value) {}
+    replace_by_flag(T _new_value) : new_value(_new_value) {}
 
     template <typename _T1, typename _T2>
     T
-    operator()(_T1&& a, _T2&& s) const
+    operator()(_T1&& a, _T2&& flag) const
     {
-        return pred(s) ? new_value : a;
+        return flag ? new_value : a;
     }
 
   private:
-    Predicate pred;
     const T new_value;
 };
 

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -79,9 +79,15 @@ typename __difference<_Ip>::__type
 __calculate_input_sequence_length(const _Ip __first, const _Ip __last, const _Sp __stride)
 {
     assert(__stride != 0);
-
-    return (__stride > 0) ? ((__last - __first + (__stride - 1)) / __stride)
-                          : ((__first - __last - (__stride + 1)) / -__stride);
+    if constexpr (std::is_unsigned_v<_Sp>)
+    {
+        return (__last - __first + (__stride - 1)) / __stride;
+    }
+    else
+    {
+        return (__stride > 0) ? ((__last - __first + (__stride - 1)) / __stride)
+                              : ((__first - __last - (__stride + 1)) / -__stride);
+    }
 }
 
 template <typename _Ip>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -740,8 +740,8 @@ enum class search_algorithm;
 template <typename Comp, typename T, search_algorithm func>
 struct __custom_brick;
 
-template <typename T, typename Predicate>
-struct replace_if_fun;
+template <typename T>
+struct replace_by_flag;
 
 template <typename ValueType, typename FlagType, typename BinaryOp>
 struct scan_by_key_fun;
@@ -763,9 +763,9 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::__
 {
 };
 
-template <typename T, typename Predicate>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::replace_if_fun, T, Predicate)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<T, Predicate>
+template <typename T>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::replace_by_flag, T)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<T>
 {
 };
 

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -49,10 +49,10 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::internal::__custom_brick<
                       noop_device_copyable, int_device_copyable, oneapi::dpl::internal::search_algorithm::lower_bound>>,
                   "__custom_brick is not device copyable with device copyable types");
-    //replace_if_fun
+    //replace_by_flag
     static_assert(
-        sycl::is_device_copyable_v<oneapi::dpl::internal::replace_if_fun<int_device_copyable, noop_device_copyable>>,
-        "replace_if_fun is not device copyable with device copyable types");
+        sycl::is_device_copyable_v<oneapi::dpl::internal::replace_by_flag<int_device_copyable, noop_device_copyable>>,
+        "replace_by_flag is not device copyable with device copyable types");
     //scan_by_key_fun
     static_assert(
         sycl::is_device_copyable_v<
@@ -320,10 +320,10 @@ test_non_device_copyable()
         !sycl::is_device_copyable_v<oneapi::dpl::internal::__custom_brick<
             noop_device_copyable, int_non_device_copyable, oneapi::dpl::internal::search_algorithm::lower_bound>>,
         "__custom_brick is device copyable with non device copyable types");
-    //replace_if_fun
+    //replace_by_flag
     static_assert(!sycl::is_device_copyable_v<
-                      oneapi::dpl::internal::replace_if_fun<int_device_copyable, noop_non_device_copyable>>,
-                  "replace_if_fun is device copyable with non device copyable types");
+                      oneapi::dpl::internal::replace_by_flag<int_device_copyable, noop_non_device_copyable>>,
+                  "replace_by_flag is device copyable with non device copyable types");
     //scan_by_key_fun
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::internal::scan_by_key_fun<int_non_device_copyable, int_device_copyable,

--- a/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
@@ -137,7 +137,8 @@ template <typename FStep>
 void
 test_merge_by_type(size_t start_size, size_t max_size, FStep fstep)
 {
-    test_merge_by_type<std::int32_t>([](size_t v) { return (v % 2 == 0 ? v : -v) * 3; }, [](size_t v) { return v * 2; }, start_size, max_size, fstep);
+    test_merge_by_type<std::int32_t>([](std::int32_t v) { return (v % 2 == 0 ? v : -v) * 3; },
+                                     [](std::int32_t v) { return v * 2; }, start_size, max_size, fstep);
 #if !ONEDPL_FPGA_DEVICE
     test_merge_by_type<float64_t>([](size_t v) { return float64_t(v); }, [](size_t v) { return float64_t(v - 100); }, start_size, max_size, fstep);
 #endif

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
@@ -87,7 +87,7 @@ run_algo_tests()
 int
 main()
 {
-    using ValueType = ::std::uint32_t;
+    using ValueType = std::int32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
     run_algo_tests<ValueType, perm_it_index_tags_usm_shared>();

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -113,8 +113,7 @@ is_equal_val(const T1& val1, const T2& val2)
         const auto eps = std::numeric_limits<T>::epsilon();
         return std::fabs(T(val1) - T(val2)) < eps;
     }
-
-    if constexpr (std::is_same_v<T1, T2>)
+    else if constexpr (std::is_same_v<T1, T2>)
     {
         return val1 == val2;
     }


### PR DESCRIPTION
The PR fixes warning like:

merge test:

> merge.pass.cpp(140): warning C4146: unary minus operator applied to unsigned type, result still unsigned

for_loop implementation:
> for_loop_impl.h(84): warning C4146: unary minus operator applied to unsigned type, result still unsigned

permutation iterator test:
> C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.43.34808\include\functional(62): warning C4146: unary minus operator applied to unsigned type, result still unsigned
...
oneDPL\test\parallel_api\iterator\permutation_iterator_parallel_transform_reduce.pass.cpp(96): note: see reference to...


exlusive_scan_by_segment implementation:
> C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.43.34808\include\functional(62): warning C4146: unary minus operator applied to unsigned type, result still unsigned
internal/exclusive_scan_by_segment_impl.h(84): note: see reference to class template instantiation 'std::negate<oneapi::dpl::__internal::__pattern_exclusive_scan_by_segment::FlagType>' being compiled


The case with the segmented exclusive scan is peculiar. It turned out `std::negate` was applied to `unsigned integer` flags, which should contain only `0` or `1`. It caused unsigned overflow to `1` values, which still resulted in `true` result. Now, flags are checked as they are, but the result is the same.

