### PR TITLE
CI: remove fixed warnings from -Werror exclusions

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -205,9 +205,9 @@ jobs:
           mkdir build && cd build
           lscpu
 
-          warning_flags="-Wall -Werror -Wno-error=unused-parameter -Wno-error=sign-compare -Wno-error=deprecated-copy"
+          warning_flags="-Wall -Werror -Wno-error=sign-compare"
           if [[ "${{ matrix.cxx_compiler }}" != "g++" ]]; then
-            warning_flags="${warning_flags} -Wno-error=deprecated-copy-with-user-provided-copy -Wno-error=pass-failed"
+            warning_flags="${warning_flags} -Wno-error=pass-failed"
           fi
           if [[ "${{ matrix.cxx_compiler }}" == "icpx" ]]; then
             warning_flags="${warning_flags} -Wno-error=recommended-option"
@@ -378,7 +378,7 @@ jobs:
           export OpenMP_ROOT=$(brew --prefix)/opt/libomp
           mkdir build && cd build
 
-          warning_flags="-Wall -Werror -Wno-error=unused-parameter -Wno-error=sign-compare -Wno-error=deprecated-copy -Wno-error=deprecated-copy-with-user-provided-copy -Wno-error=pass-failed -Wno-error=macro-redefined"
+          warning_flags="-Wall -Werror -Wno-error=sign-compare -Wno-error=pass-failed"
 
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_CXX_FLAGS="${warning_flags}" ..


### PR DESCRIPTION
Note that some of these warnings still occur when building all the tests with device backend (which is not currently covered in this CI). Anyway, let's have a strict warning policy with what we currently have in the CI.