### PR TITLE
[docs] Indirectly device accessible update

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -107,9 +107,9 @@ When called with device execution policies, |onedpl_short| algorithms apply the 
 |dpcpp_short| does (see the |dpcpp_cpp| documentation and the SYCL specification for details), such as:
 
 * Adding buffers to a lambda capture list is not allowed for lambdas passed to an algorithm, as buffers are not
- `SYCL device-copyable`_.
-* Data types which are not SYCL device-copyable may only be passed to |onedpl_short| algorithms via USM pointers. SYCL
-buffers or host-allocated containers must have a SYCL device-copyable value type.
+  `SYCL device-copyable`_.
+* Data types which are not SYCL device-copyable may only be passed to |onedpl_short| algorithms via USM pointers. 
+  SYCL buffers or host-allocated containers must have a SYCL device-copyable value type.
 * Objects of pointer-to-member types cannot be passed to an algorithm.
 * The definition of lambda functions used with parallel algorithms should not depend on preprocessor macros
   that makes it different for the host and the device. Otherwise, the behavior is undefined.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -117,7 +117,7 @@ When called with device execution policies, |onedpl_short| algorithms apply the 
   whose type meets SYCL requirements for use in kernels and for data transfer, respectively. 
 * Calling the API that throws exception is not allowed within callable objects passed to an algorithm.
 
-Please see `Pass Data to Algorithms<pass-data-algorithms>`_ for more details on how to pass data to algorithms, and the
+Please see :ref:`Pass Data to Algorithms <pass-data-algorithms>` for more details on how to pass data to algorithms, and the
 restrictions on the data types that can be passed to algorithms executed with device execution policies.
 
 Known Limitations

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -106,15 +106,19 @@ Restrictions
 When called with device execution policies, |onedpl_short| algorithms apply the same restrictions as
 |dpcpp_short| does (see the |dpcpp_cpp| documentation and the SYCL specification for details), such as:
 
-* Adding buffers to a lambda capture list is not allowed for lambdas passed to an algorithm.
-* Passing data types, which are not trivially copyable, is only allowed via USM,
-  but not via buffers or host-allocated containers.
+* Adding buffers to a lambda capture list is not allowed for lambdas passed to an algorithm, as buffers are not
+ `SYCL device-copyable`_.
+* Data types which are not SYCL device-copyable may only be passed to |onedpl_short| algorithms via USM pointers. SYCL
+buffers or host-allocated containers must have a SYCL device-copyable value type.
 * Objects of pointer-to-member types cannot be passed to an algorithm.
 * The definition of lambda functions used with parallel algorithms should not depend on preprocessor macros
   that makes it different for the host and the device. Otherwise, the behavior is undefined.
 * When used within SYCL kernels or transferred to/from a device, a container class can only hold objects
-  whose type meets SYCL requirements for use in kernels and for data transfer, respectively.
+  whose type meets SYCL requirements for use in kernels and for data transfer, respectively. 
 * Calling the API that throws exception is not allowed within callable objects passed to an algorithm.
+
+Please see `Pass Data to Algorithms<pass-data-algorithms>`_ for more details on how to pass data to algorithms, and the
+restrictions on the data types that can be passed to algorithms executed with device execution policies.
 
 Known Limitations
 *****************
@@ -179,3 +183,4 @@ Known Limitations
   to find information about the relevant Rolling and LTS releases.
 
 .. _`SYCL Specification`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html
+.. _`SYCL device-copyable`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -117,7 +117,7 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
   elements of data represented by an iterator need to be processed by an algorithm as though they were contiguous.
   An example is copying every other element to an output iterator. The source iterator cannot be a host-side iterator
   in cases where algorithms are executed with device policies. ``permutation_iterator`` is SYCL device-copyable if both
-  the SourceIterator and the IndexMap are SYCL device-copyable. permutation_iterator is indirectly device accessible if
+  the SourceIterator and the IndexMap are SYCL device-copyable. ``permutation_iterator`` is indirectly device accessible if
   both the SourceIterator and the IndexMap are indirectly device accessible.
 
   The ``make_permutation_iterator`` is provided to simplify construction of iterator instances. The function

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -131,6 +131,8 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
     auto permutation_last = permutation_first + num_elements;
     dpl::copy(dpl::execution::dpcpp_default, permutation_first, permutation_last, result);
 
+.. _iterator-properties-table:
+
 Iterators with Device Execution Policies
 ----------------------------------------
 The iterators described above can be used with device execution policies according to the rules described in

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -3,19 +3,21 @@ Iterators
 
 Requirements For Iterator Use With Device Policies
 --------------------------------------------------
-Iterators and iterator-like types may or may not refer to content accessible within a SYCL kernel on a device. The term
-indirectly device accessible refers to a type that represents content accessible on a device. An indirectly device
+Iterators and iterator-like types may or may not refer to content accessible within a
+`SYCL <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html>`_ kernel on a device. The term
+*indirectly device accessible* refers to a type that represents content accessible on a device. An indirectly device
 accessible iterator is such a type that can also be dereferenced within a SYCL kernel.
 
 An example of indirectly device accessible iterators include SYCL USM shared pointers which can inherently be used in a
 SYCL kernel. An example of an iterator type that is not indirectly device accessible is a random access iterator
 referring to host allocated data because dereferencing it within a SYCL kernel would result in undefined behavior.
 
-The type returned from ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` <use-buffer-wrappers> are not iterators. However,
+The `type returned from oneapi::dpl::begin and oneapi::dpl::end <use-buffer-wrappers>`_ are not iterators. However,
 they are indirectly device accessible because they represent data accessible on the device.
 
 When passed to oneDPL algorithms with a device_policy, using indirectly device accessible types will minimize data
-movement and should be equivalent to using the type directly within a SYCL kernel.
+movement and should be equivalent to using the type directly within a SYCL kernel. For iterator types, you must also
+ensure that the iterator type is SYCL device-copyable when using a device policy.
 
 
 Indirect Device Accessibility Type Trait

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -80,15 +80,15 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
   The unary functor provided to a ``transform_iterator`` should have a ``const``-qualified call operator which accepts
   the reference type of the base iterator as argument. The functor's call operator should not have any side effects and
   should not modify the state of the functor object.
-  
+
   The ``transform_iterator`` class provides the following constructors:
 
   * ``transform_iterator()``: instantiates the iterator using a default constructed base iterator and unary functor.
     This constructor participates in overload resolution only if the base iterator and unary functor are both default constructible.
-  
+
   * ``transform_iterator(iter)``: instantiates the iterator using the base iterator provided and a default constructed
     unary functor. This constructor participates in overload resolution only if the unary functor is default constructible.
-  
+
   * ``transform_iterator(iter, func)``: instantiates the iterator using the base iterator and unary functor provided.
 
   To simplify the construction of the iterator, ``oneapi::dpl::make_transform_iterator`` is provided. The
@@ -131,26 +131,3 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
     auto permutation_last = permutation_first + num_elements;
     dpl::copy(dpl::execution::dpcpp_default, permutation_first, permutation_last, result);
 
-.. _iterator-properties-table:
-
-Iterators with Device Execution Policies
-----------------------------------------
-The iterators described above can be used with device execution policies according to the rules described in
-`Pass Data to Algorithms <pass-data-algorithms>`_. The following table summarizes the characteristics of the iterators
-and their use with device execution policies:
-
-+----------------------+---------------------------------------------+-------------------------------------------+
-| Iterator             |          SYCL Device-Copyable               |        Indirectly Device Accessible       |
-+----------------------+---------------------------------------------+-------------------------------------------+
-| counting_iterator    | Yes                                         | Yes                                       |
-+----------------------+---------------------------------------------+-------------------------------------------+
-| discard_iterator     | Yes                                         | Yes                                       |
-+----------------------+---------------------------------------------+-------------------------------------------+
-| zip_iterator         | If all Source Iterators are                 | If all Source Iterators are               |
-+----------------------+---------------------------------------------+-------------------------------------------+
-| transform_iterator   | If the Source Iterator is                   | If the Source Iterator is                 |
-+----------------------+---------------------------------------------+-------------------------------------------+
-| permutation_iterator | If both Source Iterator and Index Map are   | If both Source Iterator and Index Map are |
-+----------------------+---------------------------------------------+-------------------------------------------+
-
-.. _`SYCL device-copyable`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -139,7 +139,6 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
     auto permutation_last = permutation_first + num_elements;
     dpl::copy(dpl::execution::dpcpp_default, permutation_first, permutation_last, result);
 
-
 Customization For User Defined Iterators
 ----------------------------------------
 |onedpl_short| provides a mechanism to indicate whether custom iterators are indirectly device accessible.
@@ -155,7 +154,6 @@ indirectly device accessible. The function overload to use must be selected with
 .. note::
   Therefore, according to the rules in the C++ Standard, a derived type for which there is no function overload
   will match its most specific base type for which an overload exists.
-
 
 Once ``is_onedpl_indirectly_device_accessible(T)`` is defined, the `public trait <indirectly-device-accessible-trait>`_
 ``template<typename T> oneapi::dpl::is_indirectly_device_accessible[_v]`` will return the appropriate value. This public

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -158,10 +158,10 @@ indirectly device accessible. The function overload to use must be selected with
 Once ``is_onedpl_indirectly_device_accessible(T)`` is defined, the `public trait <indirectly-device-accessible-trait>`_
 ``template<typename T> oneapi::dpl::is_indirectly_device_accessible[_v]`` will return the appropriate value. This public
 trait can also be used to define the return type of ``is_onedpl_indirectly_device_accessible(T)`` by applying it to any
-source iterator component types. 
+source iterator component types.
 
-The following example shows how to define a customization for ``is_indirectly_device_accessible`` trait for a simple
-user defined iterator. It also shows a more complicated example where the customization is defined as a hidden friend of
+The following example shows how to define a customization for the ``is_indirectly_device_accessible`` trait for a simple
+user defined iterator. It also shows a more complex example where the customization is defined as a hidden friend of
 the iterator class.
 
 .. code:: cpp

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -10,7 +10,7 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
   counter. Instances of a ``counting_iterator`` provide read-only dereference operations. The counter of an
   ``counting_iterator`` instance changes according to the arithmetic of the random-access iterator type.
   ``counting_iterator`` is `SYCL device-copyable`_, and is an
-  `indirectly device accessible <_indirectly-device-accessible>`_ iterator.
+  `indirectly device accessible <indirectly-device-accessible>`_ iterator.
 
   .. code:: cpp
 
@@ -142,7 +142,7 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
 Customization For User Defined Iterators
 ----------------------------------------
-oneDPL provides a mechanism to indicate whether custom iterators are indirectly device accessible.
+|onedpl_short| provides a mechanism to indicate whether custom iterators are indirectly device accessible.
 
 Applications may define a free function ``is_onedpl_indirectly_device_accessible(T)``, which accepts an argument of type
 ``T`` and returns a type with the base characteristic of ``std::true_type`` if ``T`` is indirectly device accessible.

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -140,7 +140,7 @@ The iterators described above can be used with device execution policies accordi
 and their use with device execution policies:
 
 +----------------------+---------------------------------------------+-------------------------------------------+
-| Iterator             |          SYCL device-copyable               |        Indirectly device accessible       |
+| Iterator             |          SYCL Device-Copyable               |        Indirectly Device Accessible       |
 +----------------------+---------------------------------------------+-------------------------------------------+
 | counting_iterator    | Yes                                         | Yes                                       |
 +----------------------+---------------------------------------------+-------------------------------------------+

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -1,43 +1,7 @@
+.. _iterator-details:
+
 Iterators
 #########
-
-Requirements For Iterator Use With Device Policies
---------------------------------------------------
-Iterators and iterator-like types may or may not refer to content accessible within a
-`SYCL <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html>`_ kernel on a device. The term
-*indirectly device accessible* refers to a type that represents content accessible on a device. An indirectly device
-accessible iterator is such a type that can also be dereferenced within a SYCL kernel.
-
-An example of indirectly device accessible iterators include SYCL USM shared pointers which can inherently be used in a
-SYCL kernel. An example of an iterator type that is not indirectly device accessible is a random access iterator
-referring to host allocated data because dereferencing it within a SYCL kernel would result in undefined behavior.
-
-The `type returned from oneapi::dpl::begin and oneapi::dpl::end <use-buffer-wrappers>`_ are not iterators. However,
-they are indirectly device accessible because they represent data accessible on the device.
-
-When passed to oneDPL algorithms with a device_policy, using indirectly device accessible types will minimize data
-movement and should be equivalent to using the type directly within a SYCL kernel. For iterator types, you must also
-ensure that the iterator type is SYCL device-copyable when using a device policy.
-
-
-Indirect Device Accessibility Type Trait
-----------------------------------------
-The following class template and variable template are defined in ``<oneapi/dpl/iterator>`` inside the namespace
-``oneapi::dpl:``
-
-.. code:: cpp
-  template <typename T>
-  struct is_indirectly_device_accessible{ /* see below */ };
-
-  template <typename T>
-  inline constexpr bool is_indirectly_device_accessible_v = is_indirectly_device_accessible<T>::value;
-
-``template <typename T> oneapi::dpl::is_indirectly_device_accessible`` is a template which has the base characteristic
-of ``std::true_type`` if ``T`` is indirectly device accessible. Otherwise, it has the base characteristic of
-``std::false_type``.
-
-oneDPL Iterators
-----------------
 
 The definitions of the iterators are available through the ``<oneapi/dpl/iterator>``
 header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
@@ -45,7 +9,8 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 * ``counting_iterator``: a random-access iterator-like type whose dereferenced value is an integer
   counter. Instances of a ``counting_iterator`` provide read-only dereference operations. The counter of an
   ``counting_iterator`` instance changes according to the arithmetic of the random-access iterator type.
-  ``counting_iterator`` is SYCL device-copyable, and is an indirectly device accessible iterator.
+  ``counting_iterator`` is `SYCL device-copyable`_, and is an
+  `indirectly device accessible <_indirectly-device-accessible>`_ iterator.
 
   .. code:: cpp
 
@@ -192,7 +157,7 @@ indirectly device accessible. The function overload to use must be selected with
   will match its most specific base type for which an overload exists.
 
 
-Once ``is_onedpl_indirectly_device_accessible(T)`` is defined, the public trait 
+Once ``is_onedpl_indirectly_device_accessible(T)`` is defined, the `public trait <indirectly-device-accessible-trait>`_
 ``template<typename T> oneapi::dpl::is_indirectly_device_accessible[_v]`` will return the appropriate value. This public
 trait can also be used to define the return type of ``is_onedpl_indirectly_device_accessible(T)`` by applying it to any
 source iterator component types. 
@@ -244,3 +209,5 @@ the iterator class.
                                   it_pair<usr::accessible_it, usr::accessible_it>> == true);
   static_assert(oneapi::dpl::is_indirectly_device_accessible<
                                   it_pair<usr::accessible_it, usr::inaccessible_it>> == false);
+
+.. _`SYCL device-copyable`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -139,14 +139,18 @@ The iterators described above can be used with device execution policies accordi
 `Pass Data to Algorithms <pass-data-algorithms>`_. The following table summarizes the characteristics of the iterators
 and their use with device execution policies:
 
-+----------------------+--------------------------------------------+------------------------------------------+
-| Iterator             |          SYCL device-copyable              |        Indirectly device accessible      |
-+----------------------+--------------------------------------------+------------------------------------------+
-| counting_iterator    | Yes                                        | Yes                                      |
-| discard_iterator     | Yes                                        | Yes                                      |
-| zip_iterator         | If all Source Iterators are                | If all Source Iterators are              |
-| transform_iterator   | If the Source Iterator is                  | If the Source Iterator is                |
-| permutation_iterator | If the Source Iterator and Index Map are   | If the Source Iterator and Index Map are |
-+----------------------+--------------------------------------------+------------------------------------------+
++----------------------+---------------------------------------------+-------------------------------------------+
+| Iterator             |          SYCL device-copyable               |        Indirectly device accessible       |
++----------------------+---------------------------------------------+-------------------------------------------+
+| counting_iterator    | Yes                                         | Yes                                       |
++----------------------+---------------------------------------------+-------------------------------------------+
+| discard_iterator     | Yes                                         | Yes                                       |
++----------------------+---------------------------------------------+-------------------------------------------+
+| zip_iterator         | If all Source Iterators are                 | If all Source Iterators are               |
++----------------------+---------------------------------------------+-------------------------------------------+
+| transform_iterator   | If the Source Iterator is                   | If the Source Iterator is                 |
++----------------------+---------------------------------------------+-------------------------------------------+
+| permutation_iterator | If both Source Iterator and Index Map are   | If both Source Iterator and Index Map are |
++----------------------+---------------------------------------------+-------------------------------------------+
 
 .. _`SYCL device-copyable`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -290,14 +290,14 @@ The example below shows how to define such an overload:
 
 .. code:: cpp
 
-  #include <iterator>
-  #include <cstddef>
-  #include <iostream>
-
   #include <oneapi/dpl/execution>
   #include <oneapi/dpl/iterator>
   #include <oneapi/dpl/numeric>
   #include <oneapi/dpl/algorithm>
+  #include <iterator>
+  #include <cstddef>
+  #include <iostream>
+  #include <sycl/sycl.hpp>
 
   template <typename It>
   class strided_iterator

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -263,6 +263,7 @@ user defined iterator. It also shows a more complex example where the customizat
 the iterator class.
 
 .. code:: cpp
+
   namespace usr
   {
       struct accessible_it

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -39,7 +39,7 @@ Iterators and iterator-like types may or may not refer to content accessible wit
 *indirectly device accessible* refers to a type that represents content accessible on a device. An indirectly device
 accessible iterator is such a type that can also be dereferenced within a SYCL kernel.
 
-When passed to oneDPL algorithms with a device_policy, using indirectly device accessible types will minimize data
+When passed to |onedpl_short| algorithms with a device_policy, using indirectly device accessible types will minimize data
 movement and should be equivalent to using the type directly within a SYCL kernel. For iterator types, you must also
 ensure that the iterator type is `SYCL device-copyable`_ when using a device policy.
 
@@ -83,7 +83,7 @@ to explicitly control which access mode should be applied to a particular buffer
 a SYCL kernel to a device:
 
 The return types of the ``begin`` and ``end`` functions are
-`indirectly device accessible <_indirectly-device-accessible>`_.
+`indirectly device accessible <indirectly-device-accessible>`_.
 
 .. code:: cpp
 
@@ -149,7 +149,7 @@ When using device USM, such as allocated by ``malloc_device``, you are responsib
 transfers to and from the device to ensure that input data is device accessible during oneDPL
 algorithm execution and that the result is available to the subsequent operations.
 
-USM shared and device pointers are `indirectly device accessible <_indirectly-device-accessible>`_.
+USM shared and device pointers are `indirectly device accessible <indirectly-device-accessible>`_.
 
 .. _use-std-vector:
 
@@ -216,7 +216,7 @@ Make sure that the allocator and the execution policy use the same SYCL queue:
     return 0;
   }
 
-Iterators to ``std::vector`` are `indirectly device accessible <_indirectly-device-accessible>`_ if and only if a 
+Iterators to ``std::vector`` are `indirectly device accessible <indirectly-device-accessible>`_ if and only if a 
 ``sycl::usm_allocator`` is used. For ``std::vector`` with a USM allocator we recommend to use ``std::vector::data()`` in
 combination with ``std::vector::size()`` as shown in the example above, rather than iterators to
 ``std::vector``. That is because for some implementations of the C++ Standard Library it might not
@@ -229,10 +229,10 @@ Retrieving USM pointers from ``std::vector`` as shown guarantees no unintended c
 Use Iterators
 -------------
 
-oneDPL provides a set of `iterators <_iterators-details>`_ that can be used to pass data to algorithms in combination with
-the data described above. They generally hold the characteristics of the iterator type they wrap. Look to their
-descriptions for the details of their use, specifically with regard to their indirect device accessibility and sycl 
-device copyability when using device policies.
+|onedpl_short| provides a set of `iterators <iterators-details>`_ that can be used to pass data to algorithms in
+combination with the data described above. They generally hold the characteristics of the iterator type they wrap. Look
+to their descriptions for the details of their use, specifically with regard to their indirect device accessibility and
+sycl device copyability when using device policies.
 
 .. _use-range-views:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -236,7 +236,7 @@ These properties of the |onedpl_short| iterators are described in `this table <i
 
 Use Custom Iterators
 --------------------
-If the provided iterators are sufficient for your needs, you can create your own iterators that can be used as input
+If the provided iterators are not sufficient for your needs, you can create your own iterators that can be used as input
 to |onedpl_short| algorithms. To pass data to an algorithm with a device execution policy, the custom iterator must
 be `SYCL device-copyable`_ and indirectly device accessible. 
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -32,32 +32,6 @@ with parallel execution policies.
 
 The following subsections describe proper ways to pass data to an algorithm invoked with a device execution policy.
 
-.. _indirectly-device-accessible:
-
-Indirectly Device Accessible
-----------------------------
-Iterators and iterator-like types may or may not refer to content accessible within a
-`SYCL <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html>`_ kernel on a device. The term
-*indirectly device accessible* refers to a type that represents content accessible on a device. An indirectly device
-accessible iterator is a type that can also be dereferenced within a SYCL kernel.
-
-When passed to |onedpl_short| algorithms with a device execution policy, indirectly device accessible types minimize
-data movement and behave equivalently to using the type directly within a SYCL kernel.
-
-The following class template and variable template are defined in ``<oneapi/dpl/iterator>`` inside the namespace
-``oneapi::dpl`` :
-
-.. code:: cpp
-  template <typename T>
-  struct is_indirectly_device_accessible{ /* see below */ };
-
-  template <typename T>
-  inline constexpr bool is_indirectly_device_accessible_v = is_indirectly_device_accessible<T>::value;
-
-``template <typename T> oneapi::dpl::is_indirectly_device_accessible`` is a template which has the base characteristic
-of ``std::true_type`` if ``T`` is indirectly device accessible. Otherwise, it has the base characteristic of
-``std::false_type``.
-
 .. _use-buffer-wrappers:
 
 Use oneapi::dpl::begin and oneapi::dpl::end Functions
@@ -77,9 +51,6 @@ a `SYCL buffer`_ and return an object of an unspecified type that provides the f
 The ``begin`` and ``end`` functions can take SYCL 2020 deduction tags and ``sycl::no_init`` as arguments
 to explicitly control which access mode should be applied to a particular buffer when submitting
 a SYCL kernel to a device:
-
-The return types of the ``begin`` and ``end`` functions are
-`indirectly device accessible <indirectly-device-accessible>`_.
 
 .. code:: cpp
 
@@ -144,8 +115,6 @@ the USM allocation use the same SYCL queue. For example:
 When using device USM, such as allocated by ``malloc_device``, you are responsible for data
 transfers to and from the device to ensure that input data is device accessible during oneDPL
 algorithm execution and that the result is available to the subsequent operations.
-
-USM shared and device pointers are `indirectly device accessible <indirectly-device-accessible>`_.
 
 .. _use-std-vector:
 
@@ -212,8 +181,7 @@ Make sure that the allocator and the execution policy use the same SYCL queue:
     return 0;
   }
 
-Iterators to ``std::vector`` are `indirectly device accessible <indirectly-device-accessible>`_ if and only if a 
-``sycl::usm_allocator`` is used. For ``std::vector`` with a USM allocator we recommend to use ``std::vector::data()`` in
+For ``std::vector`` with a USM allocator we recommend to use ``std::vector::data()`` in
 combination with ``std::vector::size()`` as shown in the example above, rather than iterators to
 ``std::vector``. That is because for some implementations of the C++ Standard Library it might not
 be possible for |onedpl_short| to detect that iterators are pointing to USM-allocated data. In that
@@ -272,88 +240,146 @@ data transformation pipelines that also can be used with parallel range algorith
 Use |onedpl_short| Iterators
 ----------------------------
 
-|onedpl_short| provides a set of `iterators <iterators-details>`_ that can be used to pass data to algorithms, in
-combination with the iterators described above and with the return of ``oneapi::dpl::begin()`` and
-``oneapi::dpl::end()``. To pass data to an algorithm with a device execution policy with minimum data movement, use
-iterators that are both `SYCL device-copyable`_ and `indirectly device accessible <indirectly-device-accessible>`_.
-These properties of the |onedpl_short| iterators are described in `this table <iterator-properties-table>`_.
+You can use iterators defined in ``<oneapi/dpl/iterator>`` header in the ``oneapi::dpl`` namespace:
+
+- ``counting_iterator``
+- ``zip_iterator``
+- ``transform_iterator``
+- ``discard_iterator``
+- ``permutation_iterator``
+
+:ref:`Iterators <iterator-details>` section describes them in detail and provides usage examples.
+
+If you want to use these iterators in combination with your own custom iterators,
+make sure to follow the guidelines in the :ref:`Use Custom Iterators <use-custom-iterators>` section.
+
+.. _use-custom-iterators:
 
 Use Custom Iterators
 --------------------
-If the provided iterators are not sufficient for your needs, you can create your own iterators that can be used as input
-to |onedpl_short| algorithms. To pass data efficiently to an algorithm with a device execution policy, the custom
-iterator must be SYCL device-copyable and indirectly device accessible. If a custom iterator is *not* defined to be
-indirectly device accessible, the algorithm will create a temporary SYCL buffer to copy the data from the iterator to
-the device. This may lead to performance degradation, and also requires that the data be accessible on the host to be
-copied into the temporary SYCL buffer.
 
-You may customize your own iterator type ``T`` to define its indirectly device accessible property by defining a free
-function ``is_onedpl_indirectly_device_accessible(T)``, which returns a type with the base characteristic of
-``std::true_type`` if ``T`` is indirectly device accessible. Otherwise, it returns a type with the base characteristic
-of ``std::false_type``. The function must be discoverable by argument-dependent lookup (ADL). It may be provided as a
-forward declaration only, without defining a body.
+You can create your own iterators that can be used as input to |onedpl_short| algorithms.
 
-The return type of ``is_onedpl_indirectly_device_accessible`` is examined at compile time to determine if ``T`` is
-indirectly device accessible. The function overload to use must be selected with argument-dependent lookup.
+These custom iterators must meet the following requirements:
+
+- They must be random access iterators.
+- They must be SYCL device-copyable.
+- They must be *indirectly device accessible* if they point to data that is accessible on a device.
 
 .. note::
-  Therefore, according to the rules in the C++ Standard, a derived type for which there is no function overload
-  will match its most specific base type for which an overload exists.
+  If a custom iterator is **not** *indirectly device accessible*,
+  the algorithm will create a temporary memory buffer and
+  copy the data from the iterator to this buffer before processing on a device.
+  This may lead to performance degradation, and also requires that the data be accessible on the host to be
+  copied into the temporary memory buffer.
 
-Once ``is_onedpl_indirectly_device_accessible(T)`` is defined, the `public trait <indirectly-device-accessible>`_
-``template<typename T> oneapi::dpl::is_indirectly_device_accessible[_v]`` will return the appropriate value. This public
-trait can also be used to define the return type of ``is_onedpl_indirectly_device_accessible(T)`` by applying it to any
-source iterator component types.
+The term *indirectly device accessible* means that the data referenced by the iterator
+can be accessed from within a SYCL kernel (that is, on a device).
+|onedpl_short| determines this by examining the return type of the free function
+``is_onedpl_indirectly_device_accessible(It)``, where ``It`` is the iterator type.
+If the return type is ``std::true_type``, the iterator is considered *indirectly device accessible*.
+This function is defined in ``<oneapi/dpl/iterator>`` in the ``oneapi::dpl`` namespace.
 
-The following example shows how to define a customization for the ``is_indirectly_device_accessible`` trait for a simple
-user defined iterator. It also shows a more complex example where the customization is defined as a hidden friend of
-the iterator class.
+To make a custom iterator *indirectly device accessible* (assume its type is ``It``),
+define an overload of ``is_onedpl_indirectly_device_accessible``
+that accepts an argument of type ``It`` and returns ``std::true_type``.
+This overload must be visible through argument-dependent lookup.
+If it is found, the trait ``oneapi::dpl::is_onedpl_indirectly_device_accessible_v<It>``,
+which is also defined in ``<oneapi/dpl/iterator>``, evaluates to ``true``.
+The example below shows how to define such an overload:
 
 .. code:: cpp
 
-  namespace usr
+  #include <iterator>
+  #include <cstddef>
+  #include <iostream>
+
+  #include <oneapi/dpl/execution>
+  #include <oneapi/dpl/iterator>
+  #include <oneapi/dpl/numeric>
+  #include <oneapi/dpl/algorithm>
+
+  template <typename It>
+  class strided_iterator
   {
-      struct accessible_it
-      {
-          /* user definition of an indirectly device accessible iterator */
-      };
+  public:
+      using value_type = typename std::iterator_traits<It>::value_type;
+      using difference_type = typename std::iterator_traits<It>::difference_type;
+      using iterator_category = std::random_access_iterator_tag;
+      using reference = typename std::iterator_traits<It>::reference;
+      using pointer = typename std::iterator_traits<It>::pointer;
 
-      std::true_type
-      is_onedpl_indirectly_device_accessible(accessible_it);
+      strided_iterator(It ptr, difference_type stride): ptr(ptr), stride(stride) {}
 
-      struct inaccessible_it
-      {
-          /* user definition of an iterator which is not indirectly device accessible */
-      };
+      reference operator*() const { return *ptr; }
+      pointer operator->() const { return ptr; }
+      reference operator[](difference_type n) const { return *(*this + n);}
 
-      // The following could be omitted, as returning std::false_type matches the default behavior.
-      std::false_type
-      is_onedpl_indirectly_device_accessible(inaccessible_it);
+      strided_iterator& operator++() { ptr += stride; return *this; }
+      strided_iterator& operator--() { ptr -= stride; return *this; }
+      strided_iterator& operator+=(difference_type n) { ptr += n * stride; return *this;}
+      strided_iterator& operator-=(difference_type n) { ptr -= n * stride; return *this; }
+      strided_iterator operator+(difference_type n) const { return strided_iterator(ptr + n * stride, stride);}
+      strided_iterator operator-(difference_type n) const { return strided_iterator(ptr - n * stride, stride); }
+      difference_type operator-(const strided_iterator& other) const {return (ptr - other.ptr) / stride; }
+
+      bool operator==(const strided_iterator& other) const { return ptr == other.ptr; }
+      bool operator!=(const strided_iterator& other) const { return ptr != other.ptr; }
+      bool operator<(const strided_iterator& other) const { return ptr < other.ptr; }
+      bool operator>(const strided_iterator& other) const { return ptr > other.ptr; }
+      bool operator<=(const strided_iterator& other) const { return ptr <= other.ptr; }
+      bool operator>=(const strided_iterator& other) const { return ptr >= other.ptr; }
+
+      // Another way to make this iterator indirectly device accessible
+      // friend oneapi::dpl::is_indirectly_device_accessible<It> is_onedpl_indirectly_device_accessible(strided_iterator) { return {}; }
+  private:
+      It ptr;
+      difference_type stride;
+  };
+
+  // Make strided_iterator indirectly device accessible when it wraps an indirectly device accessible type
+  template <typename It>
+  auto is_onedpl_indirectly_device_accessible(strided_iterator<It>) -> oneapi::dpl::is_indirectly_device_accessible<It>;
+
+  int main() {
+      sycl::queue q{};
+      const int n = 10;
+      int* d_head = sycl::malloc_device<int>(n, q);
+
+      // Fill the memory with values from 0 to 9
+      oneapi::dpl::copy(oneapi::dpl::execution::make_device_policy<class copy_kernel>(q),
+                        oneapi::dpl::counting_iterator<int>(0),
+                        oneapi::dpl::counting_iterator<int>(n),
+                        d_head);
+
+      // Reduce every second element, 5 elements in total: 0, 2, 4, 6, 8
+      strided_iterator<int*> stride2(d_head, 2);
+      auto res = oneapi::dpl::reduce(oneapi::dpl::execution::make_device_policy<class reduce_kernel>(q),
+                                     stride2, stride2 + 5);
+
+      // is_indirectly_device_accessible_v: 1
+      // result: 20
+      std::cout << "is_indirectly_device_accessible_v: "
+                << (oneapi::dpl::is_indirectly_device_accessible_v<strided_iterator<int*>>) << std::endl;
+      std::cout << "result: " << res << std::endl;
+
+      sycl::free(d_head, q);
+      return 0;
   }
 
-  static_assert(oneapi::dpl::is_indirectly_device_accessible<usr::accessible_it> == true);
-  static_assert(oneapi::dpl::is_indirectly_device_accessible<usr::inaccessible_it> == false);
+The example above uses ``oneapi::dpl::is_indirectly_device_accessible<It>``, where ``It`` is ``int*``.
+|onedpl_short| predefines an overload of
+``oneapi::dpl::is_indirectly_device_accessible<int*>`` that returns ``std::true_type``
+assuming that pointers refer to USM-allocated data.
+It also automatically treats the following entities as *indirectly device accessible*:
 
-  // Example with base iterators and ADL overload as a hidden friend
-  template <typename It1, typename It2>
-  struct it_pair
-   {
-        It1 first;
-        It2 second;
-        friend auto
-        is_onedpl_indirectly_device_accessible(it_pair) ->
-            std::conjunction<oneapi::dpl::is_indirectly_device_accessible<It1>,
-                             oneapi::dpl::is_indirectly_device_accessible<It2>>
-        {
-            return {};
-        }
-    };
+- Iterators to ``std::vector`` with a USM allocator.
+- ``counting_iterator`` and ``discard_iterator``.
+- ``zip_iterator``, ``transform_iterator``, and ``permutation_iterator``,
+  if their underlying iterators are *indirectly device accessible*.
 
-  static_assert(oneapi::dpl::is_indirectly_device_accessible<
-                                  it_pair<usr::accessible_it, usr::accessible_it>> == true);
-  static_assert(oneapi::dpl::is_indirectly_device_accessible<
-                                  it_pair<usr::accessible_it, usr::inaccessible_it>> == false);
-
+For more information, refer to the
+`Iterators section of oneDPL specification <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneDPL/source/parallel_api/iterators.html>`_.
 
 .. _`SYCL buffer`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:buffers
 .. _`SYCL device-copyable`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -39,9 +39,8 @@ Iterators and iterator-like types may or may not refer to content accessible wit
 *indirectly device accessible* refers to a type that represents content accessible on a device. An indirectly device
 accessible iterator is such a type that can also be dereferenced within a SYCL kernel.
 
-When passed to |onedpl_short| algorithms with a device_policy, using indirectly device accessible types will minimize data
-movement and should be equivalent to using the type directly within a SYCL kernel. For iterator types, you must also
-ensure that the iterator type is `SYCL device-copyable`_ when using a device policy.
+When passed to |onedpl_short| algorithms with a device_policy, indirectly device accessible types will minimize
+data movement and should be equivalent to using the type directly within a SYCL kernel.
 
 .. _indirectly-device-accessible-trait:
 
@@ -229,9 +228,10 @@ Use Iterators
 -------------
 
 |onedpl_short| provides a set of `iterators <iterators-details>`_ that can be used to pass data to algorithms in
-combination with the data described above. They generally hold the characteristics of the iterator type they wrap. Look
-to their descriptions for the details of their use, specifically with regard to their indirect device accessibility and
-sycl device copyability when using device policies.
+combination with the data described above. To pass data to an algorithm with a device execution policy, use
+iterators which are `SYCL device-copyable`_ and `indirectly device accessible <indirectly-device-accessible>`_. Each
+provided iterator's description contains for rules about their indirect device accessible and SYCL device-copyable
+properties.
 
 .. _use-range-views:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -1,3 +1,5 @@
+.. _pass-data-algorithms:
+
 Pass Data to Algorithms
 #######################
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -37,10 +37,10 @@ Indirectly Device Accessible
 Iterators and iterator-like types may or may not refer to content accessible within a
 `SYCL <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html>`_ kernel on a device. The term
 *indirectly device accessible* refers to a type that represents content accessible on a device. An indirectly device
-accessible iterator is such a type that can also be dereferenced within a SYCL kernel.
+accessible iterator is a type that can also be dereferenced within a SYCL kernel.
 
-When passed to |onedpl_short| algorithms with a device_policy, indirectly device accessible types will minimize
-data movement and should be equivalent to using the type directly within a SYCL kernel.
+When passed to |onedpl_short| algorithms with a device execution policy, indirectly device accessible types minimize
+data movement and behave equivalently to using the type directly within a SYCL kernel.
 
 .. _indirectly-device-accessible-trait:
 
@@ -227,11 +227,11 @@ Retrieving USM pointers from ``std::vector`` as shown guarantees no unintended c
 Use Iterators
 -------------
 
-|onedpl_short| provides a set of `iterators <iterators-details>`_ that can be used to pass data to algorithms in
-combination with the data described above. To pass data to an algorithm with a device execution policy, use
-iterators which are `SYCL device-copyable`_ and `indirectly device accessible <indirectly-device-accessible>`_. Each
-provided iterator's description contains for rules about their indirect device accessible and SYCL device-copyable
-properties.
+|onedpl_short| provides a set of `iterators <iterators-details>`_ that can be used to pass data to algorithms, in
+combination with the data storage types described above. To pass data to an algorithm with a device execution policy,
+use iterators that are both `SYCL device-copyable`_ and `indirectly device accessible <indirectly-device-accessible>`_.
+Each provided iterator's description includes information about its indirect device accessibility and SYCL
+device-copyable properties.
 
 .. _use-range-views:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -237,8 +237,10 @@ These properties of the |onedpl_short| iterators are described in `this table <i
 Use Custom Iterators
 --------------------
 If the provided iterators are not sufficient for your needs, you can create your own iterators that can be used as input
-to |onedpl_short| algorithms. To pass data to an algorithm with a device execution policy, the custom iterator must
-be `SYCL device-copyable`_ and indirectly device accessible. 
+to |onedpl_short| algorithms. To pass data efficiently to an algorithm with a device execution policy, the custom
+iterator must be `SYCL device-copyable`_ and indirectly device accessible. If a custom iterator is *not* defined to be
+indirectly device accessible, the algorithm will create a temporary SYCL buffer to copy the data from the iterator to
+the device. This may lead to performance degradation, and also requires that the data be accessible on the host.
 
 You may customize your own iterator type ``T`` to be indirectly device accessible by defining a free function
 ``is_onedpl_indirectly_device_accessible(T)``, which returns a type with the base characteristic of ``std::true_type``

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -61,7 +61,6 @@ The following class template and variable template are defined in ``<oneapi/dpl/
 of ``std::true_type`` if ``T`` is indirectly device accessible. Otherwise, it has the base characteristic of
 ``std::false_type``.
 
-
 .. _use-buffer-wrappers:
 
 Use oneapi::dpl::begin and oneapi::dpl::end Functions

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -374,6 +374,7 @@ assuming that pointers refer to USM-allocated data.
 It also automatically treats the following entities as *indirectly device accessible*:
 
 - Iterators to ``std::vector`` with a USM allocator.
+- Objects returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` functions. 
 - ``counting_iterator`` and ``discard_iterator``.
 - ``zip_iterator``, ``transform_iterator``, and ``permutation_iterator``,
   if their underlying iterators are *indirectly device accessible*.

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -374,7 +374,7 @@ assuming that pointers refer to USM-allocated data.
 It also automatically treats the following entities as *indirectly device accessible*:
 
 - Iterators to ``std::vector`` with a USM allocator.
-- Objects returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` functions. 
+- Objects returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` functions.
 - ``counting_iterator`` and ``discard_iterator``.
 - ``zip_iterator``, ``transform_iterator``, and ``permutation_iterator``,
   if their underlying iterators are *indirectly device accessible*.

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -232,8 +232,7 @@ Use |onedpl_short| Iterators
 |onedpl_short| provides a set of `iterators <iterators-details>`_ that can be used to pass data to algorithms, in
 combination with the data storage types described above. To pass data to an algorithm with a device execution policy,
 use iterators that are both `SYCL device-copyable`_ and `indirectly device accessible <indirectly-device-accessible>`_.
-Each provided iterator's description includes information about its indirect device accessibility and SYCL
-device-copyable properties.
+These properties of the |onedpl_short| iterators are described in `this table <iterator-properties-table>`_.
 
 Use Custom Iterators
 --------------------


### PR DESCRIPTION
Update iterators page from the oneDPL guide to provide information about indirectly device accessible.  
Mention public trait and ADL-based customization point.  Add details about mentioned iterators.
