### PR TITLE
[Draft] Relocate SYCL scan-by-segment to `pstl/hetero/dpcpp`

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -23,7 +23,7 @@
 #include "function.h"
 #include "by_segment_extension_defs.h"
 #include "../pstl/utils.h"
-#include "scan_by_segment_impl.h"
+#include "../pstl/hetero/algorithm_impl_hetero.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -27,7 +27,7 @@
 #include "../pstl/parallel_backend.h"
 #include "function.h"
 #include "../pstl/utils.h"
-#include "scan_by_segment_impl.h"
+#include "../pstl/hetero/algorithm_impl_hetero.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -31,7 +31,6 @@
 
 #include <cstddef> // std::nullptr_t
 #include <utility> // std::forward
-#include <cassert>
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -2167,7 +2167,8 @@ __pattern_scan_by_segment(__hetero_tag<_BackendTag>, _Policy&& __policy, _InputI
     using _IterValueType = typename std::iterator_traits<_InputIterator2>::value_type;
 
     // Currently, this pattern requires a known identity for the binary operator.
-    assert((unseq_backend::__has_known_identity<_Operator, _IterValueType>::value));
+    static_assert(unseq_backend::__has_known_identity<_Operator, _IterValueType>::value,
+                  "Calls to __pattern_scan_by_segment require a known identity for the provided binary operator");
     constexpr _IterValueType __identity = unseq_backend::__known_identity<_Operator, _IterValueType>;
 
     __bknd::__parallel_scan_by_segment<_Inclusive::value>(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -31,6 +31,7 @@
 
 #include <cstddef> // std::nullptr_t
 #include <utility> // std::forward
+#include <cassert>
 
 namespace oneapi
 {
@@ -2139,6 +2140,39 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
     return oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment(
         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __keys.all_view(), __values.all_view(),
         __out_keys.all_view(), __out_values.all_view(), __binary_pred, __binary_op);
+}
+
+template <typename _BackendTag, typename _Policy, typename _InputIterator1, typename _InputIterator2,
+          typename _OutputIterator, typename _T, typename _BinaryPredicate, typename _Operator, typename _Inclusive>
+_OutputIterator
+__pattern_scan_by_segment(__hetero_tag<_BackendTag>, _Policy&& __policy, _InputIterator1 __first1,
+                          _InputIterator1 __last1, _InputIterator2 __first2, _OutputIterator __result, _T __init,
+                          _BinaryPredicate __binary_pred, _Operator __binary_op, _Inclusive)
+{
+    const auto __n = std::distance(__first1, __last1);
+
+    // Check for empty element ranges
+    if (__n <= 0)
+        return __result;
+
+    namespace __bknd = oneapi::dpl::__par_backend_hetero;
+
+    auto __keep_keys = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, _InputIterator1>();
+    auto __key_buf = __keep_keys(__first1, __last1);
+    auto __keep_values = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, _InputIterator2>();
+    auto __value_buf = __keep_values(__first2, __first2 + __n);
+    auto __keep_value_outputs = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::write, _OutputIterator>();
+    auto __value_output_buf = __keep_value_outputs(__result, __result + __n);
+    using _IterValueType = typename std::iterator_traits<_InputIterator2>::value_type;
+
+    // Currently, this pattern requires a known identity for the binary operator.
+    assert((unseq_backend::__has_known_identity<_Operator, _IterValueType>::value));
+    constexpr _IterValueType __identity = unseq_backend::__known_identity<_Operator, _IterValueType>;
+
+    __bknd::__parallel_scan_by_segment<_Inclusive::value>(
+        _BackendTag{}, std::forward<_Policy>(__policy), __key_buf.all_view(), __value_buf.all_view(),
+        __value_output_buf.all_view(), __binary_pred, __binary_op, __init, __identity);
+    return __result + __n;
 }
 
 } // namespace __internal

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -2161,7 +2161,8 @@ __pattern_scan_by_segment(__hetero_tag<_BackendTag>, _Policy&& __policy, _InputI
     auto __key_buf = __keep_keys(__first1, __last1);
     auto __keep_values = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, _InputIterator2>();
     auto __value_buf = __keep_values(__first2, __first2 + __n);
-    auto __keep_value_outputs = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::write, _OutputIterator>();
+    auto __keep_value_outputs =
+        oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, _OutputIterator>();
     auto __value_output_buf = __keep_value_outputs(__result, __result + __n);
     using _IterValueType = typename std::iterator_traits<_InputIterator2>::value_type;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -42,6 +42,7 @@
 #include "parallel_backend_sycl_merge_sort.h"
 #include "parallel_backend_sycl_reduce_by_segment.h"
 #include "parallel_backend_sycl_reduce_then_scan.h"
+#include "parallel_backend_sycl_scan_by_segment.h"
 #include "execution_sycl_defs.h"
 #include "sycl_iterator.h"
 #include "unseq_backend_sycl.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -55,7 +55,7 @@
 #include "sycl_traits.h"
 
 #include "../../utils.h"
-#include "../../../internal/scan_by_segment_impl.h"
+#include "parallel_backend_sycl_scan_by_segment.h"
 
 namespace oneapi
 {


### PR DESCRIPTION
This addresses https://github.com/uxlfoundation/oneDPL/issues/2210.

The current SYCL implementation of the scan-by-segment algorithms is in the `internal` directory in the `oneapi::dpl::__par_backend_hetero` namespace. This does not align with our general architecture, so the implementation has been moved to `pstl/hetero/dpcpp/parallel_backend_sycl_scan_by_segment.h`. Furthermore, `__pattern_scan_by_segment` has been relocated to `pstl/hetero/algorithm_impl_hetero.h`.

Additionally, the following small tweaks are made:

- `::std` -> `std`
- A correction of an access mode in `__pattern_scan_by_segment`
- An added static assert