### PR TITLE
Using the same created `dpcpp` policy instance in tests

### DIFF
--- a/test/general/header_inclusion_order_async_0.pass.cpp
+++ b/test/general/header_inclusion_order_async_0.pass.cpp
@@ -23,7 +23,8 @@ main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
 
-    sycl::queue q = TestUtils::get_test_queue();
+    auto policy = TestUtils::dpcpp_policy();
+    sycl::queue q = policy.queue();
 
     constexpr std::size_t n = 100;
 
@@ -33,7 +34,7 @@ main()
     allocator alloc(q);
     std::vector<T, allocator> data(n, 1, alloc);
 
-    auto f = oneapi::dpl::experimental::reduce_async(TestUtils::make_device_policy(q), data.begin(), data.end());
+    auto f = oneapi::dpl::experimental::reduce_async(policy, data.begin(), data.end());
     f.wait();
 
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/general/header_inclusion_order_async_0.pass.cpp
+++ b/test/general/header_inclusion_order_async_0.pass.cpp
@@ -23,7 +23,7 @@ main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
 
-    auto policy = TestUtils::dpcpp_policy();
+    auto policy = TestUtils::get_dpcpp_test_policy();
     sycl::queue q = policy.queue();
 
     constexpr std::size_t n = 100;

--- a/test/general/header_inclusion_order_async_1.pass.cpp
+++ b/test/general/header_inclusion_order_async_1.pass.cpp
@@ -23,7 +23,8 @@ main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
 
-    sycl::queue q = TestUtils::get_test_queue();
+    auto policy = TestUtils::dpcpp_policy();
+    sycl::queue q = policy.queue();
 
     constexpr std::size_t n = 100;
 
@@ -33,7 +34,7 @@ main()
     allocator alloc(q);
     std::vector<T, allocator> data(n, 1, alloc);
 
-    auto f = oneapi::dpl::experimental::reduce_async(TestUtils::make_device_policy(q), data.begin(), data.end());
+    auto f = oneapi::dpl::experimental::reduce_async(policy, data.begin(), data.end());
     f.wait();
 
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/general/header_inclusion_order_async_1.pass.cpp
+++ b/test/general/header_inclusion_order_async_1.pass.cpp
@@ -23,7 +23,7 @@ main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
 
-    auto policy = TestUtils::dpcpp_policy();
+    auto policy = TestUtils::get_dpcpp_test_policy();
     sycl::queue q = policy.queue();
 
     constexpr std::size_t n = 100;

--- a/test/general/header_order_ranges_0.pass.cpp
+++ b/test/general/header_order_ranges_0.pass.cpp
@@ -27,7 +27,7 @@ main()
 {
 #if _ENABLE_RANGES_TESTING
     using namespace oneapi::dpl::experimental::ranges;
-    all_of(TestUtils::dpcpp_policy(), views::fill(-1, 10), [](auto i) { return i == -1;});
+    all_of(TestUtils::get_dpcpp_test_policy(), views::fill(-1, 10), [](auto i) { return i == -1;});
 #endif
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/general/header_order_ranges_0.pass.cpp
+++ b/test/general/header_order_ranges_0.pass.cpp
@@ -27,7 +27,7 @@ main()
 {
 #if _ENABLE_RANGES_TESTING
     using namespace oneapi::dpl::experimental::ranges;
-    all_of(TestUtils::default_dpcpp_policy, views::fill(-1, 10), [](auto i) { return i == -1;});
+    all_of(TestUtils::dpcpp_policy(), views::fill(-1, 10), [](auto i) { return i == -1;});
 #endif
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/general/header_order_ranges_1.pass.cpp
+++ b/test/general/header_order_ranges_1.pass.cpp
@@ -27,7 +27,7 @@ main()
 {
 #if _ENABLE_RANGES_TESTING
     using namespace oneapi::dpl::experimental::ranges;
-    all_of(TestUtils::dpcpp_policy(), views::fill(-1, 10), [](auto i) { return i == -1;});
+    all_of(TestUtils::get_dpcpp_test_policy(), views::fill(-1, 10), [](auto i) { return i == -1;});
 #endif
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/general/header_order_ranges_1.pass.cpp
+++ b/test/general/header_order_ranges_1.pass.cpp
@@ -27,7 +27,7 @@ main()
 {
 #if _ENABLE_RANGES_TESTING
     using namespace oneapi::dpl::experimental::ranges;
-    all_of(TestUtils::default_dpcpp_policy, views::fill(-1, 10), [](auto i) { return i == -1;});
+    all_of(TestUtils::dpcpp_policy(), views::fill(-1, 10), [](auto i) { return i == -1;});
 #endif
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -33,7 +33,7 @@ int main() {
     auto buf_begin = oneapi::dpl::begin(buf);
     auto buf_end = buf_begin + n;
 
-    const auto policy = TestUtils::dpcpp_policy();
+    const auto policy = TestUtils::get_dpcpp_test_policy();
     auto buf_begin_discard_write = oneapi::dpl::begin(buf, sycl::write_only, sycl::property::no_init{});
 
     ::std::fill(policy, buf_begin_discard_write, buf_begin_discard_write + n, 1);

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -33,7 +33,7 @@ int main() {
     auto buf_begin = oneapi::dpl::begin(buf);
     auto buf_end = buf_begin + n;
 
-    const auto policy = TestUtils::default_dpcpp_policy;
+    const auto policy = TestUtils::dpcpp_policy();
     auto buf_begin_discard_write = oneapi::dpl::begin(buf, sycl::write_only, sycl::property::no_init{});
 
     ::std::fill(policy, buf_begin_discard_write, buf_begin_discard_write + n, 1);

--- a/test/parallel_api/iterator/input_data_sweep_counting_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_counting_iter.pass.cpp
@@ -62,7 +62,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto policy = TestUtils::dpcpp_policy();
+    auto policy = TestUtils::get_dpcpp_test_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_counting_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_counting_iter.pass.cpp
@@ -62,9 +62,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto q = TestUtils::get_test_queue();
-
-    auto policy = TestUtils::make_new_policy<class Kernel1>(q);
+    auto policy = TestUtils::dpcpp_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_host_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_host_iter.pass.cpp
@@ -59,9 +59,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto q = TestUtils::get_test_queue();
-
-    auto policy = TestUtils::make_new_policy<class Kernel1>(q);
+    auto policy = TestUtils::dpcpp_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_host_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_host_iter.pass.cpp
@@ -59,7 +59,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto policy = TestUtils::dpcpp_policy();
+    auto policy = TestUtils::get_dpcpp_test_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -60,9 +60,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto q = TestUtils::get_test_queue();
-
-    auto policy = TestUtils::make_new_policy<class Kernel1>(q);
+    auto policy = TestUtils::dpcpp_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -60,7 +60,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto policy = TestUtils::dpcpp_policy();
+    auto policy = TestUtils::get_dpcpp_test_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
@@ -95,9 +95,7 @@ main()
 #if TEST_DPCPP_BACKEND_PRESENT
     constexpr size_t n = 10;
 
-    auto q = TestUtils::get_test_queue();
-
-    auto policy = TestUtils::make_new_policy<class Kernel1>(q);
+    auto policy = TestUtils::dpcpp_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
@@ -95,7 +95,7 @@ main()
 #if TEST_DPCPP_BACKEND_PRESENT
     constexpr size_t n = 10;
 
-    auto policy = TestUtils::dpcpp_policy();
+    auto policy = TestUtils::get_dpcpp_test_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_usm_device.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_device.pass.cpp
@@ -58,9 +58,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto q = TestUtils::get_test_queue();
-
-    auto policy = TestUtils::make_new_policy<class Kernel1>(q);
+    auto policy = TestUtils::dpcpp_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_usm_device.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_device.pass.cpp
@@ -58,7 +58,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto policy = TestUtils::dpcpp_policy();
+    auto policy = TestUtils::get_dpcpp_test_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_usm_shared.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_shared.pass.cpp
@@ -61,7 +61,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto policy = TestUtils::dpcpp_policy();
+    auto policy = TestUtils::get_dpcpp_test_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/input_data_sweep_usm_shared.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_shared.pass.cpp
@@ -61,9 +61,7 @@ main()
 
     constexpr size_t n = 10;
 
-    auto q = TestUtils::get_test_queue();
-
-    auto policy = TestUtils::make_new_policy<class Kernel1>(q);
+    auto policy = TestUtils::dpcpp_policy();
 
     auto policy1 = TestUtils::create_new_policy_idx<0>(policy);
     auto policy2 = TestUtils::create_new_policy_idx<1>(policy);

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -70,7 +70,7 @@ main()
               "Wrong result of std::distance<permutationIterator1, permutationIterator2)");
 
     std::vector<int> resultCopy(perm_size_result);
-    auto itCopiedDataEnd = dpl::copy(default_dpcpp_policy, permItBegin, permItEnd, resultCopy.begin());
+    auto itCopiedDataEnd = dpl::copy(TestUtils::dpcpp_policy(), permItBegin, permItEnd, resultCopy.begin());
     EXPECT_EQ(true, resultCopy.end() == itCopiedDataEnd, "Wrong result of dpl::copy");
 
     const std::vector<int> expectedCopy = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18};

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -70,7 +70,7 @@ main()
               "Wrong result of std::distance<permutationIterator1, permutationIterator2)");
 
     std::vector<int> resultCopy(perm_size_result);
-    auto itCopiedDataEnd = dpl::copy(TestUtils::dpcpp_policy(), permItBegin, permItEnd, resultCopy.begin());
+    auto itCopiedDataEnd = dpl::copy(TestUtils::get_dpcpp_test_policy(), permItBegin, permItEnd, resultCopy.begin());
     EXPECT_EQ(true, resultCopy.end() == itCopiedDataEnd, "Wrong result of dpl::copy");
 
     const std::vector<int> expectedCopy = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18};

--- a/test/parallel_api/ranges/adjacent_find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/adjacent_find_ranges_sycl.pass.cpp
@@ -40,7 +40,7 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(n));
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/adjacent_find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/adjacent_find_ranges_sycl.pass.cpp
@@ -40,7 +40,7 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/all_any_none_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/all_any_none_of_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));
 
-        auto exec1 = TestUtils::dpcpp_policy();
+        auto exec1 = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec1);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec1);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec1);

--- a/test/parallel_api/ranges/all_any_none_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/all_any_none_of_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));
 
-        auto exec1 = TestUtils::default_dpcpp_policy;
+        auto exec1 = TestUtils::dpcpp_policy();
         using Policy = decltype(exec1);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec1);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec1);

--- a/test/parallel_api/ranges/copy_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_if_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
 
     auto src = views::iota(0, max_n);
 
-    auto exec1 = TestUtils::dpcpp_policy();
+    auto exec1 = TestUtils::get_dpcpp_test_policy();
     using Policy = decltype(exec1);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec1);
     auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec1);

--- a/test/parallel_api/ranges/copy_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_if_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
 
     auto src = views::iota(0, max_n);
 
-    auto exec1 = TestUtils::default_dpcpp_policy;
+    auto exec1 = TestUtils::dpcpp_policy();
     using Policy = decltype(exec1);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec1);
     auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec1);

--- a/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
@@ -44,7 +44,7 @@ main()
         auto view = iota_view(0, max_n) | views::transform(lambda1);
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
@@ -44,7 +44,7 @@ main()
         auto view = iota_view(0, max_n) | views::transform(lambda1);
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = views::reverse(sv) | views::transform(lambda1);
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = views::reverse(sv) | views::transform(lambda1);
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/count_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/count_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
 
         auto view = views::all(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/count_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/count_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
 
         auto view = views::all(A);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/equal_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/equal_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
 
         auto view = views::all(A);
                           
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/equal_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/equal_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
 
         auto view = views::all(A);
                           
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -44,7 +44,7 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res1 = ranges::all_view<int, sycl::access::mode::write>(B1);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -44,8 +44,8 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res1 = ranges::all_view<int, sycl::access::mode::write>(B1);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 
         ranges::exclusive_scan(exec, A, view_res1, 100);

--- a/test/parallel_api/ranges/fill_generate_factory.pass.cpp
+++ b/test/parallel_api/ranges/fill_generate_factory.pass.cpp
@@ -52,7 +52,7 @@ main()
         sycl::buffer<int> A(expected1, sycl::range<1>(max_n));
         sycl::buffer<int> B(expected2, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/fill_generate_factory.pass.cpp
+++ b/test/parallel_api/ranges/fill_generate_factory.pass.cpp
@@ -52,7 +52,7 @@ main()
         sycl::buffer<int> A(expected1, sycl::range<1>(max_n));
         sycl::buffer<int> B(expected2, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
         auto view_a = all_view(A);
         auto view_b = all_view(B);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
         auto view_a = all_view(A);
         auto view_b = all_view(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
         auto view_a = all_view(A);
         auto view_b = all_view(B);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
         auto view_a = all_view(A);
         auto view_b = all_view(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
@@ -45,8 +45,8 @@ main()
 
         auto view = all_view(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
 
         res1 = find(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, val); //check passing all_view
         res1 = find(make_new_policy<new_kernel_name<Policy, 1>>(exec), A, val);    //check passing sycl::buffer directly

--- a/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
@@ -45,7 +45,7 @@ main()
 
         auto view = all_view(A);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
 
         res1 = find(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, val); //check passing all_view

--- a/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
@@ -40,7 +40,7 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
@@ -40,7 +40,7 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view_res1 = ranges::all_view<int, sycl::access::mode::write>(B1);
         auto view_res3 = ranges::all_view<int, sycl::access::mode::write>(B3);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -46,8 +46,8 @@ main()
         auto view_res1 = ranges::all_view<int, sycl::access::mode::write>(B1);
         auto view_res3 = ranges::all_view<int, sycl::access::mode::write>(B3);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
 

--- a/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);

--- a/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
@@ -41,8 +41,8 @@ main()
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
 

--- a/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
@@ -42,7 +42,7 @@ main()
 
         auto view  = all_view(A);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 

--- a/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
@@ -42,8 +42,8 @@ main()
 
         auto view  = all_view(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 
         res1 = is_sorted_until(exec, view);

--- a/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
@@ -47,7 +47,7 @@ main()
         sycl::buffer<T> D(out1, sycl::range<1>(out_n));
         sycl::buffer<T> E(out2, sycl::range<1>(out_n));
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
 
         merge(exec, all_view(A), all_view(B), all_view<T, sycl::access::mode::write>(D));
         merge(TestUtils::make_device_policy<class merge_2>(exec), A, B, E, ::std::less<T>()); //check passing sycl buffers directly

--- a/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
@@ -47,7 +47,7 @@ main()
         sycl::buffer<T> D(out1, sycl::range<1>(out_n));
         sycl::buffer<T> E(out2, sycl::range<1>(out_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
 
         merge(exec, all_view(A), all_view(B), all_view<T, sycl::access::mode::write>(D));
         merge(TestUtils::make_device_policy<class merge_2>(exec), A, B, E, ::std::less<T>()); //check passing sycl buffers directly

--- a/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
@@ -47,8 +47,8 @@ main()
 
         auto view = all_view(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
         auto exec4 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 4>>(exec);

--- a/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
@@ -47,7 +47,7 @@ main()
 
         auto view = all_view(A);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);

--- a/test/parallel_api/ranges/move_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/move_ranges_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
 
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/move_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/move_ranges_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
 
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
@@ -44,7 +44,7 @@ main()
     using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
 
-    auto exec = TestUtils::default_dpcpp_policy;
+    auto exec = TestUtils::dpcpp_policy();
 
     [[maybe_unused]] auto res = reduce_by_segment(exec, views::all_read(A), views::all_read(B),
                                                   views::all_write(C), views::all_write(D));

--- a/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
@@ -44,7 +44,7 @@ main()
     using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
 
-    auto exec = TestUtils::dpcpp_policy();
+    auto exec = TestUtils::get_dpcpp_test_policy();
 
     [[maybe_unused]] auto res = reduce_by_segment(exec, views::all_read(A), views::all_read(B),
                                                   views::all_write(C), views::all_write(D));

--- a/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
@@ -39,8 +39,8 @@ main()
 
         auto view = all_view<int, sycl::access::mode::read>(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
 

--- a/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
 
         auto view = all_view<int, sycl::access::mode::read>(A);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);

--- a/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
     {
         sycl::buffer<T> A(in.data(), sycl::range<1>(in.size()));
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
     {
         sycl::buffer<T> A(in.data(), sycl::range<1>(in.size()));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
     {
         sycl::buffer<T> A(in.data(), sycl::range<1>(in.size()));
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
     {
         sycl::buffer<T> A(in.data(), sycl::range<1>(in.size()));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/replace_copy_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_copy_if_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::iota(0, max_n);
-    auto res = replace_copy_if(TestUtils::default_dpcpp_policy, src, A, pred, new_val);
+    auto res = replace_copy_if(TestUtils::dpcpp_policy(), src, A, pred, new_val);
 
     //check result
     int expected[max_n];

--- a/test/parallel_api/ranges/replace_copy_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_copy_if_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::iota(0, max_n);
-    auto res = replace_copy_if(TestUtils::dpcpp_policy(), src, A, pred, new_val);
+    auto res = replace_copy_if(TestUtils::get_dpcpp_test_policy(), src, A, pred, new_val);
 
     //check result
     int expected[max_n];

--- a/test/parallel_api/ranges/replace_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_copy_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::fill(old_val, max_n);
-    auto res = replace_copy(TestUtils::default_dpcpp_policy, src, A, old_val, new_val);
+    auto res = replace_copy(TestUtils::dpcpp_policy(), src, A, old_val, new_val);
 
     //check result
     EXPECT_TRUE(res == max_n, "wrong result from replace_copy");

--- a/test/parallel_api/ranges/replace_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_copy_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::fill(old_val, max_n);
-    auto res = replace_copy(TestUtils::dpcpp_policy(), src, A, old_val, new_val);
+    auto res = replace_copy(TestUtils::get_dpcpp_test_policy(), src, A, old_val, new_val);
 
     //check result
     EXPECT_TRUE(res == max_n, "wrong result from replace_copy");

--- a/test/parallel_api/ranges/replace_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
 
         auto view = views::all(A);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/replace_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
 
         auto view = views::all(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/reverse_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reverse_copy_ranges_sycl.pass.cpp
@@ -37,7 +37,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::iota(0, max_n);
-    auto res = reverse_copy(TestUtils::dpcpp_policy(), src, A);
+    auto res = reverse_copy(TestUtils::get_dpcpp_test_policy(), src, A);
 
     //check result
     EXPECT_TRUE(res == max_n, "wrong result from reverse_copy");

--- a/test/parallel_api/ranges/reverse_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reverse_copy_ranges_sycl.pass.cpp
@@ -37,7 +37,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::iota(0, max_n);
-    auto res = reverse_copy(TestUtils::default_dpcpp_policy, src, A);
+    auto res = reverse_copy(TestUtils::dpcpp_policy(), src, A);
 
     //check result
     EXPECT_TRUE(res == max_n, "wrong result from reverse_copy");

--- a/test/parallel_api/ranges/reverse_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reverse_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     auto iota = views::iota(0, max_n);
     //the name nano::ranges::copy is not injected into oneapi::dpl::experimental::ranges namespace
     __nanorange::nano::ranges::copy(iota, views::host_all(A).begin());
-    reverse(TestUtils::dpcpp_policy(), A);
+    reverse(TestUtils::get_dpcpp_test_policy(), A);
 
     for(auto v: views::host_all(A))
         ::std::cout << v << " ";

--- a/test/parallel_api/ranges/reverse_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reverse_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     auto iota = views::iota(0, max_n);
     //the name nano::ranges::copy is not injected into oneapi::dpl::experimental::ranges namespace
     __nanorange::nano::ranges::copy(iota, views::host_all(A).begin());
-    reverse(TestUtils::default_dpcpp_policy, A);
+    reverse(TestUtils::dpcpp_policy(), A);
 
     for(auto v: views::host_all(A))
         ::std::cout << v << " ";

--- a/test/parallel_api/ranges/rotate_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/rotate_copy_ranges_sycl.pass.cpp
@@ -38,7 +38,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::iota(0, max_n);
-    auto res = rotate_copy(TestUtils::default_dpcpp_policy, src, rotate_val, A);
+    auto res = rotate_copy(TestUtils::dpcpp_policy(), src, rotate_val, A);
 
     //check result
     EXPECT_TRUE(res == max_n, "wrong result from rotate_copy");

--- a/test/parallel_api/ranges/rotate_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/rotate_copy_ranges_sycl.pass.cpp
@@ -38,7 +38,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::iota(0, max_n);
-    auto res = rotate_copy(TestUtils::dpcpp_policy(), src, rotate_val, A);
+    auto res = rotate_copy(TestUtils::get_dpcpp_test_policy(), src, rotate_val, A);
 
     //check result
     EXPECT_TRUE(res == max_n, "wrong result from rotate_copy");

--- a/test/parallel_api/ranges/rotate_view_sycl.pass.cpp
+++ b/test/parallel_api/ranges/rotate_view_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
         sycl::buffer<int> B(expected, sycl::range<1>(max_n));
-        ranges::copy(TestUtils::default_dpcpp_policy, 
+        ranges::copy(TestUtils::dpcpp_policy(), 
                      ranges::views::all_read(A) | ranges::views::rotate(rotate_val), ranges::views::all_write(B));
     }
 

--- a/test/parallel_api/ranges/rotate_view_sycl.pass.cpp
+++ b/test/parallel_api/ranges/rotate_view_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
         sycl::buffer<int> B(expected, sycl::range<1>(max_n));
-        ranges::copy(TestUtils::dpcpp_policy(), 
+        ranges::copy(TestUtils::get_dpcpp_test_policy(), 
                      ranges::views::all_read(A) | ranges::views::rotate(rotate_val), ranges::views::all_write(B));
     }
 

--- a/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
 
         auto view_a = all_view(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
 
         auto view_a = all_view(A);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
@@ -47,7 +47,7 @@ main()
         auto view_a = all_view(A);
         auto view_b = all_view(B);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
 
         res1 = search(exec, A, view_b);

--- a/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
@@ -47,8 +47,8 @@ main()
         auto view_a = all_view(A);
         auto view_b = all_view(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
 
         res1 = search(exec, A, view_b);
         res2 = search(make_new_policy<new_kernel_name<Policy, 0>>(exec), view_a, B, [](auto a, auto b) { return a == b; });

--- a/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
@@ -40,7 +40,7 @@ main()
     using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
 
-    auto exec = TestUtils::dpcpp_policy();
+    auto exec = TestUtils::get_dpcpp_test_policy();
     using Policy = decltype(exec);
     {
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));

--- a/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
@@ -40,8 +40,8 @@ main()
     using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
 
-    auto exec = TestUtils::default_dpcpp_policy;
-    using Policy = decltype(TestUtils::default_dpcpp_policy);
+    auto exec = TestUtils::dpcpp_policy();
+    using Policy = decltype(exec);
     {
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));

--- a/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
@@ -38,7 +38,7 @@ main()
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 

--- a/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
@@ -38,8 +38,8 @@ main()
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 
         stable_sort(exec, A); //check passing sycl buffer directly

--- a/test/parallel_api/ranges/std_ranges_mismatch_unsized.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_mismatch_unsized.pass.cpp
@@ -55,7 +55,7 @@ main()
     }
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    auto exec = dpcpp_policy();
+    auto exec = TestUtils::dpcpp_policy();
     {
     auto [res1, res2] = dpl_ranges::mismatch(exec, view1, view2, binary_pred, proj, proj);
     EXPECT_TRUE(ex_res1 == res1, err_msg);

--- a/test/parallel_api/ranges/std_ranges_mismatch_unsized.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_mismatch_unsized.pass.cpp
@@ -55,7 +55,7 @@ main()
     }
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    auto exec = TestUtils::dpcpp_policy();
+    auto exec = TestUtils::get_dpcpp_test_policy();
     {
     auto [res1, res2] = dpl_ranges::mismatch(exec, view1, view2, binary_pred, proj, proj);
     EXPECT_TRUE(ex_res1 == res1, err_msg);

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -57,12 +57,10 @@ inline constexpr std::array<int, 2> big_sz = {/*serial*/ small_size, /*par*/ med
 #endif
 
 #if TEST_DPCPP_BACKEND_PRESENT
-template<int call_id = 0>
+template<typename PolicyName = class TestPolicyName, int call_id = 0>
 auto dpcpp_policy()
 {
-    auto exec = TestUtils::default_dpcpp_policy;
-    using Policy = decltype(exec);
-    return TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, call_id>>(TestUtils::default_dpcpp_policy);
+    return TestUtils::make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(TestUtils::get_test_queue());
 }
 #endif //TEST_DPCPP_BACKEND_PRESENT
 

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -614,7 +614,7 @@ struct test_range_algo
     {
         test<T, host_subrange<T>, mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, view, std::identity{}, args...);
 #if TEST_DPCPP_BACKEND_PRESENT
-        test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(n_device, TestUtils::dpcpp_policy<class Test, call_id>(), algo, checker, view, std::identity{}, args...);
+        test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id>(), algo, checker, view, std::identity{}, args...);
 #endif //TEST_DPCPP_BACKEND_PRESENT
     }
 
@@ -650,14 +650,14 @@ struct test_range_algo
 #endif
             {
                 test<T, usm_vector<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, TestUtils::dpcpp_policy<class Test, call_id + 10>(), algo, checker, subrange_view, subrange_view, args...);
+                    n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id + 10>(), algo, checker, subrange_view, subrange_view, args...);
                 test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, TestUtils::dpcpp_policy<class Test, call_id + 30>(), algo, checker, std::identity{}, std::identity{}, args...);
+                    n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id + 30>(), algo, checker, std::identity{}, std::identity{}, args...);
 #if TEST_CPP20_SPAN_PRESENT
                 test<T, usm_vector<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, TestUtils::dpcpp_policy<class Test, call_id + 20>(), algo, checker, span_view, subrange_view, args...);
+                    n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id + 20>(), algo, checker, span_view, subrange_view, args...);
                 test<T, usm_span<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, TestUtils::dpcpp_policy<class Test, call_id + 40>(), algo, checker, std::identity{}, std::identity{}, args...);
+                    n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id + 40>(), algo, checker, std::identity{}, std::identity{}, args...);
 #endif
             }
         }

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -622,7 +622,7 @@ struct test_range_algo
     {
         test<T, host_subrange<T>, mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, view, std::identity{}, args...);
 #if TEST_DPCPP_BACKEND_PRESENT
-        test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(n_device, dpcpp_policy<call_id>(), algo, checker, view, std::identity{}, args...);
+        test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(n_device, dpcpp_policy<class Test, call_id>(), algo, checker, view, std::identity{}, args...);
 #endif //TEST_DPCPP_BACKEND_PRESENT
     }
 
@@ -658,14 +658,14 @@ struct test_range_algo
 #endif
             {
                 test<T, usm_vector<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, dpcpp_policy<call_id + 10>(), algo, checker, subrange_view, subrange_view, args...);
+                    n_device, dpcpp_policy<class Test, call_id + 10>(), algo, checker, subrange_view, subrange_view, args...);
                 test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, dpcpp_policy<call_id + 30>(), algo, checker, std::identity{}, std::identity{}, args...);
+                    n_device, dpcpp_policy<class Test, call_id + 30>(), algo, checker, std::identity{}, std::identity{}, args...);
 #if TEST_CPP20_SPAN_PRESENT
                 test<T, usm_vector<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, dpcpp_policy<call_id + 20>(), algo, checker, span_view, subrange_view, args...);
+                    n_device, dpcpp_policy<class Test, call_id + 20>(), algo, checker, span_view, subrange_view, args...);
                 test<T, usm_span<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, dpcpp_policy<call_id + 40>(), algo, checker, std::identity{}, std::identity{}, args...);
+                    n_device, dpcpp_policy<class Test, call_id + 40>(), algo, checker, std::identity{}, std::identity{}, args...);
 #endif
             }
         }

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -614,7 +614,7 @@ struct test_range_algo
     {
         test<T, host_subrange<T>, mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, view, std::identity{}, args...);
 #if TEST_DPCPP_BACKEND_PRESENT
-        test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id>(), algo, checker, view, std::identity{}, args...);
+        test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(n_device, TestUtils::get_dpcpp_test_policy<call_id>(), algo, checker, view, std::identity{}, args...);
 #endif //TEST_DPCPP_BACKEND_PRESENT
     }
 
@@ -650,14 +650,14 @@ struct test_range_algo
 #endif
             {
                 test<T, usm_vector<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id + 10>(), algo, checker, subrange_view, subrange_view, args...);
+                    n_device, TestUtils::get_dpcpp_test_policy<call_id + 10>(), algo, checker, subrange_view, subrange_view, args...);
                 test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id + 30>(), algo, checker, std::identity{}, std::identity{}, args...);
+                    n_device, TestUtils::get_dpcpp_test_policy<call_id + 30>(), algo, checker, std::identity{}, std::identity{}, args...);
 #if TEST_CPP20_SPAN_PRESENT
                 test<T, usm_vector<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id + 20>(), algo, checker, span_view, subrange_view, args...);
+                    n_device, TestUtils::get_dpcpp_test_policy<call_id + 20>(), algo, checker, span_view, subrange_view, args...);
                 test<T, usm_span<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, TestUtils::get_dpcpp_test_policy<class Test, call_id + 40>(), algo, checker, std::identity{}, std::identity{}, args...);
+                    n_device, TestUtils::get_dpcpp_test_policy<call_id + 40>(), algo, checker, std::identity{}, std::identity{}, args...);
 #endif
             }
         }

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -56,14 +56,6 @@ inline constexpr std::array<int, 3> big_sz = {/*serial*/ small_size, /*par*/ med
 inline constexpr std::array<int, 2> big_sz = {/*serial*/ small_size, /*par*/ medium_size};
 #endif
 
-#if TEST_DPCPP_BACKEND_PRESENT
-template<typename PolicyName = class TestPolicyName, int call_id = 0>
-auto dpcpp_policy()
-{
-    return TestUtils::make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(TestUtils::get_test_queue());
-}
-#endif //TEST_DPCPP_BACKEND_PRESENT
-
 enum TestDataMode
 {
     data_in,
@@ -622,7 +614,7 @@ struct test_range_algo
     {
         test<T, host_subrange<T>, mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, view, std::identity{}, args...);
 #if TEST_DPCPP_BACKEND_PRESENT
-        test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(n_device, dpcpp_policy<class Test, call_id>(), algo, checker, view, std::identity{}, args...);
+        test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(n_device, TestUtils::dpcpp_policy<class Test, call_id>(), algo, checker, view, std::identity{}, args...);
 #endif //TEST_DPCPP_BACKEND_PRESENT
     }
 
@@ -658,14 +650,14 @@ struct test_range_algo
 #endif
             {
                 test<T, usm_vector<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, dpcpp_policy<class Test, call_id + 10>(), algo, checker, subrange_view, subrange_view, args...);
+                    n_device, TestUtils::dpcpp_policy<class Test, call_id + 10>(), algo, checker, subrange_view, subrange_view, args...);
                 test<T, usm_subrange<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, dpcpp_policy<class Test, call_id + 30>(), algo, checker, std::identity{}, std::identity{}, args...);
+                    n_device, TestUtils::dpcpp_policy<class Test, call_id + 30>(), algo, checker, std::identity{}, std::identity{}, args...);
 #if TEST_CPP20_SPAN_PRESENT
                 test<T, usm_vector<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, dpcpp_policy<class Test, call_id + 20>(), algo, checker, span_view, subrange_view, args...);
+                    n_device, TestUtils::dpcpp_policy<class Test, call_id + 20>(), algo, checker, span_view, subrange_view, args...);
                 test<T, usm_span<T>, mode, DataGen1, DataGen2>{}(
-                    n_device, dpcpp_policy<class Test, call_id + 40>(), algo, checker, std::identity{}, std::identity{}, args...);
+                    n_device, TestUtils::dpcpp_policy<class Test, call_id + 40>(), algo, checker, std::identity{}, std::identity{}, args...);
 #endif
             }
         }

--- a/test/parallel_api/ranges/std_ranges_transform_iota_sycl.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_transform_iota_sycl.pass.cpp
@@ -30,7 +30,7 @@ main()
     std::vector<int> src(n), expected(n);
     std::ranges::transform(view1, view2, expected.begin(), binary_f, proj, proj);
 
-    auto exec = TestUtils::dpcpp_policy();
+    auto exec = TestUtils::get_dpcpp_test_policy();
     using Policy = decltype(exec);
     auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/std_ranges_transform_iota_sycl.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_transform_iota_sycl.pass.cpp
@@ -30,7 +30,7 @@ main()
     std::vector<int> src(n), expected(n);
     std::ranges::transform(view1, view2, expected.begin(), binary_f, proj, proj);
 
-    auto exec = dpcpp_policy();
+    auto exec = TestUtils::dpcpp_policy();
     using Policy = decltype(exec);
     auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/swap_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/swap_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
         sycl::buffer<int> C(data3, sycl::range<1>(max_n_2));
         sycl::buffer<int> D(data4, sycl::range<1>(max_n));
                           
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/swap_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/swap_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
         sycl::buffer<int> C(data3, sycl::range<1>(max_n_2));
         sycl::buffer<int> D(data4, sycl::range<1>(max_n));
                           
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
@@ -45,7 +45,7 @@ main()
         auto view = oneapi::dpl::experimental::ranges::iota_view(0, max_n) | oneapi::dpl::experimental::ranges::views::transform(lambda1);
         auto range_res = oneapi::dpl::experimental::ranges::all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
@@ -45,7 +45,7 @@ main()
         auto view = oneapi::dpl::experimental::ranges::iota_view(0, max_n) | oneapi::dpl::experimental::ranges::views::transform(lambda1);
         auto range_res = oneapi::dpl::experimental::ranges::all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
@@ -45,7 +45,7 @@ main()
         auto view = oneapi::dpl::experimental::ranges::views::reverse(sv) | oneapi::dpl::experimental::ranges::views::transform(lambda1);
 
         auto range_res = oneapi::dpl::experimental::ranges::all_view<int, sycl::access::mode::write>(B);
-        oneapi::dpl::experimental::ranges::transform(TestUtils::dpcpp_policy(), view, view, range_res, lambda2);
+        oneapi::dpl::experimental::ranges::transform(TestUtils::get_dpcpp_test_policy(), view, view, range_res, lambda2);
     }
 
     //check result

--- a/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
@@ -45,7 +45,7 @@ main()
         auto view = oneapi::dpl::experimental::ranges::views::reverse(sv) | oneapi::dpl::experimental::ranges::views::transform(lambda1);
 
         auto range_res = oneapi::dpl::experimental::ranges::all_view<int, sycl::access::mode::write>(B);
-        oneapi::dpl::experimental::ranges::transform(TestUtils::default_dpcpp_policy, view, view, range_res, lambda2);
+        oneapi::dpl::experimental::ranges::transform(TestUtils::dpcpp_policy(), view, view, range_res, lambda2);
     }
 
     //check result

--- a/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res = ranges::all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res = ranges::all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res1 = ranges::all_view<int, sycl::access::mode::write>(B1);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 

--- a/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
@@ -46,8 +46,8 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res1 = ranges::all_view<int, sycl::access::mode::write>(B1);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
 
         ranges::transform_inclusive_scan(exec, A, view_res1, ::std::plus<int>(), lambda);

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = iota_view(0, max_n) | views::transform(lambda1);
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = iota_view(0, max_n) | views::transform(lambda1);
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = views::reverse(sv) | views::transform(lambda1);
 
         auto range_res = all_view<int, sycl::access::mode::write>(B);
-        transform(TestUtils::dpcpp_policy(), view, range_res, lambda2);
+        transform(TestUtils::get_dpcpp_test_policy(), view, range_res, lambda2);
     }
 
     //check result

--- a/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = views::reverse(sv) | views::transform(lambda1);
 
         auto range_res = all_view<int, sycl::access::mode::write>(B);
-        transform(TestUtils::default_dpcpp_policy, view, range_res, lambda2);
+        transform(TestUtils::dpcpp_policy(), view, range_res, lambda2);
     }
 
     //check result

--- a/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
@@ -40,8 +40,8 @@ main()
 
         auto view = oneapi::dpl::experimental::ranges::all_view<int, sycl::access::mode::read>(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::dpcpp_policy();
+        using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);
 

--- a/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
@@ -40,7 +40,7 @@ main()
 
         auto view = oneapi::dpl::experimental::ranges::all_view<int, sycl::access::mode::read>(A);
 
-        auto exec = TestUtils::dpcpp_policy();
+        auto exec = TestUtils::get_dpcpp_test_policy();
         using Policy = decltype(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 2>>(exec);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 3>>(exec);

--- a/test/parallel_api/ranges/unique_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/unique_copy_ranges_sycl.pass.cpp
@@ -35,7 +35,7 @@ main()
 
     auto is_equal = [](auto i, auto j) { return i == j; };
 
-    auto exec = TestUtils::default_dpcpp_policy;
+    auto exec = TestUtils::dpcpp_policy();
     using Policy = decltype(exec);
     auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/unique_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/unique_copy_ranges_sycl.pass.cpp
@@ -35,7 +35,7 @@ main()
 
     auto is_equal = [](auto i, auto j) { return i == j; };
 
-    auto exec = TestUtils::dpcpp_policy();
+    auto exec = TestUtils::get_dpcpp_test_policy();
     using Policy = decltype(exec);
     auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp
@@ -35,7 +35,7 @@ main()
 
     auto is_equal = [](auto i, auto j) { return i == j; };
 
-    auto exec = TestUtils::default_dpcpp_policy;
+    auto exec = TestUtils::dpcpp_policy();
     using Policy = decltype(exec);
     auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp
@@ -35,7 +35,7 @@ main()
 
     auto is_equal = [](auto i, auto j) { return i == j; };
 
-    auto exec = TestUtils::dpcpp_policy();
+    auto exec = TestUtils::get_dpcpp_test_policy();
     using Policy = decltype(exec);
     auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -201,6 +201,13 @@ inline void unsupported_types_notifier(const sycl::device& device)
 template <::std::size_t CallNumber = 0>
 struct invoke_on_all_hetero_policies
 {
+    sycl::queue queue;
+
+    invoke_on_all_hetero_policies(sycl::queue _queue = get_test_queue())
+        : queue(_queue)
+    {
+    }
+
     template <typename Op, typename... Args>
     void
     operator()(Op op, Args&&... rest)

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -118,7 +118,7 @@ make_new_policy(sycl::queue _queue)
 #endif
 }
 
-template <typename PolicyName = class TestPolicyName, int call_id = 0>
+template <int call_id = 0, typename PolicyName = class TestPolicyName>
 auto
 get_dpcpp_test_policy()
 {
@@ -220,8 +220,7 @@ struct invoke_on_all_hetero_policies
     void
     operator()(Op op, Args&&... rest)
     {
-        using kernel_name = unique_kernel_name<Op, CallNumber>;
-        auto my_policy = get_dpcpp_test_policy<kernel_name>();
+        auto my_policy = get_dpcpp_test_policy<CallNumber, Op>();
 
         sycl::queue queue = my_policy.queue();
 

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -20,6 +20,12 @@
 
 #include "iterator_utils.h"
 
+#ifdef ONEDPL_USE_PREDEFINED_POLICIES
+#  define TEST_USE_PREDEFINED_POLICIES ONEDPL_USE_PREDEFINED_POLICIES
+#else
+#  define TEST_USE_PREDEFINED_POLICIES 1
+#endif
+
 namespace TestUtils
 {
 #if TEST_DPCPP_BACKEND_PRESENT
@@ -112,10 +118,19 @@ make_new_policy(sycl::queue _queue)
 #endif
 }
 
-template<typename PolicyName = class TestPolicyName, int call_id = 0>
-auto get_dpcpp_test_policy(sycl::queue _queue = get_test_queue())
+template <typename PolicyName = class TestPolicyName, int call_id = 0>
+auto
+get_dpcpp_test_policy()
 {
-    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(_queue);
+#    if TEST_USE_PREDEFINED_POLICIES
+#        if ONEDPL_FPGA_DEVICE
+    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(oneapi::dpl::execution::dpcpp_fpga);
+#        else
+    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(oneapi::dpl::execution::dpcpp_default);
+#        endif // ONEDPL_FPGA_DEVICE
+#    else
+    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(get_test_queue());
+#    endif // TEST_USE_PREDEFINED_POLICIES
 }
 
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -222,7 +222,7 @@ struct invoke_on_all_hetero_policies
             // performs some checks that fail. As a workaround, define for functors which have this issue
             // __functor_type(see kernel_type definition) type field which doesn't have any pointers in it's name.
             using kernel_name = unique_kernel_name<Op, CallNumber>;
-            auto my_policy = make_new_policy<kernel_name>(queue);
+            auto my_policy = dpcpp_policy<kernel_name>();
             iterator_invoker<::std::random_access_iterator_tag, /*IsReverse*/ ::std::false_type>()(
                 my_policy, op, ::std::forward<Args>(rest)...);
         }

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -201,13 +201,6 @@ inline void unsupported_types_notifier(const sycl::device& device)
 template <::std::size_t CallNumber = 0>
 struct invoke_on_all_hetero_policies
 {
-    sycl::queue queue;
-
-    invoke_on_all_hetero_policies(sycl::queue _queue = get_test_queue())
-        : queue(_queue)
-    {
-    }
-
     template <typename Op, typename... Args>
     void
     operator()(Op op, Args&&... rest)

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -88,12 +88,6 @@ make_new_policy(_Policy&& __policy)
     return TestUtils::make_device_policy<_NewKernelName>(::std::forward<_Policy>(__policy));
 }
 
-template<typename PolicyName = class TestPolicyName, int call_id = 0>
-auto dpcpp_policy()
-{
-    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(get_test_queue());
-}
-
 #if ONEDPL_FPGA_DEVICE
 template <typename _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_Policy, int> = 0>
@@ -116,6 +110,12 @@ make_new_policy(sycl::queue _queue)
 #else
     return TestUtils::make_device_policy<KernelName>(_queue);
 #endif
+}
+
+template<typename PolicyName = class TestPolicyName, int call_id = 0>
+auto dpcpp_policy()
+{
+    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(get_test_queue());
 }
 
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -122,15 +122,20 @@ template <int call_id = 0, typename PolicyName = class TestPolicyName>
 auto
 get_dpcpp_test_policy()
 {
+    using _NewKernelName = TestUtils::new_kernel_name<PolicyName, call_id>;
+
+    const auto& __arg =
 #    if TEST_USE_PREDEFINED_POLICIES
 #        if ONEDPL_FPGA_DEVICE
-    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(oneapi::dpl::execution::dpcpp_fpga);
+        oneapi::dpl::execution::dpcpp_fpga;
 #        else
-    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(oneapi::dpl::execution::dpcpp_default);
+        oneapi::dpl::execution::dpcpp_default;
 #        endif // ONEDPL_FPGA_DEVICE
 #    else
-    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(get_test_queue());
+        get_test_queue();
 #    endif // TEST_USE_PREDEFINED_POLICIES
+
+    return TestUtils::make_new_policy<_NewKernelName>(__arg);
 }
 
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -24,6 +24,9 @@ namespace TestUtils
 {
 #if TEST_DPCPP_BACKEND_PRESENT
 
+// Implemented in utils_sycl.h, required to include this file.
+sycl::queue get_test_queue();
+
 template <sycl::usm::alloc alloc_type>
 constexpr ::std::size_t
 uniq_kernel_index()
@@ -85,6 +88,12 @@ make_new_policy(_Policy&& __policy)
     return TestUtils::make_device_policy<_NewKernelName>(::std::forward<_Policy>(__policy));
 }
 
+template<typename PolicyName = class TestPolicyName, int call_id = 0>
+auto dpcpp_policy()
+{
+    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(get_test_queue());
+}
+
 #if ONEDPL_FPGA_DEVICE
 template <typename _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_Policy, int> = 0>
@@ -139,9 +148,6 @@ struct invoke_on_all_host_policies
 };
 
 #if TEST_DPCPP_BACKEND_PRESENT
-
-// Implemented in utils_sycl.h, required to include this file.
-sycl::queue get_test_queue();
 
 ////////////////////////////////////////////////////////////////////////////////
 // check fp16/fp64 support by a device

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -113,9 +113,9 @@ make_new_policy(sycl::queue _queue)
 }
 
 template<typename PolicyName = class TestPolicyName, int call_id = 0>
-auto dpcpp_policy()
+auto dpcpp_policy(sycl::queue _queue = get_test_queue())
 {
-    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(get_test_queue());
+    return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(_queue);
 }
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
@@ -222,7 +222,7 @@ struct invoke_on_all_hetero_policies
             // performs some checks that fail. As a workaround, define for functors which have this issue
             // __functor_type(see kernel_type definition) type field which doesn't have any pointers in it's name.
             using kernel_name = unique_kernel_name<Op, CallNumber>;
-            auto my_policy = dpcpp_policy<kernel_name>();
+            auto my_policy = dpcpp_policy<kernel_name>(queue);
             iterator_invoker<::std::random_access_iterator_tag, /*IsReverse*/ ::std::false_type>()(
                 my_policy, op, ::std::forward<Args>(rest)...);
         }

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -113,7 +113,7 @@ make_new_policy(sycl::queue _queue)
 }
 
 template<typename PolicyName = class TestPolicyName, int call_id = 0>
-auto dpcpp_policy(sycl::queue _queue = get_test_queue())
+auto get_dpcpp_test_policy(sycl::queue _queue = get_test_queue())
 {
     return make_new_policy<TestUtils::new_kernel_name<PolicyName, call_id>>(_queue);
 }
@@ -222,7 +222,7 @@ struct invoke_on_all_hetero_policies
             // performs some checks that fail. As a workaround, define for functors which have this issue
             // __functor_type(see kernel_type definition) type field which doesn't have any pointers in it's name.
             using kernel_name = unique_kernel_name<Op, CallNumber>;
-            auto my_policy = dpcpp_policy<kernel_name>(queue);
+            auto my_policy = get_dpcpp_test_policy<kernel_name>(queue);
             iterator_invoker<::std::random_access_iterator_tag, /*IsReverse*/ ::std::false_type>()(
                 my_policy, op, ::std::forward<Args>(rest)...);
         }

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -455,7 +455,7 @@ test_default_name_gen(SortTestConfig config)
     TestUtils::Sequence<int> in({1, 0, 3, 2, 5, 4, 7, 6, 9, 8});
     TestUtils::Sequence<int> expected(in);
     TestUtils::Sequence<int> tmp(in);
-    auto my_policy = TestUtils::make_device_policy(TestUtils::get_test_queue());
+    auto my_policy = TestUtils::dpcpp_policy();
 
     TestUtils::iterator_invoker<std::random_access_iterator_tag, /*IsReverse*/ std::false_type>()(
         my_policy, test_sort_op<int>{config}, tmp.begin(), tmp.end(), expected.begin(), expected.end(),

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -455,7 +455,7 @@ test_default_name_gen(SortTestConfig config)
     TestUtils::Sequence<int> in({1, 0, 3, 2, 5, 4, 7, 6, 9, 8});
     TestUtils::Sequence<int> expected(in);
     TestUtils::Sequence<int> tmp(in);
-    auto my_policy = TestUtils::dpcpp_policy();
+    auto my_policy = TestUtils::get_dpcpp_test_policy();
 
     TestUtils::iterator_invoker<std::random_access_iterator_tag, /*IsReverse*/ std::false_type>()(
         my_policy, test_sort_op<int>{config}, tmp.begin(), tmp.end(), expected.begin(), expected.end(),

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -34,11 +34,6 @@
 #include "utils_invoke.h"
 #include "utils_test_base.h"
 
-#ifdef ONEDPL_USE_PREDEFINED_POLICIES
-#  define TEST_USE_PREDEFINED_POLICIES ONEDPL_USE_PREDEFINED_POLICIES
-#else
-#  define TEST_USE_PREDEFINED_POLICIES 1
-#endif
 #include _PSTL_TEST_HEADER(execution)
 
 namespace TestUtils

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -88,25 +88,12 @@ inline auto default_selector =
 #    else
         sycl::ext::intel::fpga_selector{};
 #    endif // ONEDPL_FPGA_EMULATOR
-
-inline auto&& default_dpcpp_policy =
-#    if TEST_USE_PREDEFINED_POLICIES
-        oneapi::dpl::execution::dpcpp_fpga;
-#    else
-        TestUtils::make_fpga_policy(sycl::queue{default_selector});
-#    endif
 #else
 inline auto default_selector =
 #    if TEST_LIBSYCL_VERSION >= 60000
         sycl::default_selector_v;
 #    else
         sycl::default_selector{};
-#    endif
-inline auto&& default_dpcpp_policy =
-#    if TEST_USE_PREDEFINED_POLICIES
-        oneapi::dpl::execution::dpcpp_default;
-#    else
-        TestUtils::make_device_policy(sycl::queue{default_selector});
 #    endif
 #endif     // ONEDPL_FPGA_DEVICE
 

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -112,22 +112,6 @@ sycl::queue get_test_queue()
     }
 }
 
-#if ONEDPL_FPGA_DEVICE
-inline auto&& default_dpcpp_policy =
-#    if TEST_USE_PREDEFINED_POLICIES
-        oneapi::dpl::execution::dpcpp_fpga;
-#    else
-        TestUtils::make_fpga_policy(get_test_queue());
-#    endif
-#else
-inline auto&& default_dpcpp_policy =
-#    if TEST_USE_PREDEFINED_POLICIES
-        oneapi::dpl::execution::dpcpp_default;
-#    else
-        TestUtils::make_device_policy(get_test_queue());
-#    endif
-#endif     // ONEDPL_FPGA_DEVICE
-
 template <sycl::usm::alloc alloc_type>
 constexpr bool
 required_test_sycl_buffer()


### PR DESCRIPTION
In this PR we replace `TestUtils::default_dpcpp_policy` inline variable by `TestUtils::get_dpcpp_test_policy()` function calls.

The `TestUtils::default_dpcpp_policy` inline variable has been deleted.

The goal - to make code more readable and to highlight that inside `get_dpcpp_test_policy()` function we have some logic which may return different policies for testing.