### PR TITLE
Fix Misc sycl traits; adding device_copyable to CI

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -195,8 +195,8 @@ jobs:
             done
 
             #set targets to just sycl iterator for dpcpp tests
-            make_targets="build-onedpl-sycl_iterator-tests build-onedpl-ranges-tests"
-            ctest_flags="-R (sycl_iterator_.*)|(std_ranges_.*)\.pass"
+            make_targets="build-onedpl-sycl_iterator-tests build-onedpl-ranges-tests build-onedpl-implementation_details-tests"
+            ctest_flags="-R (sycl_iterator_.*)|(std_ranges_.*)|(device_copyable)\.pass"
           else
             make_targets="build-onedpl-tests"
           fi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -444,6 +444,9 @@ struct __write_to_id_if_else;
 template <typename _BinaryPred>
 struct __write_red_by_seg;
 
+template <typename _Assign>
+struct __write_multiple_to_id;
+
 template <typename _Pred>
 struct __early_exit_find_or;
 
@@ -452,6 +455,12 @@ struct __leaf_sorter;
 
 template <typename _BinaryOp>
 struct __red_by_seg_op;
+
+template <typename _SetOpCount, typename _Compare>
+struct __gen_set_balanced_path;
+
+template <typename _SetOpCount, typename _TempData, typename _Compare>
+struct __gen_set_op_from_known_balanced_path;
 
 } // namespace oneapi::dpl::__par_backend_hetero
 
@@ -523,6 +532,13 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 
+template <typename _Assign>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_multiple_to_id,
+                                                       _Assign)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_Assign>
+{
+};
+
 template <typename _Pred>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__early_exit_find_or, _Pred)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Pred>
@@ -539,6 +555,20 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 template <typename _BinaryOp>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__red_by_seg_op, _BinaryOp)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryOp>
+{
+};
+
+template <typename _SetOpCount, typename _Compare>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path,
+                                                       _SetOpCount, _Compare)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_Compare>
+{
+};
+
+template <typename _SetOpCount, typename _TempData, typename _Compare>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
+    oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path, _SetOpCount, _TempData, _Compare)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_Compare>
 {
 };
 

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -190,6 +190,19 @@ test_device_copyable()
                       oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>>,
                   "__gen_expand_count_mask is not device copyable with device copyable types");
 
+    //__gen_set_balanced_path
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
+                      oneapi::dpl::__par_backend_hetero::__set_intersection,
+                      binary_op_device_copyable>>,
+                  "__gen_set_balanced_path is device copyable with non device copyable types");
+
+    //__gen_set_op_from_known_balanced_path
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
+                      oneapi::dpl::__par_backend_hetero::__set_intersection,
+                      oneapi::dpl::__par_backend_hetero::__noop_temp_data,
+                      binary_op_device_copyable>>,
+                  "__gen_set_op_from_known_balanced_path is device copyable with non device copyable types");
+
     //__write_to_id_if
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, assign_device_copyable>>,
@@ -204,6 +217,11 @@ test_device_copyable()
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_red_by_seg<binary_op_device_copyable>>,
         "__write_red_by_seg is not device copyable with device copyable types");
+
+    //__write_multiple_to_id
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__write_multiple_to_id<assign_device_copyable>>,
+                  "__write_multiple_to_id is not device copyable with device copyable types");
 
     // __early_exit_find_or
     static_assert(
@@ -282,12 +300,6 @@ test_device_copyable()
     //__is_heap_check
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__is_heap_check<noop_device_copyable>>,
                   "__is_heap_check is not device copyable with device copyable types");
-    //equal_predicate
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::equal_predicate<noop_device_copyable>>,
-                  "equal_predicate is not device copyable with device copyable types");
-    //adjacent_find_fn
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::adjacent_find_fn<noop_device_copyable>>,
-                  "adjacent_find_fn is not device copyable with device copyable types");
     //__create_mask_unique_copy
     static_assert(sycl::is_device_copyable_v<
                       oneapi::dpl::__internal::__create_mask_unique_copy<noop_device_copyable, int_device_copyable>>,
@@ -450,6 +462,19 @@ test_non_device_copyable()
                       oneapi::dpl::__par_backend_hetero::__gen_mask<noop_non_device_copyable>>>,
                   "__gen_expand_count_mask is device copyable with non device copyable types");
 
+    //__gen_set_balanced_path
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
+                      oneapi::dpl::__par_backend_hetero::__set_intersection,
+                      binary_op_non_device_copyable>>,
+                  "__gen_set_balanced_path is device copyable with non device copyable types");
+
+    //__gen_set_op_from_known_balanced_path
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
+                      oneapi::dpl::__par_backend_hetero::__set_intersection,
+                      oneapi::dpl::__par_backend_hetero::__noop_temp_data,
+                      binary_op_non_device_copyable>>,
+                  "__gen_set_op_from_known_balanced_path is device copyable with non device copyable types");
+
     //__write_to_id_if
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, assign_non_device_copyable>>,
@@ -464,6 +489,11 @@ test_non_device_copyable()
     static_assert(!sycl::is_device_copyable_v<
                       oneapi::dpl::__par_backend_hetero::__write_red_by_seg<binary_op_non_device_copyable>>,
                   "__write_red_by_seg is device copyable with non device copyable types");
+
+    //__write_multiple_to_id
+    static_assert(!sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__write_multiple_to_id<assign_non_device_copyable>>,
+                  "__write_multiple_to_id is device copyable with non device copyable types");
 
     // __early_exit_find_or
     static_assert(
@@ -549,14 +579,6 @@ test_non_device_copyable()
     //__is_heap_check
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__is_heap_check<noop_non_device_copyable>>,
                   "__is_heap_check is device copyable with non device copyable types");
-
-    //equal_predicate
-    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::equal_predicate<noop_non_device_copyable>>,
-                  "equal_predicate is device copyable with non device copyable types");
-
-    //adjacent_find_fn
-    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::adjacent_find_fn<noop_non_device_copyable>>,
-                  "adjacent_find_fn is device copyable with non device copyable types");
 
     //__create_mask_unique_copy
     static_assert(


### PR DESCRIPTION
Fixing some issues with sycl traits and device copyable tests from 
#2247 (not removing associated device copyable tests)
#2147 (not adding sycl traits for new building blocks for set algorithms) The only exposure for this is if someone provides a Compare "equal" operator which is device copyable but not trivially copyable, using reduce then scan for the set algorithms, very unlikely.

Also, this adds device copyable tests coverage to the per-commit CI.  Previously was missed because dpcpp tests only run sycl_iterator tests.