### PR TITLE
Remove extra `sycl::queue` instances on stack

### DIFF
--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -77,10 +77,8 @@ struct test_shift
         using _ValueType = typename ::std::iterator_traits<It>::value_type;
         using _DiffType = typename ::std::iterator_traits<It>::difference_type;
 
-        auto queue = exec.queue();
-
         // allocate USM memory and copying data to USM shared/device memory
-        TestUtils::usm_data_transfer<alloc_type, _ValueType> dt_helper(queue, first, m);
+        TestUtils::usm_data_transfer<alloc_type, _ValueType> dt_helper(exec.queue(), first, m);
 
         auto ptr = dt_helper.get_data();
         auto het_res =

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -358,12 +358,10 @@ test_usm(SortTestConfig config,
 
     using ValueType = typename std::iterator_traits<OutputIterator>::value_type;
 
-    auto queue = exec.queue();
-
     // Call sort algorithm on prepared data
     const auto it_from = tmp_first + 1;
     const auto it_to = tmp_last - 1;
-    TestUtils::usm_data_transfer<alloc_type, ValueType> dt_helper(queue, it_from, it_to);
+    TestUtils::usm_data_transfer<alloc_type, ValueType> dt_helper(exec.queue(), it_from, it_to);
     auto sortingData = dt_helper.get_data();
 
     const std::int32_t count0 = KeyCount;


### PR DESCRIPTION
In this PR we remove extra `sycl::queue` instances on stack.