### PR TITLE
Fix return type in some test predicates

### DIFF
--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -76,9 +76,9 @@ auto pred = [](auto&& val) { return val == 5; };
 auto binary_pred = [](auto&& val1, auto&& val2) { return val1 == val2; };
 auto binary_pred_const = [](const auto& val1, const auto& val2) { return val1 == val2; };
 
-auto pred1 = [](auto&& val) -> decltype(auto) { return val > 0; };
-auto pred2 = [](auto&& val) -> decltype(auto) { return val == 4; };
-auto pred3 = [](auto&& val) -> decltype(auto) { return val < 0; };
+auto pred1 = [](auto&& val) -> bool { return val > 0; };
+auto pred2 = [](auto&& val) -> bool { return val == 4; };
+auto pred3 = [](auto&& val) -> bool { return val < 0; };
 
 struct P2
 {

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/binary.search/binary_search2_g.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/binary.search/binary_search2_g.pass.cpp
@@ -19,7 +19,7 @@
 
 #include "support/utils.h"
 
-// A comparison, equalivalent to std::greater<int> without the
+// A comparison, equivalent to std::greater<int> without the
 // dependency on <functional>.
 struct gt
 {

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range2_g.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/equal.range/equal_range2_g.pass.cpp
@@ -21,7 +21,7 @@
 
 #include "support/utils.h"
 
-// A comparison, equalivalent to std::greater<int> without the
+// A comparison, equivalent to std::greater<int> without the
 // dependency on <functional>.
 struct gt
 {


### PR DESCRIPTION
In this PR we fix return type in some test predicates:
from
```C++
auto pred1 = [](auto&& val) -> decltype(auto) { return val > 0; };
auto pred2 = [](auto&& val) -> decltype(auto) { return val == 4; };
auto pred3 = [](auto&& val) -> decltype(auto) { return val < 0; };
```
to
```C++
auto pred1 = [](auto&& val) -> bool { return val > 0; };
auto pred2 = [](auto&& val) -> bool { return val == 4; };
auto pred3 = [](auto&& val) -> bool { return val < 0; };
```

because they return result of some compare operation which is always `bool` type.

Also corrected two spelling check errors in comments.