### PR TITLE
Forward execution policy in test environment

### DIFF
--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -464,7 +464,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
                          ::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
-        op(::std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
+        op(std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
     }
 
     // A version with 2 iterators which is used for non_const testcases
@@ -473,7 +473,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
                          ::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
-        op(::std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
+        op(std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
            make_iterator<OutputIterator>()(out_iter));
     }
 

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -379,8 +379,8 @@ struct iterator_invoker
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
-        invoke_if<Iterator>()(n <= sizeLimit<decltype(n)>, op, exec, make_iterator<Iterator>()(begin), n,
-                              ::std::forward<Rest>(rest)...);
+        invoke_if<Iterator>()(n <= sizeLimit<decltype(n)>, op, std::forward<Policy>(exec),
+                              make_iterator<Iterator>()(begin), n, std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
@@ -388,9 +388,10 @@ struct iterator_invoker
                            !::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
-        invoke_if<Iterator>()(
-            std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>, op, exec,
-            make_iterator<Iterator>()(inputBegin), make_iterator<Iterator>()(inputEnd), std::forward<Rest>(rest)...);
+        invoke_if<Iterator>()(std::distance(inputBegin, inputEnd) <=
+                                  sizeLimit<decltype(std::distance(inputBegin, inputEnd))>,
+                              op, std::forward<Policy>(exec), make_iterator<Iterator>()(inputBegin),
+                              make_iterator<Iterator>()(inputEnd), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
@@ -398,10 +399,11 @@ struct iterator_invoker
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
-        invoke_if<InputIterator>()(
-            std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>, op, exec,
-            make_iterator<InputIterator>()(inputBegin), make_iterator<InputIterator>()(inputEnd),
-            make_iterator<OutputIterator>()(outputBegin), std::forward<Rest>(rest)...);
+        invoke_if<InputIterator>()(std::distance(inputBegin, inputEnd) <=
+                                       sizeLimit<decltype(std::distance(inputBegin, inputEnd))>,
+                                   op, std::forward<Policy>(exec), make_iterator<InputIterator>()(inputBegin),
+                                   make_iterator<InputIterator>()(inputEnd),
+                                   make_iterator<OutputIterator>()(outputBegin), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
@@ -410,10 +412,10 @@ struct iterator_invoker
                OutputIterator outputEnd, Rest&&... rest)
     {
         invoke_if<InputIterator>()(
-            std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>, op, exec,
-            make_iterator<InputIterator>()(inputBegin), make_iterator<InputIterator>()(inputEnd),
-            make_iterator<OutputIterator>()(outputBegin), make_iterator<OutputIterator>()(outputEnd),
-            std::forward<Rest>(rest)...);
+            std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>, op,
+            std::forward<Policy>(exec), make_iterator<InputIterator>()(inputBegin),
+            make_iterator<InputIterator>()(inputEnd), make_iterator<OutputIterator>()(outputBegin),
+            make_iterator<OutputIterator>()(outputEnd), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -424,10 +426,10 @@ struct iterator_invoker
     {
         invoke_if<InputIterator1>()(
             std::distance(inputBegin1, inputEnd1) <= sizeLimit<decltype(std::distance(inputBegin1, inputEnd1))>, op,
-            exec, make_iterator<InputIterator1>()(inputBegin1), make_iterator<InputIterator1>()(inputEnd1),
-            make_iterator<InputIterator2>()(inputBegin2), make_iterator<InputIterator2>()(inputEnd2),
-            make_iterator<OutputIterator>()(outputBegin), make_iterator<OutputIterator>()(outputEnd),
-            std::forward<Rest>(rest)...);
+            std::forward<Policy>(exec), make_iterator<InputIterator1>()(inputBegin1),
+            make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator2>()(inputBegin2),
+            make_iterator<InputIterator2>()(inputEnd2), make_iterator<OutputIterator>()(outputBegin),
+            make_iterator<OutputIterator>()(outputEnd), std::forward<Rest>(rest)...);
     }
     
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename InputIterator3, typename OutputIterator,
@@ -439,11 +441,11 @@ struct iterator_invoker
     {
         invoke_if<InputIterator1>()(
             std::distance(inputBegin1, inputEnd1) <= sizeLimit<decltype(std::distance(inputBegin1, inputEnd1))>, op,
-            exec, make_iterator<InputIterator1>()(inputBegin1), make_iterator<InputIterator1>()(inputEnd1),
-            make_iterator<InputIterator2>()(inputBegin2), make_iterator<InputIterator2>()(inputEnd2),
-            make_iterator<InputIterator3>()(inputBegin3), make_iterator<InputIterator3>()(inputEnd3),
-            make_iterator<OutputIterator>()(outputBegin), make_iterator<OutputIterator>()(outputEnd),
-            std::forward<Rest>(rest)...);
+            std::forward<Policy>(exec), make_iterator<InputIterator1>()(inputBegin1),
+            make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator2>()(inputBegin2),
+            make_iterator<InputIterator2>()(inputEnd2), make_iterator<InputIterator3>()(inputBegin3),
+            make_iterator<InputIterator3>()(inputEnd3), make_iterator<OutputIterator>()(outputBegin),
+            make_iterator<OutputIterator>()(outputEnd), std::forward<Rest>(rest)...);
     }
 };
 

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -297,14 +297,14 @@ struct non_const_wrapper_tagged : non_const_wrapper
     ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category_v<Iterator, IteratorTag>>
     operator()(Policy&& exec, Iterator iter)
     {
-        Op()(exec, iter);
+        Op()(std::forward<Policy>(exec), iter);
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
     ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category_v<OutputIterator, IteratorTag>>
     operator()(Policy&& exec, InputIterator input_iter, OutputIterator out_iter)
     {
-        Op()(exec, input_iter, out_iter);
+        Op()(std::forward<Policy>(exec), input_iter, out_iter);
     }
 
     template <typename Policy, typename Iterator>
@@ -371,7 +371,8 @@ struct iterator_invoker
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n,
         Iterator expected, Rest&&... rest)
     {
-        op(exec, make_iterator<Iterator>()(begin), n, make_iterator<Iterator>()(expected), ::std::forward<Rest>(rest)...);
+        op(std::forward<Policy>(exec), make_iterator<Iterator>()(begin), n, make_iterator<Iterator>()(expected),
+           std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
@@ -479,7 +480,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         if (n <= sizeLimit<decltype(n)>)
-            op(exec, make_iterator<Iterator>()(begin + n), n, ::std::forward<Rest>(rest)...);
+            op(std::forward<Policy>(exec), make_iterator<Iterator>()(begin + n), n, std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
@@ -488,7 +489,8 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
         Rest&&... rest)
     {
         if (n <= sizeLimit<decltype(n)>)
-            op(exec, make_iterator<Iterator>()(begin + n), n, make_iterator<Iterator>()(expected + n), ::std::forward<Rest>(rest)...);
+            op(std::forward<Policy>(exec), make_iterator<Iterator>()(begin + n), n,
+               make_iterator<Iterator>()(expected + n), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
@@ -496,7 +498,8 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected, Rest&&... rest)
     {
         if (n <= sizeLimit<decltype(n)>)
-            op(exec, make_iterator<Iterator>()(std::next(begin, n)), n, make_iterator<Iterator>()(std::next(expected, n)), ::std::forward<Rest>(rest)...);
+            op(std::forward<Policy>(exec), make_iterator<Iterator>()(std::next(begin, n)), n,
+               make_iterator<Iterator>()(std::next(expected, n)), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
@@ -505,7 +508,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
         if (std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>)
-            op(exec, make_iterator<Iterator>()(inputEnd), make_iterator<Iterator>()(inputBegin),
+            op(std::forward<Policy>(exec), make_iterator<Iterator>()(inputEnd), make_iterator<Iterator>()(inputBegin),
                std::forward<Rest>(rest)...);
     }
 
@@ -515,7 +518,8 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
                Rest&&... rest)
     {
         if (std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>)
-            op(exec, make_iterator<InputIterator>()(inputEnd), make_iterator<InputIterator>()(inputBegin),
+            op(std::forward<Policy>(exec), make_iterator<InputIterator>()(inputEnd),
+               make_iterator<InputIterator>()(inputBegin),
                make_iterator<OutputIterator>()(outputBegin + (inputEnd - inputBegin)), std::forward<Rest>(rest)...);
     }
 
@@ -525,9 +529,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
                OutputIterator outputEnd, Rest&&... rest)
     {
         if (std::distance(inputBegin, inputEnd) <= sizeLimit<decltype(std::distance(inputBegin, inputEnd))>)
-            op(exec, make_iterator<InputIterator>()(inputEnd), make_iterator<InputIterator>()(inputBegin),
-               make_iterator<OutputIterator>()(outputEnd), make_iterator<OutputIterator>()(outputBegin),
-               std::forward<Rest>(rest)...);
+            op(std::forward<Policy>(exec), make_iterator<InputIterator>()(inputEnd),
+               make_iterator<InputIterator>()(inputBegin), make_iterator<OutputIterator>()(outputEnd),
+               make_iterator<OutputIterator>()(outputBegin), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -537,10 +541,10 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
         if (std::distance(inputBegin1, inputEnd1) <= sizeLimit<decltype(std::distance(inputBegin1, inputEnd1))>)
-            op(exec, make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator1>()(inputBegin1),
-               make_iterator<InputIterator2>()(inputEnd2), make_iterator<InputIterator2>()(inputBegin2),
-               make_iterator<OutputIterator>()(outputEnd), make_iterator<OutputIterator>()(outputBegin),
-               std::forward<Rest>(rest)...);
+            op(std::forward<Policy>(exec), make_iterator<InputIterator1>()(inputEnd1),
+               make_iterator<InputIterator1>()(inputBegin1), make_iterator<InputIterator2>()(inputEnd2),
+               make_iterator<InputIterator2>()(inputBegin2), make_iterator<OutputIterator>()(outputEnd),
+               make_iterator<OutputIterator>()(outputBegin), std::forward<Rest>(rest)...);
     }
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename InputIterator3,
@@ -551,11 +555,11 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
                OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
         if (std::distance(inputBegin1, inputEnd1) <= sizeLimit<decltype(std::distance(inputBegin1, inputEnd1))>)
-            op(exec, make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator1>()(inputBegin1),
-               make_iterator<InputIterator2>()(inputEnd2), make_iterator<InputIterator2>()(inputBegin2),
-               make_iterator<InputIterator3>()(inputEnd3), make_iterator<InputIterator3>()(inputBegin3),
-               make_iterator<OutputIterator>()(outputEnd), make_iterator<OutputIterator>()(outputBegin),
-               std::forward<Rest>(rest)...);
+            op(std::forward<Policy>(exec), make_iterator<InputIterator1>()(inputEnd1),
+               make_iterator<InputIterator1>()(inputBegin1), make_iterator<InputIterator2>()(inputEnd2),
+               make_iterator<InputIterator2>()(inputBegin2), make_iterator<InputIterator3>()(inputEnd3),
+               make_iterator<InputIterator3>()(inputBegin3), make_iterator<OutputIterator>()(outputEnd),
+               make_iterator<OutputIterator>()(outputBegin), std::forward<Rest>(rest)...);
     }
 
 };

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -945,7 +945,7 @@ template <typename _NewKernelName, typename Policy, ::std::enable_if_t<__is_able
 auto
 create_new_policy(Policy&& policy)
 {
-    return TestUtils::make_new_policy<_NewKernelName>(::std::forward<Policy>(policy));
+    return TestUtils::make_new_policy<_NewKernelName>(std::forward<Policy>(policy));
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
@@ -953,7 +953,7 @@ template <typename _NewKernelName, typename Policy, ::std::enable_if_t<!__is_abl
 auto
 create_new_policy(Policy&& policy)
 {
-    return ::std::forward<Policy>(policy);
+    return std::forward<Policy>(policy);
 }
 
 template <int idx, typename Policy>
@@ -961,9 +961,9 @@ auto
 create_new_policy_idx(Policy&& policy)
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    return create_new_policy<TestUtils::new_kernel_name<Policy, idx>>(::std::forward<Policy>(policy));
+    return create_new_policy<TestUtils::new_kernel_name<Policy, idx>>(std::forward<Policy>(policy));
 #else
-    return ::std::forward<Policy>(policy);
+    return std::forward<Policy>(policy);
 #endif
 }
 

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -91,7 +91,7 @@ auto
 make_new_policy(_Policy&& __policy)
     -> decltype(TestUtils::make_device_policy<_NewKernelName>(::std::forward<_Policy>(__policy)))
 {
-    return TestUtils::make_device_policy<_NewKernelName>(::std::forward<_Policy>(__policy));
+    return TestUtils::make_device_policy<_NewKernelName>(std::forward<_Policy>(__policy));
 }
 
 #if ONEDPL_FPGA_DEVICE
@@ -102,8 +102,8 @@ make_new_policy(_Policy&& __policy)
     -> decltype(TestUtils::make_fpga_policy<::std::decay_t<_Policy>::unroll_factor, _NewKernelName>(
         ::std::forward<_Policy>(__policy)))
 {
-    return TestUtils::make_fpga_policy<::std::decay_t<_Policy>::unroll_factor, _NewKernelName>(
-        ::std::forward<_Policy>(__policy));
+    return TestUtils::make_fpga_policy<std::decay_t<_Policy>::unroll_factor, _NewKernelName>(
+        std::forward<_Policy>(__policy));
 }
 #endif
 

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -386,6 +386,8 @@ run_test(SortTestConfig config,
     // Run tests for USM shared memory (external testing for USM shared memory, once already covered in sycl_iterator.pass.cpp)
     if (config.test_usm_shared)
     {
+        // TODO required later to create temporary policy instance here
+        // and pass it to test_usm with value category like exec paramter
         test_usm<sycl::usm::alloc::shared>(config, exec, tmp_first, tmp_last,
                                            expected_first, expected_last,first, last, n, compare...);
     }

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -387,7 +387,7 @@ run_test(SortTestConfig config,
     if (config.test_usm_shared)
     {
         // TODO required later to create temporary policy instance here
-        // and pass it to test_usm with value category like exec paramter
+        // and pass it to test_usm with value category like exec parameter
         test_usm<sycl::usm::alloc::shared>(config, exec, tmp_first, tmp_last,
                                            expected_first, expected_last,first, last, n, compare...);
     }

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -386,8 +386,7 @@ run_test(SortTestConfig config,
     // Run tests for USM shared memory (external testing for USM shared memory, once already covered in sycl_iterator.pass.cpp)
     if (config.test_usm_shared)
     {
-        // TODO required later to create temporary policy instance here
-        // and pass it to test_usm with value category like exec parameter
+        // TODO: Create a temporary policy instance and pass it to test_usm with the needed value category
         test_usm<sycl::usm::alloc::shared>(config, exec, tmp_first, tmp_last,
                                            expected_first, expected_last,first, last, n, compare...);
     }


### PR DESCRIPTION
In this PR we forward execution policy in test environment through `std::forward` call.
It's important for some another PR which we going to apply later.