### PR TITLE
Fix definition with same mangled name in `parallel_find_or`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1579,9 +1579,8 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     {
         // We shouldn't have any restrictions for _AtomicType type here
         // because we have a single work-group and we don't need to use atomics for inter-work-group communication.
-
-        using __find_or_one_wg_kernel_name =
-            oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__find_or_kernel_one_wg<_CustomName>>;
+        using __find_or_one_wg_kernel_name = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+            __find_or_kernel_one_wg<_BrickTag, _CustomName>>;
 
         // Single WG implementation
         __result = __parallel_find_or_impl_one_wg<__or_tag_check, __find_or_one_wg_kernel_name>()(
@@ -1592,8 +1591,8 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
         assert("This device does not support 64-bit atomics" &&
                (sizeof(_AtomicType) < 8 || __q_local.get_device().has(sycl::aspect::atomic64)));
 
-        using __find_or_kernel_name =
-            oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__find_or_kernel<_CustomName>>;
+        using __find_or_kernel_name = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+            __find_or_kernel<_BrickTag, _CustomName>>;
 
         // Multiple WG implementation
         __result = __parallel_find_or_impl_multiple_wgs<__or_tag_check, __find_or_kernel_name>()(


### PR DESCRIPTION
In this PR we fix definition with same mangled name in `parallel_find_or`, which happens in build of `find_end_ranges_sycl.pass` test:
```
cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_STANDARD=20 -DONEDPL_BACKEND=dpcpp -DONEDPL_DEVICE_TYPE=GPU '-DCMAKE_CXX_FLAGS=-DTEST_LONG_RUN=0 -fsycl-device-code-split=per_kernel ' -DCMAKE_BUILD_TYPE=release -D_ENABLE_RANGES_TESTING=1 ..

make find_end_ranges_sycl.pass
```

Build error log:
```
Building CXX object test/CMakeFiles/find_end_ranges_sycl.pass.dir/parallel_api/ranges/find_end_ranges_sycl.pass.cpp.o
In file included from /oneDPL/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp:18:
In file included from /oneDPL/include/oneapi/dpl/execution:67:
In file included from /oneDPL/include/oneapi/dpl/pstl/algorithm_impl.h:28:
In file included from /oneDPL/include/oneapi/dpl/pstl/execution_impl.h:22:
In file included from /oneDPL/include/oneapi/dpl/pstl/parallel_backend.h:32:
/oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1443:17: error: definition with same mangled name '_ZTSN6oneapi3dpl20__par_backend_hetero23__find_or_kernel_one_wgIJN9TestUtils18unique_kernel_nameINS0_9execution5__dpl13device_policyINS4_INS3_14TestPolicyNameELm0EEEEELm0EEEEEE' as another definition
1443 |                 [=](sycl::nd_item</*dim=*/1> __item_id) {
      |                 ^
/oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1443:17: note: previous definition is here
/oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1510:21: error: definition with same mangled name '_ZTSN6oneapi3dpl20__par_backend_hetero16__find_or_kernelIJN9TestUtils18unique_kernel_nameINS0_9execution5__dpl13device_policyINS4_INS3_14TestPolicyNameELm0EEEEELm0EEEEEE' as another definition
1510 |                     [=](sycl::nd_item</*dim=*/1> __item_id) {
      |                     ^
/oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1510:21: note: previous definition is here
/oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1443:17: error: definition with same mangled name '_ZTSN6oneapi3dpl20__par_backend_hetero23__find_or_kernel_one_wgIJN9TestUtils18unique_kernel_nameINS0_9execution5__dpl13device_policyINS4_INS3_14TestPolicyNameELm0EEEEELm1EEEEEE' as another definition
1443 |                 [=](sycl::nd_item</*dim=*/1> __item_id) {
      |                 ^
/oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1443:17: note: previous definition is here
/oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1510:21: error: definition with same mangled name '_ZTSN6oneapi3dpl20__par_backend_hetero16__find_or_kernelIJN9TestUtils18unique_kernel_nameINS0_9execution5__dpl13device_policyINS4_INS3_14TestPolicyNameELm0EEEEELm1EEEEEE' as another definition
1510 |                     [=](sycl::nd_item</*dim=*/1> __item_id) {
      |                     ^
/oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1510:21: note: previous definition is here
4 errors generated.
make[3]: *** [test/CMakeFiles/find_end_ranges_sycl.pass.dir/build.make:76: test/CMakeFiles/find_end_ranges_sycl.pass.dir/parallel_api/ranges/find_end_ranges_sycl.pass.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:13967: test/CMakeFiles/find_end_ranges_sycl.pass.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:2980: test/CMakeFiles/build-onedpl-tests.dir/rule] Error 2
```

### Justification:
In the function 
```C++
template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Pred>
oneapi::dpl::__internal::__difference_t<_Range1>
__pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
                   _Pred __pred)
{
    //trivial pre-checks
    if (__rng1.empty() || __rng2.empty() || __rng1.size() < __rng2.size())
        return __rng1.size();

    if (__rng1.size() == __rng2.size())
    {
        const bool __res = __ranges::__pattern_equal(__tag, ::std::forward<_ExecutionPolicy>(__exec), __rng1,
                                                     ::std::forward<_Range2>(__rng2), __pred);
        return __res ? 0 : __rng1.size();
    }

    using _Predicate = unseq_backend::multiple_match_pred<_Pred>;
    using _IndexType = oneapi::dpl::__internal::__difference_t<_Range1>;
    using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_IndexType>;
    using __size_calc = oneapi::dpl::__ranges::__first_size_calc;

    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{__pred}, _TagType{}, __size_calc{},
        std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
}
```

we calls `oneapi::dpl::__par_backend_hetero::__parallel_find_or` twice:
-	The first call – through `__pattern_equal` with the tag `__par_backend_hetero::__parallel_find_backward_tag<_IndexType>`
-	The second call – through `__parallel_find_or` with the tag `oneapi::dpl::__par_backend_hetero::__parallel_or_tag`

But the name inside `__parallel_find_or` still the same:

```C++
        using __find_or_one_wg_kernel_name =
            oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__find_or_kernel_one_wg<_CustomName>>;
```
```C++
        using __find_or_kernel_name =
            oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__find_or_kernel<_CustomName>>;
```
for both cases.

So we should add `BrickTag` type into `__find_or_kernel_one_wg` and ` __find_or_kernel` template parameters:
```C++
        using __find_or_one_wg_kernel_name = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
            __find_or_kernel_one_wg<_BrickTag, _CustomName>>;
```

```C++
        using __find_or_kernel_name = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
            __find_or_kernel<_BrickTag, _CustomName>>;
```