### PR TITLE
Fix definition with same mangled name in `find_end`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -257,7 +257,7 @@ __pattern_find_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R
 //------------------------------------------------------------------------
 
 template <typename Name>
-class __equal_wrapper;
+struct __equal_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Pred>
 oneapi::dpl::__internal::__difference_t<_Range1>


### PR DESCRIPTION
Alternative to #2297.  
Fix for `find_end` same mangled name error. 
Wrap kernel name for runtime branch which results in a different kernel.