### PR TITLE
Ensure the correct type is scanned over in SYCL reduce-then-scan

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -133,7 +133,9 @@ Known Limitations
   If these conditions are not met, the result of these algorithm calls is undefined.
 * For ``transform_exclusive_scan``, ``transform_inclusive_scan`` algorithms the result of the unary operation should be
   convertible to the type of the initial value if one is provided, otherwise it is convertible to the type of values
-  in the processed data sequence: ``std::iterator_traits<IteratorType>::value_type``.
+  in the processed data sequence: ``std::iterator_traits<InputIt>::value_type``. Similarly, for ``inclusive_scan`` and
+  ``exclusive_scan``, ``std::iterator_traits<InputIt>::value_type`` should be convertible to the initial value type if
+  provided.
 * ``exclusive_scan`` and ``transform_exclusive_scan`` algorithms may provide wrong results with
   unsequenced execution policies when building a program with GCC 10 and using ``-O0`` option.
 * Compiling ``reduce`` and ``transform_reduce`` algorithms with |dpcpp_cpp| versions 2021 and older

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -700,7 +700,9 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
         }
         if (__use_reduce_then_scan)
         {
-            using _GenInput = oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation>;
+            using _GenInput =
+                oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation,
+                                                                         typename _InitType::__value_type>;
             using _ScanInputTransform = oneapi::dpl::__internal::__no_op;
             using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -238,8 +238,9 @@ struct __write_multiple_to_id
 
 // __parallel_transform_scan
 
-// A generator which applies a unary operation to the input range element at an index and returns the result.
-template <typename _UnaryOp>
+// A generator which applies a unary operation to the input range element at an index and returns the result
+// converted to an underlying init type.
+template <typename _UnaryOp, typename _InitType>
 struct __gen_transform_input
 {
     using TempData = __noop_temp_data;
@@ -251,7 +252,7 @@ struct __gen_transform_input
         // process zip_iterator input where the reference type is a tuple of a references. This prevents the caller
         // from modifying the input range when altering the return of this functor.
         using _ValueType = oneapi::dpl::__internal::__value_t<_InRng>;
-        return __unary_op(_ValueType{__in_rng[__id]});
+        return static_cast<_InitType>(__unary_op(_ValueType{__in_rng[__id]}));
     }
     _UnaryOp __unary_op;
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -413,7 +413,7 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::experimental
 namespace oneapi::dpl::__par_backend_hetero
 {
 
-template <typename _UnaryOp>
+template <typename _UnaryOp, typename _OutputType>
 struct __gen_transform_input;
 
 template <typename _BinaryPred>
@@ -463,9 +463,9 @@ struct __gen_set_op_from_known_balanced_path;
 
 } // namespace oneapi::dpl::__par_backend_hetero
 
-template <typename _UnaryOp>
+template <typename _UnaryOp, typename _OutputType>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_transform_input,
-                                                       _UnaryOp)>
+                                                       _UnaryOp, _OutputType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_UnaryOp>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -413,7 +413,7 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::experimental
 namespace oneapi::dpl::__par_backend_hetero
 {
 
-template <typename _UnaryOp, typename _OutputType>
+template <typename _UnaryOp, typename _InitType>
 struct __gen_transform_input;
 
 template <typename _BinaryPred>
@@ -463,9 +463,9 @@ struct __gen_set_op_from_known_balanced_path;
 
 } // namespace oneapi::dpl::__par_backend_hetero
 
-template <typename _UnaryOp, typename _OutputType>
+template <typename _UnaryOp, typename _InitType>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_transform_input,
-                                                       _UnaryOp, _OutputType)>
+                                                       _UnaryOp, _InitType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_UnaryOp>
 {
 };

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -158,7 +158,8 @@ test_device_copyable()
 
     //__gen_transform_input
     static_assert(
-        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_transform_input<noop_device_copyable>>,
+        sycl::is_device_copyable_v<
+            oneapi::dpl::__par_backend_hetero::__gen_transform_input<noop_device_copyable, int_device_copyable>>,
         "__gen_transform_input is not device copyable with device copyable types");
 
     //__gen_red_by_seg_reduce_input
@@ -439,7 +440,8 @@ test_non_device_copyable()
 
     //__gen_transform_input
     static_assert(
-        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_transform_input<noop_non_device_copyable>>,
+        !sycl::is_device_copyable_v<
+            oneapi::dpl::__par_backend_hetero::__gen_transform_input<noop_non_device_copyable, int_device_copyable>>,
         "__gen_transform_input is device copyable with non device copyable types");
 
     //__gen_red_by_seg_reduce_input

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -63,7 +63,7 @@ struct test_inclusive_scan_with_plus
         ::std::fill_n(out_first, n, trash);
     }
     // inclusive_scan with reverse_iterator between different iterator types results in a compilation error even if
-    // the call should be valid.
+    // the call should be valid. Please see: https://github.com/uxlfoundation/oneDPL/issues/2296
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
     std::enable_if_t<TestUtils::is_reverse_v<Iterator1> && !std::is_same_v<Iterator1, Iterator2>>
     operator()(Policy&& /*exec*/, Iterator1 /*in_first*/, Iterator1 /*in_last*/, Iterator2 /*out_first*/,
@@ -88,6 +88,8 @@ struct test_exclusive_scan_with_plus
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from exclusive_scan");
         ::std::fill_n(out_first, n, trash);
     }
+    // exclusive_scan with reverse_iterator between different iterator types results in a compilation error even if
+    // the call should be valid. Please see: https://github.com/uxlfoundation/oneDPL/issues/2296
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
     std::enable_if_t<TestUtils::is_reverse_v<Iterator1> && !std::is_same_v<Iterator1, Iterator2>>
     operator()(Policy&& /*exec*/, Iterator1 /*in_first*/, Iterator1 /*in_last*/, Iterator2 /*out_first*/,

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -37,29 +37,46 @@ using namespace TestUtils;
 // flag inclusive, which is set to each alternative by main().
 //static bool inclusive;
 
-template <typename Type>
 struct test_inclusive_scan_with_plus
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
-    void
+    std::enable_if_t<!TestUtils::is_reverse_v<Iterator1> || std::is_same_v<Iterator1, Iterator2>>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T /* init */, T trash)
+               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, [[maybe_unused]] T init, T trash)
     {
         using namespace std;
-
-        inclusive_scan_serial(in_first, in_last, expected_first);
-        auto orr = inclusive_scan(exec, in_first, in_last, out_first);
+        Iterator3 orr;
+        // If the types are different, apply the init
+        constexpr bool use_init = !std::is_same_v<Iterator1, Iterator2>;
+        if constexpr (use_init)
+        {
+            inclusive_scan_serial(in_first, in_last, expected_first, std::plus<>{}, init);
+            orr = inclusive_scan(exec, in_first, in_last, out_first, std::plus<>{}, init);
+        }
+        else
+        {
+            inclusive_scan_serial(in_first, in_last, expected_first);
+            orr = inclusive_scan(exec, in_first, in_last, out_first);
+        }
         EXPECT_TRUE(out_last == orr, "inclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from inclusive_scan");
         ::std::fill_n(out_first, n, trash);
     }
+    // inclusive_scan with reverse_iterator between different iterator types results in a compilation error even if
+    // the call should be valid.
+    template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
+    std::enable_if_t<TestUtils::is_reverse_v<Iterator1> && !std::is_same_v<Iterator1, Iterator2>>
+    operator()(Policy&& /*exec*/, Iterator1 /*in_first*/, Iterator1 /*in_last*/, Iterator2 /*out_first*/,
+               Iterator2 /*out_last*/, Iterator3 /*expected_first*/, Iterator3 /*expected_last*/, Size /*n*/,
+               T /*init*/, T /*trash*/)
+    {
+    }
 };
 
-template <typename Type>
 struct test_exclusive_scan_with_plus
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
-    void
+    std::enable_if_t<!TestUtils::is_reverse_v<Iterator1> || std::is_same_v<Iterator1, Iterator2>>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, T trash)
     {
@@ -71,31 +88,38 @@ struct test_exclusive_scan_with_plus
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from exclusive_scan");
         ::std::fill_n(out_first, n, trash);
     }
+    template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
+    std::enable_if_t<TestUtils::is_reverse_v<Iterator1> && !std::is_same_v<Iterator1, Iterator2>>
+    operator()(Policy&& /*exec*/, Iterator1 /*in_first*/, Iterator1 /*in_last*/, Iterator2 /*out_first*/,
+               Iterator2 /*out_last*/, Iterator3 /*expected_first*/, Iterator3 /*expected_last*/, Size /*n*/,
+               T /*init*/, T /*trash*/)
+    {
+    }
 };
 
-template <typename T, typename Convert>
+template <typename In, typename Out, typename Convert>
 void
-test_with_plus(T init, T trash, Convert convert)
+test_with_plus(Out init, Out trash, Convert convert)
 {
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> in(n, convert);
-        Sequence<T> expected(in);
-        Sequence<T> out(n, [&](std::int32_t) { return trash; });
+        Sequence<In> in(n, convert);
+        Sequence<Out> expected(n);
+        Sequence<Out> out(n, [&](std::int32_t) { return trash; });
 
 #ifdef _PSTL_TEST_INCLUSIVE_SCAN
 
-        invoke_on_all_policies<0>()(test_inclusive_scan_with_plus<T>(), in.begin(), in.end(), out.begin(), out.end(),
+        invoke_on_all_policies<0>()(test_inclusive_scan_with_plus(), in.begin(), in.end(), out.begin(), out.end(),
                                     expected.begin(), expected.end(), in.size(), init, trash);
-        invoke_on_all_policies<1>()(test_inclusive_scan_with_plus<T>(), in.cbegin(), in.cend(), out.begin(),
-                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
+        invoke_on_all_policies<1>()(test_inclusive_scan_with_plus(), in.cbegin(), in.cend(), out.begin(), out.end(),
+                                    expected.begin(), expected.end(), in.size(), init, trash);
 #endif
 
 #ifdef _PSTL_TEST_EXCLUSIVE_SCAN
 
-        invoke_on_all_policies<2>()(test_exclusive_scan_with_plus<T>(), in.begin(), in.end(), out.begin(),
-                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
-        invoke_on_all_policies<3>()(test_exclusive_scan_with_plus<T>(), in.cbegin(), in.cend(), out.begin(), out.end(),
+        invoke_on_all_policies<2>()(test_exclusive_scan_with_plus(), in.begin(), in.end(), out.begin(), out.end(),
+                                    expected.begin(), expected.end(), in.size(), init, trash);
+        invoke_on_all_policies<3>()(test_exclusive_scan_with_plus(), in.cbegin(), in.cend(), out.begin(), out.end(),
                                     expected.begin(), expected.end(), in.size(), init, trash);
 #endif
     }
@@ -109,16 +133,16 @@ test_with_plus(T init, T trash, Convert convert)
         100000000;
 #endif
 
-    Sequence<T> in(n, convert);
-    Sequence<T> expected(in);
-    Sequence<T> out(n, [&](std::int32_t) { return trash; });
+    Sequence<In> in(n, convert);
+    Sequence<Out> expected(n);
+    Sequence<Out> out(n, [&](std::int32_t) { return trash; });
 #ifdef _PSTL_TEST_INCLUSIVE_SCAN
-    invoke_on_all_hetero_policies<4>()(test_inclusive_scan_with_plus<T>(), in.begin(), in.end(), out.begin(), out.end(),
-                                expected.begin(), expected.end(), in.size(), init, trash);
+    invoke_on_all_hetero_policies<4>()(test_inclusive_scan_with_plus(), in.begin(), in.end(), out.begin(), out.end(),
+                                       expected.begin(), expected.end(), in.size(), init, trash);
 #endif
 #ifdef _PSTL_TEST_EXCLUSIVE_SCAN
-    invoke_on_all_hetero_policies<5>()(test_exclusive_scan_with_plus<T>(), in.begin(), in.end(), out.begin(),
-                                out.end(), expected.begin(), expected.end(), in.size(), init, trash);
+    invoke_on_all_hetero_policies<5>()(test_exclusive_scan_with_plus(), in.begin(), in.end(), out.begin(), out.end(),
+                                       expected.begin(), expected.end(), in.size(), init, trash);
 #endif
 #endif // TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
 }
@@ -290,8 +314,13 @@ main()
 
     // Since the implicit "+" forms of the scan delegate to the generic forms,
     // there's little point in using a highly restricted type, so just use double.
-    test_with_plus<float64_t>(0.0, -666.0, [](std::uint32_t k) { return float64_t((k % 991 + 1) ^ (k % 997 + 2)); });
-    test_with_plus<std::int32_t>(0.0, -666.0, [](std::uint32_t k) { return std::int32_t((k % 991 + 1) ^ (k % 997 + 2)); });
+    test_with_plus<float64_t, float64_t>(0.0, -666.0,
+                                         [](std::uint32_t k) { return float64_t((k % 991 + 1) ^ (k % 997 + 2)); });
+    test_with_plus<std::int32_t, std::int32_t>(
+        0.0, -666.0, [](std::uint32_t k) { return std::int32_t((k % 991 + 1) ^ (k % 997 + 2)); });
+
+    // When testing from bool to uint32_t, we must give a uint32_t init type to scan over integers
+    test_with_plus<bool, std::uint32_t>(0, 123456, [](std::uint32_t k) { return std::uint32_t{k % 2 == 0}; });
 
     test_with_multiplies<std::uint64_t>();
 

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -37,6 +37,7 @@ using namespace TestUtils;
 // flag inclusive, which is set to each alternative by main().
 //static bool inclusive;
 
+template <typename In, typename Out>
 struct test_inclusive_scan_with_plus
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
@@ -73,6 +74,7 @@ struct test_inclusive_scan_with_plus
     }
 };
 
+template <typename In, typename Out>
 struct test_exclusive_scan_with_plus
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
@@ -111,18 +113,18 @@ test_with_plus(Out init, Out trash, Convert convert)
 
 #ifdef _PSTL_TEST_INCLUSIVE_SCAN
 
-        invoke_on_all_policies<0>()(test_inclusive_scan_with_plus(), in.begin(), in.end(), out.begin(), out.end(),
-                                    expected.begin(), expected.end(), in.size(), init, trash);
-        invoke_on_all_policies<1>()(test_inclusive_scan_with_plus(), in.cbegin(), in.cend(), out.begin(), out.end(),
-                                    expected.begin(), expected.end(), in.size(), init, trash);
+        invoke_on_all_policies<0>()(test_inclusive_scan_with_plus<In, Out>(), in.begin(), in.end(), out.begin(),
+                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
+        invoke_on_all_policies<1>()(test_inclusive_scan_with_plus<In, Out>(), in.cbegin(), in.cend(), out.begin(),
+                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
 #endif
 
 #ifdef _PSTL_TEST_EXCLUSIVE_SCAN
 
-        invoke_on_all_policies<2>()(test_exclusive_scan_with_plus(), in.begin(), in.end(), out.begin(), out.end(),
-                                    expected.begin(), expected.end(), in.size(), init, trash);
-        invoke_on_all_policies<3>()(test_exclusive_scan_with_plus(), in.cbegin(), in.cend(), out.begin(), out.end(),
-                                    expected.begin(), expected.end(), in.size(), init, trash);
+        invoke_on_all_policies<2>()(test_exclusive_scan_with_plus<In, Out>(), in.begin(), in.end(), out.begin(),
+                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
+        invoke_on_all_policies<3>()(test_exclusive_scan_with_plus<In, Out>(), in.cbegin(), in.cend(), out.begin(),
+                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
 #endif
     }
 
@@ -139,12 +141,12 @@ test_with_plus(Out init, Out trash, Convert convert)
     Sequence<Out> expected(n);
     Sequence<Out> out(n, [&](std::int32_t) { return trash; });
 #ifdef _PSTL_TEST_INCLUSIVE_SCAN
-    invoke_on_all_hetero_policies<4>()(test_inclusive_scan_with_plus(), in.begin(), in.end(), out.begin(), out.end(),
-                                       expected.begin(), expected.end(), in.size(), init, trash);
+    invoke_on_all_hetero_policies<4>()(test_inclusive_scan_with_plus<In, Out>(), in.begin(), in.end(), out.begin(),
+                                       out.end(), expected.begin(), expected.end(), in.size(), init, trash);
 #endif
 #ifdef _PSTL_TEST_EXCLUSIVE_SCAN
-    invoke_on_all_hetero_policies<5>()(test_exclusive_scan_with_plus(), in.begin(), in.end(), out.begin(), out.end(),
-                                       expected.begin(), expected.end(), in.size(), init, trash);
+    invoke_on_all_hetero_policies<5>()(test_exclusive_scan_with_plus<In, Out>(), in.begin(), in.end(), out.begin(),
+                                       out.end(), expected.begin(), expected.end(), in.size(), init, trash);
 #endif
 #endif // TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
 }


### PR DESCRIPTION
Currently, the result of `__unary_op` in `__gen_transform_input` will be scanned over in the reduce-then-scan implementation. This is incorrect, particularly if an initial value is provided by the user. We fix this by converting the resulting of `__unary_op` to the initial value type.

This requires an assumption that the input iterator's value type is convertible to the initial value type which is a known limitation with the TBB backend and the legacy SYCL scan implementation.