### PR TITLE
[Draft] RFC future type and keepalives

### DIFF
--- a/rfcs/proposed/future_and_keepalive/README.md
+++ b/rfcs/proposed/future_and_keepalive/README.md
@@ -62,11 +62,11 @@ we use to implement them under the hood:
 `set_symmetric_difference` as a combination of scan-like algorithms and merge algorithms because of the need to write 
 from the second input set.
 
-(a) is better for larger inputs, and (b) is better for smaller inputs, and also may be required when we don't have 
-access to the scan-like algorithm (3). This means that with a run-time decision, we must choose between a set of calls 
-which ends with a scan-like operation, or a merge operation, and we must align their return type. This may be difficult 
-enough when considering the actual result itself, but becomes untenable when also considering keepalives in the return 
-type. One option is to work around this issue by making the calls blocking, but that spoils any hope for asynchrony for 
+(a) is better for larger inputs, and (b) is better for smaller inputs, and also may be required when we don't have
+access to the scan-like algorithm (3). This means that with a run-time decision, we must choose between a set of calls
+which ends with a scan-like operation, or a merge operation, and we must align their return type. This may be difficult
+enough when considering the actual result itself, but becomes untenable when also considering keepalives in the return
+type. One option is to work around this issue by making the calls blocking, but that spoils any hope for asynchrony for
 these algorithms with deferred waiting or the asynchronous API.
 
 ## Proposal
@@ -79,7 +79,7 @@ these allocations. We may see a slight performance regression for hardware that 
 USM, but that is acceptable to remove the complexity of the combined type. For this change, let's keep the 
 `__kernel_scratch_storage` in the `__future` type, so we can do this step-by-step.
 
-2) Improve the system for `__future::get()` to handle the `__kernel_result` type and number of elements appropriately. 
+2) Improve the system for `__future::get()` to handle the `__kernel_result` type and number of elements appropriately.
 Allow the caller to specify the number of arguments to return (default to either 1 or to a tuple of all elements in the 
 future).
 
@@ -90,25 +90,27 @@ The following options have been raised:
 - a) Use the experimental SYCL feature for [asynchronous memory allocation](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_async_memory_alloc.asciidoc) and free to schedule freeing of temporary 
 storage after a kernel completes. This is a good option, but requires a fallback, as it will not always be available in 
 all environments.
-- b) Use another location, such as a component of the execution policy, to store keepalives. A container for this 
+- b) Use another location, such as a component of the execution policy, to store keepalives. A container for this
 purpose can be extracted from the policy within the backend and passed explicitly. For deferred waiting, we can provide
-tools for the user to clear temporary storage once the event has been waited on.
-- c) Use a globally allocated storage system where keepalives can be registered. Use a host_task scheduled in the SYCL 
-queue to mark the temporary storage for deletion when the kernels complete. This also requires a separate thread to run 
+tools for the user to clear temporary storage once the event has been waited on. This requires a public API and
+documentation for users to clear keepalives. This also requires either a blocking destructor, -or- that users be aware
+that deferred wait execution policy must be kept alive until waiting on queue.
+- c) Use a globally allocated storage system where keepalives can be registered. Use a host_task scheduled in the SYCL
+queue to mark the temporary storage for deletion when the kernels complete. This also requires a separate thread to run
 cleanup after the host_task marks it as OK, because the deallocation step should not be launched directly from a 
 host_task due to restrictions about initiating an L0 call from an L0 callback and host_task will be implemented as a
 L0 callbacks in the future.
-- d) Create a type `event_with_keepalive` similar to `__future` where `get()` is not defined, which can be used as the 
-`event` in a `__future`. This allows us to fix the semantic problem with `__future` by explicitly controlling what is a 
+- d) Create a type `event_with_keepalive` similar to `__future` where `get()` is not defined, which can be used as the
+`event` in a `__future`. This allows us to fix the semantic problem with `__future` by explicitly controlling what is a
 return value and what is a keepalive, while still relying on future for the functional keepalive behavior.
 
 The following table describes the options presented, whether they resolve the remaining issues, and their biggest 
 downside.
 
-| Option              | Return Type                | Implementation Details                        | Biggest Downside                                         |
+| Option              | Return Type                | Implementation Details                        | Biggest Downside(s)                                      |
 |---------------------|----------------------------|-----------------------------------------------|----------------------------------------------------------|
 | Async free          | Resolved* (when available) | Resolved* (when available)                    | Not available everywhere, needs fallback                 |
-| Execution policy    | Resolved                   | Somewhat fixed, requires public interface     | Possibly not compatible with async free                  |
+| Execution policy    | Resolved                   | Somewhat fixed, may require public interface  | Passes responsibility to user, possibly not compatible with async free |
 | Global storage      | Resolved                   | Resolved                                      | Very complex, requires extra thread, global memory, complexity |
 | Event with keepalive| Not fixed, still an issue  | Mostly fixed, with separation of actual future from keepalive | Does not fix return type issue                           |
 
@@ -116,15 +118,15 @@ This infrastructure allows us to proceed with a more robust deferred waiting fea
 existing asynchronous API.
 
 ### Other Options for Changes to `__future`
-* Remove `__future` usage from all internal levels of oneDPL and use it only in the async API for return values. This 
-is implemented in [this PR](https://github.com/uxlfoundation/oneDPL/pull/2261). This replaces `__future` in our 
-internals with a `std::tuple` of all results and keepalives (or combinations via `__result_and_scratch_storage`). This 
-gets rid of the semantic issues we have with future, where we are including keepalives. However, it does not change the 
+* Remove `__future` usage from all internal levels of oneDPL and use it only in the async API for return values. This
+is implemented in [this PR](https://github.com/uxlfoundation/oneDPL/pull/2261). This replaces `__future` in our
+internals with a `std::tuple` of all results and keepalives (or combinations via `__result_and_scratch_storage`). This
+gets rid of the semantic issues we have with future, where we are including keepalives. However, it does not change the
 requirements to align our return type. It may be a step to consider, in combination with a way to address keepalives.
 
 ### Other Options for Changes to `__result_and_scratch_storage`
-* Extend the functionality of `__result_and_scratch_storage` to allow independent types for the result and the scratch 
-storage. This allows more flexibility for `__result_and_scratch_storage`. However, with separate types it really begs 
+* Extend the functionality of `__result_and_scratch_storage` to allow independent types for the result and the scratch
+storage. This allows more flexibility for `__result_and_scratch_storage`. However, with separate types it really begs
 the question of why these two entities are fused together.
 
 ## Open Questions


### PR DESCRIPTION
This is a work in progress draft.

This RFC outlines some issues with our current `__future` and `__result_and_scratch_storage`, and start to lay out a path to toward improvements.