### PR TITLE
RFC for Kernel Templates

### DIFF
--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -206,6 +206,7 @@ Currently, the specializations of the algorithms belong to different namespaces.
 
 Using a tag as a function or a template parameter should be considered as well.
 This method has both advantages and disadvantages compared to namespace-based separation.
+
 Pros:
 - Avoids potential name clashes caused by `using` directives.
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -18,7 +18,7 @@ with many design aspects yet to be addressed.
 See the [Open Questions](#open-questions) list.
 
 Algorithms which are already implemented are described in
-https://uxlfoundation.github.io/oneDPL/kernel_templates_main.html.
+[Kernel Templates API](https://uxlfoundation.github.io/oneDPL/kernel_templates_main.html).
 
 ## Proposal
 
@@ -289,6 +289,20 @@ The `kernel_param` targets a single kernel, and currently, only one instance can
 
 Currently, it is unclear if we should defferentiate algorithms
 which rely on compiler extensions.
+
+### Kernel Templates as a Backend for Algorithms with Standard Interfaces
+
+It should be evaluated whether the proposed algorithms can serve as a backend for oneDPL algorithms
+that use the standard C++ interfaces and device execution policies.
+
+It will affect which data-passing mechanisms,
+as described in [Abstract Algorithm Signature](abstract-algorithm-signature) section, are allowed.
+In particular, it should be investigated if supporting these entities is necessary and
+whether they can be handled by an additional thin layer between
+the algorithms with standard interfaces and Kernel Templates:
+- `oneapi::dpl::begin` and `oneapi::dpl::end`, which mimic iterators to pass `sycl::buffer` to algorithms accepting iterators.
+- Iterators to a host-allocated `std::vector` as described in
+  [Pass Data to Algorithms > Use std::vector](https://github.com/uxlfoundation/oneDPL/blob/release/2022.9.0/documentation/library_guide/parallel_api/pass_data_algorithms.rst#use-stdvector)
 
 ## Exit Criteria
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -166,11 +166,15 @@ int main()
 
 The testing harness should cover:
  - Varying numbers of elements to process, from thousands to millions.
- - Different element types.
- - Diverse types of input sequences.
- - Representative data distributions.
+ - Different element types, depending on the algorithm and its implementation details.
+   For example, tests for radix should cover various arithmetic types
+   due to differing ordered bit transformations.
+ - All supported input sequence types.
+   For example, if the algorithm supports
+   `sycl::buffer`, `oneapi::dpl::begin`/`oneapi::dpl::end`, or USM pointers, each should be tested.
  - Various combinations of other parameters, depending on the signature of the algorithm.
- - Edge cases (for example, zero-sized sequences).
+ - Edge cases.
+   For example, zero-sized sequences.
 
 Due to the unlimited number of possible kernel parameter combinations, it is recommended to:
  - Always test the most representative configurations

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -179,7 +179,7 @@ The testing harness should cover:
    due to differing ordered bit transformations.
  - All supported input sequence types.
    For example, if the algorithm supports
-   `sycl::buffer`, `oneapi::dpl::begin`/`oneapi::dpl::end`, or USM pointers, each should be tested.
+   `sycl::buffer` or USM pointers, each should be tested.
  - Various combinations of other parameters, depending on the signature of the algorithm.
  - Edge cases.
    For example, zero-sized sequences.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -277,7 +277,7 @@ The `kernel_param` targets a single kernel, and currently, only one instance can
 ### Compiler Extension and Differentiation of Algorithms
 
 Currently, it is unclear if we should defferentiate algorithms
-which rely compiler extensions.
+which rely on compiler extensions.
 
 ## Exit Criteria
 
@@ -286,7 +286,7 @@ The proposed set of algorithms should become fully supported if:
   [Kernel Configuration](kernel_configuration/README.md#open-questions) sections are either addressed
   or provided with a justification to postpone or ignore.
 - A significant portion of the algorithms listed in
-  [Algorithms to Implement](#algorithms-to-implement) is implemented.
+  [Algorithms to Implement](#algorithms-to-implement) are implemented.
 - Evidence of sufficiently good performance is provided.
 - There is positive adoption feedback.
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -221,12 +221,12 @@ Additionally, it reduces the number of interfaces that need to be supported.
 This should be done in conjunction with the
 [Global and Local Memory Requirements](#reporting-global-and-local-memory-requirements) interface.
 
-### Asynchronous Execution
+### Asynchronous Execution and Dependency Chaining
 
 The algorithms return a `sycl::event` but do not accept any input events.
-As a result, they are not fully asynchronous.
+That limits how they can be embedded in asynchronous dependency chains.
 
-It should be investigated whether full asynchrony is desirable,
+It should be investigated whether passing input events is desirable,
 and if so, how to implement it correctly.
 
 ### Separation of Specializations Based on a Problem Size

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -272,6 +272,11 @@ making default values less relevant.
 It needs to be explored how to configure algorithms with multiple performance-critical kernels.
 The `kernel_param` targets a single kernel, and currently, only one instance can be passed.
 
+### Compiler Extension and Differentiation of Algorithms
+
+Currently, it is unclear if we should defferentiate algorithms
+which rely compiler extensions.
+
 ## Exit Criteria
 
 The proposed set of algorithms should transition to an extension if:

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -104,7 +104,11 @@ for algorithms with device policies.
 Additionally, a plain `sycl::buffer` can also be used.
 Specialized algorithms may impose additional restrictions on how data is passed.
 
-If an algorithm allocates global memory, it must throw `std::bad_alloc` if the allocation is unsuccessful.
+If an algorithm allocates global memory and that allocation is unsuccessful,
+it must throw `std::bad_alloc`.
+That behaviour may change depending on how
+[External Allocation of Global Memory](#external-allocation-of-global-memory)
+is addressed.
 
 ### Example
 
@@ -183,7 +187,7 @@ The renaming requires changing the corresponding namespace.
 ### Specializations and their Differntiation
 
 Currently, the specializations of the algorithms belong to different namespaces.
-Using tags instead tags offers several advantages,
+Using tags instead namespaces offers several advantages,
 for example easier dispatching between specializations and avoiding deeply nested namespaces.
 
 ### Reporting Global and Local Memory Requirements
@@ -237,7 +241,7 @@ for a given workload and hardware.
 
 The proposed set of algorithms should transition to an extension if:
 - All the [Open Questions](#open-questions) are addressed.
-  Note, in the future, some questions may arise,
+  Note that in the future, some questions may arise
   addressing which is unnecessary for the transition.
 - A significant portion of the algorithms listed in
   [Algorithms to Implement](#algorithms-to-implement) is implemented.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -98,11 +98,10 @@ sycl::event kernel_template (
 ```
 
 `Arg1`, ..., `ArgN` include the sequences to be processed.
-Data can be passed in the same ways as described in the
+Data can be passed using the same mechanisms described in the
 [documentation on passing data](https://uxlfoundation.github.io/oneDPL/parallel_api/pass_data_algorithms.html#pass-data-to-algorithms)
 for algorithms with device policies.
-Additionally, a plain `sycl::buffer` can also be used.
-Specialized algorithms may impose additional restrictions on how data is passed.
+Specialized algorithms may extend or restrict the supported data passing mechanisms.
 
 If an algorithm allocates global memory and that allocation is unsuccessful,
 it must throw `std::bad_alloc`.
@@ -215,7 +214,7 @@ This should be done in conjunction with the
 
 ### Asynchronous Execution
 
-The algorithms return a `sycl::event` but do not accept any input events as inputs.
+The algorithms return a `sycl::event` but do not accept any input events.
 As a result, they are not fully asynchronous.
 
 It should be investigated whether full asynchrony is desirable,

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -314,20 +314,6 @@ Several questions arise:
 It should be evaluated whether the proposed algorithms can serve as a backend for oneDPL algorithms
 that use the standard C++ interfaces and device execution policies.
 
-### Encoding Requirements
-
-Some requirements, for example forward-progress guarantees between work-groups,
-are currently only described in documentation.
-Encoding such requirements programmatically would improve visibility and
-help avoid unintended usage.
-If fallback implementations exist,
-this also enables smooth switching when the target device changes.
-
-One option is to define a macro for each such requirement.
-These macros could be used to select appropriate implementations
-for algorithms with standard interfaces, as described in
-[Kernel Templates as a Backend for Algorithms with Standard Interfaces](kernel-templates-as-a-backend-for-algorithms-with-standard-interfaces).
-
 ## Exit Criteria
 
 The proposed set of algorithms should become fully supported if:

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -314,18 +314,6 @@ Several questions arise:
 It should be evaluated whether the proposed algorithms can serve as a backend for oneDPL algorithms
 that use the standard C++ interfaces and device execution policies.
 
-An additional question is how to handle hardware requirements that cannot be queried directly
-through standard SYCL mechanisms. For example, selecting a more performant kernel template
-might depend on forward-progress guarantees between work-groups.
-While oneAPI DPC++ supports querying this via
-the [Root Group](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc)
-experimental extension, other SYCL implementations may lack a corresponding feature.
-Furthermore, even if a device does not explicitly support cooperative kernel launch,
-it may still provide sufficient guarantees in limited cases
-such as chain-like synchronization between work-groups.
-A possible solution is to allow users to define a macro
-indicating that the required hardware capability is present.
-
 ### Encoding Requirements
 
 Some requirements, for example forward-progress guarantees between work-groups,

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -103,7 +103,7 @@ If an algorithm allocates global memory, it must throw `std::bad_alloc` if the a
 ### Example
 
 The example demonstrates the use of a kernel template
-and describes how it is tuned for better performance and what makes it less portable
+and describes how it is tuned for better performance and what makes it less general
 than an alternative algorithm with a standard interface.
 It uses `oneapi::dpl::experimental::kt::gpu::esimd::radix_sort`,
 which can be compared to `oneapi::dpl::stable_sort`.
@@ -119,8 +119,7 @@ global memory access, and the utilization of hardware computational resources.
 They can be easily adjusted for another GPU with different hardware characteristics.
 
 The kernle template relies on ESIMD technology
-and certain forward progress guarantees between work-groups,
-which leads to better performance at the expense of portability.
+and certain forward progress guarantees between work-groups.
 
 ```c++
 // icpx -fsycl radix_sort.cpp -o radix_sort -I /path/to/oneDPL/include && ./radix_sort

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -7,20 +7,26 @@ designed to achieve optimal performance on specific hardware and workloads.
 They prioritize efficiency over generality when compared to
 algorithms that conform to standard C++ interfaces and use device execution policies.
 
-These algorithms are intended for use with SYCL and are expected to evolve into an extension.
+These algorithms are intended for use with SYCL.
 
-This set of algorithms is in an early stage of development, with many questions yet to be addressed.
+The terms "kernel template" and "algorithm" are used interchangeably in this RFC.
+
+## Status
+
+Kernel Templates proposal is expected to evolve into an extension.
+This set of algorithms is in an early stage of development,
+with many design aspects yet to be addressed.
+See the [Open Questions](#open-questions) list.
 
 Algorithms which are already implemented are described in
 https://uxlfoundation.github.io/oneDPL/kernel_templates_main.html.
 
-The terms "kernel template" and "algorithm" are used interchangeably in this RFC.
-
-## Design
+## Proposal
 
 ### High-Level Structure
 
-The algorithms are defined in `<oneapi/dpl/experimental/kernel_templates>`, in `namespace oneapi::dpl::experimental::kt`.
+The algorithms are defined in `<oneapi/dpl/experimental/kernel_templates>`,
+in `namespace oneapi::dpl::experimental::kt`.
 This namespace contains portable algorithms and namespaces with more specialized implementations.
 
 Below is an example of such a structure with possible algorithms:
@@ -167,8 +173,6 @@ for example through cmake arguments.
 
 ## Open Questions
 
-There are several design aspects which should be addressed to make it a fully-supported extension.
-
 ### Name
 
 The name "Kernel Templates" may be misleading because
@@ -228,3 +232,17 @@ A list of algorithms to implement should be defined.
 
 A benchmark suite can help select the best configuration and parameters
 for a given workload and hardware.
+
+## Exit Criteria
+
+The proposed set of algorithms should transition to an extension if:
+- All the [Open Questions](#open-questions) are addressed.
+  Note, in the future, some questions may arise,
+  addressing which is unnecessary for the transition.
+- A significant portion of the algorithms listed in
+  [Algorithms to Implement](#algorithms-to-implement) is implemented.
+- They are performant.
+- There is a positive adoption feedback.
+
+Some individual algorithms may remain experimental
+and have their own exit criteria.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -104,9 +104,17 @@ sycl::event kernel_template (
 ```
 
 `Arg1`, ..., `ArgN` include sequences to process.
-Data must be passed using the same mechanisms described in the
-[documentation on passing data](https://uxlfoundation.github.io/oneDPL/parallel_api/pass_data_algorithms.html#pass-data-to-algorithms)
-for algorithms with device policies.
+These arguments must reference data which is ready for processing;
+any necessary data transfers must be completed in advance or managed automatically.
+Supported data storage types include:
+- [SYCL buffers](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:buffers).
+- Unified Shared Memory ([USM](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:usm)).
+- `std::vector` with `sycl::usm_allocator`.
+
+Supported data passing mechanisms are listed in
+the [documentation on passing data](https://uxlfoundation.github.io/oneDPL/parallel_api/pass_data_algorithms.html#pass-data-to-algorithms).
+The `oneapi::dpl::begin` and `oneapi::dpl::end` helper functions are not supported;
+however, `sycl::buffer` objects may be passed directly.
 Specialized algorithms may extend or restrict the supported data passing mechanisms.
 
 If an algorithm allocates global memory and that allocation is unsuccessful,
@@ -305,16 +313,6 @@ Several questions arise:
 
 It should be evaluated whether the proposed algorithms can serve as a backend for oneDPL algorithms
 that use the standard C++ interfaces and device execution policies.
-
-It will affect which data-passing mechanisms,
-as described in [Abstract Algorithm Signature](abstract-algorithm-signature) section, are allowed.
-In particular, it should be investigated if supporting these entities is necessary and
-whether they can be handled by an additional thin layer between
-the algorithms with standard interfaces and Kernel Templates:
-- `oneapi::dpl::begin` and `oneapi::dpl::end`,
-   which mimic iterators to pass `sycl::buffer` to iterator-based algorithms.
-- Iterators to a host-allocated `std::vector` as described in
-  [Pass Data to Algorithms > Use std::vector](https://github.com/uxlfoundation/oneDPL/blob/release/2022.9.0/documentation/library_guide/parallel_api/pass_data_algorithms.rst#use-stdvector)
 
 An additional question is how to handle hardware requirements that cannot be queried directly
 through standard SYCL mechanisms. For example, selecting a more performant kernel template

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -4,7 +4,6 @@
 
 This RFC describes an experimental set of algorithms with easily tunable controls,
 designed to achieve optimal performance on specific hardware and workloads.
-
 They prioritize efficiency over generality when compared to
 algorithms that conform to standard C++ interfaces and use device execution policies.
 
@@ -13,7 +12,7 @@ These algorithms are intended for use with SYCL and are expected to evolve into 
 This set of algorithms is in an early stage of development, with many questions yet to be addressed.
 
 Algorithms which are already implemented are described in
-https://uxlfoundation.github.io/oneDPL/kernel_templates_main.html
+https://uxlfoundation.github.io/oneDPL/kernel_templates_main.html.
 
 The terms "kernel template" and "algorithm" are used interchangeably in this RFC.
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -13,7 +13,6 @@ The terms "kernel template" and "algorithm" are used interchangeably in this RFC
 
 ## Status
 
-Kernel Templates proposal is expected to evolve into an extension.
 This set of algorithms is in an early stage of development,
 with many design aspects yet to be addressed.
 See the [Open Questions](#open-questions) list.
@@ -252,7 +251,7 @@ for a given workload and hardware.
 is placed before all the deduced parameters to simplify
 a potential addition of a default value in the future.
 However, it is unclear if a default value should be provided,
-especially given the extension's focus on performance tuning.
+especially given the focus on performance tuning.
 
 Creation of a default value with optimal settings is impossible right now.
 `kernel_param` template argument, which substitutes `KernelParam`,
@@ -278,7 +277,7 @@ which rely compiler extensions.
 
 ## Exit Criteria
 
-The proposed set of algorithms should transition to an extension if:
+The proposed set of algorithms should become fully supported if:
 - All the questions under [Kernel Templates](#open-questions) and
   [Kernel Configuration](kernel_configuration/README.md#open-questions) sections are either addressed
   or provided with a justification to postpone or ignore.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -211,10 +211,14 @@ by providing an easy way to get memory requirements and apply fallbacks if neede
 
 There are scenarios which benefit from passing pre-allocated temporary memory to an algorithm.
 For example, a user program may manage a reusable memory pool.
-This is especially useful when an algorithm is called in a loop and the allocation overhead
+Also, this is especially useful when an algorithm is called in a loop and the allocation overhead
 cannot be amortized by memory pools provided by the device or compiler runtime.
 
-It may be preferable to make this the only option and avoid internal global memory allocation.
+It may be preferable to make this the only option and
+avoid internal global memory allocations altogether.
+This approach eliminates the overhead associated with `host_task`,
+which retains temporary memory until an algorithm completes its asynchronous execution.
+Additionally, it reduces the number of interfaces that need to be supported.
 
 This should be done in conjunction with the
 [Global and Local Memory Requirements](#global-and-local-memory-requirements) interface.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -148,7 +148,7 @@ namespace kt = oneapi::dpl::experimental::kt;
 
 int main()
 {
-   std::size_t n = 6;
+   const std::size_t n = 6;
    sycl::queue q{sycl::gpu_selector_v};
    std::uint32_t* keys = sycl::malloc_shared<std::uint32_t>(n, q);
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -32,36 +32,43 @@ This namespace contains portable algorithms and namespaces with more specialized
 Below is an example of such a structure with possible algorithms:
 
 ```c++
-// Namespace for portable kernels and namespaces with platform-specific implementations
 namespace oneapi::dpl::experimental::kt
 {
+// Portable algorithms
+/*return*/ reduce(/*args*/);
+/*return*/ transform(/*args*/);
+/*return*/ inclusive_scan(/*args*/);
+/*return*/ radix_sort(/*args*/);
+// ...
 
-// The nested namespace for kernels optimized for GPU architectures
-namespace gpu
-{
-  // Algorithms optimized for GPU
-  /*return*/ reduce(/*args*/);
-  /*return*/ transform(/*args*/);
-  /*return*/ inclusive_scan(/*args*/);
-  /*return*/ radix_sort(/*args*/);
-  // ...
-
-  // Algorithms optimized for Intel GPUs supporting ESIMD technology.
-  namespace esimd
+  namespace gpu
   {
-    /*return*/ inclusive_scan(/*args*/);
-    /*return*/ radix_sort(/*args*/);
+    // Algorithms optimized for GPU architectures
+    /*return*/ reduce(/*args*/);
+    /*return*/ transform(/*args*/);
+    // ...
+
+    namespace esimd
+    {
+      // Algorithms optimized for Intel GPUs supporting ESIMD technology.
+      /*return*/ reduce(/*args*/);
+      /*return*/ transform(/*args*/);
+      // ...
+    }
+  } // namespace oneapi::dpl::experimental::kt::gpu
+
+  namespace cpu
+  {
+    // Algorithms optimized for CPU architectures
     // ...
   }
-}
 
-// The nested namespace for kernels optimized for CPU architectures
-namespace cpu { /*...*/ }
-
-} // oneapi::dpl::experimental::kt
+} // namespace oneapi::dpl::experimental::kt
 ```
 
-### Abstract Signature
+There is no requirement for the sets of algorithms in each namespace to be identical.
+
+### Abstract Algorithm Signature
 
 A kernel template is a C++ function invoked from the host.
 
@@ -183,7 +190,7 @@ these entities more act like algorithms rather than SYCL kernels.
 Probably, a better name is "Algorithm Templates".
 The renaming requires changing the corresponding namespace.
 
-### Specializations and their Differntiation
+### Specializations and their Differentiation
 
 Currently, the specializations of the algorithms belong to different namespaces.
 Using tags instead namespaces offers several advantages,

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -309,9 +309,36 @@ as described in [Abstract Algorithm Signature](abstract-algorithm-signature) sec
 In particular, it should be investigated if supporting these entities is necessary and
 whether they can be handled by an additional thin layer between
 the algorithms with standard interfaces and Kernel Templates:
-- `oneapi::dpl::begin` and `oneapi::dpl::end`, which mimic iterators to pass `sycl::buffer` to algorithms accepting iterators.
+- `oneapi::dpl::begin` and `oneapi::dpl::end`,
+   which mimic iterators to pass `sycl::buffer` to iterator-based algorithms.
 - Iterators to a host-allocated `std::vector` as described in
   [Pass Data to Algorithms > Use std::vector](https://github.com/uxlfoundation/oneDPL/blob/release/2022.9.0/documentation/library_guide/parallel_api/pass_data_algorithms.rst#use-stdvector)
+
+An additional question is how to handle hardware requirements that cannot be queried directly
+through standard SYCL mechanisms. For example, selecting a more performant kernel template
+might depend on forward-progress guarantees between work-groups.
+While oneAPI DPC++ supports querying this via
+the [Root Group](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc)
+experimental extension, other SYCL implementations may lack a corresponding feature.
+Furthermore, even if a device does not explicitly support cooperative kernel launch,
+it may still provide sufficient guarantees in limited cases
+such as chain-like synchronization between work-groups.
+A possible solution is to allow users to define a macro
+indicating that the required hardware capability is present.
+
+### Encoding Requirements
+
+Some requirements, for example forward-progress guarantees between work-groups,
+are currently only described in documentation.
+Encoding such requirements programmatically would improve visibility and
+help avoid unintended usage.
+If fallback implementations exist,
+this also enables smooth switching when the target device changes.
+
+One option is to define a macro for each such requirement.
+These macros could be used to select appropriate implementations
+for algorithms with standard interfaces, as described in
+[Kernel Templates as a Backend for Algorithms with Standard Interfaces](kernel-templates-as-a-backend-for-algorithms-with-standard-interfaces).
 
 ## Exit Criteria
 
@@ -324,5 +351,4 @@ The proposed set of algorithms should become fully supported if:
 - Evidence of sufficiently good performance is provided.
 - There is positive adoption feedback.
 
-Some individual algorithms may remain experimental
-and have their own exit criteria.
+Some individual algorithms may remain experimental and have their own exit criteria.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -200,9 +200,11 @@ Using a tag as a function or a template parameter should be considered as well.
 This method has both advantages and disadvantages compared to namespace-based separation.
 Pros:
 - Avoids potential name clashes caused by `using` directives.
+
 Cons:
 - Does not replicate the hierarchical structure provided by namespaces,
   unless namespeces are built into the tag name.
+
 Other aspects:
 - Is an additional parameter, possibly with its own namespaces,
   preferred over adding namespaces directly to an algorithm?

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -123,6 +123,28 @@ That behaviour may change depending on how
 [External Allocation of Global Memory](#external-allocation-of-global-memory)
 is addressed.
 
+### Algorithms to Implement
+
+The following list outlines the most desirable algorithms to add,
+but it is neither exhaustive nor restrictive.
+
+Algorithms in the portable namespace may include:
+- Loops: `fill`, `for_each`, `transform`
+- Copying: `copy`, `copy_if`
+- Reduction: `reduce`, `transform_reduce`
+- Prefix sum: `inclusive_scan`, `exclusive_scan`,
+  `transform_inclusive_scan`, `transform_exclusive_scan`
+- Sorting: `merge_sort`, `radix_sort`, `merge_sort_by_key`, `radix_sort_by_key`
+
+This selection is based on a set of experimental asynchronous algorithms,
+as kernel templates are considered a potential replacement
+(see [General architecture for asynchronous API](https://github.com/uxlfoundation/oneDPL/blob/oneDPL-2022.9.0-release/rfcs/archived/asynchronous_api_general/readme.md)).
+The additional inclusion of `copy_if` reflects its widespread use,
+and sorting algorithms are divided into radix, merge, and by-key categories for performance reasons.
+
+Specialized namespaces may contain a different set algorithms,
+based on user demand and performance considerations.
+
 ### Example
 
 The example demonstrates the use of a kernel template
@@ -261,10 +283,6 @@ Different approaches may be more effective when processing different number of e
 For example, a small number of elements can be processed by a single work-group.
 
 Separating such cases would reduce compilation time.
-
-### Algorithms to Implement
-
-A list of algorithms to implement should be defined.
 
 ### Benchmarking
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -127,7 +127,7 @@ which can be compared to `oneapi::dpl::stable_sort`.
 Performance tuning controls:
 1. Algorithm-specific: the number of bits sorted per radix sort pass (`8`).
 2. Common: the number of elements processed per sub-group (`416`)
-  and the work-group size (`64`).
+  and the number of sub-groups per work-group (`64`).
 
 These parameters influence various factors,
 including the number of kernels launched, register and local memory usage,

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -5,7 +5,7 @@
 This RFC describes an experimental set of algorithms with easily tunable controls,
 designed to achieve optimal performance on specific hardware and workloads.
 They prioritize efficiency over generality when compared to
-algorithms that conform to standard C++ interfaces and use device execution policies.
+algorithms that conform to the standard C++ interfaces.
 
 These algorithms are intended for use with SYCL.
 
@@ -74,7 +74,7 @@ A kernel template is a C++ function invoked from the host.
 
 Each function takes a `sycl::queue` as its first argument and
 an instance of the [kernel_param](kernel_configuration/README.md) template,
-which applies settings common to all kernel templates, as its last argument.
+which specializes parameters common to all kernel templates, as its last argument.
 The arguments in between vary depending on the specific algorithm.
 The function may also have algorithm-specific non-deducible template parameters.
 
@@ -187,8 +187,7 @@ for example through cmake arguments.
 
 The name "Kernel Templates" may be misleading because
 these entities more act like algorithms rather than SYCL kernels.
-Probably, a better name is "Algorithm Templates".
-The renaming requires changing the corresponding namespace.
+Renaming would require changing the top-level namespace.
 
 ### Specializations and their Differentiation
 
@@ -216,8 +215,8 @@ cannot be amortized by memory pools provided by the device or compiler runtime.
 
 It may be preferable to make this the only option and
 avoid internal global memory allocations altogether.
-This approach eliminates the overhead associated with `host_task`,
-which retains temporary memory until an algorithm completes its asynchronous execution.
+This approach eliminates the overhead associated with retaining temporary memory
+until an algorithm completes its asynchronous execution.
 Additionally, it reduces the number of interfaces that need to be supported.
 
 This should be done in conjunction with the
@@ -281,11 +280,11 @@ which rely compiler extensions.
 
 The proposed set of algorithms should transition to an extension if:
 - All the questions under [Kernel Templates](#open-questions) and
-  [Kernel Configuration](kernel_configuration/README.md#open-questions) sections are addressed,
-  unless a question is marked as not mandatory.
+  [Kernel Configuration](kernel_configuration/README.md#open-questions) sections are either addressed
+  or provided with a justification to postpone or ignore.
 - A significant portion of the algorithms listed in
   [Algorithms to Implement](#algorithms-to-implement) is implemented.
-- They are performant.
+- Evidence of sufficiently good performance is provided.
 - There is positive adoption feedback.
 
 Some individual algorithms may remain experimental

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -115,6 +115,7 @@ Supported data passing mechanisms are listed in
 the [documentation on passing data](https://uxlfoundation.github.io/oneDPL/parallel_api/pass_data_algorithms.html#pass-data-to-algorithms).
 The `oneapi::dpl::begin` and `oneapi::dpl::end` helper functions are not supported;
 however, `sycl::buffer` objects may be passed directly.
+Using host-allocated data in a `std::vector` is not supported as input.
 Specialized algorithms may extend or restrict the supported data passing mechanisms.
 
 If an algorithm allocates global memory and that allocation is unsuccessful,

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -193,7 +193,7 @@ The renaming requires changing the corresponding namespace.
 ### Specializations and their Differentiation
 
 Currently, the specializations of the algorithms belong to different namespaces.
-Using tags instead namespaces offers several advantages,
+Using tags instead of namespaces offers several advantages,
 for example easier dispatching between specializations and avoiding deeply nested namespaces.
 
 ### Reporting Global and Local Memory Requirements
@@ -243,7 +243,7 @@ A list of algorithms to implement should be defined.
 A benchmark suite can help select the best configuration and parameters
 for a given workload and hardware.
 
-### Default KernelParam Values
+### Default Kernel Configuration Values
 
 `KernelParam` template parameter
 is placed before all the deduced parameters to simplify

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -354,7 +354,7 @@ and to address concerns related to usability and expressiveness.
 - Range support:
   Should ranges be supported in the interface, or are iterators sufficient?
 
-### Vectorizing/Widenning of Load and Store Operations
+### Vectorizing/Widening of Load and Store Operations
 
 Many GPU architectures often support wide load and store operations
 (128B, 256B, or larger depending on a specific architecture) per sub-group

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -89,7 +89,7 @@ template <
     typename AlgorithmParameter2,  // ...
     typename AlgorithmParameterN,  // manually specified, may have a default
 
-    typename KernelParam,          // manually specified, may have a default in future
+    typename KernelParam,          // deduced, may have a default in future
 
     typename Arg1,                 // deduced, may have a default
     typename Arg2,                 // ...
@@ -100,7 +100,7 @@ sycl::event kernel_template (
     /* any cvref */ Arg1 arg1,
     /* any cvref */ Arg2 arg2,
     /* any cvref */ ArgN argn,
-    KernelParam param
+    KernelParam param              // manually specified, may have a default in future
 );
 ```
 
@@ -126,8 +126,8 @@ which can be compared to `oneapi::dpl::stable_sort`.
 
 Performance tuning controls:
 1. Algorithm-specific: the number of bits sorted per radix sort pass (`8`).
-2. Common: the number of elements processed per sub-group (`416`)
-  and the number of sub-groups per work-group (`64`).
+2. Common: the number of elements processed per work-item (`416`)
+  and the number of work-items in a work-group (`64`).
 
 These parameters influence various factors,
 including the number of kernels launched, register and local memory usage,

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -285,10 +285,19 @@ making default values less relevant.
 It needs to be explored how to configure algorithms with multiple performance-critical kernels.
 The `kernel_param` targets a single kernel, and currently, only one instance can be passed.
 
-### Compiler Extension and Differentiation of Algorithms
+### Compiler Extensions and Differentiation of Algorithms
 
-Currently, it is unclear if we should defferentiate algorithms
-which rely on compiler extensions.
+It is unclear how to defferentiate algorithms relying on compiler extensions.
+
+For example, oneAPI DPC++ compiler has
+[Root Group](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc)
+extension, which provides additional forward progress guarantess between work-groups to select
+a more performant algorithmic strategy.
+
+Several questions arise:
+- Should algorithms relying on such extensions reside in a separate namespace?
+- Should they be conditionally available only when the required extension is supported?
+- Should they provide a fallback implementation when the extension is not present?
 
 ### Kernel Templates as a Backend for Algorithms with Standard Interfaces
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -342,16 +342,15 @@ and to address concerns related to usability and expressiveness.
 
 - Handling `sycl::buffer`:
   Should a `sycl::buffer` be passed as a range, or should there be a dedicated overload?
-  If passed separately,
-  it cannot participate in range-based compositions (for example, `std::ranges::zip_view`).
-  However, is range integration feasible in practice?
+  Is passing as a range feasible in practice, and is it be possible
+  to use range-based compositions such as `std::ranges::zip_view` with `sycl::buffer`?
   Is it even better to allow passing `oneapi::dpl::begin` and `oneapi::dpl::end`
   helper functions to support `sycl::buffer` with iterators such as `oneapi::dpl::zip_iterator`?
 - Iterator parameter:
-  Should algorithms accept (`first`, `last`) or (`last`, `size`)?
+  Should algorithms accept (`first`, `last`) or (`first`, `size`)?
   The latter avoids passing an explicit index type, see
   [Kernel Configuration](kernel_configuration/README.md#indexing-type), but
-  it is not consistent with the standard C++ algorithms interfaces.
+  it is not consistent with the standard C++ algorithm interfaces.
 - Range support:
   Should ranges be supported in the interface, or are iterators sufficient?
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -104,8 +104,8 @@ sycl::event kernel_template (
 );
 ```
 
-`Arg1`, ..., `ArgN` include the sequences to be processed.
-Data can be passed using the same mechanisms described in the
+`Arg1`, ..., `ArgN` include sequences to process.
+Data must be passed using the same mechanisms described in the
 [documentation on passing data](https://uxlfoundation.github.io/oneDPL/parallel_api/pass_data_algorithms.html#pass-data-to-algorithms)
 for algorithms with device policies.
 Specialized algorithms may extend or restrict the supported data passing mechanisms.
@@ -134,7 +134,7 @@ including the number of kernels launched, register and local memory usage,
 global memory access, and the utilization of hardware computational resources.
 They can be easily adjusted for another GPU with different hardware characteristics.
 
-The kernle template relies on ESIMD technology
+The kernel template relies on ESIMD technology
 and certain forward progress guarantees between work-groups.
 
 ```c++

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -275,13 +275,13 @@ The `kernel_param` targets a single kernel, and currently, only one instance can
 ## Exit Criteria
 
 The proposed set of algorithms should transition to an extension if:
-- All the [Open Questions](#open-questions) are addressed.
-  Note that in the future, some questions may arise
-  addressing which is unnecessary for the transition.
+- All the questions under [Kernel Templates](#open-questions) and
+  [Kernel Configuration](kernel_configuration/README.md#open-questions) sections are addressed,
+  unless a question is marked as not mandatory.
 - A significant portion of the algorithms listed in
   [Algorithms to Implement](#algorithms-to-implement) is implemented.
 - They are performant.
-- There is a positive adoption feedback.
+- There is positive adoption feedback.
 
 Some individual algorithms may remain experimental
 and have their own exit criteria.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -334,6 +334,27 @@ Several questions arise:
 It should be evaluated whether the proposed algorithms can serve as a backend for oneDPL algorithms
 that use the standard C++ interfaces and device execution policies.
 
+### Input Parameters Design Considerations
+
+There are several questions regarding the input parameters that need to be explored to
+ensure that algorithm interfaces are consistent
+and to address concerns related to usability and expressiveness.
+
+- Handling `sycl::buffer`:
+  Should a `sycl::buffer` be passed as a range, or should there be a dedicated overload?
+  If passed separately,
+  it cannot participate in range-based compositions (for example, `std::ranges::zip_view`).
+  However, is range integration feasible in practice?
+  Is it even better to allow passing `oneapi::dpl::begin` and `oneapi::dpl::end`
+  helper functions to support `sycl::buffer` with iterators such as `oneapi::dpl::zip_iterator`?
+- Iterator parameter:
+  Should algorithms accept (`first`, `last`) or (`last`, `size`)?
+  The latter avoids passing an explicit index type, see
+  [Kernel Configuration](kernel_configuration/README.md#indexing-type), but
+  it is not consistent with the standard C++ algorithms interfaces.
+- Range support:
+  Should ranges be supported in the interface, or are iterators sufficient?
+
 ## Exit Criteria
 
 The proposed set of algorithms should become fully supported if:

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -195,8 +195,19 @@ Renaming would require changing the top-level namespace.
 ### Specializations and their Differentiation
 
 Currently, the specializations of the algorithms belong to different namespaces.
-Using tags instead of namespaces offers several advantages,
-for example easier dispatching between specializations and avoiding deeply nested namespaces.
+
+Using a tag as a function or a template parameter should be considered as well.
+This method has both advantages and disadvantages compared to namespace-based separation.
+Pros:
+- Avoids potential name clashes caused by `using` directives.
+Cons:
+- Does not replicate the hierarchical structure provided by namespaces,
+  unless namespeces are built into the tag name.
+Other aspects:
+- Is an additional parameter, possibly with its own namespaces,
+  preferred over adding namespaces directly to an algorithm?
+- Specializations may not share the same set of arguments,
+  which reduces the value of tag-based dispatching.
 
 ### Reporting Global and Local Memory Requirements
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -102,23 +102,25 @@ If an algorithm allocates global memory, it must throw `std::bad_alloc` if the a
 
 ### Example
 
-The algorithm in the example below is tuned for better performance using:
-1. An algorithm-specific parameter: the number of bits sorted per radix sort pass (`8`).
-2. A common set of parameters: the number of elements processed per sub-group (`416`)
-  and the work-group size (`64`). [kernel_param](kernel_configuration/README.md)
-  page has for more detailed description.
+The example demonstrates the use of a kernel template
+and describes how it is tuned for better performance and what makes it less portable
+than an alternative algorithm with a standard interface.
+It uses `oneapi::dpl::experimental::kt::gpu::esimd::radix_sort`,
+which can be compared to `oneapi::dpl::stable_sort`.
 
-These parameters affect how many kernels are launched, how much register and local memory is used,
-how much global memory accessed,
-how well the hardware computational resources are utilized for a given number of elements to sort,
-and many other performance factors.
-The parameters differ for each GPU and can be easily adjusted.
-`oneapi::dpl::stable_sort`, an algorithm with a standard interface,
-does not provide such tuning capabilities.
+Performance tuning controls:
+1. Algorithm-specific: the number of bits sorted per radix sort pass (`8`).
+2. Common: the number of elements processed per sub-group (`416`)
+  and the work-group size (`64`).
 
-`oneapi::dpl::experimental::kt::gpu::esimd::radix_sort` kernel template relies on
-ESIMD technology and certain forward progress guarantees between work-groups,
-which allows using hardware resources more effectively, but it limits portability.
+These parameters influence various factors,
+including the number of kernels launched, register and local memory usage,
+global memory access, and the utilization of hardware computational resources.
+They can be easily adjusted for another GPU with different hardware characteristics.
+
+The kernle template relies on ESIMD technology
+and certain forward progress guarantees between work-groups,
+which leads to better performance at the expense of portability.
 
 ```c++
 // icpx -fsycl radix_sort.cpp -o radix_sort -I /path/to/oneDPL/include && ./radix_sort

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -56,9 +56,6 @@ namespace cpu { /*...*/ }
 } // oneapi::dpl::experimental::kt
 ```
 
-It is possible to implement another approach to select specializations via tags.
-It is denoted in [Open Questions](#open-questions).
-
 ### Abstract Signature
 
 A kernel template is a C++ function invoked from the host.
@@ -102,7 +99,7 @@ for algorithms with device policies.
 Additionally, a plain `sycl::buffer` can also be used.
 Specialized algorithms may impose additional restrictions on how data is passed.
 
-If an algorithm allocates global memory, it must throw `std::bad_alloc` if the allocation is unsuccessfull.
+If an algorithm allocates global memory, it must throw `std::bad_alloc` if the allocation is unsuccessful.
 
 ### Example
 
@@ -176,7 +173,7 @@ There are several design aspects which should be addressed to make it a fully-su
 The name "Kernel Templates" may be misleading because
 these entities more act like algorithms rather than SYCL kernels.
 Probably, a better name is "Algorithm Templates".
-The renaming requires chaning the corresponding namespace.
+The renaming requires changing the corresponding namespace.
 
 ### Specializations and their Differntiation
 
@@ -200,15 +197,15 @@ by providing an easy way to get that information and fallback if necessary.
 
 It must be beneficial to allow passing externally allocated memory to an algorithm.
 For example, a user program may manage a pool of memory, which can be reused.
-It is especially useful if an algorihtm is called in a loop and the allocation overhead
+It is especially useful if an algorithm is called in a loop and the allocation overhead
 cannot be ammortized by memory pools provided by device or compiler runtime.
 
-It may also make sence to make it the only option
+It may also make sense to make it the only option
 and do not allocate global memory internally at all.
 It must be done in conjuciton with
 [Global and Local Memory Requirements](#global-and-local-memory-requirements)
 
-### Asynchronious Execution
+### Asynchronous Execution
 
 The algorithms return a `sycl::event` but do not accept any input events as inputs.
 As a result, they are not fully asynchronous.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -111,13 +111,13 @@ The algorithm in the example below is tuned for better performance using:
 
 These parameters affect how many kernels are launched, how much register and local memory is used,
 how much global memory accessed,
-how well the hardware computational resources are utilized for a given the number of elements to sort,
+how well the hardware computational resources are utilized for a given number of elements to sort,
 and many other performance factors.
 The parameters differ for each GPU and can be easily adjusted.
 `oneapi::dpl::stable_sort`, an algorithm with a standard interface,
 does not provide such tuning capabilities.
 
-Also `oneapi::dpl::experimental::kt::gpu::esimd::radix_sort` kernel template relies on
+`oneapi::dpl::experimental::kt::gpu::esimd::radix_sort` kernel template relies on
 ESIMD technology and certain forward progress guarantees between work-groups,
 which allows using hardware resources more effectively, but it limits portability.
 
@@ -183,27 +183,26 @@ for example easier dispatching between specializations and avoiding deeply neste
 
 ### Reporting Global and Local Memory Requirements
 
-Currently, there is no an interface which returns amount of memory to be allocated
-based on the algorithm, its configuration and input parameters.
+Currently, there is no interface that returns the amount of memory to be allocated
+based on the algorithm, its configuration, and input parameters.
 
-Instead there is a description in the documentation which gives an estimation, see
-https://uxlfoundation.github.io/oneDPL/kernel_templates/single_pass_scan.html#memory-requirements
-as an example for `oneapi::dpl::experimental::gpu::inclusive_scan`.
+Instead, the documentation provides only an estimation, for example see
+https://uxlfoundation.github.io/oneDPL/kernel_templates/single_pass_scan.html#memory-requirements.
 
-The corresponding interfaces will make usage of the algorithms safer
-by providing an easy way to get that information and fallback if necessary.
+The corresponding interfaces would make algorithms safer
+by providing an easy way to get memory requirements and apply fallbacks if needed.
 
 ### External Allocation of Global Memory
 
-It must be beneficial to allow passing externally allocated memory to an algorithm.
-For example, a user program may manage a pool of memory, which can be reused.
-It is especially useful if an algorithm is called in a loop and the allocation overhead
-cannot be ammortized by memory pools provided by device or compiler runtime.
+It is possible to pass externally allocated memory to an algorithm.
+For example, a user program may manage a reusable memory pool.
+This is especially useful when an algorithm is called in a loop and the allocation overhead
+cannot be amortized by memory pools provided by the device or compiler runtime.
 
-It may also make sense to make it the only option
-and do not allocate global memory internally at all.
-It must be done in conjuciton with
-[Global and Local Memory Requirements](#global-and-local-memory-requirements)
+It may be preferable to make this the only option and avoid internal global memory allocation.
+
+This should be done in conjunction with the
+[Global and Local Memory Requirements](#global-and-local-memory-requirements) interface.
 
 ### Asynchronous Execution
 
@@ -211,20 +210,20 @@ The algorithms return a `sycl::event` but do not accept any input events as inpu
 As a result, they are not fully asynchronous.
 
 It should be investigated whether full asynchrony is desirable,
-and if so,how to implement it correctly.
+and if so, how to implement it correctly.
 
 ### Separation of Specializations Based on a Problem Size
 
 Different approaches may be more effective when processing different number of elements.
 For example, a small number of elements can be processed by a single work-group.
 
-Separation of these cases may be beneficial to avoid extra compilation time.
+Separating such cases would reduce compilation time.
 
 ### Algorithms to Implement
 
-A list of algorithms to be implemented must be defined.
+A list of algorithms to implement should be defined.
 
 ### Benchmarking
 
-A benchmark suit can help to select
-the best configuration and parameters for a given workload and hardware.
+A benchmark suite can help select the best configuration and parameters
+for a given workload and hardware.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -93,7 +93,7 @@ sycl::event kernel_template (
 
 `Arg1`, ..., `ArgN` include the sequences to be processed.
 Data can be passed in the same ways as described in the
-[documentation on passing data]((https://uxlfoundation.github.io/oneDPL/parallel_api/pass_data_algorithms.html#pass-data-to-algorithms))
+[documentation on passing data](https://uxlfoundation.github.io/oneDPL/parallel_api/pass_data_algorithms.html#pass-data-to-algorithms)
 for algorithms with device policies.
 Additionally, a plain `sycl::buffer` can also be used.
 Specialized algorithms may impose additional restrictions on how data is passed.
@@ -157,7 +157,8 @@ The testing harness should cover:
  - Edge cases (for example, zero-sized sequences).
 
 Due to the unlimited number of possible kernel parameter combinations, it is recommended to:
- - Always test the most representative configurations for a given algorithm from performance standpoint
+ - Always test the most representative configurations
+  (most likely to be used and achieve the best performance).
  - Randomly select a subset of additional parameter combinations to broaden coverage.
 
 The testing harness should generate or enable tests with limited portability on demand,
@@ -193,7 +194,7 @@ by providing an easy way to get memory requirements and apply fallbacks if neede
 
 ### External Allocation of Global Memory
 
-It is possible to pass externally allocated memory to an algorithm.
+There are scenarios which benefit from passing pre-allocated temporary memory to an algorithm.
 For example, a user program may manage a reusable memory pool.
 This is especially useful when an algorithm is called in a loop and the allocation overhead
 cannot be amortized by memory pools provided by the device or compiler runtime.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -1,0 +1,233 @@
+# Kernel Templates
+
+## Introduction
+
+This RFC describes an experimental set of algorithms with easily tunable controls,
+designed to achieve optimal performance on specific hardware and workloads.
+
+They prioritize efficiency over generality when compared to
+algorithms that conform to standard C++ interfaces and use device execution policies.
+
+These algorithms are intended for use with SYCL and are expected to evolve into an extension.
+
+This set of algorithms is in an early stage of development, with many questions yet to be addressed.
+
+Algorithms which are already implemented are described in
+https://uxlfoundation.github.io/oneDPL/kernel_templates_main.html
+
+The terms "kernel template" and "algorithm" are used interchangeably in this RFC.
+
+## Design
+
+### High-Level Structure
+
+The algorithms are defined in `<oneapi/dpl/experimental/kernel_templates>`, in `namespace oneapi::dpl::experimental::kt`.
+This namespace contains portable algorithms and namespaces with more specialized implementations.
+
+Below is an example of such a structure with possible algorithms:
+
+```c++
+// Namespace for portable kernels and namespaces with platform-specific implementations
+namespace oneapi::dpl::experimental::kt
+{
+
+// The nested namespace for kernels optimized for GPU architectures
+namespace gpu
+{
+  // Algorithms optimized for GPU
+  /*return*/ reduce(/*args*/);
+  /*return*/ transform(/*args*/);
+  /*return*/ inclusive_scan(/*args*/);
+  /*return*/ radix_sort(/*args*/);
+  // ...
+
+  // Algorithms optimized for Intel GPUs supporting ESIMD technology.
+  namespace esimd
+  {
+    /*return*/ inclusive_scan(/*args*/);
+    /*return*/ radix_sort(/*args*/);
+    // ...
+  }
+}
+
+// The nested namespace for kernels optimized for CPU architectures
+namespace cpu { /*...*/ }
+
+} // oneapi::dpl::experimental::kt
+```
+
+It is possible to implement another approach to select specializations via tags.
+It is denoted in [Open Questions](#open-questions).
+
+### Abstract Signature
+
+A kernel template is a C++ function invoked from the host.
+
+Each function takes a `sycl::queue` as its first argument and
+an instance of the [kernel_param](kernel_configuration/README.md) template,
+which applies settings common to all kernel templates, as its last argument.
+The arguments in between vary depending on the specific algorithm.
+The function may also have algorithm-specific non-deducible template parameters.
+
+Below is an abstract signature of a kernel template:
+
+```c++
+// defined in <oneapi/dpl/experimental/kernel_templates>
+// in namespace oneapi::dpl::experimental::kt
+
+template <
+    typename AlgorithmParameter1,  // manually specified, may have a default
+    typename AlgorithmParameter2,  // ...
+    typename AlgorithmParameterN,  // manually specified, may have a default
+
+    typename KernelParam,          // manually specified, may have a default in future
+
+    typename Arg1,                 // deduced, may have a default
+    typename Arg2,                 // ...
+    typename ArgN                  // deduced, may have a default
+>
+sycl::event kernel_template (
+    sycl::queue q,
+    /* any cvref */ Arg1 arg1,
+    /* any cvref */ Arg2 arg2,
+    /* any cvref */ ArgN argn,
+    KernelParam param
+);
+```
+
+`Arg1`, ..., `ArgN` include the sequences to be processed.
+Data can be passed in the same ways as described in the
+[documentation on passing data]((https://uxlfoundation.github.io/oneDPL/parallel_api/pass_data_algorithms.html#pass-data-to-algorithms))
+for algorithms with device policies.
+Additionally, a plain `sycl::buffer` can also be used.
+Specialized algorithms may impose additional restrictions on how data is passed.
+
+If an algorithm allocates global memory, it must throw `std::bad_alloc` if the allocation is unsuccessfull.
+
+### Example
+
+The algorithm in the example below is tuned for better performance using:
+1. An algorithm-specific parameter: the number of bits sorted per radix sort pass (`8`).
+2. A common set of parameters: the number of elements processed per sub-group (`416`)
+  and the work-group size (`64`). [kernel_param](kernel_configuration/README.md)
+  page has for more detailed description.
+
+These parameters affect how many kernels are launched, how much register and local memory is used,
+how much global memory accessed,
+how well the hardware computational resources are utilized for a given the number of elements to sort,
+and many other performance factors.
+The parameters differ for each GPU and can be easily adjusted.
+`oneapi::dpl::stable_sort`, an algorithm with a standard interface,
+does not provide such tuning capabilities.
+
+Also `oneapi::dpl::experimental::kt::gpu::esimd::radix_sort` kernel template relies on
+ESIMD technology and certain forward progress guarantees between work-groups,
+which allows using hardware resources more effectively, but it limits portability.
+
+```c++
+// icpx -fsycl radix_sort.cpp -o radix_sort -I /path/to/oneDPL/include && ./radix_sort
+#include <cstdint>
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+#include <oneapi/dpl/experimental/kernel_templates>
+
+namespace kt = oneapi::dpl::experimental::kt;
+
+int main()
+{
+   std::size_t n = 6;
+   sycl::queue q{sycl::gpu_selector_v};
+   std::uint32_t* keys = sycl::malloc_shared<std::uint32_t>(n, q);
+
+   keys[0] = 3, keys[1] = 2, keys[2] = 1, keys[3] = 5, keys[4] = 3, keys[5] = 3;
+
+   auto e = kt::gpu::esimd::radix_sort<false, 8>(q, keys, keys + n, kt::kernel_param<416, 64>{});
+   e.wait();
+
+   sycl::free(keys, q);
+   return 0;
+}
+```
+
+## Testing
+
+The testing harness should cover:
+ - Varying numbers of elements to process, from thousands to millions.
+ - Different element types.
+ - Diverse types of input sequences.
+ - Representative data distributions.
+ - Various combinations of other parameters, depending on the signature of the algorithm.
+ - Edge cases (for example, zero-sized sequences).
+
+Due to the unlimited number of possible kernel parameter combinations, it is recommended to:
+ - Always test the most representative configurations for a given algorithm from performance standpoint
+ - Randomly select a subset of additional parameter combinations to broaden coverage.
+
+The testing harness should generate or enable tests with limited portability on demand,
+for example through cmake arguments.
+
+## Open Questions
+
+There are several design aspects which should be addressed to make it a fully-supported extension.
+
+### Name
+
+The name "Kernel Templates" may be misleading because
+these entities more act like algorithms rather than SYCL kernels.
+Probably, a better name is "Algorithm Templates".
+The renaming requires chaning the corresponding namespace.
+
+### Specializations and their Differntiation
+
+Currently, the specializations of the algorithms belong to different namespaces.
+Using tags instead tags offers several advantages,
+for example easier dispatching between specializations and avoiding deeply nested namespaces.
+
+### Reporting Global and Local Memory Requirements
+
+Currently, there is no an interface which returns amount of memory to be allocated
+based on the algorithm, its configuration and input parameters.
+
+Instead there is a description in the documentation which gives an estimation, see
+https://uxlfoundation.github.io/oneDPL/kernel_templates/single_pass_scan.html#memory-requirements
+as an example for `oneapi::dpl::experimental::gpu::inclusive_scan`.
+
+The corresponding interfaces will make usage of the algorithms safer
+by providing an easy way to get that information and fallback if necessary.
+
+### External Allocation of Global Memory
+
+It must be beneficial to allow passing externally allocated memory to an algorithm.
+For example, a user program may manage a pool of memory, which can be reused.
+It is especially useful if an algorihtm is called in a loop and the allocation overhead
+cannot be ammortized by memory pools provided by device or compiler runtime.
+
+It may also make sence to make it the only option
+and do not allocate global memory internally at all.
+It must be done in conjuciton with
+[Global and Local Memory Requirements](#global-and-local-memory-requirements)
+
+### Asynchronious Execution
+
+The algorithms return a `sycl::event` but do not accept any input events as inputs.
+As a result, they are not fully asynchronous.
+
+It should be investigated whether full asynchrony is desirable,
+and if so,how to implement it correctly.
+
+### Separation of Specializations Based on a Problem Size
+
+Different approaches may be more effective when processing different number of elements.
+For example, a small number of elements can be processed by a single work-group.
+
+Separation of these cases may be beneficial to avoid extra compilation time.
+
+### Algorithms to Implement
+
+A list of algorithms to be implemented must be defined.
+
+### Benchmarking
+
+A benchmark suit can help to select
+the best configuration and parameters for a given workload and hardware.

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -221,7 +221,7 @@ which retains temporary memory until an algorithm completes its asynchronous exe
 Additionally, it reduces the number of interfaces that need to be supported.
 
 This should be done in conjunction with the
-[Global and Local Memory Requirements](#global-and-local-memory-requirements) interface.
+[Global and Local Memory Requirements](#reporting-global-and-local-memory-requirements) interface.
 
 ### Asynchronous Execution
 

--- a/rfcs/experimental/kernel_templates/README.md
+++ b/rfcs/experimental/kernel_templates/README.md
@@ -236,6 +236,31 @@ A list of algorithms to implement should be defined.
 A benchmark suite can help select the best configuration and parameters
 for a given workload and hardware.
 
+### Default KernelParam Values
+
+`KernelParam` template parameter
+is placed before all the deduced parameters to simplify
+a potential addition of a default value in the future.
+However, it is unclear if a default value should be provided,
+especially given the extension's focus on performance tuning.
+
+Creation of a default value with optimal settings is impossible right now.
+`kernel_param` template argument, which substitutes `KernelParam`,
+includes compile-time values, whose optimal selection depends on run-time information,
+such is the number of elements to process.
+
+[Runtime Parameters](kernel_configuration/README.md#runtime-parameters) raises a question
+of providing them at run-time.
+However, doing so would likely require querying device properties, introducing overhead.
+
+The complexity of manual selection of these values may be reduced by the [Benchmarks](#benchmarking),
+making default values less relevant.
+
+### Configuring an Algorithm with Multiple Kernels
+
+It needs to be explored how to configure algorithms with multiple performance-critical kernels.
+The `kernel_param` targets a single kernel, and currently, only one instance can be passed.
+
 ## Exit Criteria
 
 The proposed set of algorithms should transition to an extension if:

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -50,13 +50,15 @@ is an implementation-defined vectorization factor.
 `kernel_name` is an optional parameter that is used to set a kernel name.
 If omitted, SYCL kernel name(s) will be automatically generated.
 If provided, it must be a unique C++ typename that satisfies the requirements
-for SYCL kernel names in the `SYCL 2020 Specification`_.
+for SYCL kernel names in the
+[SYCL 2020 Specification](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels)
 
-**Note:** Passing `kernel_name` might be required in case an implementation of SYCL
-is not fully compliant with the `SYCL 2020 Specification`_
+Passing `kernel_name` might be required in case an implementation of SYCL
+is not fully compliant with the
+[SYCL 2020 Specification](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels)
 and does not support optional kernel names.
 
-**Note:** The provided name can be augmented by oneDPL
+The provided name can be augmented by oneDPL
 when used with a template that creates multiple SYCL kernels.
 
 ## Open Questions
@@ -68,5 +70,3 @@ but their optimal values depend on the number of elements to process, which is k
 
 It should be investigated whether these parameters can be made run-time configurable
 without compromising efficiency.
-
-.. `SYCL 2020 Specification`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -6,7 +6,7 @@
 Each kernel template is invoked with a `kernel_param` type or object.
 Typically, a kernel template supports multiple values for the configuration parameters.
 Optimal values may depend on the invoked kernel, the data size and type(s),
-as well as on the used device.
+and underlying hardware characteristics.
 
 ## Signature
 

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -36,8 +36,6 @@ but their optimal values depend on the number of elements to process, which is k
 It should be investigated whether these parameters can be made run-time configurable
 without compromising efficiency.
 
-.. `SYCL 2020 Specification`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels
-
 ### Sub-group Size as a Parameter
 
 Choosing an appropriate sub-group size is important for performance,

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -12,15 +12,12 @@ as well as on the used device.
 
 ```c++
 // defined in <oneapi/dpl/experimental/kernel_templates>
-
-namespace oneapi::dpl::experimental::kt {
+// in namespace oneapi::dpl::experimental::kt
 
 template <std::uint16_t DataPerWorkItem,
           std::uint16_t WorkGroupSize,
           typename KernelName = /*unspecified*/>
 struct kernel_param;
-
-}
 ```
 
 The library guide describes all the signature details in

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -10,8 +10,6 @@ as well as on the used device.
 
 ## Signature
 
-A synopsis of the `kernel_param` struct is provided below:
-
 ```c++
 // defined in <oneapi/dpl/experimental/kernel_templates>
 
@@ -25,41 +23,8 @@ struct kernel_param;
 }
 ```
 
-### Static Member Constants
-
-| Name                                               | Value             |
-|----------------------------------------------------|-------------------|
-| `static constexpr std::uint16_t data_per_workitem` | `DataPerWorkItem` |
-| `static constexpr std::uint16_t workgroup_size`    | `WorkGroupSize`   |
-
-`data_per_workitem` is the number of iterations to be processed by a work-item.
-`workgroup_size` is he number of work-items within a work-group.
-
-The ``data_per_workitem`` parameter has a special meaning in ESIMD-based kernel templates.
-Usually, each work-item processes ``data_per_workitem`` input elements sequentially.
-However, work-items in ESIMD-based kernel templates perform vectorization,
-so the sequential work is ``data_per_workitem / vector_length`` elements, where ``vector_length``
-is an implementation-defined vectorization factor.
-
-### Member Types
-
-| Type          | Definition   |
-|---------------|--------------|
-| `kernel_name` | `KernelName` |
-
-`kernel_name` is an optional parameter that is used to set a kernel name.
-If omitted, SYCL kernel name(s) will be automatically generated.
-If provided, it must be a unique C++ typename that satisfies the requirements
-for SYCL kernel names in the
-[SYCL 2020 Specification](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels)
-
-Passing `kernel_name` might be required in case an implementation of SYCL
-is not fully compliant with the
-[SYCL 2020 Specification](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels)
-and does not support optional kernel names.
-
-The provided name can be augmented by oneDPL
-when used with a template that creates multiple SYCL kernels.
+The library guide describes all the signature details in
+https://github.com/uxlfoundation/oneDPL/blob/oneDPL-2022.8.0-release/documentation/library_guide/kernel_templates/kernel_configuration.rst.
 
 ## Open Questions
 
@@ -70,3 +35,16 @@ but their optimal values depend on the number of elements to process, which is k
 
 It should be investigated whether these parameters can be made run-time configurable
 without compromising efficiency.
+
+.. `SYCL 2020 Specification`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels
+
+### Sub-group Size as a Parameter
+
+Choosing an appropriate sub-group size is important for performance,
+as it impacts factors such as register pressure and
+the number of sub-groups to synchronize.
+The optimal value depends on the device architecture and
+the characteristics of the workload, for example, the type of elements being processed.
+
+The performance benefit should be demonstrated in practice,
+given the added complexity to the interface.

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -1,0 +1,72 @@
+# Kernel Configuration
+
+## Introduction
+
+`kernel_param` is a generic structure for configuring SYCL kernels.
+Each kernel template is invoked with a `kernel_param` type or object.
+Typically, a kernel template supports multiple values for the configuration parameters.
+Optimal values may depend on the invoked kernel, the data size and type(s),
+as well as on the used device.
+
+## Signature
+
+A synopsis of the `kernel_param` struct is provided below:
+
+```c++
+// defined in <oneapi/dpl/experimental/kernel_templates>
+
+namespace oneapi::dpl::experimental::kt {
+
+template <std::uint16_t DataPerWorkItem,
+          std::uint16_t WorkGroupSize,
+          typename KernelName = /*unspecified*/>
+struct kernel_param;
+
+}
+```
+
+### Static Member Constants
+
+| Name                                               | Value             |
+|----------------------------------------------------|-------------------|
+| `static constexpr std::uint16_t data_per_workitem` | `DataPerWorkItem` |
+| `static constexpr std::uint16_t workgroup_size`    | `WorkGroupSize`   |
+
+`data_per_workitem` is the number of iterations to be processed by a work-item.
+`workgroup_size` is he number of work-items within a work-group.
+
+The ``data_per_workitem`` parameter has a special meaning in ESIMD-based kernel templates.
+Usually, each work-item processes ``data_per_workitem`` input elements sequentially.
+However, work-items in ESIMD-based kernel templates perform vectorization,
+so the sequential work is ``data_per_workitem / vector_length`` elements, where ``vector_length``
+is an implementation-defined vectorization factor.
+
+### Member Types
+
+| Type          | Definition   |
+|---------------|--------------|
+| `kernel_name` | `KernelName` |
+
+`kernel_name` is an optional parameter that is used to set a kernel name.
+If omitted, SYCL kernel name(s) will be automatically generated.
+If provided, it must be a unique C++ typename that satisfies the requirements
+for SYCL kernel names in the `SYCL 2020 Specification`_.
+
+**Note:** Passing `kernel_name` might be required in case an implementation of SYCL
+is not fully compliant with the `SYCL 2020 Specification`_
+and does not support optional kernel names.
+
+**Note:** The provided name can be augmented by oneDPL
+when used with a template that creates multiple SYCL kernels.
+
+## Open Quesitons
+
+### Runtime Parameters
+
+The `data_per_workitem` and `workgroup_size` parameters are currently provided at compile time,
+but their optimal values depend on the number of elements to process, which is known only at run time.
+
+It should be investigated whether these parameters can be made run-time configurable
+without compromising efficiency.
+
+.. `SYCL 2020 Specification`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -43,3 +43,16 @@ the characteristics of the workload, for example, the type of elements being pro
 
 The performance benefit should be demonstrated in practice,
 given the added complexity to the interface.
+
+### Indexing Type
+
+32-bit indices have been shown to improve the performance of algorithms with standard interfaces
+from the binary search and merge families,
+when the index range is sufficient to process the given input sequences.
+
+It should be investigated whether this parameter should be exposed in Kernel Templates.
+To determine where to introduce it, we need to assess how many algorithms would benefit:
+- If the number is small,
+  a more specialized kernel configuration structure that includes the parameter may be added.
+- If the number is larger,
+  the parameter may be added into `kernel_param`, either as an optional or mandatory member.

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -56,3 +56,14 @@ To determine where to introduce it, we need to assess how many algorithms would 
   a more specialized kernel configuration structure that includes the parameter may be added.
 - If the number is larger,
   the parameter may be added into `kernel_param`, either as an optional or mandatory member.
+
+Another possible solution is to let the user specify the number of elements as a parameter,
+and then deduce the index type from the type of this parameter. For example:
+
+```c++
+template <typename InputIt, typename SizeType, typename OutputIt, typename KernelParam>
+sycl::event copy_n(InputIt input, SizeType n, OutputIt output, KernelParam param);
+```
+
+However, this method is not compatible with range-based inputs,
+where the number of elements is determined implicitly from the range itself.

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -59,7 +59,7 @@ and does not support optional kernel names.
 **Note:** The provided name can be augmented by oneDPL
 when used with a template that creates multiple SYCL kernels.
 
-## Open Quesitons
+## Open Questions
 
 ### Runtime Parameters
 

--- a/rfcs/experimental/kernel_templates/kernel_configuration/README.md
+++ b/rfcs/experimental/kernel_templates/kernel_configuration/README.md
@@ -28,14 +28,14 @@ https://github.com/uxlfoundation/oneDPL/blob/oneDPL-2022.8.0-release/documentati
 ### Runtime Parameters
 
 The `data_per_workitem` and `workgroup_size` parameters are currently provided at compile time,
-but their optimal values depend on the number of elements to process, which is known only at run time.
+but their optimal values may depend on the number of elements to process, which is known only at run time.
 
-It should be investigated whether these parameters can be made run-time configurable
+It should be investigated whether dynamic, run-time configurable parameters can be supported
 without compromising efficiency.
 
 ### Sub-group Size as a Parameter
 
-Choosing an appropriate sub-group size is important for performance,
+For some devices configuring a sub-group size might be important for performance,
 as it impacts factors such as register pressure and
 the number of sub-groups to synchronize.
 The optimal value depends on the device architecture and


### PR DESCRIPTION
The RFC describes the structure and common design of kernel templates. It also lists design gaps and potential improvements.

RFCs for the individual kernel templates will be added separately.