### PR TITLE
Add Slack notification for RFCs opened as a discussion.

### DIFF
--- a/.github/workflows/slack-pr.yaml
+++ b/.github/workflows/slack-pr.yaml
@@ -2,33 +2,7 @@ name: Slack PR Notification
 on:
   # use pull_request_target to run on PRs from forks and have access to secrets
   pull_request_target:
-    types: [labeled]
-
-env:
-  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-  channel: "onedpl"
-
-permissions:
-  pull-requests: read
-
-jobs:
-  rfc:
-    name: RFC Notification
-    runs-on: ubuntu-latest
-    # Trigger when labeling a PR with "RFC"
-    if: |
-      github.event.action == 'labeled' &&
-      contains(toJson(github.event.pull_request.labels.*.name), '"RFC"')
-    steps: 
-    - name: Notify Slack
-      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
-      with:
-        channel-id: ${{ env.channel }}
-        slack-message: "${{ github.actor }} posted a RFC: ${{ github.event.pull_request.title }}. URL: ${{ github.event.pull_request.html_url }}"
-
-name: Slack Discussion Notification
-on:
-  # Allow RFCs to start as labeled discussions as well
+    types: [opened, labeled]
   discussion:
     types: [created, labeled]
 
@@ -37,18 +11,27 @@ env:
   channel: "onedpl"
 
 permissions:
+  pull-requests: read
   discussions: read
 
 jobs:
   rfc:
     name: RFC Notification
     runs-on: ubuntu-latest
-    # Trigger when labeling a Discussion with "RFC"
+    # Trigger when labeling a PR or Discussion with "RFC"
     if: |
-      (github.event.action == 'labeled' || github.event.action == 'created') &&
+      contains(toJson(github.event.pull_request.labels.*.name), '"RFC"') ||
       contains(toJson(github.event.discussion.labels.*.name), '"RFC"')
     steps:
-    - name: Notify Slack
+    - name: Notify Slack for Pull Request
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+      with:
+        channel-id: ${{ env.channel }}
+        slack-message: "${{ github.actor }} posted a RFC: ${{ github.event.pull_request.title }}. URL: ${{ github.event.pull_request.html_url }}"
+
+    - name: Notify Slack for a Discussion
+      if: ${{ github.event_name == 'discussion' }}
       uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
       with:
         channel-id: ${{ env.channel }}


### PR DESCRIPTION
The PR updates the action that currently announces PR labeled as RFC to the oneDPL Slack channel to include discussions labeled as RFC as well.

This is a second attempt at the work started in #1742 