### PR TITLE
Fix missing `examples/dynamic_selection/CMakeLists.txt`

### DIFF
--- a/examples/dynamic_selection/CMakeLists.txt
+++ b/examples/dynamic_selection/CMakeLists.txt
@@ -1,0 +1,3 @@
+# defines targets and sources
+add_subdirectory(nstream)
+add_subdirectory(sepia-filter-ds)

--- a/examples/dynamic_selection/CMakeLists.txt
+++ b/examples/dynamic_selection/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required (VERSION 3.4)
+
 # defines targets and sources
 add_subdirectory(nstream)
 add_subdirectory(sepia-filter-ds)


### PR DESCRIPTION
This PR fixes the missing `CMakeLists.txt` file in the `dynamic_selection` example directory.  
- Adds the `CMakeLists.txt` file to define targets and sources for the subdirectories.  
- Integrates subdirectories `nstream` and `sepia-filter-ds` into the build.

The goal - to fix CI build errors like in https://github.com/uxlfoundation/oneDPL/actions/runs/15554464988/job/43791778045?pr=2294 :
```
make[1]: Leaving directory '/home/runner/work/oneDPL/oneDPL/examples/dot_product/build'
/usr/local/bin/cmake -E cmake_progress_start /home/runner/work/oneDPL/oneDPL/examples/dot_product/build/CMakeFiles 0
+ ctest --timeout 360 --output-on-failure
+ tee ctest.log
Test project /home/runner/work/oneDPL/oneDPL/examples/dot_product/build
    Start 1: dot_product
1/1 Test #1: dot_product ......................   Passed    0.09 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.09 sec
+ for example_dir in ${GITHUB_WORKSPACE}/examples/*
+ [[ -d /home/runner/work/oneDPL/oneDPL/examples/dynamic_selection ]]
+ cd /home/runner/work/oneDPL/oneDPL/examples/dynamic_selection
+ mkdir build
+ cd build
+ cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_COMPILER=icpx ..
CMake Warning:
  Ignoring extra path from command line:

   ".."


CMake Error: The source directory "/home/runner/work/oneDPL/oneDPL/examples/dynamic_selection" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
Error: Process completed with exit code 1.
```