### PR TITLE
Example CMake Fixes; Skip example without CMakeLists.txt

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -183,15 +183,18 @@ jobs:
 
           if [[ "${{ matrix.backend }}" == "dpcpp" ]]; then
             # build and run the examples
+            example_dirs=()
             for example_dir in ${GITHUB_WORKSPACE}/examples/*; do
-            # Skip the example if it is not a directory
-            if [[ -d "$example_dir" ]]; then
+              if [[ -d "$example_dir" && -f "$example_dir/CMakeLists.txt" ]]; then
+                example_dirs+=("$example_dir")
+              fi
+            done
+            for example_dir in "${example_dirs[@]}"; do
               cd "$example_dir"
               mkdir build && cd build
               cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} ..
               make VERBOSE=1 |& tee build.log
               ctest --timeout ${TEST_TIMEOUT} --output-on-failure |& tee ctest.log
-            fi
             done
 
             #set targets to just sycl iterator for dpcpp tests
@@ -295,9 +298,14 @@ jobs:
           set BASE_DIR=%cd%
           if "${{ matrix.backend }}" == "dpcpp" (
             :: Build and run examples
+            set "example_dirs="
             for /D %%i in (%GITHUB_WORKSPACE%\examples\*) do (
-              cd "%%i"
-              :: Get current directory name
+              if exist "%%i\CMakeLists.txt" (
+                set "example_dirs=!example_dirs! "%%i""
+              )
+            )
+            for %%d in (!example_dirs!) do (
+              cd "%%d"
               mkdir build && cd build
               cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} ..
               if !errorlevel! neq 0 set exit_code=!errorlevel!
@@ -308,7 +316,7 @@ jobs:
               type ctest_ex.log
               type build_ex.log
               if !exit_code! neq 0 exit /b !exit_code!
-
+              cd %BASE_DIR%
             )
 
             set ninja_targets=build-onedpl-sycl_iterator-tests build-onedpl-implementation_details-tests

--- a/examples/pSTL_offload/CMakeLists.txt
+++ b/examples/pSTL_offload/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required (VERSION 3.4.0)
 
-set(CMAKE_CXX_COMPILER "icpx")
+if (UNIX)
+	# Direct CMake to use icpx rather than the default C++ compiler/linker
+	set(CMAKE_CXX_COMPILER icpx)
+else() # Windows
+	# Force CMake to use icx-cl rather than the default C++ compiler/linker
+	# (needed on Windows only)
+	include (CMakeForceCompiler)
+	CMAKE_FORCE_CXX_COMPILER (icx-cl IntelDPCPP)
+	include (Platform/Windows-Clang)
+endif()
 
 project (pSTL_offload)
 # Set default build type to RelWithDebInfo if not specified

--- a/examples/pSTL_offload/CMakeLists.txt
+++ b/examples/pSTL_offload/CMakeLists.txt
@@ -1,17 +1,20 @@
-cmake_minimum_required (VERSION 3.4.0)
-
-if (UNIX)
-	# Direct CMake to use icpx rather than the default C++ compiler/linker
-	set(CMAKE_CXX_COMPILER icpx)
-else() # Windows
-	# Force CMake to use icx-cl rather than the default C++ compiler/linker
-	# (needed on Windows only)
-	include (CMakeForceCompiler)
-	CMAKE_FORCE_CXX_COMPILER (icx-cl IntelDPCPP)
-	include (Platform/Windows-Clang)
+if (CMAKE_HOST_WIN32)
+    # Requires version 3.20 for baseline support of icx, icx-cl
+    cmake_minimum_required(VERSION 3.20)
+    list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
+    find_package(oneDPLWindowsIntelLLVM)
+else()
+    # Requires version 3.11 for use of icpc with c++17 requirement
+    cmake_minimum_required(VERSION 3.11)
 endif()
 
 project (pSTL_offload)
+
+set(ONEDPL_BACKEND dpcpp)
+# Add oneDPL to the build.
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../ ${CMAKE_CURRENT_BINARY_DIR}/oneDPL)
+
+
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)
 	message (STATUS "Default CMAKE_BUILD_TYPE not set using Release with Debug Info")


### PR DESCRIPTION
Fixes cmake to allow build for PSTL offlead examples (no tests running yet). For the other new examples #2191, skipping them in the CI for now with no CMakeLists.txt in the top level dir.  This allows development to continue for active PRs, using the CI without further interruption. 
We will follow up with another PR to fix for the new examples so they all build, run and pass.

