### PR TITLE
Perfect forwarding of execution policy in tests

### DIFF
--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -39,7 +39,7 @@ void test_policy_instance(Policy&& policy)
     static ::std::vector<int> a(n);
 
     ::std::fill(a.begin(), a.end(), 0);
-    ::std::fill(std::forward<Policy>(policy), a.begin(), a.end(), -1);
+    std::fill(std::forward<Policy>(policy), a.begin(), a.end(), -1);
 #if _PSTL_SYCL_TEST_USM
     queue.wait_and_throw();
 #endif

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -26,20 +26,22 @@
 #if TEST_DPCPP_BACKEND_PRESENT
 
 template<typename Policy>
-void test_policy_instance(const Policy& policy)
+void test_policy_instance(Policy&& policy)
 {
-    auto __max_work_group_size = policy.queue().get_device().template get_info<sycl::info::device::max_work_group_size>();
+    sycl::queue queue = policy.queue();
+
+    auto __max_work_group_size = queue.get_device().template get_info<sycl::info::device::max_work_group_size>();
     EXPECT_TRUE(__max_work_group_size > 0, "policy: wrong work group size");
-    auto __max_compute_units = policy.queue().get_device().template get_info<sycl::info::device::max_compute_units>();
+    auto __max_compute_units = queue.get_device().template get_info<sycl::info::device::max_compute_units>();
     EXPECT_TRUE(__max_compute_units > 0, "policy: wrong number of compute units");
 
     const int n = 10;
     static ::std::vector<int> a(n);
 
     ::std::fill(a.begin(), a.end(), 0);
-    ::std::fill(policy, a.begin(), a.end(), -1);
+    ::std::fill(std::forward<Policy>(policy), a.begin(), a.end(), -1);
 #if _PSTL_SYCL_TEST_USM
-    policy.queue().wait_and_throw();
+    queue.wait_and_throw();
 #endif
     EXPECT_TRUE(::std::all_of(a.begin(), a.end(), [](int i) { return i == -1; }), "wrong result of ::std::fill with policy");
 }

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -34,7 +34,7 @@ struct test_one_policy
     {
         auto mid = init(first1, last1, first2, last2, generator1, generator2, m);
         ::std::inplace_merge(first1, mid.first, last1, comp);
-        ::std::inplace_merge(std::forward<Policy>(exec), first2, mid.second, last2, comp);
+        std::inplace_merge(std::forward<Policy>(exec), first2, mid.second, last2, comp);
         EXPECT_EQ_N(first1, first2, n, "wrong effect from inplace_merge with predicate");
     }
 
@@ -45,7 +45,7 @@ struct test_one_policy
     {
         auto mid = init(first1, last1, first2, last2, generator1, generator2, m);
         ::std::inplace_merge(first1, mid.first, last1);
-        ::std::inplace_merge(std::forward<Policy>(exec), first2, mid.second, last2);
+        std::inplace_merge(std::forward<Policy>(exec), first2, mid.second, last2);
         EXPECT_EQ_N(first1, first2, n, "wrong effect from inplace_merge without predicate");
     }
 
@@ -155,7 +155,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        inplace_merge(std::forward<Policy>(exec), iter, iter, iter, non_const(::std::less<T>()));
+        inplace_merge(std::forward<Policy>(exec), iter, iter, iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -34,7 +34,7 @@ struct test_one_policy
     {
         auto mid = init(first1, last1, first2, last2, generator1, generator2, m);
         ::std::inplace_merge(first1, mid.first, last1, comp);
-        ::std::inplace_merge(exec, first2, mid.second, last2, comp);
+        ::std::inplace_merge(std::forward<Policy>(exec), first2, mid.second, last2, comp);
         EXPECT_EQ_N(first1, first2, n, "wrong effect from inplace_merge with predicate");
     }
 
@@ -45,7 +45,7 @@ struct test_one_policy
     {
         auto mid = init(first1, last1, first2, last2, generator1, generator2, m);
         ::std::inplace_merge(first1, mid.first, last1);
-        ::std::inplace_merge(exec, first2, mid.second, last2);
+        ::std::inplace_merge(std::forward<Policy>(exec), first2, mid.second, last2);
         EXPECT_EQ_N(first1, first2, n, "wrong effect from inplace_merge without predicate");
     }
 
@@ -155,7 +155,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        inplace_merge(exec, iter, iter, iter, non_const(::std::less<T>()));
+        inplace_merge(std::forward<Policy>(exec), iter, iter, iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
@@ -33,7 +33,7 @@ struct test_merge
                OutputIterator out_first, OutputIterator out_last)
     {
         using namespace std;
-        const auto res = merge(exec, first1, last1, first2, last2, out_first);
+        const auto res = merge(std::forward<Policy>(exec), first1, last1, first2, last2, out_first);
         EXPECT_TRUE(res == out_last, "wrong return result from merge");
         EXPECT_TRUE(is_sorted(out_first, res), "wrong result from merge");
     }
@@ -47,7 +47,7 @@ struct test_merge
     {
         using namespace std;
         typedef typename std::iterator_traits<std::reverse_iterator<InputIterator1>>::value_type T;
-        const auto res = merge(exec, first1, last1, first2, last2, out_first, std::greater<T>());
+        const auto res = merge(std::forward<Policy>(exec), first1, last1, first2, last2, out_first, std::greater<T>());
 
         EXPECT_TRUE(res == out_last, "wrong return result from merge with predicate");
         EXPECT_TRUE(is_sorted(out_first, res, std::greater<T>()), "wrong result from merge with predicate");
@@ -68,7 +68,7 @@ struct test_merge_compare
                OutputIterator out_first, OutputIterator out_last, Compare comp)
     {
         using namespace std;
-        const auto res = merge(exec, first1, last1, first2, last2, out_first, comp);
+        const auto res = merge(std::forward<Policy>(exec), first1, last1, first2, last2, out_first, comp);
         EXPECT_TRUE(res == out_last, "wrong return result from merge with predicate");
         EXPECT_TRUE(is_sorted(out_first, res, comp), "wrong result from merge with predicate");
         EXPECT_TRUE(includes(out_first, res, first1, last1, comp), "first sequence is not a part of result");
@@ -86,7 +86,7 @@ struct test_merge_compare
     {
         using namespace std;
         typedef typename std::iterator_traits<std::reverse_iterator<InputIterator1>>::value_type T;
-        const auto res = merge(exec, first1, last1, first2, last2, out_first, std::greater<T>());
+        const auto res = merge(std::forward<Policy>(exec), first1, last1, first2, last2, out_first, std::greater<T>());
 
         EXPECT_TRUE(res == out_last, "wrong return result from merge with predicate");
         EXPECT_TRUE(is_sorted(out_first, res, std::greater<T>()), "wrong result from merge with predicate");
@@ -158,7 +158,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputIterator out_iter)
     {
-        merge(exec, input_iter, input_iter, input_iter, input_iter, out_iter, non_const(std::less<T>()));
+        merge(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(std::less<T>()));
     }
 };
 
@@ -170,7 +170,7 @@ struct test_merge_tuple
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                OutputIterator out_first, Compare comp, Checker check)
     {
-        std::merge(exec, first1, last1, first2, last2, out_first, comp);
+        std::merge(std::forward<Policy>(exec), first1, last1, first2, last2, out_first, comp);
         check();
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
@@ -67,7 +67,7 @@ struct run_copy_if
 
         // Run copy_if
         [[maybe_unused]] auto i = copy_if(first, last, expected_first, pred);
-        auto k = copy_if(exec, first, last, out_first, pred);
+        auto k = copy_if(std::forward<Policy>(exec), first, last, out_first, pred);
 #if !TEST_DPCPP_BACKEND_PRESENT
         EXPECT_EQ_N(expected_first, out_first, n, "wrong copy_if effect");
         for (size_t j = 0; j < GuardSize; ++j)
@@ -123,7 +123,7 @@ template <typename InputIterator, typename OutputIterator, typename OutputIterat
 
         // Run remove_copy_if
         [[maybe_unused]] auto i = remove_copy_if(first, last, expected_first, TestUtils::NotPred<T, Predicate>{pred});
-        auto k = remove_copy_if(exec, first, last, out_first, TestUtils::NotPred<T, Predicate>{pred});
+        auto k = remove_copy_if(std::forward<Policy>(exec), first, last, out_first, TestUtils::NotPred<T, Predicate>{pred});
 #if !TEST_DPCPP_BACKEND_PRESENT
         EXPECT_EQ_N(expected_first, out_first, n, "wrong remove_copy_if effect");
         for (size_t j = 0; j < GuardSize; ++j)
@@ -192,7 +192,7 @@ struct test_non_const_copy_if
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
         auto is_even = TestUtils::IsEven<float64_t>{};
-        copy_if(exec, input_iter, input_iter, out_iter, non_const(is_even));
+        copy_if(std::forward<Policy>(exec), input_iter, input_iter, out_iter, non_const(is_even));
     }
 };
 
@@ -203,7 +203,7 @@ struct test_non_const_remove_copy_if
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
         auto is_even = TestUtils::IsEven<float64_t>{};
-        remove_copy_if(exec, input_iter, input_iter, out_iter, non_const(is_even));
+        remove_copy_if(std::forward<Policy>(exec), input_iter, input_iter, out_iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
@@ -30,7 +30,7 @@ struct test_is_partitioned
     operator()(ExecutionPolicy&& exec, Iterator1 begin1, Iterator1 end1, Predicate pred)
     {
         const bool expected = ::std::is_partitioned(begin1, end1, pred);
-        const bool actual = ::std::is_partitioned(std::forward<ExecutionPolicy>(exec), begin1, end1, pred);
+        const bool actual = std::is_partitioned(std::forward<ExecutionPolicy>(exec), begin1, end1, pred);
         EXPECT_TRUE(actual == expected, "wrong return result from is_partitioned");
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
@@ -30,7 +30,7 @@ struct test_is_partitioned
     operator()(ExecutionPolicy&& exec, Iterator1 begin1, Iterator1 end1, Predicate pred)
     {
         const bool expected = ::std::is_partitioned(begin1, end1, pred);
-        const bool actual = ::std::is_partitioned(exec, begin1, end1, pred);
+        const bool actual = ::std::is_partitioned(std::forward<ExecutionPolicy>(exec), begin1, end1, pred);
         EXPECT_TRUE(actual == expected, "wrong return result from is_partitioned");
     }
 };
@@ -66,7 +66,7 @@ struct test_non_const
     operator()(Policy&& exec, Iterator iter)
     {
         auto is_even = TestUtils::IsEven<float64_t>{};
-        is_partitioned(exec, iter, iter, non_const(is_even));
+        is_partitioned(std::forward<Policy>(exec), iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -76,7 +76,7 @@ struct test_partition
                UnaryOp unary_op, Generator generator)
     {
         fill_data(first, last, generator);
-        BiDirIt actual_ret = ::std::partition(std::forward<Policy>(exec), first, last, unary_op);
+        BiDirIt actual_ret = std::partition(std::forward<Policy>(exec), first, last, unary_op);
         EXPECT_TRUE(::std::all_of(first, actual_ret, unary_op) && !::std::any_of(actual_ret, last, unary_op),
                     "wrong effect from partition");
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -76,7 +76,7 @@ struct test_partition
                UnaryOp unary_op, Generator generator)
     {
         fill_data(first, last, generator);
-        BiDirIt actual_ret = ::std::partition(exec, first, last, unary_op);
+        BiDirIt actual_ret = ::std::partition(std::forward<Policy>(exec), first, last, unary_op);
         EXPECT_TRUE(::std::all_of(first, actual_ret, unary_op) && !::std::any_of(actual_ret, last, unary_op),
                     "wrong effect from partition");
     }
@@ -113,7 +113,7 @@ struct test_non_const_partition
     operator()(Policy&& exec, Iterator iter)
     {
         auto is_even = TestUtils::IsEven<float64_t>{};
-        partition(exec, iter, iter, non_const(is_even));
+        partition(std::forward<Policy>(exec), iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
@@ -36,7 +36,7 @@ struct test_partition_copy
                OutputIterator, OutputIterator2 false_first, OutputIterator2, UnaryOp unary_op)
     {
 
-        auto actual_ret = ::std::partition_copy(std::forward<Policy>(exec), first, last, true_first, false_first, unary_op);
+        auto actual_ret = std::partition_copy(std::forward<Policy>(exec), first, last, true_first, false_first, unary_op);
 
         EXPECT_TRUE(::std::distance(true_first, actual_ret.first) == ::std::count_if(first, last, unary_op),
                     "partition_copy has wrong effect from true sequence");

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
@@ -36,7 +36,7 @@ struct test_partition_copy
                OutputIterator, OutputIterator2 false_first, OutputIterator2, UnaryOp unary_op)
     {
 
-        auto actual_ret = ::std::partition_copy(exec, first, last, true_first, false_first, unary_op);
+        auto actual_ret = ::std::partition_copy(std::forward<Policy>(exec), first, last, true_first, false_first, unary_op);
 
         EXPECT_TRUE(::std::distance(true_first, actual_ret.first) == ::std::count_if(first, last, unary_op),
                     "partition_copy has wrong effect from true sequence");
@@ -93,7 +93,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        partition_copy(exec, input_iter, input_iter, out_iter, out_iter, non_const(TestUtils::IsEven<float64_t>{}));
+        partition_copy(std::forward<Policy>(exec), input_iter, input_iter, out_iter, out_iter, non_const(TestUtils::IsEven<float64_t>{}));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -78,7 +78,7 @@ struct test_stable_partition
         fill_data(exp_first, exp_last, generator);
         BiDirIt exp_ret = ::std::stable_partition(exp_first, exp_last, unary_op);
         fill_data(first, last, generator);
-        BiDirIt actual_ret = ::std::stable_partition(std::forward<Policy>(exec), first, last, unary_op);
+        BiDirIt actual_ret = std::stable_partition(std::forward<Policy>(exec), first, last, unary_op);
 
         EXPECT_TRUE(::std::distance(first, actual_ret) == ::std::distance(exp_first, exp_ret),
                     "wrong result from stable_partition");

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -78,7 +78,7 @@ struct test_stable_partition
         fill_data(exp_first, exp_last, generator);
         BiDirIt exp_ret = ::std::stable_partition(exp_first, exp_last, unary_op);
         fill_data(first, last, generator);
-        BiDirIt actual_ret = ::std::stable_partition(exec, first, last, unary_op);
+        BiDirIt actual_ret = ::std::stable_partition(std::forward<Policy>(exec), first, last, unary_op);
 
         EXPECT_TRUE(::std::distance(first, actual_ret) == ::std::distance(exp_first, exp_ret),
                     "wrong result from stable_partition");
@@ -117,7 +117,7 @@ struct test_non_const_stable_partition
     operator()(Policy&& exec, Iterator iter)
     {
         auto is_even = TestUtils::IsEven<float64_t>{};
-        stable_partition(exec, iter, iter, non_const(is_even));
+        stable_partition(std::forward<Policy>(exec), iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -51,7 +51,7 @@ struct test_one_policy
 
         copy(data_b, data_e, actual_b);
 
-        reverse(exec, actual_b, actual_e);
+        reverse(std::forward<ExecutionPolicy>(exec), actual_b, actual_e);
 
         bool check = equal(data_b, data_e, reverse_iterator<Iterator2>(actual_e));
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -46,7 +46,7 @@ struct test_one_policy
     {
         using namespace std;
         fill(actual_b, actual_e, T2(-123));
-        Iterator2 actual_return = reverse_copy(exec, data_b, data_e, actual_b);
+        Iterator2 actual_return = reverse_copy(std::forward<ExecutionPolicy>(exec), data_b, data_e, actual_b);
 
         EXPECT_TRUE(actual_return == actual_e, "wrong result of reverse_copy");
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
@@ -45,7 +45,7 @@ struct run_copy
 
         // Run copy
         copy(first, last, expected_first);
-        auto k = copy(exec, first, last, out_first);
+        auto k = copy(std::forward<Policy>(exec), first, last, out_first);
         for (size_t j = 0; j < GuardSize; ++j)
             ++k;
         EXPECT_EQ_N(expected_first, out_first, size, "wrong effect from copy");
@@ -68,7 +68,7 @@ struct run_copy_n
 
         // Run copy_n
         copy(first, last, expected_first);
-        auto k = copy_n(exec, first, n, out_first);
+        auto k = copy_n(std::forward<Policy>(exec), first, n, out_first);
         for (size_t j = 0; j < GuardSize; ++j)
             ++k;
         EXPECT_EQ_N(expected_first, out_first, size, "wrong effect from copy_n");
@@ -91,7 +91,7 @@ struct run_move
 
         // Run move
         move(first, last, expected_first);
-        auto k = move(exec, first, last, out_first);
+        auto k = move(std::forward<Policy>(exec), first, last, out_first);
         for (size_t j = 0; j < GuardSize; ++j)
             ++k;
         EXPECT_EQ_N(expected_first, out_first, size, "wrong effect from move");
@@ -113,7 +113,7 @@ struct run_move<Wrapper<T>>
         Wrapper<T>::SetMoveCount(0);
 
         // Run move
-        auto k = move(exec, first, last, out_first);
+        auto k = move(std::forward<Policy>(exec), first, last, out_first);
         for (size_t j = 0; j < GuardSize; ++j)
             ++k;
         EXPECT_TRUE(Wrapper<T>::MoveCount() == size, "wrong effect from move");

--- a/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
@@ -46,7 +46,7 @@ struct test_fill
     {
         fill(first, last, T(value + 1)); // initialize memory with different value
 
-        fill(exec, first, last, value);
+        fill(std::forward<Policy>(exec), first, last, value);
         EXPECT_TRUE(check(first, last, value), "fill wrong result");
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
@@ -54,7 +54,7 @@ struct test_generate
     {
         using namespace std;
         Generator_count<T> g;
-        generate(exec, first, last, g);
+        generate(std::forward<Policy>(exec), first, last, g);
         EXPECT_TRUE(::std::count(first, last, g.default_value()) == n, "generate wrong result for generate");
         ::std::fill(first, last, T(0));
     }
@@ -71,7 +71,7 @@ struct test_generate_n
 
         Generator_count<T> g;
         const auto m = n / 2;
-        auto gen_last = generate_n(exec, first, m, g);
+        auto gen_last = generate_n(std::forward<Policy>(exec), first, m, g);
         EXPECT_TRUE(::std::count(first, gen_last, g.default_value()) == m && gen_last == ::std::next(first, m),
                     "generate_n wrong result for generate_n");
         ::std::fill(first, gen_last, T(0));
@@ -114,7 +114,7 @@ struct test_non_const_generate
     operator()(Policy&& exec, Iterator iter)
     {
         auto gen = GenerateOp<T>{};
-        generate(exec, iter, iter, non_const(gen));
+        generate(std::forward<Policy>(exec), iter, iter, non_const(gen));
     }
 };
 
@@ -126,7 +126,7 @@ struct test_non_const_generate_n
     operator()(Policy&& exec, Iterator iter)
     {
         auto gen = GenerateOp<T>{};
-        generate_n(exec, iter, 0, non_const(gen));
+        generate_n(std::forward<Policy>(exec), iter, 0, non_const(gen));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
@@ -43,7 +43,7 @@ struct run_remove
 
         // Run remove
         OutputIterator i = remove(expected_first, expected_last, value);
-        OutputIterator k = remove(exec, out_first, out_last, value);
+        OutputIterator k = remove(std::forward<Policy>(exec), out_first, out_last, value);
         EXPECT_TRUE(::std::distance(expected_first, i) == ::std::distance(out_first, k), "wrong return value from remove");
         EXPECT_EQ_N(expected_first, out_first, ::std::distance(expected_first, i), "wrong remove effect");
     }
@@ -64,7 +64,7 @@ struct run_remove_if
 
         // Run remove_if
         OutputIterator i = remove_if(expected_first, expected_last, pred);
-        OutputIterator k = remove_if(exec, out_first, out_last, pred);
+        OutputIterator k = remove_if(std::forward<Policy>(exec), out_first, out_last, pred);
         EXPECT_TRUE(::std::distance(expected_first, i) == ::std::distance(out_first, k),
                     "wrong return value from remove_if");
         EXPECT_EQ_N(expected_first, out_first, ::std::distance(expected_first, i), "wrong remove_if effect");
@@ -101,7 +101,7 @@ struct test_non_const
     operator()(Policy&& exec, Iterator iter)
     {
         auto is_even = TestUtils::IsEven<float64_t>{};
-        remove_if(exec, iter, iter, non_const(is_even));
+        remove_if(std::forward<Policy>(exec), iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
@@ -41,7 +41,7 @@ struct run_remove_copy
 
         // Run copy_if
         [[maybe_unused]] auto i = remove_copy(first, last, expected_first, value);
-        auto k = remove_copy(exec, first, last, out_first, value);
+        auto k = remove_copy(std::forward<Policy>(exec), first, last, out_first, value);
 #if !TEST_DPCPP_BACKEND_PRESENT
         EXPECT_EQ_N(expected_first, out_first, n, "wrong remove_copy effect");
         for (size_t j = 0; j < GuardSize; ++j)

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -70,7 +70,7 @@ struct test_replace
         copy(data_b, data_e, actual_b);
 
         replace(expected_b, expected_e, old_value, value);
-        replace(exec, actual_b, actual_e, old_value, value);
+        replace(std::forward<ExecutionPolicy>(exec), actual_b, actual_e, old_value, value);
 
         EXPECT_TRUE((check<T, Iterator2>(actual_b, actual_e)), "wrong result of self assignment check");
         EXPECT_TRUE(equal(expected_b, expected_e, actual_b), "wrong result of replace");
@@ -105,7 +105,7 @@ struct test_replace_if
         copy(data_b, data_e, actual_b);
 
         replace_if(expected_b, expected_e, pred, value);
-        replace_if(exec, actual_b, actual_e, pred, value);
+        replace_if(std::forward<ExecutionPolicy>(exec), actual_b, actual_e, pred, value);
         EXPECT_TRUE(equal(expected_b, expected_e, actual_b), "wrong result of replace_if");
     }
 };
@@ -152,7 +152,7 @@ struct test_non_const
     operator()(Policy&& exec, Iterator iter)
     {
         auto is_even = TestUtils::IsEven<float64_t>{};
-        replace_if(exec, iter, iter, non_const(is_even), T(0));
+        replace_if(std::forward<Policy>(exec), iter, iter, non_const(is_even), T(0));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
@@ -44,7 +44,7 @@ struct test_replace_copy
         ::std::fill_n(out_first, n, trash);
         // Run replace_copy
         ::std::replace_copy(first, last, expected_first, old_value, new_value);
-        auto k = ::std::replace_copy(exec, first, last, out_first, old_value, new_value);
+        auto k = ::std::replace_copy(std::forward<Policy>(exec), first, last, out_first, old_value, new_value);
         EXPECT_EQ_N(expected_first, out_first, n, "wrong replace_copy effect");
         EXPECT_TRUE(out_last == k, "wrong return value from replace_copy");
     }
@@ -65,7 +65,7 @@ struct test_replace_copy_if
         ::std::fill_n(out_first, n, trash);
         // Run replace_copy_if
         replace_copy_if(first, last, expected_first, pred, new_value);
-        auto k = replace_copy_if(exec, first, last, out_first, pred, new_value);
+        auto k = replace_copy_if(std::forward<Policy>(exec), first, last, out_first, pred, new_value);
         EXPECT_EQ_N(expected_first, out_first, n, "wrong replace_copy_if effect");
         EXPECT_TRUE(out_last == k, "wrong return value from replace_copy_if");
     }
@@ -105,7 +105,7 @@ struct test_non_const
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
         auto is_even = TestUtils::IsEven<float64_t>{};
-        replace_copy_if(exec, input_iter, input_iter, out_iter, non_const(is_even), T(0));
+        replace_copy_if(std::forward<Policy>(exec), input_iter, input_iter, out_iter, non_const(is_even), T(0));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
@@ -44,7 +44,7 @@ struct test_replace_copy
         ::std::fill_n(out_first, n, trash);
         // Run replace_copy
         ::std::replace_copy(first, last, expected_first, old_value, new_value);
-        auto k = ::std::replace_copy(std::forward<Policy>(exec), first, last, out_first, old_value, new_value);
+        auto k = std::replace_copy(std::forward<Policy>(exec), first, last, out_first, old_value, new_value);
         EXPECT_EQ_N(expected_first, out_first, n, "wrong replace_copy effect");
         EXPECT_TRUE(out_last == k, "wrong return value from replace_copy");
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate_copy.pass.cpp
@@ -84,7 +84,7 @@ struct test_one_policy
         Iterator1 data_m = ::std::next(data_b, shift);
 
         fill(actual_b, actual_e, T(-123));
-        Iterator2 actual_return = rotate_copy(exec, data_b, data_m, data_e, actual_b);
+        Iterator2 actual_return = rotate_copy(std::forward<ExecutionPolicy>(exec), data_b, data_m, data_e, actual_b);
 
         EXPECT_TRUE(actual_return == actual_e, "wrong result of rotate_copy");
         auto comparer = comparator<T, Iterator1, Iterator2>();

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -60,7 +60,7 @@ struct test_shift
     operator()(Policy&& exec, It first, typename ::std::iterator_traits<It>::difference_type m,
         It first_exp, typename ::std::iterator_traits<It>::difference_type n, Algo algo)
     {
-        //run a test with host policy and host itertors
+        //run a test with host policy and host iterators
         It res = algo(::std::forward<Policy>(exec), first, ::std::next(first, m), n);
         //check result
         algo.check(res, first, m, first_exp, n);
@@ -101,12 +101,12 @@ struct test_shift
         using _ValueType = typename std::iterator_traits<It>::value_type;
         using _DiffType = typename std::iterator_traits<It>::difference_type;
         auto buffer_policy = TestUtils::make_device_policy<BufferKernelName<_ValueType, Algo>>(exec);
-        //1.1 run a test with hetero policy and host itertors
+        //1.1 run a test with hetero policy and host iterators
         auto res = algo(buffer_policy, first, first + m, n);
         //1.2 check result
         algo.check(res, first, m, first_exp, n);
 
-        //2.1 run a test with hetero policy and hetero itertors
+        //2.1 run a test with hetero policy and hetero iterators
         _DiffType res_idx(0);
         {//scope for SYCL buffer lifetime
             sycl::buffer<_ValueType> buf(first, first + m);

--- a/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
@@ -102,7 +102,7 @@ struct test_one_policy
         iota(data_b, data_e, 0);
         iota(actual_b, actual_e, ::std::distance(data_b, data_e));
 
-        Iterator2 actual_return = swap_ranges(exec, data_b, data_e, actual_b);
+        Iterator2 actual_return = swap_ranges(std::forward<ExecutionPolicy>(exec), data_b, data_e, actual_b);
         bool check_return = (actual_return == actual_e);
         EXPECT_TRUE(check_return, "wrong result of swap_ranges");
         if (check_return)

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -30,7 +30,7 @@ struct test_one_policy
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 /* last2 */,
                OutputIterator out_first, OutputIterator /* out_last */, BinaryOp op)
     {
-        ::std::transform(exec, first1, last1, first2, out_first, op);
+        ::std::transform(std::forward<Policy>(exec), first1, last1, first2, out_first, op);
         check_and_reset(first1, last1, first2, out_first);
     }
 
@@ -133,7 +133,7 @@ struct test_non_const
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
         InputIterator input_iter2 = input_iter;
-        transform(exec, input_iter, input_iter, input_iter2, out_iter, non_const(::std::plus<T>()));
+        transform(std::forward<Policy>(exec), input_iter, input_iter, input_iter2, out_iter, non_const(::std::plus<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -30,7 +30,7 @@ struct test_one_policy
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 /* last2 */,
                OutputIterator out_first, OutputIterator /* out_last */, BinaryOp op)
     {
-        ::std::transform(std::forward<Policy>(exec), first1, last1, first2, out_first, op);
+        std::transform(std::forward<Policy>(exec), first1, last1, first2, out_first, op);
         check_and_reset(first1, last1, first2, out_first);
     }
 
@@ -133,7 +133,7 @@ struct test_non_const
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
         InputIterator input_iter2 = input_iter;
-        transform(std::forward<Policy>(exec), input_iter, input_iter, input_iter2, out_iter, non_const(::std::plus<T>()));
+        transform(std::forward<Policy>(exec), input_iter, input_iter, input_iter2, out_iter, non_const(std::plus<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
@@ -31,7 +31,7 @@ struct test_one_policy
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, UnaryOp op)
     {
-        auto orr = ::std::transform(exec, first, last, out_first, op);
+        auto orr = ::std::transform(std::forward<Policy>(exec), first, last, out_first, op);
         EXPECT_TRUE(out_last == orr, "transform returned wrong iterator");
         check_and_reset(first, last, out_first);
     }
@@ -108,7 +108,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        transform(exec, input_iter, input_iter, out_iter, non_const(::std::negate<T>()));
+        transform(std::forward<Policy>(exec), input_iter, input_iter, out_iter, non_const(::std::negate<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
@@ -31,7 +31,7 @@ struct test_one_policy
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, UnaryOp op)
     {
-        auto orr = ::std::transform(std::forward<Policy>(exec), first, last, out_first, op);
+        auto orr = std::transform(std::forward<Policy>(exec), first, last, out_first, op);
         EXPECT_TRUE(out_last == orr, "transform returned wrong iterator");
         check_and_reset(first, last, out_first);
     }
@@ -108,7 +108,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        transform(std::forward<Policy>(exec), input_iter, input_iter, out_iter, non_const(::std::negate<T>()));
+        transform(std::forward<Policy>(exec), input_iter, input_iter, out_iter, non_const(std::negate<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
@@ -37,7 +37,7 @@ struct run_unique
         fill_data(first2, last2, generator);
 
         ForwardIt i = unique(first1, last1);
-        ForwardIt k = unique(exec, first2, last2);
+        ForwardIt k = unique(std::forward<Policy>(exec), first2, last2);
 
         auto n = ::std::distance(first1, i);
         EXPECT_TRUE(::std::distance(first2, k) == n, "wrong return value from unique without predicate");
@@ -60,7 +60,7 @@ struct run_unique_predicate
         fill_data(first2, last2, generator);
 
         ForwardIt i = unique(first1, last1, pred);
-        ForwardIt k = unique(exec, first2, last2, pred);
+        ForwardIt k = unique(std::forward<Policy>(exec), first2, last2, pred);
 
         auto n = ::std::distance(first1, i);
         EXPECT_TRUE(::std::distance(first2, k) == n, "wrong return value from unique with predicate");
@@ -112,7 +112,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        unique(exec, iter, iter, non_const(::std::equal_to<T>()));
+        unique(std::forward<Policy>(exec), iter, iter, non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
@@ -112,7 +112,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        unique(std::forward<Policy>(exec), iter, iter, non_const(::std::equal_to<T>()));
+        unique(std::forward<Policy>(exec), iter, iter, non_const(std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
@@ -178,7 +178,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        unique_copy(std::forward<Policy>(exec), input_iter, input_iter, out_iter, non_const(::std::equal_to<T>()));
+        unique_copy(std::forward<Policy>(exec), input_iter, input_iter, out_iter, non_const(std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
@@ -61,7 +61,7 @@ struct run_unique_copy
 
         // Run unique_copy
         [[maybe_unused]] auto i = unique_copy(first, last, expected_first);
-        auto k = unique_copy(exec, first, last, out_first);
+        auto k = unique_copy(std::forward<Policy>(exec), first, last, out_first);
 #if !TEST_DPCPP_BACKEND_PRESENT
         EXPECT_EQ_N(expected_first, out_first, n, "wrong unique_copy effect");
         for (size_t j = 0; j < GuardSize; ++j)
@@ -120,7 +120,7 @@ struct run_unique_copy_predicate
 
         // Run unique_copy with predicate
         [[maybe_unused]] auto i = unique_copy(first, last, expected_first, pred);
-        auto k = unique_copy(exec, first, last, out_first, pred);
+        auto k = unique_copy(std::forward<Policy>(exec), first, last, out_first, pred);
 #if !TEST_DPCPP_BACKEND_PRESENT
         EXPECT_EQ_N(expected_first, out_first, n, "wrong unique_copy with predicate effect");
         for (size_t j = 0; j < GuardSize; ++j)
@@ -178,7 +178,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        unique_copy(exec, input_iter, input_iter, out_iter, non_const(::std::equal_to<T>()));
+        unique_copy(std::forward<Policy>(exec), input_iter, input_iter, out_iter, non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/adjacent_find.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/adjacent_find.pass.cpp
@@ -32,7 +32,7 @@ struct test_adjacent_find
         using namespace std;
 
         auto k = ::std::adjacent_find(first, last);
-        auto i = adjacent_find(exec, first, last);
+        auto i = adjacent_find(std::forward<Policy>(exec), first, last);
         EXPECT_TRUE(i == k, "wrong return value from adjacent_find without predicate");
     }
 };
@@ -47,7 +47,7 @@ struct test_adjacent_find_predicate
         using namespace std;
 
         auto k = ::std::adjacent_find(first, last, pred);
-        auto i = adjacent_find(exec, first, last, pred);
+        auto i = adjacent_find(std::forward<Policy>(exec), first, last, pred);
         EXPECT_TRUE(i == k, "wrong return value from adjacent_find with predicate");
     }
 };
@@ -145,7 +145,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        adjacent_find(exec, iter, iter, non_const(::std::equal_to<T>()));
+        adjacent_find(std::forward<Policy>(exec), iter, iter, non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/adjacent_find.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/adjacent_find.pass.cpp
@@ -145,7 +145,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        adjacent_find(std::forward<Policy>(exec), iter, iter, non_const(::std::equal_to<T>()));
+        adjacent_find(std::forward<Policy>(exec), iter, iter, non_const(std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
@@ -41,7 +41,7 @@ struct test_all_of
     operator()(ExecutionPolicy&& exec, Iterator begin, Iterator end, Predicate pred, bool expected)
     {
 
-        auto actualr = ::std::all_of(std::forward<ExecutionPolicy>(exec), begin, end, pred);
+        auto actualr = std::all_of(std::forward<ExecutionPolicy>(exec), begin, end, pred);
         EXPECT_EQ(expected, actualr, "result for all_of");
     }
 };

--- a/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
@@ -41,7 +41,7 @@ struct test_all_of
     operator()(ExecutionPolicy&& exec, Iterator begin, Iterator end, Predicate pred, bool expected)
     {
 
-        auto actualr = ::std::all_of(exec, begin, end, pred);
+        auto actualr = ::std::all_of(std::forward<ExecutionPolicy>(exec), begin, end, pred);
         EXPECT_EQ(expected, actualr, "result for all_of");
     }
 };
@@ -102,7 +102,7 @@ struct test_non_const
     operator()(Policy&& exec, Iterator iter)
     {
         auto is_even = TestUtils::IsEven<float64_t>{};
-        all_of(exec, iter, iter, non_const(is_even));
+        all_of(std::forward<Policy>(exec), iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
@@ -41,7 +41,7 @@ struct test_any_of
     operator()(ExecutionPolicy&& exec, Iterator begin, Iterator end, Predicate pred, bool expected)
     {
 
-        auto actualr = ::std::any_of(exec, begin, end, pred);
+        auto actualr = ::std::any_of(std::forward<ExecutionPolicy>(exec), begin, end, pred);
         EXPECT_EQ(expected, actualr, "result for any_of");
     }
 };
@@ -87,7 +87,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        any_of(exec, iter, iter, non_const(TestUtils::IsEven<float64_t>{}));
+        any_of(std::forward<Policy>(exec), iter, iter, non_const(TestUtils::IsEven<float64_t>{}));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
@@ -41,7 +41,7 @@ struct test_any_of
     operator()(ExecutionPolicy&& exec, Iterator begin, Iterator end, Predicate pred, bool expected)
     {
 
-        auto actualr = ::std::any_of(std::forward<ExecutionPolicy>(exec), begin, end, pred);
+        auto actualr = std::any_of(std::forward<ExecutionPolicy>(exec), begin, end, pred);
         EXPECT_EQ(expected, actualr, "result for any_of");
     }
 };

--- a/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
@@ -36,7 +36,7 @@ struct test_count
     operator()(Policy&& exec, Iterator first, Iterator last, T needle)
     {
         auto expected = ::std::count(first, last, needle);
-        auto result = ::std::count(exec, first, last, needle);
+        auto result = ::std::count(std::forward<Policy>(exec), first, last, needle);
         EXPECT_EQ(expected, result, "wrong count result");
     }
 };
@@ -49,7 +49,7 @@ struct test_count_if
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         auto expected = ::std::count_if(first, last, pred);
-        auto result = ::std::count_if(exec, first, last, pred);
+        auto result = ::std::count_if(std::forward<Policy>(exec), first, last, pred);
         EXPECT_EQ(expected, result, "wrong count_if result");
     }
 };
@@ -96,7 +96,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        count_if(exec, iter, iter, non_const(TestUtils::IsEven<float64_t>{}));
+        count_if(std::forward<Policy>(exec), iter, iter, non_const(TestUtils::IsEven<float64_t>{}));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
@@ -36,7 +36,7 @@ struct test_count
     operator()(Policy&& exec, Iterator first, Iterator last, T needle)
     {
         auto expected = ::std::count(first, last, needle);
-        auto result = ::std::count(std::forward<Policy>(exec), first, last, needle);
+        auto result = std::count(std::forward<Policy>(exec), first, last, needle);
         EXPECT_EQ(expected, result, "wrong count result");
     }
 };
@@ -49,7 +49,7 @@ struct test_count_if
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         auto expected = ::std::count_if(first, last, pred);
-        auto result = ::std::count_if(std::forward<Policy>(exec), first, last, pred);
+        auto result = std::count_if(std::forward<Policy>(exec), first, last, pred);
         EXPECT_EQ(expected, result, "wrong count_if result");
     }
 };

--- a/test/parallel_api/algorithm/alg.nonmodifying/find.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find.pass.cpp
@@ -31,7 +31,7 @@ struct test_find
     operator()(Policy&& exec, Iterator first, Iterator last, Value value)
     {
         auto i = ::std::find(first, last, value);
-        auto j = find(exec, first, last, value);
+        auto j = find(std::forward<Policy>(exec), first, last, value);
         EXPECT_TRUE(i == j, "wrong return value from find");
     }
 };

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
@@ -36,7 +36,7 @@ struct test_find_end
     {
         using namespace std;
         auto expected = find_end(b, e, bsub, esub, pred);
-        auto actual = find_end(exec, b, e, bsub, esub);
+        auto actual = find_end(std::forward<ExecutionPolicy>(exec), b, e, bsub, esub);
         EXPECT_TRUE(actual == expected, "wrong return result from find_end");
     }
 };
@@ -50,7 +50,7 @@ struct test_find_end_predicate
     {
         using namespace std;
         auto expected = find_end(b, e, bsub, esub, pred);
-        auto actual = find_end(exec, b, e, bsub, esub, pred);
+        auto actual = find_end(std::forward<ExecutionPolicy>(exec), b, e, bsub, esub, pred);
         EXPECT_TRUE(actual == expected, "wrong return result from find_end with a predicate");
     }
 };
@@ -64,7 +64,7 @@ struct test_search
     {
         using namespace std;
         auto expected = search(b, e, bsub, esub, pred);
-        auto actual = search(exec, b, e, bsub, esub);
+        auto actual = search(std::forward<ExecutionPolicy>(exec), b, e, bsub, esub);
         EXPECT_TRUE(actual == expected, "wrong return result from search");
     }
 };
@@ -78,7 +78,7 @@ struct test_search_predicate
     {
         using namespace std;
         auto expected = search(b, e, bsub, esub, pred);
-        auto actual = search(exec, b, e, bsub, esub, pred);
+        auto actual = search(std::forward<ExecutionPolicy>(exec), b, e, bsub, esub, pred);
         EXPECT_TRUE(actual == expected, "wrong return result from search with a predicate");
     }
 };
@@ -139,7 +139,7 @@ struct test_non_const_find_end
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        find_end(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
+        find_end(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
     }
 };
 
@@ -150,7 +150,7 @@ struct test_non_const_search
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        search(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
+        search(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
@@ -139,7 +139,7 @@ struct test_non_const_find_end
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        find_end(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
+        find_end(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(std::equal_to<T>()));
     }
 };
 
@@ -150,7 +150,7 @@ struct test_non_const_search
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        search(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
+        search(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
@@ -31,7 +31,7 @@ struct test_find_first_of
     {
         using namespace std;
         Iterator1 expected = find_first_of(b, e, bsub, esub);
-        Iterator1 actual = find_first_of(exec, b, e, bsub, esub);
+        Iterator1 actual = find_first_of(std::forward<ExecutionPolicy>(exec), b, e, bsub, esub);
         EXPECT_TRUE(actual == expected, "wrong return result from find_first_of");
     }
 };
@@ -45,7 +45,7 @@ struct test_find_first_of_predicate
     {
         using namespace std;
         Iterator1 expected = find_first_of(b, e, bsub, esub, pred);
-        Iterator1 actual = find_first_of(exec, b, e, bsub, esub, pred);
+        Iterator1 actual = find_first_of(std::forward<ExecutionPolicy>(exec), b, e, bsub, esub, pred);
         EXPECT_TRUE(actual == expected, "wrong return result from find_first_of with a predicate");
     }
 };
@@ -108,7 +108,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        find_first_of(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
+        find_first_of(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
@@ -108,7 +108,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        find_first_of(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::equal_to<T>()));
+        find_first_of(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
@@ -36,7 +36,7 @@ struct test_find_if
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred, NotPredicate /* not_pred */)
     {
         auto i = ::std::find_if(first, last, pred);
-        auto j = find_if(exec, first, last, pred);
+        auto j = find_if(std::forward<Policy>(exec), first, last, pred);
         EXPECT_TRUE(i == j, "wrong return value from find_if");
     }
 };
@@ -49,7 +49,7 @@ struct test_find_if_not
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred, NotPredicate not_pred)
     {
         auto i = ::std::find_if(first, last, pred);
-        auto i_not = find_if_not(exec, first, last, not_pred);
+        auto i_not = find_if_not(std::forward<Policy>(exec), first, last, not_pred);
         EXPECT_TRUE(i_not == i, "wrong return value from find_if_not");
     }
 };
@@ -89,7 +89,7 @@ struct test_non_const_find_if
     operator()(Policy&& exec, Iterator iter)
     {
         TestUtils::IsEven<float64_t> is_even;
-        find_if(exec, iter, iter, non_const(is_even));
+        find_if(std::forward<Policy>(exec), iter, iter, non_const(is_even));
     }
 };
 
@@ -100,7 +100,7 @@ struct test_non_const_find_if_not
     operator()(Policy&& exec, Iterator iter)
     {
         TestUtils::IsEven<float64_t> is_even;
-        find_if_not(exec, iter, iter, non_const(is_even));
+        find_if_not(std::forward<Policy>(exec), iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
@@ -60,7 +60,7 @@ struct test_for_each
 
         // Try for_each
         ::std::for_each(expected_first, expected_last, Flip<T>(1));
-        for_each(exec, first, last, Flip<T>(1));
+        for_each(std::forward<Policy>(exec), first, last, Flip<T>(1));
         EXPECT_EQ_N(expected_first, first, n, "wrong effect from for_each");
     }
 };
@@ -76,7 +76,7 @@ struct test_for_each_n
 
         // Try for_each_n
         ::std::for_each_n(oneapi::dpl::execution::seq, expected_first, n, Flip<T>(1));
-        for_each_n(exec, first, n, Flip<T>(1));
+        for_each_n(std::forward<Policy>(exec), first, n, Flip<T>(1));
         EXPECT_EQ_N(expected_first, first, n, "wrong effect from for_each_n");
     }
 };
@@ -116,7 +116,7 @@ struct test_non_const_for_each
     operator()(Policy&& exec, Iterator iter)
     {
         auto f = TransformOp<typename std::iterator_traits<Iterator>::reference>{};
-        for_each(exec, iter, iter, non_const(f));
+        for_each(std::forward<Policy>(exec), iter, iter, non_const(f));
     }
 };
 
@@ -127,7 +127,7 @@ struct test_non_const_for_each_n
     operator()(Policy&& exec, Iterator iter)
     {
         auto f = TransformOp<typename std::iterator_traits<Iterator>::reference>{};
-        for_each_n(exec, iter, 0, non_const(f));
+        for_each_n(std::forward<Policy>(exec), iter, 0, non_const(f));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/mismatch.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/mismatch.pass.cpp
@@ -62,7 +62,7 @@ struct test_mismatch_predicate
         typedef typename iterator_traits<Iterator1>::value_type T;
         {
             const auto expected = ::std::mismatch(first1, last1, first2, ::std::equal_to<T>());
-            const auto res3 = mismatch(std::forward<Policy>(exec), first1, last1, first2, ::std::equal_to<T>());
+            const auto res3 = mismatch(std::forward<Policy>(exec), first1, last1, first2, std::equal_to<T>());
             EXPECT_TRUE(expected == res3, "wrong return result from mismatch with predicate");
         }
     }
@@ -74,7 +74,7 @@ struct test_mismatch_predicate
         typedef typename iterator_traits<Iterator1>::value_type T;
         {
             const auto expected = mismatch(oneapi::dpl::execution::seq, first1, last1, first2, last2, ::std::equal_to<T>());
-            const auto res1 = mismatch(std::forward<Policy>(exec), first1, last1, first2, last2, ::std::equal_to<T>());
+            const auto res1 = mismatch(std::forward<Policy>(exec), first1, last1, first2, last2, std::equal_to<T>());
             EXPECT_TRUE(expected == res1, "wrong return result from mismatch with predicate");
         }
     }
@@ -173,7 +173,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        mismatch(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::less<T>()));
+        mismatch(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/mismatch.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/mismatch.pass.cpp
@@ -33,7 +33,7 @@ struct test_mismatch
         typedef typename iterator_traits<Iterator1>::value_type T;
         {
             const auto expected = ::std::mismatch(first1, last1, first2, ::std::equal_to<T>());
-            const auto res4 = mismatch(exec, first1, last1, first2);
+            const auto res4 = mismatch(std::forward<Policy>(exec), first1, last1, first2);
             EXPECT_TRUE(expected == res4, "wrong return result from mismatch");
         }
     }
@@ -45,7 +45,7 @@ struct test_mismatch
         typedef typename iterator_traits<Iterator1>::value_type T;
         {
             const auto expected = mismatch(oneapi::dpl::execution::seq, first1, last1, first2, last2, ::std::equal_to<T>());
-            const auto res2 = mismatch(exec, first1, last1, first2, last2);
+            const auto res2 = mismatch(std::forward<Policy>(exec), first1, last1, first2, last2);
             EXPECT_TRUE(expected == res2, "wrong return result from mismatch");
         }
     }
@@ -62,7 +62,7 @@ struct test_mismatch_predicate
         typedef typename iterator_traits<Iterator1>::value_type T;
         {
             const auto expected = ::std::mismatch(first1, last1, first2, ::std::equal_to<T>());
-            const auto res3 = mismatch(exec, first1, last1, first2, ::std::equal_to<T>());
+            const auto res3 = mismatch(std::forward<Policy>(exec), first1, last1, first2, ::std::equal_to<T>());
             EXPECT_TRUE(expected == res3, "wrong return result from mismatch with predicate");
         }
     }
@@ -74,7 +74,7 @@ struct test_mismatch_predicate
         typedef typename iterator_traits<Iterator1>::value_type T;
         {
             const auto expected = mismatch(oneapi::dpl::execution::seq, first1, last1, first2, last2, ::std::equal_to<T>());
-            const auto res1 = mismatch(exec, first1, last1, first2, last2, ::std::equal_to<T>());
+            const auto res1 = mismatch(std::forward<Policy>(exec), first1, last1, first2, last2, ::std::equal_to<T>());
             EXPECT_TRUE(expected == res1, "wrong return result from mismatch with predicate");
         }
     }
@@ -173,7 +173,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        mismatch(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::less<T>()));
+        mismatch(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
@@ -40,7 +40,7 @@ struct test_none_of
     void
     operator()(ExecutionPolicy&& exec, Iterator begin, Iterator end, Predicate pred, bool expected)
     {
-        auto actualr = ::std::none_of(std::forward<ExecutionPolicy>(exec), begin, end, pred);
+        auto actualr = std::none_of(std::forward<ExecutionPolicy>(exec), begin, end, pred);
         EXPECT_EQ(expected, actualr, "result for none_of");
     }
 };

--- a/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
@@ -40,7 +40,7 @@ struct test_none_of
     void
     operator()(ExecutionPolicy&& exec, Iterator begin, Iterator end, Predicate pred, bool expected)
     {
-        auto actualr = ::std::none_of(exec, begin, end, pred);
+        auto actualr = ::std::none_of(std::forward<ExecutionPolicy>(exec), begin, end, pred);
         EXPECT_EQ(expected, actualr, "result for none_of");
     }
 };
@@ -84,7 +84,7 @@ struct test_non_const
     operator()(Policy&& exec, Iterator iter)
     {
         TestUtils::IsEven<float64_t> is_even;
-        none_of(exec, iter, iter, non_const(is_even));
+        none_of(std::forward<Policy>(exec), iter, iter, non_const(is_even));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -178,7 +178,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        nth_element(std::forward<Policy>(exec), iter, iter, iter, non_const(::std::less<T>()));
+        nth_element(std::forward<Policy>(exec), iter, iter, iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -178,7 +178,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        nth_element(exec, iter, iter, iter, non_const(::std::less<T>()));
+        nth_element(std::forward<Policy>(exec), iter, iter, iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
@@ -92,7 +92,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        search_n(std::forward<Policy>(exec), iter, iter, 0, T(0), non_const(::std::equal_to<T>()));
+        search_n(std::forward<Policy>(exec), iter, iter, 0, T(0), non_const(std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
@@ -31,7 +31,7 @@ struct test_search_n
     {
         using namespace std;
         auto expected = search_n(b, e, count, value, pred);
-        auto actual = search_n(exec, b, e, count, value);
+        auto actual = search_n(std::forward<ExecutionPolicy>(exec), b, e, count, value);
         EXPECT_TRUE(actual == expected, "wrong return result from search_n");
     }
 };
@@ -45,7 +45,7 @@ struct test_search_n_predicate
     {
         using namespace std;
         auto expected = search_n(b, e, count, value, pred);
-        auto actual = search_n(exec, b, e, count, value, pred);
+        auto actual = search_n(std::forward<ExecutionPolicy>(exec), b, e, count, value, pred);
         EXPECT_TRUE(actual == expected, "wrong return result from search_n with a predicate");
     }
 };
@@ -92,7 +92,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        search_n(exec, iter, iter, 0, T(0), non_const(::std::equal_to<T>()));
+        search_n(std::forward<Policy>(exec), iter, iter, 0, T(0), non_const(::std::equal_to<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/transform_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/transform_if.pass.cpp
@@ -75,7 +75,7 @@ struct test_transform_if_binary
         using in_value_type2 = typename ::std::iterator_traits<InputIterator2>::value_type;
         using out_value_type = typename ::std::iterator_traits<OutputIterator>::value_type;
         // call transform_if
-        oneapi::dpl::transform_if(exec, first, last, mask, result_begin,
+        oneapi::dpl::transform_if(std::forward<Policy>(exec), first, last, mask, result_begin,
                                   mutable_negate_first<in_value_type1, in_value_type2>{},
                                   mutable_check_mask_second<in_value_type1, in_value_type2>{});
 
@@ -108,7 +108,7 @@ struct test_transform_if_unary
         using out_value_type = typename ::std::iterator_traits<OutputIterator>::value_type;
 
         // call transform_if
-        oneapi::dpl::transform_if(exec, first, last, result_begin, mutable_negate<in_value_type>{},
+        oneapi::dpl::transform_if(std::forward<Policy>(exec), first, last, result_begin, mutable_negate<in_value_type>{},
                                   mutable_check_mod3_is_0<in_value_type>{});
 
         //calculate expected
@@ -141,7 +141,7 @@ struct test_transform_if_unary_inplace
         std::copy(first, last, result_begin);
 
         // call transform_if inplace
-        oneapi::dpl::transform_if(exec, result_begin, result_end, result_begin, mutable_negate<in_value_type>{},
+        oneapi::dpl::transform_if(std::forward<Policy>(exec), result_begin, result_end, result_begin, mutable_negate<in_value_type>{},
                                   mutable_check_mod3_is_0<in_value_type>{});
 
         //calculate expected

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -53,7 +53,7 @@ struct test_is_heap
     {
         using namespace std;
         bool expected = is_heap(first, last);
-        bool actual = is_heap(exec, first, last);
+        bool actual = is_heap(std::forward<Policy>(exec), first, last);
         EXPECT_TRUE(expected == actual, "wrong return value from is_heap");
     }
 
@@ -74,7 +74,7 @@ struct test_is_heap_predicate
     {
         using namespace std;
         bool expected = is_heap(first, last, pred);
-        bool actual = is_heap(exec, first, last, pred);
+        bool actual = is_heap(std::forward<Policy>(exec), first, last, pred);
         EXPECT_TRUE(expected == actual, "wrong return value from is_heap with predicate");
     }
 
@@ -95,7 +95,7 @@ struct test_is_heap_until
     {
         using namespace std;
         Iterator expected = is_heap_until(first, last);
-        Iterator actual = is_heap_until(exec, first, last);
+        Iterator actual = is_heap_until(std::forward<Policy>(exec), first, last);
         EXPECT_TRUE(expected == actual, "wrong return value from is_heap_until");
     }
 
@@ -116,7 +116,7 @@ struct test_is_heap_until_predicate
     {
         using namespace std;
         const Iterator expected = is_heap_until(first, last, pred);
-        const Iterator actual = is_heap_until(exec, first, last, pred);
+        const Iterator actual = is_heap_until(std::forward<Policy>(exec), first, last, pred);
         EXPECT_TRUE(expected == actual, "wrong return value from is_heap_until with predicate");
     }
 
@@ -193,7 +193,7 @@ struct test_non_const_is_heap
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        is_heap(exec, iter, iter, non_const(::std::less<T>()));
+        is_heap(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
     }
 };
 
@@ -204,7 +204,7 @@ struct test_non_const_is_heap_until
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        is_heap_until(exec, iter, iter, non_const(::std::less<T>()));
+        is_heap_until(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -193,7 +193,7 @@ struct test_non_const_is_heap
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        is_heap(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
+        is_heap(std::forward<Policy>(exec), iter, iter, non_const(std::less<T>()));
     }
 };
 
@@ -204,7 +204,7 @@ struct test_non_const_is_heap_until
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        is_heap_until(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
+        is_heap_until(std::forward<Policy>(exec), iter, iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
@@ -34,7 +34,7 @@ struct test_one_policy
                Predicate pred)
     {
         const bool expected = ::std::lexicographical_compare(begin1, end1, begin2, end2, pred);
-        const bool actual = ::std::lexicographical_compare(exec, begin1, end1, begin2, end2, pred);
+        const bool actual = ::std::lexicographical_compare(std::forward<ExecutionPolicy>(exec), begin1, end1, begin2, end2, pred);
         EXPECT_TRUE(actual == expected, "wrong return result from lexicographical compare with predicate");
     }
 
@@ -43,7 +43,7 @@ struct test_one_policy
     operator()(ExecutionPolicy&& exec, Iterator1 begin1, Iterator1 end1, Iterator2 begin2, Iterator2 end2)
     {
         const bool expected = ::std::lexicographical_compare(begin1, end1, begin2, end2);
-        const bool actual = ::std::lexicographical_compare(exec, begin1, end1, begin2, end2);
+        const bool actual = ::std::lexicographical_compare(std::forward<ExecutionPolicy>(exec), begin1, end1, begin2, end2);
         EXPECT_TRUE(actual == expected, "wrong return result from lexicographical compare without predicate");
     }
 };
@@ -161,7 +161,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        lexicographical_compare(exec, first_iter, first_iter, second_iter, second_iter, non_const(::std::less<T>()));
+        lexicographical_compare(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
@@ -34,7 +34,7 @@ struct test_one_policy
                Predicate pred)
     {
         const bool expected = ::std::lexicographical_compare(begin1, end1, begin2, end2, pred);
-        const bool actual = ::std::lexicographical_compare(std::forward<ExecutionPolicy>(exec), begin1, end1, begin2, end2, pred);
+        const bool actual = std::lexicographical_compare(std::forward<ExecutionPolicy>(exec), begin1, end1, begin2, end2, pred);
         EXPECT_TRUE(actual == expected, "wrong return result from lexicographical compare with predicate");
     }
 
@@ -43,7 +43,7 @@ struct test_one_policy
     operator()(ExecutionPolicy&& exec, Iterator1 begin1, Iterator1 end1, Iterator2 begin2, Iterator2 end2)
     {
         const bool expected = ::std::lexicographical_compare(begin1, end1, begin2, end2);
-        const bool actual = ::std::lexicographical_compare(std::forward<ExecutionPolicy>(exec), begin1, end1, begin2, end2);
+        const bool actual = std::lexicographical_compare(std::forward<ExecutionPolicy>(exec), begin1, end1, begin2, end2);
         EXPECT_TRUE(actual == expected, "wrong return result from lexicographical compare without predicate");
     }
 };
@@ -161,7 +161,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, FirstIterator first_iter, SecondInterator second_iter)
     {
-        lexicographical_compare(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(::std::less<T>()));
+        lexicographical_compare(std::forward<Policy>(exec), first_iter, first_iter, second_iter, second_iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -41,7 +41,7 @@ struct check_minelement
     operator()(Policy&& exec, Iterator begin, Iterator end)
     {
         const Iterator expect = ::std::min_element(begin, end);
-        const Iterator result = ::std::min_element(exec, begin, end);
+        const Iterator result = ::std::min_element(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(expect == result, "wrong return result from min_element");
     }
 };
@@ -55,7 +55,7 @@ struct check_minelement_predicate
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         const Iterator expect = ::std::min_element(begin, end);
-        const Iterator result_pred = ::std::min_element(exec, begin, end, ::std::less<T>());
+        const Iterator result_pred = ::std::min_element(std::forward<Policy>(exec), begin, end, ::std::less<T>());
         EXPECT_TRUE(expect == result_pred, "wrong return result from min_element with predicate");
     }
 };
@@ -68,7 +68,7 @@ struct check_maxelement
     operator()(Policy&& exec, Iterator begin, Iterator end)
     {
         const Iterator expect = ::std::max_element(begin, end);
-        const Iterator result = ::std::max_element(exec, begin, end);
+        const Iterator result = ::std::max_element(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(expect == result, "wrong return result from max_element");
     }
 };
@@ -82,7 +82,7 @@ struct check_maxelement_predicate
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         const Iterator expect = ::std::max_element(begin, end);
-        const Iterator result_pred = ::std::max_element(exec, begin, end, ::std::less<T>());
+        const Iterator result_pred = ::std::max_element(std::forward<Policy>(exec), begin, end, ::std::less<T>());
         EXPECT_TRUE(expect == result_pred, "wrong return result from max_element with predicate");
     }
 };
@@ -95,7 +95,7 @@ struct check_minmaxelement
     operator()(Policy&& exec, Iterator begin, Iterator end)
     {
         const ::std::pair<Iterator, Iterator> expect = ::std::minmax_element(begin, end);
-        const ::std::pair<Iterator, Iterator> got = ::std::minmax_element(exec, begin, end);
+        const ::std::pair<Iterator, Iterator> got = ::std::minmax_element(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(expect.first == got.first, "wrong return result from minmax_element (min part)");
         EXPECT_TRUE(expect.second == got.second, "wrong return result from minmax_element (max part)");
     }
@@ -110,7 +110,7 @@ struct check_minmaxelement_predicate
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         const ::std::pair<Iterator, Iterator> expect = ::std::minmax_element(begin, end);
-        const ::std::pair<Iterator, Iterator> got_pred = ::std::minmax_element(exec, begin, end, ::std::less<T>());
+        const ::std::pair<Iterator, Iterator> got_pred = ::std::minmax_element(std::forward<Policy>(exec), begin, end, ::std::less<T>());
         EXPECT_TRUE(expect == got_pred, "wrong return result from minmax_element with predicate");
     }
 };
@@ -238,7 +238,7 @@ struct test_non_const_max_element
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        max_element(exec, iter, iter, non_const(::std::less<T>()));
+        max_element(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
     }
 };
 
@@ -249,7 +249,7 @@ struct test_non_const_min_element
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        min_element(exec, iter, iter, non_const(::std::less<T>()));
+        min_element(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
     }
 };
 
@@ -260,7 +260,7 @@ struct test_non_const_minmax_element
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        minmax_element(exec, iter, iter, non_const(::std::less<T>()));
+        minmax_element(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -41,7 +41,7 @@ struct check_minelement
     operator()(Policy&& exec, Iterator begin, Iterator end)
     {
         const Iterator expect = ::std::min_element(begin, end);
-        const Iterator result = ::std::min_element(std::forward<Policy>(exec), begin, end);
+        const Iterator result = std::min_element(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(expect == result, "wrong return result from min_element");
     }
 };
@@ -55,7 +55,7 @@ struct check_minelement_predicate
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         const Iterator expect = ::std::min_element(begin, end);
-        const Iterator result_pred = ::std::min_element(std::forward<Policy>(exec), begin, end, ::std::less<T>());
+        const Iterator result_pred = std::min_element(std::forward<Policy>(exec), begin, end, std::less<T>());
         EXPECT_TRUE(expect == result_pred, "wrong return result from min_element with predicate");
     }
 };
@@ -68,7 +68,7 @@ struct check_maxelement
     operator()(Policy&& exec, Iterator begin, Iterator end)
     {
         const Iterator expect = ::std::max_element(begin, end);
-        const Iterator result = ::std::max_element(std::forward<Policy>(exec), begin, end);
+        const Iterator result = std::max_element(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(expect == result, "wrong return result from max_element");
     }
 };
@@ -82,7 +82,7 @@ struct check_maxelement_predicate
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         const Iterator expect = ::std::max_element(begin, end);
-        const Iterator result_pred = ::std::max_element(std::forward<Policy>(exec), begin, end, ::std::less<T>());
+        const Iterator result_pred = std::max_element(std::forward<Policy>(exec), begin, end, std::less<T>());
         EXPECT_TRUE(expect == result_pred, "wrong return result from max_element with predicate");
     }
 };
@@ -95,7 +95,7 @@ struct check_minmaxelement
     operator()(Policy&& exec, Iterator begin, Iterator end)
     {
         const ::std::pair<Iterator, Iterator> expect = ::std::minmax_element(begin, end);
-        const ::std::pair<Iterator, Iterator> got = ::std::minmax_element(std::forward<Policy>(exec), begin, end);
+        const std::pair<Iterator, Iterator> got = std::minmax_element(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(expect.first == got.first, "wrong return result from minmax_element (min part)");
         EXPECT_TRUE(expect.second == got.second, "wrong return result from minmax_element (max part)");
     }
@@ -110,7 +110,7 @@ struct check_minmaxelement_predicate
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         const ::std::pair<Iterator, Iterator> expect = ::std::minmax_element(begin, end);
-        const ::std::pair<Iterator, Iterator> got_pred = ::std::minmax_element(std::forward<Policy>(exec), begin, end, ::std::less<T>());
+        const std::pair<Iterator, Iterator> got_pred = std::minmax_element(std::forward<Policy>(exec), begin, end, std::less<T>());
         EXPECT_TRUE(expect == got_pred, "wrong return result from minmax_element with predicate");
     }
 };
@@ -238,7 +238,7 @@ struct test_non_const_max_element
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        max_element(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
+        max_element(std::forward<Policy>(exec), iter, iter, non_const(std::less<T>()));
     }
 };
 
@@ -249,7 +249,7 @@ struct test_non_const_min_element
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        min_element(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
+        min_element(std::forward<Policy>(exec), iter, iter, non_const(std::less<T>()));
     }
 };
 
@@ -260,7 +260,7 @@ struct test_non_const_minmax_element
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        minmax_element(std::forward<Policy>(exec), iter, iter, non_const(::std::less<T>()));
+        minmax_element(std::forward<Policy>(exec), iter, iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -54,7 +54,7 @@ struct test_without_compare
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto expect_res = ::std::includes(first1, last1, first2, last2);
-        auto res = ::std::includes(exec, first1, last1, first2, last2);
+        auto res = ::std::includes(std::forward<Policy>(exec), first1, last1, first2, last2);
 
         EXPECT_TRUE(expect_res == res, "wrong result for includes without predicate");
     }
@@ -76,7 +76,7 @@ struct test_with_compare
     {
 
         auto expect_res = ::std::includes(first1, last1, first2, last2, comp);
-        auto res = ::std::includes(exec, first1, last1, first2, last2, comp);
+        auto res = ::std::includes(std::forward<Policy>(exec), first1, last1, first2, last2, comp);
 
         EXPECT_TRUE(expect_res == res, "wrong result for includes with predicate");
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -54,7 +54,7 @@ struct test_without_compare
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto expect_res = ::std::includes(first1, last1, first2, last2);
-        auto res = ::std::includes(std::forward<Policy>(exec), first1, last1, first2, last2);
+        auto res = std::includes(std::forward<Policy>(exec), first1, last1, first2, last2);
 
         EXPECT_TRUE(expect_res == res, "wrong result for includes without predicate");
     }
@@ -76,7 +76,7 @@ struct test_with_compare
     {
 
         auto expect_res = ::std::includes(first1, last1, first2, last2, comp);
-        auto res = ::std::includes(std::forward<Policy>(exec), first1, last1, first2, last2, comp);
+        auto res = std::includes(std::forward<Policy>(exec), first1, last1, first2, last2, comp);
 
         EXPECT_TRUE(expect_res == res, "wrong result for includes with predicate");
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -86,7 +86,7 @@ struct test_set_union
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_union(first1, last1, first2, last2, expect.begin(), comp);
-        auto res = ::std::set_union(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin(), comp);
+        auto res = std::set_union(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin(), comp);
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_union");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_union effect");
@@ -100,7 +100,7 @@ struct test_set_union
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_union(first1, last1, first2, last2, expect.begin());
-        auto res = ::std::set_union(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
+        auto res = std::set_union(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_union without comparator");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_union effect without comparator");
@@ -190,7 +190,7 @@ struct test_set_intersection
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_intersection(first1, last1, first2, last2, expect.begin());
-        auto res = ::std::set_intersection(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
+        auto res = std::set_intersection(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_intersection without comparator");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_intersection effect without comparator");
@@ -221,7 +221,7 @@ struct test_set_difference
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_difference(first1, last1, first2, last2, expect.begin(), comp);
-        auto res = ::std::set_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin(), comp);
+        auto res = std::set_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin(), comp);
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_difference");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_difference effect");
@@ -235,7 +235,7 @@ struct test_set_difference
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_difference(first1, last1, first2, last2, expect.begin());
-        auto res = ::std::set_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
+        auto res = std::set_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(),
                     "wrong result for set_difference without comparator");
@@ -268,7 +268,7 @@ struct test_set_symmetric_difference
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_symmetric_difference(first1, last1, first2, last2, expect.begin(), comp);
-        auto res = ::std::set_symmetric_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin(), comp);
+        auto res = std::set_symmetric_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin(), comp);
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_symmetric_difference");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res),
@@ -283,7 +283,7 @@ struct test_set_symmetric_difference
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_symmetric_difference(first1, last1, first2, last2, expect.begin());
-        auto res = ::std::set_symmetric_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
+        auto res = std::set_symmetric_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(),
                     "wrong result for set_symmetric_difference without comparator");

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -86,7 +86,7 @@ struct test_set_union
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_union(first1, last1, first2, last2, expect.begin(), comp);
-        auto res = ::std::set_union(exec, first1, last1, first2, last2, out.begin(), comp);
+        auto res = ::std::set_union(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin(), comp);
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_union");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_union effect");
@@ -100,7 +100,7 @@ struct test_set_union
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_union(first1, last1, first2, last2, expect.begin());
-        auto res = ::std::set_union(exec, first1, last1, first2, last2, out.begin());
+        auto res = ::std::set_union(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_union without comparator");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_union effect without comparator");
@@ -190,7 +190,7 @@ struct test_set_intersection
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_intersection(first1, last1, first2, last2, expect.begin());
-        auto res = ::std::set_intersection(exec, first1, last1, first2, last2, out.begin());
+        auto res = ::std::set_intersection(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_intersection without comparator");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_intersection effect without comparator");
@@ -221,7 +221,7 @@ struct test_set_difference
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_difference(first1, last1, first2, last2, expect.begin(), comp);
-        auto res = ::std::set_difference(exec, first1, last1, first2, last2, out.begin(), comp);
+        auto res = ::std::set_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin(), comp);
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_difference");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_difference effect");
@@ -235,7 +235,7 @@ struct test_set_difference
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_difference(first1, last1, first2, last2, expect.begin());
-        auto res = ::std::set_difference(exec, first1, last1, first2, last2, out.begin());
+        auto res = ::std::set_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(),
                     "wrong result for set_difference without comparator");
@@ -268,7 +268,7 @@ struct test_set_symmetric_difference
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_symmetric_difference(first1, last1, first2, last2, expect.begin(), comp);
-        auto res = ::std::set_symmetric_difference(exec, first1, last1, first2, last2, out.begin(), comp);
+        auto res = ::std::set_symmetric_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin(), comp);
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_symmetric_difference");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res),
@@ -283,7 +283,7 @@ struct test_set_symmetric_difference
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_symmetric_difference(first1, last1, first2, last2, expect.begin());
-        auto res = ::std::set_symmetric_difference(exec, first1, last1, first2, last2, out.begin());
+        auto res = ::std::set_symmetric_difference(std::forward<Policy>(exec), first1, last1, first2, last2, out.begin());
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(),
                     "wrong result for set_symmetric_difference without comparator");

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_difference.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_difference.pass.cpp
@@ -22,7 +22,7 @@ struct test_non_const_set_difference
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        set_difference(exec, input_iter, input_iter, input_iter, input_iter, out_iter, non_const(::std::less<T>()));
+        set_difference(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_difference.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_difference.pass.cpp
@@ -22,7 +22,7 @@ struct test_non_const_set_difference
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        set_difference(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(::std::less<T>()));
+        set_difference(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_intersection.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_intersection.pass.cpp
@@ -22,7 +22,7 @@ struct test_non_const_set_intersection
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        set_intersection(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(::std::less<T>()));
+        set_intersection(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_intersection.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_intersection.pass.cpp
@@ -22,7 +22,7 @@ struct test_non_const_set_intersection
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        set_intersection(exec, input_iter, input_iter, input_iter, input_iter, out_iter, non_const(::std::less<T>()));
+        set_intersection(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_symmetric_difference.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_symmetric_difference.pass.cpp
@@ -22,7 +22,7 @@ struct test_non_const_set_symmetric_difference
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        set_symmetric_difference(exec, input_iter, input_iter, input_iter, input_iter, out_iter,
+        set_symmetric_difference(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter,
                                  non_const(::std::less<T>()));
     }
 };

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_union.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_union.pass.cpp
@@ -22,7 +22,7 @@ struct test_non_const_set_union
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        set_union(exec, input_iter, input_iter, input_iter, input_iter, out_iter, non_const(::std::less<T>()));
+        set_union(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_union.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_union.pass.cpp
@@ -22,7 +22,7 @@ struct test_non_const_set_union
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        set_union(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(::std::less<T>()));
+        set_union(std::forward<Policy>(exec), input_iter, input_iter, input_iter, input_iter, out_iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
@@ -55,7 +55,7 @@ struct test_is_sorted_predicate
 
         //try random-access iterator with a predicate
         bool exam = is_sorted(first, last, ::std::less<T>());
-        bool res = is_sorted(std::forward<Policy>(exec), first, last, ::std::less<T>());
+        bool res = is_sorted(std::forward<Policy>(exec), first, last, std::less<T>());
         EXPECT_TRUE(exam == res, "is_sorted wrong result for random-access iterator");
     }
 };
@@ -88,7 +88,7 @@ struct test_is_sorted_until_predicate
 
         //try random-access iterator with a predicate
         auto iexam = is_sorted_until(first, last, ::std::less<T>());
-        auto ires = is_sorted_until(std::forward<Policy>(exec), first, last, ::std::less<T>());
+        auto ires = is_sorted_until(std::forward<Policy>(exec), first, last, std::less<T>());
         EXPECT_TRUE(iexam == ires, "is_sorted_until with predicate wrong result for random-access iterator");
     }
 };
@@ -207,7 +207,7 @@ struct test_non_const_is_sorted
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        is_sorted(std::forward<Policy>(exec), iter, iter, ::std::less<T>());
+        is_sorted(std::forward<Policy>(exec), iter, iter, std::less<T>());
     }
 };
 
@@ -218,7 +218,7 @@ struct test_non_const_is_sorted_until
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        is_sorted_until(std::forward<Policy>(exec), iter, iter, ::std::less<T>());
+        is_sorted_until(std::forward<Policy>(exec), iter, iter, std::less<T>());
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
@@ -38,7 +38,7 @@ struct test_is_sorted
 
         //try random-access iterator
         bool exam = is_sorted(first, last);
-        bool res = is_sorted(exec, first, last);
+        bool res = is_sorted(std::forward<Policy>(exec), first, last);
         EXPECT_TRUE(exam == res, "is_sorted wrong result for random-access iterator");
     }
 };
@@ -55,7 +55,7 @@ struct test_is_sorted_predicate
 
         //try random-access iterator with a predicate
         bool exam = is_sorted(first, last, ::std::less<T>());
-        bool res = is_sorted(exec, first, last, ::std::less<T>());
+        bool res = is_sorted(std::forward<Policy>(exec), first, last, ::std::less<T>());
         EXPECT_TRUE(exam == res, "is_sorted wrong result for random-access iterator");
     }
 };
@@ -71,7 +71,7 @@ struct test_is_sorted_until
 
         //try random-access iterator
         auto iexam = is_sorted_until(first, last);
-        auto ires = is_sorted_until(exec, first, last);
+        auto ires = is_sorted_until(std::forward<Policy>(exec), first, last);
         EXPECT_TRUE(iexam == ires, "is_sorted_until wrong result for random-access iterator");
     }
 };
@@ -88,7 +88,7 @@ struct test_is_sorted_until_predicate
 
         //try random-access iterator with a predicate
         auto iexam = is_sorted_until(first, last, ::std::less<T>());
-        auto ires = is_sorted_until(exec, first, last, ::std::less<T>());
+        auto ires = is_sorted_until(std::forward<Policy>(exec), first, last, ::std::less<T>());
         EXPECT_TRUE(iexam == ires, "is_sorted_until with predicate wrong result for random-access iterator");
     }
 };
@@ -207,7 +207,7 @@ struct test_non_const_is_sorted
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        is_sorted(exec, iter, iter, ::std::less<T>());
+        is_sorted(std::forward<Policy>(exec), iter, iter, ::std::less<T>());
     }
 };
 
@@ -218,7 +218,7 @@ struct test_non_const_is_sorted_until
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        is_sorted_until(exec, iter, iter, ::std::less<T>());
+        is_sorted_until(std::forward<Policy>(exec), iter, iter, ::std::less<T>());
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -75,7 +75,7 @@ struct test_brick_partial_sort
 #if !TEST_DPCPP_BACKEND_PRESENT && PSTL_USE_DEBUG
             count_comp = 0;
 #endif
-            ::std::partial_sort(exec, tmp_first, m1, tmp_last, compare);
+            ::std::partial_sort(std::forward<Policy>(exec), tmp_first, m1, tmp_last, compare);
             EXPECT_EQ_N(exp_first, tmp_first, m, "wrong effect from partial_sort with predicate");
 
 #if !TEST_DPCPP_BACKEND_PRESENT && PSTL_USE_DEBUG
@@ -120,7 +120,7 @@ struct test_brick_partial_sort
             auto m2 = exp_first + p;
 
             ::std::partial_sort(exp_first, m2, exp_last);
-            ::std::partial_sort(exec, tmp_first, m1, tmp_last);
+            ::std::partial_sort(std::forward<Policy>(exec), tmp_first, m1, tmp_last);
             EXPECT_EQ_N(exp_first, tmp_first, p, "wrong effect from partial_sort without predicate");
         }
     }
@@ -162,7 +162,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        partial_sort(exec, iter, iter, iter, non_const(::std::less<T>()));
+        partial_sort(std::forward<Policy>(exec), iter, iter, iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -75,7 +75,7 @@ struct test_brick_partial_sort
 #if !TEST_DPCPP_BACKEND_PRESENT && PSTL_USE_DEBUG
             count_comp = 0;
 #endif
-            ::std::partial_sort(std::forward<Policy>(exec), tmp_first, m1, tmp_last, compare);
+            std::partial_sort(std::forward<Policy>(exec), tmp_first, m1, tmp_last, compare);
             EXPECT_EQ_N(exp_first, tmp_first, m, "wrong effect from partial_sort with predicate");
 
 #if !TEST_DPCPP_BACKEND_PRESENT && PSTL_USE_DEBUG
@@ -120,7 +120,7 @@ struct test_brick_partial_sort
             auto m2 = exp_first + p;
 
             ::std::partial_sort(exp_first, m2, exp_last);
-            ::std::partial_sort(std::forward<Policy>(exec), tmp_first, m1, tmp_last);
+            std::partial_sort(std::forward<Policy>(exec), tmp_first, m1, tmp_last);
             EXPECT_EQ_N(exp_first, tmp_first, p, "wrong effect from partial_sort without predicate");
         }
     }
@@ -162,7 +162,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, Iterator iter)
     {
-        partial_sort(std::forward<Policy>(exec), iter, iter, iter, non_const(::std::less<T>()));
+        partial_sort(std::forward<Policy>(exec), iter, iter, iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
@@ -80,7 +80,7 @@ struct test_one_policy
     {
         prepare_data(first, last, n1, trash);
         RandomAccessIterator exp = ::std::partial_sort_copy(first, last, exp_first, exp_last, compare);
-        RandomAccessIterator res = ::std::partial_sort_copy(exec, first, last, d_first, d_last, compare);
+        RandomAccessIterator res = ::std::partial_sort_copy(std::forward<Policy>(exec), first, last, d_first, d_last, compare);
 
         EXPECT_TRUE((exp - exp_first) == (res - d_first), "wrong result from partial_sort_copy with predicate");
         EXPECT_EQ_N(exp_first, d_first, n2, "wrong effect from partial_sort_copy with predicate");
@@ -92,7 +92,7 @@ struct test_one_policy
     {
         prepare_data(first, last, n1, trash);
         RandomAccessIterator exp = ::std::partial_sort_copy(first, last, exp_first, exp_last);
-        RandomAccessIterator res = ::std::partial_sort_copy(exec, first, last, d_first, d_last);
+        RandomAccessIterator res = ::std::partial_sort_copy(std::forward<Policy>(exec), first, last, d_first, d_last);
 
         EXPECT_TRUE((exp - exp_first) == (res - d_first), "wrong result from partial_sort_copy without predicate");
         EXPECT_EQ_N(exp_first, d_first, n2, "wrong effect from partial_sort_copy without predicate");
@@ -164,7 +164,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        partial_sort_copy(exec, input_iter, input_iter, out_iter, out_iter, non_const(::std::less<T>()));
+        partial_sort_copy(std::forward<Policy>(exec), input_iter, input_iter, out_iter, out_iter, non_const(::std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
@@ -80,7 +80,7 @@ struct test_one_policy
     {
         prepare_data(first, last, n1, trash);
         RandomAccessIterator exp = ::std::partial_sort_copy(first, last, exp_first, exp_last, compare);
-        RandomAccessIterator res = ::std::partial_sort_copy(std::forward<Policy>(exec), first, last, d_first, d_last, compare);
+        RandomAccessIterator res = std::partial_sort_copy(std::forward<Policy>(exec), first, last, d_first, d_last, compare);
 
         EXPECT_TRUE((exp - exp_first) == (res - d_first), "wrong result from partial_sort_copy with predicate");
         EXPECT_EQ_N(exp_first, d_first, n2, "wrong effect from partial_sort_copy with predicate");
@@ -92,7 +92,7 @@ struct test_one_policy
     {
         prepare_data(first, last, n1, trash);
         RandomAccessIterator exp = ::std::partial_sort_copy(first, last, exp_first, exp_last);
-        RandomAccessIterator res = ::std::partial_sort_copy(std::forward<Policy>(exec), first, last, d_first, d_last);
+        RandomAccessIterator res = std::partial_sort_copy(std::forward<Policy>(exec), first, last, d_first, d_last);
 
         EXPECT_TRUE((exp - exp_first) == (res - d_first), "wrong result from partial_sort_copy without predicate");
         EXPECT_EQ_N(exp_first, d_first, n2, "wrong effect from partial_sort_copy without predicate");
@@ -164,7 +164,7 @@ struct test_non_const
     void
     operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
     {
-        partial_sort_copy(std::forward<Policy>(exec), input_iter, input_iter, out_iter, out_iter, non_const(::std::less<T>()));
+        partial_sort_copy(std::forward<Policy>(exec), input_iter, input_iter, out_iter, out_iter, non_const(std::less<T>()));
     }
 };
 

--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
@@ -106,14 +106,14 @@ template<typename Policy, typename KeyIt, typename ValIt, typename Size, typenam
 void
 call_sort(Policy&& policy, KeyIt keys_begin, ValIt vals_begin, Size n, StableSortTag, Compare... compare)
 {
-    oneapi::dpl::stable_sort_by_key(policy, keys_begin, keys_begin + n, vals_begin, compare...);
+    oneapi::dpl::stable_sort_by_key(std::forward<Policy>(policy), keys_begin, keys_begin + n, vals_begin, compare...);
 }
 
 template<typename Policy, typename KeyIt, typename ValIt, typename Size, typename... Compare>
 void
 call_sort(Policy&& policy, KeyIt keys_begin, ValIt vals_begin, Size n, UnstableSortTag, Compare... compare)
 {
-    oneapi::dpl::sort_by_key(policy, keys_begin, keys_begin + n, vals_begin, compare...);
+    oneapi::dpl::sort_by_key(std::forward<Policy>(policy), keys_begin, keys_begin + n, vals_begin, compare...);
 }
 
 template<typename KeyIt, typename ValIt, typename Size, typename Compare = std::less<>>
@@ -183,7 +183,7 @@ test_with_std_policy(Policy&& policy, Size n, StabilityTag stability_tag, Compar
     std::vector<KeyT> keys(origin_keys);
     std::vector<ValT> vals(origin_vals);
 
-    call_sort(policy, keys.begin(), vals.begin(), keys_n, stability_tag, compare...);
+    call_sort(std::forward<Policy>(policy), keys.begin(), vals.begin(), keys_n, stability_tag, compare...);
     check_sort(keys.begin(), vals.begin(), origin_keys.begin(), origin_vals.begin(), keys_n, vals_n, stability_tag, compare...);
 }
 

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -106,7 +106,7 @@ test_body_for_loop_strided(Policy&& exec, Iterator first, Iterator last, Iterato
 
     char single_stride = loop_stride > 0 ? 1 : -1;
 
-    ::std::experimental::for_loop_strided(std::forward<Policy>(exec), first, last, loop_stride, [&flip](Iterator iter) { flip(*iter); });
+    std::experimental::for_loop_strided(std::forward<Policy>(exec), first, last, loop_stride, [&flip](Iterator iter) { flip(*iter); });
 
     ::std::make_signed_t<Size> idx = 0;
     for (auto iter = expected_first; iter != expected_last; ::std::advance(iter, single_stride), ++idx)
@@ -136,7 +136,7 @@ test_body_for_loop_strided_n(Policy&& exec, Iterator first, Iterator /* last */,
 
     auto num_iters = n / loop_stride + !!(n % loop_stride);
 
-    ::std::experimental::for_loop_n_strided(std::forward<Policy>(exec), first, num_iters, loop_stride, [&flip](Iterator iter) { flip(*iter); });
+    std::experimental::for_loop_n_strided(std::forward<Policy>(exec), first, num_iters, loop_stride, [&flip](Iterator iter) { flip(*iter); });
 
     size_t idx = 0;
     for (auto iter = expected_first; iter != expected_last; ++iter, ++idx)
@@ -159,7 +159,7 @@ test_body_for_loop_strided_integral(Policy&& exec, Iterator first, Iterator /* l
 
     auto flip = Flip<T>(1);
 
-    ::std::experimental::for_loop_strided(std::forward<Policy>(exec), Size(0), n, loop_stride, [&flip, first](Size idx) {
+    std::experimental::for_loop_strided(std::forward<Policy>(exec), Size(0), n, loop_stride, [&flip, first](Size idx) {
         auto iter = first;
         ::std::advance(iter, idx);
         flip(*iter);
@@ -200,7 +200,7 @@ test_body_for_loop_strided_n_integral(Policy&& exec, Iterator first, Iterator /*
     // update the elements of first-last sequence at ::std::abs(idx) positions,
     // this works for both positive and negative values of idx and there is no
     // need to care about which base iterator to use: simply use first for both cases.
-    ::std::experimental::for_loop_n_strided(std::forward<Policy>(exec), S(0), S(num_iters), loop_stride, [&flip, first](S idx) {
+    std::experimental::for_loop_n_strided(std::forward<Policy>(exec), S(0), S(num_iters), loop_stride, [&flip, first](S idx) {
         auto iter = first;
         ::std::advance(iter, ::std::abs(idx));
         flip(*iter);

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -106,7 +106,7 @@ test_body_for_loop_strided(Policy&& exec, Iterator first, Iterator last, Iterato
 
     char single_stride = loop_stride > 0 ? 1 : -1;
 
-    ::std::experimental::for_loop_strided(exec, first, last, loop_stride, [&flip](Iterator iter) { flip(*iter); });
+    ::std::experimental::for_loop_strided(std::forward<Policy>(exec), first, last, loop_stride, [&flip](Iterator iter) { flip(*iter); });
 
     ::std::make_signed_t<Size> idx = 0;
     for (auto iter = expected_first; iter != expected_last; ::std::advance(iter, single_stride), ++idx)
@@ -136,7 +136,7 @@ test_body_for_loop_strided_n(Policy&& exec, Iterator first, Iterator /* last */,
 
     auto num_iters = n / loop_stride + !!(n % loop_stride);
 
-    ::std::experimental::for_loop_n_strided(exec, first, num_iters, loop_stride, [&flip](Iterator iter) { flip(*iter); });
+    ::std::experimental::for_loop_n_strided(std::forward<Policy>(exec), first, num_iters, loop_stride, [&flip](Iterator iter) { flip(*iter); });
 
     size_t idx = 0;
     for (auto iter = expected_first; iter != expected_last; ++iter, ++idx)
@@ -159,7 +159,7 @@ test_body_for_loop_strided_integral(Policy&& exec, Iterator first, Iterator /* l
 
     auto flip = Flip<T>(1);
 
-    ::std::experimental::for_loop_strided(exec, Size(0), n, loop_stride, [&flip, first](Size idx) {
+    ::std::experimental::for_loop_strided(std::forward<Policy>(exec), Size(0), n, loop_stride, [&flip, first](Size idx) {
         auto iter = first;
         ::std::advance(iter, idx);
         flip(*iter);
@@ -200,7 +200,7 @@ test_body_for_loop_strided_n_integral(Policy&& exec, Iterator first, Iterator /*
     // update the elements of first-last sequence at ::std::abs(idx) positions,
     // this works for both positive and negative values of idx and there is no
     // need to care about which base iterator to use: simply use first for both cases.
-    ::std::experimental::for_loop_n_strided(exec, S(0), S(num_iters), loop_stride, [&flip, first](S idx) {
+    ::std::experimental::for_loop_n_strided(std::forward<Policy>(exec), S(0), S(num_iters), loop_stride, [&flip, first](S idx) {
         auto iter = first;
         ::std::advance(iter, ::std::abs(idx));
         flip(*iter);

--- a/test/parallel_api/iterator/input_data_sweep_counting_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_counting_iter.pass.cpp
@@ -42,7 +42,7 @@ test(Policy&& policy, T trash, size_t n, const std::string& type_text)
             //counting_iterator
             wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/false, /*__write=*/false,
                          /*__check_write=*/false, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
-                         /*__is_reversible=*/true>(policy, my_counting, my_counting + n, counting, copy_out.get_data(),
+                         /*__is_reversible=*/true>(std::forward<Policy>(policy), my_counting, my_counting + n, counting, copy_out.get_data(),
                                                    my_counting, copy_out.get_data(), counting, trash,
                                                    std::string("counting_iterator<") + type_text + std::string(">"));
         }

--- a/test/parallel_api/iterator/input_data_sweep_host_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_host_iter.pass.cpp
@@ -40,7 +40,7 @@ test(Policy&& policy, T trash, size_t n, const std::string& type_text)
         std::vector<T> host_iter(n);
         wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
                      /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/false,
-                     /*__is_reversible=*/true>(policy, host_iter.begin(), host_iter.end(), copy_from,
+                     /*__is_reversible=*/true>(std::forward<Policy>(policy), host_iter.begin(), host_iter.end(), copy_from,
                                                copy_out.get_data(), host_iter.begin(), copy_out.get_data(), copy_from,
                                                trash, std::string("host_iterator<") + type_text + std::string(">"));
     }

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -40,7 +40,7 @@ test(Policy&& policy, T trash, size_t n, const std::string& type_text)
         //test all modes / wrappers
         wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
                      /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
-                     /*__is_reversible=*/false>(policy, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), counting,
+                     /*__is_reversible=*/false>(std::forward<Policy>(policy), oneapi::dpl::begin(buf), oneapi::dpl::end(buf), counting,
                                                 copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(),
                                                 counting, trash,
                                                 std::string("sycl_iterator<") + type_text + std::string(">"));

--- a/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
@@ -48,7 +48,7 @@ test_usm_shared_alloc(Policy&& policy, T trash, size_t n, const std::string& typ
             /*__check_write=*/true, /*__usable_as_perm_map=*/true,
             /*__usable_as_perm_src=*/
             TestUtils::__vector_impl_distinguishes_usm_allocator_from_default_v<decltype(shared_data_vec.begin())>,
-            /*__is_reversible=*/true>(policy, shared_data_vec.begin(), shared_data_vec.end(), counting,
+            /*__is_reversible=*/true>(std::forward<Policy>(policy), shared_data_vec.begin(), shared_data_vec.end(), counting,
                                       copy_out.get_data(), shared_data_vec.begin(), copy_out.get_data(), counting,
                                       trash, std::string("usm_shared_alloc_vector<") + type_text + std::string(">"));
     }
@@ -78,7 +78,7 @@ test_usm_host_alloc(Policy&& policy, T trash, size_t n, const std::string& type_
             __recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
             /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/
             TestUtils::__vector_impl_distinguishes_usm_allocator_from_default_v<decltype(host_data_vec.begin())>,
-            /*__is_reversible=*/true>(policy, host_data_vec.begin(), host_data_vec.end(), counting, copy_out.get_data(),
+            /*__is_reversible=*/true>(std::forward<Policy>(policy), host_data_vec.begin(), host_data_vec.end(), counting, copy_out.get_data(),
                                       host_data_vec.begin(), copy_out.get_data(), counting, trash,
                                       std::string("usm_host_alloc_vector<") + type_text + std::string(">"));
     }

--- a/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
@@ -42,7 +42,7 @@ test_usm_shared_alloc(Policy&& policy, T trash, size_t n, const std::string& typ
         //test all modes / wrappers
 
         //Only test as source iterator for permutation iterator if we can expect it to work
-        // (if the vector implementation distiguishes its iterator for this type)
+        // (if the vector implementation distinguishes its iterator for this type)
         wrap_recurse<
             __recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
             /*__check_write=*/true, /*__usable_as_perm_map=*/true,

--- a/test/parallel_api/iterator/input_data_sweep_usm_device.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_device.pass.cpp
@@ -39,7 +39,7 @@ test(Policy&& policy, T trash, size_t n, const std::string& type_text)
         TestUtils::usm_data_transfer<sycl::usm::alloc::device, T> device_data(policy.queue(), n);
         auto usm_device = device_data.get_data();
         //test all modes / wrappers
-        wrap_recurse<__recurse, 0>(policy, usm_device, usm_device + n, counting, copy_out.get_data(), usm_device,
+        wrap_recurse<__recurse, 0>(std::forward<Policy>(policy), usm_device, usm_device + n, counting, copy_out.get_data(), usm_device,
                                    copy_out.get_data(), counting, trash,
                                    std::string("usm_device<") + type_text + std::string(">"));
     }

--- a/test/parallel_api/iterator/input_data_sweep_usm_shared.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_shared.pass.cpp
@@ -41,7 +41,7 @@ test(Policy&& policy, T trash, size_t n, const std::string& type_text)
             TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> shared_data(policy.queue(), n);
             auto usm_shared = shared_data.get_data();
             //test all modes / wrappers
-            wrap_recurse<__recurse, 0>(policy, usm_shared, usm_shared + n, counting, copy_out.get_data(), usm_shared,
+            wrap_recurse<__recurse, 0>(std::forward<Policy>(policy), usm_shared, usm_shared + n, counting, copy_out.get_data(), usm_shared,
                                     copy_out.get_data(), counting, trash,
                                     std::string("usm_shared<") + type_text + std::string(">"));
         }

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
@@ -62,7 +62,7 @@ struct test_uninit_default_construct
         ::std::destroy_n(oneapi::dpl::execution::seq, begin, n);
         T::SetCount(0);
 
-        ::std::uninitialized_default_construct(exec, begin, end);
+        ::std::uninitialized_default_construct(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_default_construct");
 
     }
@@ -71,7 +71,7 @@ struct test_uninit_default_construct
     void
     operator()(Policy&& exec, Iterator begin, Iterator end, size_t /* n */, /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_default_construct(exec, begin, end);
+        ::std::uninitialized_default_construct(std::forward<Policy>(exec), begin, end);
     }
 };
 
@@ -89,7 +89,7 @@ struct test_uninit_default_construct_n
         ::std::destroy_n(oneapi::dpl::execution::seq, begin, n);
         T::SetCount(0);
 
-        ::std::uninitialized_default_construct_n(exec, begin, n);
+        ::std::uninitialized_default_construct_n(std::forward<Policy>(exec), begin, n);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_default_construct_n");
     }
 
@@ -97,7 +97,7 @@ struct test_uninit_default_construct_n
     void
     operator()(Policy&& exec, Iterator begin, Iterator /* end */, size_t n, /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_default_construct_n(exec, begin, n);
+        ::std::uninitialized_default_construct_n(std::forward<Policy>(exec), begin, n);
     }
 };
 
@@ -115,7 +115,7 @@ struct test_uninit_value_construct
         ::std::destroy_n(oneapi::dpl::execution::seq, begin, n);
         T::SetCount(0);
 
-        ::std::uninitialized_value_construct(exec, begin, end);
+        ::std::uninitialized_value_construct(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_value_construct");
     }
 
@@ -125,7 +125,7 @@ struct test_uninit_value_construct
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
 
-        ::std::uninitialized_value_construct(exec, begin, end);
+        ::std::uninitialized_value_construct(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(IsCheckValueCorrectness<T>(begin, end), "wrong uninitialized_value_construct");
     }
 };
@@ -144,7 +144,7 @@ struct test_uninit_value_construct_n
         ::std::destroy_n(oneapi::dpl::execution::seq, begin, n);
         T::SetCount(0);
 
-        ::std::uninitialized_value_construct_n(exec, begin, n);
+        ::std::uninitialized_value_construct_n(std::forward<Policy>(exec), begin, n);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_value_construct_n");
     }
 
@@ -154,7 +154,7 @@ struct test_uninit_value_construct_n
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
 
-        ::std::uninitialized_value_construct_n(exec, begin, n);
+        ::std::uninitialized_value_construct_n(std::forward<Policy>(exec), begin, n);
         EXPECT_TRUE(IsCheckValueCorrectness<T>(begin, end), "wrong uninitialized_value_construct_n");
     }
 };

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
@@ -62,7 +62,7 @@ struct test_uninit_default_construct
         ::std::destroy_n(oneapi::dpl::execution::seq, begin, n);
         T::SetCount(0);
 
-        ::std::uninitialized_default_construct(std::forward<Policy>(exec), begin, end);
+        std::uninitialized_default_construct(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_default_construct");
 
     }
@@ -71,7 +71,7 @@ struct test_uninit_default_construct
     void
     operator()(Policy&& exec, Iterator begin, Iterator end, size_t /* n */, /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_default_construct(std::forward<Policy>(exec), begin, end);
+        std::uninitialized_default_construct(std::forward<Policy>(exec), begin, end);
     }
 };
 
@@ -89,7 +89,7 @@ struct test_uninit_default_construct_n
         ::std::destroy_n(oneapi::dpl::execution::seq, begin, n);
         T::SetCount(0);
 
-        ::std::uninitialized_default_construct_n(std::forward<Policy>(exec), begin, n);
+        std::uninitialized_default_construct_n(std::forward<Policy>(exec), begin, n);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_default_construct_n");
     }
 
@@ -97,7 +97,7 @@ struct test_uninit_default_construct_n
     void
     operator()(Policy&& exec, Iterator begin, Iterator /* end */, size_t n, /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_default_construct_n(std::forward<Policy>(exec), begin, n);
+        std::uninitialized_default_construct_n(std::forward<Policy>(exec), begin, n);
     }
 };
 
@@ -115,7 +115,7 @@ struct test_uninit_value_construct
         ::std::destroy_n(oneapi::dpl::execution::seq, begin, n);
         T::SetCount(0);
 
-        ::std::uninitialized_value_construct(std::forward<Policy>(exec), begin, end);
+        std::uninitialized_value_construct(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_value_construct");
     }
 
@@ -125,7 +125,7 @@ struct test_uninit_value_construct
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
 
-        ::std::uninitialized_value_construct(std::forward<Policy>(exec), begin, end);
+        std::uninitialized_value_construct(std::forward<Policy>(exec), begin, end);
         EXPECT_TRUE(IsCheckValueCorrectness<T>(begin, end), "wrong uninitialized_value_construct");
     }
 };
@@ -144,7 +144,7 @@ struct test_uninit_value_construct_n
         ::std::destroy_n(oneapi::dpl::execution::seq, begin, n);
         T::SetCount(0);
 
-        ::std::uninitialized_value_construct_n(std::forward<Policy>(exec), begin, n);
+        std::uninitialized_value_construct_n(std::forward<Policy>(exec), begin, n);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_value_construct_n");
     }
 
@@ -154,7 +154,7 @@ struct test_uninit_value_construct_n
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
 
-        ::std::uninitialized_value_construct_n(std::forward<Policy>(exec), begin, n);
+        std::uninitialized_value_construct_n(std::forward<Policy>(exec), begin, n);
         EXPECT_TRUE(IsCheckValueCorrectness<T>(begin, end), "wrong uninitialized_value_construct_n");
     }
 };

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
@@ -62,7 +62,7 @@ struct test_uninitialized_copy
         ::std::destroy_n(oneapi::dpl::execution::seq, out_first, n);
         T::SetCount(0);
 
-        ::std::uninitialized_copy(exec, first, last, out_first);
+        ::std::uninitialized_copy(std::forward<Policy>(exec), first, last, out_first);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_copy");
     }
 
@@ -71,7 +71,7 @@ struct test_uninitialized_copy
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_copy(exec, first, last, out_first);
+        ::std::uninitialized_copy(std::forward<Policy>(exec), first, last, out_first);
         EXPECT_TRUE(IsCheckValueCorrectness(first, out_first, n), "wrong uninitialized_copy");
     }
 };
@@ -91,7 +91,7 @@ struct test_uninitialized_copy_n
         ::std::destroy_n(oneapi::dpl::execution::seq, out_first, n);
         T::SetCount(0);
 
-        ::std::uninitialized_copy_n(exec, first, n, out_first);
+        ::std::uninitialized_copy_n(std::forward<Policy>(exec), first, n, out_first);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_copy_n");
     }
 
@@ -100,7 +100,7 @@ struct test_uninitialized_copy_n
     operator()(Policy&& exec, InputIterator first, InputIterator /* last */, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_copy_n(exec, first, n, out_first);
+        ::std::uninitialized_copy_n(std::forward<Policy>(exec), first, n, out_first);
         EXPECT_TRUE(IsCheckValueCorrectness(first, out_first, n), "wrong uninitialized_copy_n");
     }
 };
@@ -120,7 +120,7 @@ struct test_uninitialized_move
         ::std::destroy_n(oneapi::dpl::execution::seq, out_first, n);
         T::SetCount(0);
 
-        ::std::uninitialized_move(exec, first, last, out_first);
+        ::std::uninitialized_move(std::forward<Policy>(exec), first, last, out_first);
         EXPECT_TRUE(T::MoveCount() == n, "wrong uninitialized_move");
     }
 
@@ -129,7 +129,7 @@ struct test_uninitialized_move
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_move(exec, first, last, out_first);
+        ::std::uninitialized_move(std::forward<Policy>(exec), first, last, out_first);
         EXPECT_TRUE(IsCheckValueCorrectness(first, out_first, n), "wrong uninitialized_move");
     }
 };
@@ -149,7 +149,7 @@ struct test_uninitialized_move_n
         ::std::destroy_n(oneapi::dpl::execution::seq, out_first, n);
         T::SetCount(0);
 
-        ::std::uninitialized_move_n(exec, first, n, out_first);
+        ::std::uninitialized_move_n(std::forward<Policy>(exec), first, n, out_first);
         EXPECT_TRUE(T::MoveCount() == n, "wrong uninitialized_move_n");
     }
 
@@ -158,7 +158,7 @@ struct test_uninitialized_move_n
     operator()(Policy&& exec, InputIterator first, InputIterator /* last */, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_move_n(exec, first, n, out_first);
+        ::std::uninitialized_move_n(std::forward<Policy>(exec), first, n, out_first);
         EXPECT_TRUE(IsCheckValueCorrectness(first, out_first, n), "wrong uninitialized_move_n");
     }
 };

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
@@ -62,7 +62,7 @@ struct test_uninitialized_copy
         ::std::destroy_n(oneapi::dpl::execution::seq, out_first, n);
         T::SetCount(0);
 
-        ::std::uninitialized_copy(std::forward<Policy>(exec), first, last, out_first);
+        std::uninitialized_copy(std::forward<Policy>(exec), first, last, out_first);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_copy");
     }
 
@@ -71,7 +71,7 @@ struct test_uninitialized_copy
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_copy(std::forward<Policy>(exec), first, last, out_first);
+        std::uninitialized_copy(std::forward<Policy>(exec), first, last, out_first);
         EXPECT_TRUE(IsCheckValueCorrectness(first, out_first, n), "wrong uninitialized_copy");
     }
 };
@@ -91,7 +91,7 @@ struct test_uninitialized_copy_n
         ::std::destroy_n(oneapi::dpl::execution::seq, out_first, n);
         T::SetCount(0);
 
-        ::std::uninitialized_copy_n(std::forward<Policy>(exec), first, n, out_first);
+        std::uninitialized_copy_n(std::forward<Policy>(exec), first, n, out_first);
         EXPECT_TRUE(T::Count() == n, "wrong uninitialized_copy_n");
     }
 
@@ -100,7 +100,7 @@ struct test_uninitialized_copy_n
     operator()(Policy&& exec, InputIterator first, InputIterator /* last */, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_copy_n(std::forward<Policy>(exec), first, n, out_first);
+        std::uninitialized_copy_n(std::forward<Policy>(exec), first, n, out_first);
         EXPECT_TRUE(IsCheckValueCorrectness(first, out_first, n), "wrong uninitialized_copy_n");
     }
 };
@@ -120,7 +120,7 @@ struct test_uninitialized_move
         ::std::destroy_n(oneapi::dpl::execution::seq, out_first, n);
         T::SetCount(0);
 
-        ::std::uninitialized_move(std::forward<Policy>(exec), first, last, out_first);
+        std::uninitialized_move(std::forward<Policy>(exec), first, last, out_first);
         EXPECT_TRUE(T::MoveCount() == n, "wrong uninitialized_move");
     }
 
@@ -129,7 +129,7 @@ struct test_uninitialized_move
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_move(std::forward<Policy>(exec), first, last, out_first);
+        std::uninitialized_move(std::forward<Policy>(exec), first, last, out_first);
         EXPECT_TRUE(IsCheckValueCorrectness(first, out_first, n), "wrong uninitialized_move");
     }
 };
@@ -149,7 +149,7 @@ struct test_uninitialized_move_n
         ::std::destroy_n(oneapi::dpl::execution::seq, out_first, n);
         T::SetCount(0);
 
-        ::std::uninitialized_move_n(std::forward<Policy>(exec), first, n, out_first);
+        std::uninitialized_move_n(std::forward<Policy>(exec), first, n, out_first);
         EXPECT_TRUE(T::MoveCount() == n, "wrong uninitialized_move_n");
     }
 
@@ -158,7 +158,7 @@ struct test_uninitialized_move_n
     operator()(Policy&& exec, InputIterator first, InputIterator /* last */, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
-        ::std::uninitialized_move_n(std::forward<Policy>(exec), first, n, out_first);
+        std::uninitialized_move_n(std::forward<Policy>(exec), first, n, out_first);
         EXPECT_TRUE(IsCheckValueCorrectness(first, out_first, n), "wrong uninitialized_move_n");
     }
 };

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
@@ -42,7 +42,7 @@ struct test_uninitialized_fill
     {
         using namespace std;
 
-        uninitialized_fill(exec, first, last, in);
+        uninitialized_fill(std::forward<Policy>(exec), first, last, in);
         size_t count = count_if(first, last, [&in](T& x) -> bool { return x == in; });
         EXPECT_TRUE(n == count, "wrong work of uninitialized_fill");
 
@@ -55,7 +55,7 @@ struct test_uninitialized_fill
     {
         using namespace std;
 
-        uninitialized_fill(exec, first, last, in);
+        uninitialized_fill(std::forward<Policy>(exec), first, last, in);
         size_t count = count_if(first, last, [&in](T& x) -> bool { return x == in; });
         EXPECT_EQ(n, count, "wrong work of uninitialized_fill");
     }
@@ -70,7 +70,7 @@ struct test_uninitialized_fill_n
     {
         using namespace std;
 
-        auto res = uninitialized_fill_n(exec, first, n, in);
+        auto res = uninitialized_fill_n(std::forward<Policy>(exec), first, n, in);
         EXPECT_TRUE(res == last, "wrong result of uninitialized_fill_n");
         size_t count = count_if(first, last, [&in](T& x) -> bool { return x == in; });
         EXPECT_TRUE(n == count, "wrong work of uninitialized_fill_n");
@@ -83,7 +83,7 @@ struct test_uninitialized_fill_n
     {
         using namespace std;
 
-        auto res = uninitialized_fill_n(exec, first, n, in);
+        auto res = uninitialized_fill_n(std::forward<Policy>(exec), first, n, in);
         size_t count = count_if(first, last, [&in](T& x) -> bool { return x == in; });
         EXPECT_EQ(n, count, "wrong work of uninitialized_fill_n");
         EXPECT_TRUE(res == last, "wrong result of uninitialized_fill_n");
@@ -105,7 +105,7 @@ struct test_destroy
 #else
         uninitialized_fill(first, last, in);
 #endif
-        destroy(exec, first, last);
+        destroy(std::forward<Policy>(exec), first, last);
         EXPECT_TRUE(T::Count() == 0, "wrong work of destroy");
     }
 
@@ -120,7 +120,7 @@ struct test_destroy
 #else
         uninitialized_fill(first, last, in);
 #endif
-        destroy(exec, first, last);
+        destroy(std::forward<Policy>(exec), first, last);
         size_t count = count_if(first, last, [&in](T& x) -> bool { return x != in; });
         size_t tmp_n = 0;
         EXPECT_EQ(tmp_n, count, "wrong work of destroy");
@@ -142,7 +142,7 @@ struct test_destroy_n
 #else
         uninitialized_fill(first, last, in);
 #endif
-        auto dres = destroy_n(exec, first, n);
+        auto dres = destroy_n(std::forward<Policy>(exec), first, n);
         EXPECT_TRUE(dres == last, "wrong result of destroy_n");
         EXPECT_TRUE(T::Count() == 0, "wrong work of destroy_n");
     }
@@ -158,7 +158,7 @@ struct test_destroy_n
 #else
         uninitialized_fill(first, last, in);
 #endif
-        auto dres = destroy_n(exec, first, n);
+        auto dres = destroy_n(std::forward<Policy>(exec), first, n);
         EXPECT_TRUE(dres == last, "wrong result of destroy_n");
         size_t count = count_if(first, last, [&in](T& x) -> bool { return x != in; });
         size_t tmp_n = 0;

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -108,7 +108,7 @@ struct test_adjacent_difference
 
         fill(actual_b, actual_e, trash);
 
-        Iterator2 actual_return = adjacent_difference(exec, data_b, data_e, actual_b);
+        Iterator2 actual_return = adjacent_difference(std::forward<ExecutionPolicy>(exec), data_b, data_e, actual_b);
         EXPECT_TRUE(compute_and_check(data_b, data_e, actual_b, T2(0), ::std::minus<T2>()),
                     "wrong effect of adjacent_difference");
         EXPECT_TRUE(actual_return == actual_e, "wrong result of adjacent_difference");
@@ -128,7 +128,7 @@ struct test_adjacent_difference_functor
 
         fill(actual_b, actual_e, trash);
 
-        Iterator2 actual_return = adjacent_difference(exec, data_b, data_e, actual_b, f);
+        Iterator2 actual_return = adjacent_difference(std::forward<ExecutionPolicy>(exec), data_b, data_e, actual_b, f);
         EXPECT_TRUE(compute_and_check(data_b, data_e, actual_b, T2(0), f),
                     "wrong effect of adjacent_difference with functor");
         EXPECT_TRUE(actual_return == actual_e, "wrong result of adjacent_difference with functor");

--- a/test/parallel_api/numeric/numeric.ops/histogram.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/histogram.pass.cpp
@@ -35,7 +35,7 @@ struct test_histogram_even_bins
     {
         const Size bin_size = bin_last - bin_first;
         histogram_sequential(in_first, in_last, bin_size, bin_min, bin_max, expected_bin_first);
-        auto orr = ::oneapi::dpl::histogram(exec, in_first, in_last, bin_size, bin_min, bin_max, bin_first);
+        auto orr = ::oneapi::dpl::histogram(std::forward<Policy>(exec), in_first, in_last, bin_size, bin_min, bin_max, bin_first);
         EXPECT_TRUE(bin_last == orr, "histogram returned wrong iterator");
         EXPECT_EQ_N(expected_bin_first, bin_first, bin_size, "wrong result from histogram");
         ::std::fill_n(bin_first, bin_size, trash);
@@ -59,7 +59,7 @@ struct test_histogram_range_bins
     {
         const Size bin_size = boundary_last - boundary_first - 1;
         histogram_sequential(in_first, in_last, boundary_first, boundary_last, expected_bin_first);
-        auto orr = ::oneapi::dpl::histogram(exec, in_first, in_last, boundary_first, boundary_last, bin_first);
+        auto orr = ::oneapi::dpl::histogram(std::forward<Policy>(exec), in_first, in_last, boundary_first, boundary_last, bin_first);
         EXPECT_TRUE(bin_last == orr, "histogram returned wrong iterator");
         EXPECT_EQ_N(expected_bin_first, bin_first, bin_size, "wrong result from histogram");
         ::std::fill_n(bin_first, bin_size, trash);

--- a/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
@@ -29,7 +29,7 @@ struct test_long_reduce
     void
     operator()(Policy&& exec, Iterator first, Iterator last, T init, BinaryOp binary, T expected)
     {
-        T result_r = ::std::reduce(std::forward<Policy>(exec), first, last, init, binary);
+        T result_r = std::reduce(std::forward<Policy>(exec), first, last, init, binary);
         EXPECT_EQ(expected, result_r, "bad result from reduce(exec, first, last, init, binary_op)");
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
@@ -29,7 +29,7 @@ struct test_long_reduce
     void
     operator()(Policy&& exec, Iterator first, Iterator last, T init, BinaryOp binary, T expected)
     {
-        T result_r = ::std::reduce(exec, first, last, init, binary);
+        T result_r = ::std::reduce(std::forward<Policy>(exec), first, last, init, binary);
         EXPECT_EQ(expected, result_r, "bad result from reduce(exec, first, last, init, binary_op)");
     }
 };
@@ -64,7 +64,7 @@ struct test_short_reduce
     {
         using namespace std;
 
-        Sum r0 = init + reduce(exec, first, last);
+        Sum r0 = init + reduce(std::forward<Policy>(exec), first, last);
         EXPECT_EQ(expected, r0, "bad result from reduce(exec, first, last)");
     }
 };
@@ -77,7 +77,7 @@ struct test_short_reduce_init
     {
         using namespace std;
 
-        Sum r1 = reduce(exec, first, last, init);
+        Sum r1 = reduce(std::forward<Policy>(exec), first, last, init);
         EXPECT_EQ(expected, r1, "bad result from reduce(exec, first, last, init)");
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -153,23 +153,25 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
         initialize_data(host_keys.get(), host_vals.get(), host_res.get(), n);
         update_data(host_keys, host_vals, host_res_keys, host_res);
 
+        sycl::queue queue = exec.queue();
+
         std::pair<Iterator3, Iterator4> res;
         if constexpr (std::is_same_v<std::equal_to<KeyT>, std::decay_t<BinaryPredicate>> &&
                       std::is_same_v<std::plus<ValT>, std::decay_t<BinaryOperation>>)
         {
-            res = oneapi::dpl::reduce_by_segment(exec, keys_first, keys_last, vals_first, key_res_first, val_res_first);
+            res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first, key_res_first, val_res_first);
         }
         else if constexpr (std::is_same_v<std::plus<ValT>, std::decay_t<BinaryOperation>>)
         {
-            res = oneapi::dpl::reduce_by_segment(exec, keys_first, keys_last, vals_first, key_res_first, val_res_first,
+            res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first, key_res_first, val_res_first,
                                                  BinaryPredicate());
         }
         else
         {
-            res = oneapi::dpl::reduce_by_segment(exec, keys_first, keys_last, vals_first, key_res_first, val_res_first,
+            res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first, key_res_first, val_res_first,
                                                  BinaryPredicate(), BinaryOperation());
         }
-        exec.queue().wait_and_throw();
+        queue.wait_and_throw();
 
         retrieve_data(host_keys, host_vals, host_res_keys, host_res);
         size_t segments_key_ret = ::std::distance(key_res_first, res.first);

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -52,12 +52,12 @@ struct test_inclusive_scan_with_plus
         if constexpr (use_init)
         {
             inclusive_scan_serial(in_first, in_last, expected_first, std::plus<>{}, init);
-            orr = inclusive_scan(exec, in_first, in_last, out_first, std::plus<>{}, init);
+            orr = inclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first, std::plus<>{}, init);
         }
         else
         {
             inclusive_scan_serial(in_first, in_last, expected_first);
-            orr = inclusive_scan(exec, in_first, in_last, out_first);
+            orr = inclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first);
         }
         EXPECT_TRUE(out_last == orr, "inclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from inclusive_scan");
@@ -85,7 +85,7 @@ struct test_exclusive_scan_with_plus
         using namespace std;
 
         exclusive_scan_serial(in_first, in_last, expected_first, init);
-        auto orr = exclusive_scan(exec, in_first, in_last, out_first, init);
+        auto orr = exclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first, init);
         EXPECT_TRUE(out_last == orr, "exclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from exclusive_scan");
         ::std::fill_n(out_first, n, trash);
@@ -165,7 +165,7 @@ struct test_inclusive_scan_with_binary_op
         using namespace std;
 
         inclusive_scan_serial(in_first, in_last, expected_first, binary_op, init);
-        auto orr = inclusive_scan(exec, in_first, in_last, out_first, binary_op, init);
+        auto orr = inclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first, binary_op, init);
 
         EXPECT_TRUE(out_last == orr, "inclusive_scan with binary operator returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from inclusive_scan with binary operator");
@@ -181,7 +181,7 @@ struct test_inclusive_scan_with_binary_op
         using namespace std;
 
         inclusive_scan_serial(in_first, in_last, expected_first, binary_op);
-        auto orr = inclusive_scan(exec, in_first, in_last, out_first, binary_op);
+        auto orr = inclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first, binary_op);
 
         EXPECT_TRUE(out_last == orr, "inclusive_scan with binary operator without init returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from inclusive_scan with binary operator without init");
@@ -218,7 +218,7 @@ struct test_exclusive_scan_with_binary_op
 
         exclusive_scan_serial(in_first, in_last, expected_first, init, binary_op);
 
-        auto orr = exclusive_scan(exec, in_first, in_last, out_first, init, binary_op);
+        auto orr = exclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first, init, binary_op);
 
         EXPECT_TRUE(out_last == orr, "exclusive_scan with binary operator returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from exclusive_scan with binary operator");

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -208,7 +208,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
         // Initialize source data in the buffer [keys_first, keys_last)
         initialize_data(keys_first, n);
 
-        testingAlgo.call_onedpl(exec, keys_first, keys_last, vals_first);
+        testingAlgo.call_onedpl(std::forward<Policy>(exec), keys_first, keys_last, vals_first);
 
         std::vector<ValT> expected(n);
         testingAlgo.call_serial(keys_first, keys_last + n, expected.data());
@@ -243,7 +243,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
         const std::vector<KeyT> source_host_keys_state(keys_first, keys_first + n);
 
         // Now we are ready to call the tested algorithm
-        testingAlgo.call_onedpl(exec, keys_first, keys_last, keys_first);
+        testingAlgo.call_onedpl(std::forward<Policy>(exec), keys_first, keys_last, keys_first);
 
         std::vector<KeyT> expected(n);
         testingAlgo.call_serial(source_host_keys_state.cbegin(), source_host_keys_state.cend(), expected.data());

--- a/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
@@ -92,7 +92,7 @@ struct test_3_iters_default_ops
                T init)
     {
         auto expectedB = ::std::inner_product(first1, last1, first2, init);
-        T resRA = ::std::transform_reduce(exec, first1, last1, first2, init);
+        T resRA = ::std::transform_reduce(std::forward<Policy>(exec), first1, last1, first2, init);
         CheckResults(expectedB, resRA, "wrong result with tranform_reduce (3 iterators, default predicates)");
     }
 };
@@ -107,7 +107,7 @@ struct test_3_iters_custom_ops
                T init, BinaryOperation1 opB1, BinaryOperation2 opB2)
     {
         auto expectedB = ::std::inner_product(first1, last1, first2, init, opB1, opB2);
-        T resRA = ::std::transform_reduce(exec, first1, last1, first2, init, opB1, opB2);
+        T resRA = ::std::transform_reduce(std::forward<Policy>(exec), first1, last1, first2, init, opB1, opB2);
         CheckResults(expectedB, resRA, "wrong result with tranform_reduce (3 iterators, custom predicates)");
     }
 };
@@ -121,7 +121,7 @@ struct test_2_iters
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, T init, BinaryOperation opB, UnaryOp opU)
     {
         auto expectedU = transform_reduce_serial(first1, last1, init, opB, opU);
-        T resRA = ::std::transform_reduce(exec, first1, last1, init, opB, opU);
+        T resRA = ::std::transform_reduce(std::forward<Policy>(exec), first1, last1, init, opB, opU);
         CheckResults(expectedU, resRA, "wrong result with tranform_reduce (2 iterators)");
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
@@ -92,7 +92,7 @@ struct test_3_iters_default_ops
                T init)
     {
         auto expectedB = ::std::inner_product(first1, last1, first2, init);
-        T resRA = ::std::transform_reduce(std::forward<Policy>(exec), first1, last1, first2, init);
+        T resRA = std::transform_reduce(std::forward<Policy>(exec), first1, last1, first2, init);
         CheckResults(expectedB, resRA, "wrong result with tranform_reduce (3 iterators, default predicates)");
     }
 };
@@ -107,7 +107,7 @@ struct test_3_iters_custom_ops
                T init, BinaryOperation1 opB1, BinaryOperation2 opB2)
     {
         auto expectedB = ::std::inner_product(first1, last1, first2, init, opB1, opB2);
-        T resRA = ::std::transform_reduce(std::forward<Policy>(exec), first1, last1, first2, init, opB1, opB2);
+        T resRA = std::transform_reduce(std::forward<Policy>(exec), first1, last1, first2, init, opB1, opB2);
         CheckResults(expectedB, resRA, "wrong result with tranform_reduce (3 iterators, custom predicates)");
     }
 };
@@ -121,7 +121,7 @@ struct test_2_iters
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, T init, BinaryOperation opB, UnaryOp opU)
     {
         auto expectedU = transform_reduce_serial(first1, last1, init, opB, opU);
-        T resRA = ::std::transform_reduce(std::forward<Policy>(exec), first1, last1, init, opB, opU);
+        T resRA = std::transform_reduce(std::forward<Policy>(exec), first1, last1, init, opB, opU);
         CheckResults(expectedU, resRA, "wrong result with tranform_reduce (2 iterators)");
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -53,7 +53,7 @@ struct test_transform_exclusive_scan
         using namespace std;
 
         transform_exclusive_scan(oneapi::dpl::execution::seq, first, last, expected_first, init, binary_op, unary_op);
-        auto orr2 = transform_exclusive_scan(exec, first, last, out_first, init, binary_op, unary_op);
+        auto orr2 = transform_exclusive_scan(std::forward<Policy>(exec), first, last, out_first, init, binary_op, unary_op);
         EXPECT_TRUE(out_last == orr2, "transform_exclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from transform_exclusive_scan");
         ::std::fill_n(out_first, n, trash);
@@ -82,7 +82,7 @@ struct test_transform_inclusive_scan_init
         using namespace std;
 
         transform_inclusive_scan(oneapi::dpl::execution::seq, first, last, expected_first, binary_op, unary_op, init);
-        auto orr2 = transform_inclusive_scan(exec, first, last, out_first, binary_op, unary_op, init);
+        auto orr2 = transform_inclusive_scan(std::forward<Policy>(exec), first, last, out_first, binary_op, unary_op, init);
         EXPECT_TRUE(out_last == orr2, "transform_inclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from transform_inclusive_scan");
         ::std::fill_n(out_first, n, trash);
@@ -113,7 +113,7 @@ struct test_transform_inclusive_scan
         if (n > 0)
         {
             transform_inclusive_scan(oneapi::dpl::execution::seq, first, last, expected_first, binary_op, unary_op);
-            auto orr2 = transform_inclusive_scan(exec, first, last, out_first, binary_op, unary_op);
+            auto orr2 = transform_inclusive_scan(std::forward<Policy>(exec), first, last, out_first, binary_op, unary_op);
             EXPECT_TRUE(out_last == orr2, "transform_inclusive_scan returned wrong iterator");
             EXPECT_EQ_N(expected_first, out_first, n, "wrong result from transform_inclusive_scan");
             ::std::fill_n(out_first, n, trash);

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -58,7 +58,7 @@ main()
     ::std::exclusive_scan(oneapi::dpl::execution::seq, data, data + max_n, expected2, 100, ::std::plus<int>());
 
     EXPECT_EQ_N(expected1, data1, max_n, "wrong effect from exclusive_scan with init, sycl ranges");
-    EXPECT_EQ_N(expected2, data2, max_n, "wrong effect from exclusive_scan with init andbinary operation, sycl ranges");
+    EXPECT_EQ_N(expected2, data2, max_n, "wrong effect from exclusive_scan with init and binary operation, sycl ranges");
 #endif //_ENABLE_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -200,7 +200,7 @@ private:
 
         typename Container::type& A = cont_in();
         decltype(auto) r_in = tr_in(A);
-        auto res = algo(exec, r_in, args...);
+        auto res = algo(std::forward<decltype(exec)>(exec), r_in, args...);
 
         //check result
         static_assert(std::is_same_v<decltype(res), decltype(checker(r_in, args...))>, "Wrong return type");
@@ -240,7 +240,7 @@ private:
         typename Container::type& A = cont_in();
         typename Container::type& B = cont_out();
 
-        auto res = algo(exec, tr_in(A), tr_out(B), args...);
+        auto res = algo(std::forward<Policy>(exec), tr_in(A), tr_out(B), args...);
 
         //check result
         static_assert(std::is_same_v<decltype(res), decltype(checker(tr_in(A), tr_out(B), args...))>, "Wrong return type");
@@ -315,7 +315,7 @@ private:
         typename Container::type& A = cont_in1();
         typename Container::type& B = cont_in2();
 
-        auto res = algo(exec, tr_in(A), tr_in(B), args...);
+        auto res = algo(std::forward<decltype(exec)>(exec), tr_in(A), tr_in(B), args...);
 
         static_assert(std::is_same_v<decltype(res), decltype(checker(tr_in(A), tr_in(B), args...))>, "Wrong return type");
 
@@ -358,7 +358,7 @@ private:
         typename Container::type& B = cont_in2();
         typename Container::type& C = cont_out();
 
-        auto res = algo(exec, tr_in(A), tr_in(B), tr_out(C), args...);
+        auto res = algo(std::forward<Policy>(exec), tr_in(A), tr_in(B), tr_out(C), args...);
 
         static_assert(std::is_same_v<decltype(res), decltype(checker(tr_in(A), tr_in(B), tr_out(C), args...))>, "Wrong return type");
 


### PR DESCRIPTION
This PR updates test cases to perfectly forward execution policies using `std::forward` and fixes spelling mistakes in comments.

- Introduce `std::forward<Policy>(exec)` (or `ExecutionPolicy`) in various algorithm test calls to preserve value category.
- Corrected typos in comments (“itertors” → “iterators”).