### PR TITLE
Support `EXPECT_EQ` call for iterators

### DIFF
--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -149,25 +149,21 @@ std::string log_value_title(TagActual)
     return " got ";
 }
 
-template <typename Tag, typename TValue>
-std::string log_value(Tag, const TValue& value, bool bCommaNeeded)
+template <typename TStream, typename Tag, typename TValue>
+ void log_value(TStream& os, Tag, const TValue& value, bool bCommaNeeded)
 {
-    std::stringstream outstr;
-
     if (bCommaNeeded)
-        outstr << ",";
-    outstr << log_value_title(Tag{});
+        os << ",";
+    os << log_value_title(Tag{});
 
-    if constexpr (IsSupportStreamOutput<TValue, decltype(outstr)>::value)
+    if constexpr (IsSupportStreamOutput<TValue, decltype(os)>::value)
     {
-        outstr << value;
+        os << value;
     }
     else
     {
-        outstr << "(unable to log value)";
+        os << "(unable to log value)";
     }
-
-    return outstr.str();
 }
 
 // Do not change signature to const T&.
@@ -179,7 +175,10 @@ expect_equal_val(const T1& expected, const T2& actual, const char* file, std::in
     if (!is_equal_val(expected, actual))
     {
         std::stringstream outstr;
-        outstr << "error at " << file << ":" << line << " - " << message << log_value(TagExpected{}, expected, true) << log_value(TagActual{}, actual, true);
+        outstr << "error at " << file << ":" << line << " - " << message;
+        log_value(outstr, TagExpected{}, expected, true);
+        log_value(outstr, TagActual{}, actual, true);
+
         issue_error_message(outstr);
     }
 }
@@ -203,8 +202,11 @@ expect_equal(const R1& expected, const R2& actual, const char* file, std::int32_
     {
         if (!is_equal_val(expected[k], actual[k]))
         {
-            ::std::stringstream outstr;
-            outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k << log_value(TagExpected{}, expected[k], false) << log_value(TagActual{}, actual[k], false);
+            std::stringstream outstr;
+            outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k;
+            log_value(outstr, TagExpected{}, expected[k], false);
+            log_value(outstr, TagActual{}, actual[k], false);
+
             issue_error_message(outstr);
             ++error_count;
         }

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -165,9 +165,6 @@ template <typename TStream, typename Tag, typename TValue>
 
     if constexpr (IsOutputStreamable<TValue, decltype(os)>::value)
     {
-        if constexpr (std::is_pointer_v<TValue>)
-            os << "0x";
-
         os << value;
     }
     else

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -232,6 +232,9 @@ expect_equal(Iterator1 expected_first, Iterator2 actual_first, Size n, const cha
         {
             ::std::stringstream outstr;
             outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k;
+            log_value(outstr, TagExpected{}, *expected_first, false);
+            log_value(outstr, TagActual{}, *actual_first, false);
+
             issue_error_message(outstr);
             ++error_count;
         }

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -131,12 +131,12 @@ is_equal_val(const T1& val1, const T2& val2)
 }
 
 template <typename T, typename TOutputStream, typename = void>
-struct IsSupportStreamOutput : std::false_type
+struct IsOutputStreamable : std::false_type
 {
 };
 
 template <typename T, typename TOutputStream>
-struct IsSupportStreamOutput<T, TOutputStream,
+struct IsOutputStreamable<T, TOutputStream,
                              std::void_t<decltype(std::declval<TOutputStream>() << std::declval<T>())>> : std::true_type
 {
 };
@@ -163,7 +163,7 @@ template <typename TStream, typename Tag, typename TValue>
         os << ",";
     os << log_value_title(Tag{});
 
-    if constexpr (IsSupportStreamOutput<TValue, decltype(os)>::value)
+    if constexpr (IsOutputStreamable<TValue, decltype(os)>::value)
     {
         if constexpr (std::is_pointer_v<TValue>)
             os << "0x";

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -137,27 +137,26 @@ struct IsSupportStreamOutput<T, TOutputStream,
 struct TagExpected{};
 struct TagActual{};
 
+inline
+std::string log_value_title(TagExpected)
+{
+    return " expected ";
+}
+
+inline
+std::string log_value_title(TagActual)
+{
+    return " got ";
+}
+
 template <typename Tag, typename TValue>
 std::string log_value(Tag, const TValue& value, bool bCommaNeeded)
 {
     std::stringstream outstr;
 
-    if constexpr (std::is_same_v<Tag, TagExpected>)
-    {
-        if (bCommaNeeded)
-            outstr << ",";
-        outstr << " expected ";
-    }
-    else if constexpr (std::is_same_v<Tag, TagActual>)
-    {
-        if (bCommaNeeded)
-            outstr << ",";
-        outstr << " got ";
-    }
-    else
-    {
-        static_assert(false, "Unknown tag");
-    }
+    if (bCommaNeeded)
+        outstr << ",";
+    outstr << log_value_title(Tag{});
 
     if constexpr (IsSupportStreamOutput<TValue, decltype(outstr)>::value)
     {

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -158,6 +158,9 @@ template <typename TStream, typename Tag, typename TValue>
 
     if constexpr (IsSupportStreamOutput<TValue, decltype(os)>::value)
     {
+        if constexpr (std::is_pointer_v<TValue>)
+            os << "0x";
+
         os << value;
     }
     else

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -180,8 +180,7 @@ expect_equal_val(const T1& expected, const T2& actual, const char* file, std::in
     if (!is_equal_val(expected, actual))
     {
         std::stringstream outstr;
-        outstr << "error at " << file << ":" << line << " - " << message << ", expected " << expected << " got "
-               << actual;
+        outstr << "error at " << file << ":" << line << " - " << message << log_value(TagExpected{}, expected, true) << log_value(TagActual{}, actual, true);
         issue_error_message(outstr);
     }
 }
@@ -206,8 +205,7 @@ expect_equal(const R1& expected, const R2& actual, const char* file, std::int32_
         if (!is_equal_val(expected[k], actual[k]))
         {
             ::std::stringstream outstr;
-            outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k << " expected "
-                   << expected[k] << " got " << actual[k];
+            outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k << log_value(TagExpected{}, expected[k], false) << log_value(TagActual{}, actual[k], false);
             issue_error_message(outstr);
             ++error_count;
         }

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -89,13 +89,20 @@ issue_error_message(::std::stringstream& outstr)
     ::std::exit(EXIT_FAILURE);
 }
 
+template <typename TStream>
+inline void
+log_file_lineno_msg(TStream& os, const char* file, std::int32_t line, const char* message)
+{
+    os << "error at " << file << ":" << line << " - " << message;
+}
+
 inline void
 expect(bool expected, bool condition, const char* file, std::int32_t line, const char* message)
 {
     if (condition != expected)
     {
-        ::std::stringstream outstr;
-        outstr << "error at " << file << ":" << line << " - " << message;
+        std::stringstream outstr;
+        log_file_lineno_msg(outstr, file, line, message);
         issue_error_message(outstr);
     }
 }
@@ -178,7 +185,7 @@ expect_equal_val(const T1& expected, const T2& actual, const char* file, std::in
     if (!is_equal_val(expected, actual))
     {
         std::stringstream outstr;
-        outstr << "error at " << file << ":" << line << " - " << message;
+        log_file_lineno_msg(outstr, file, line, message);
         log_value(outstr, TagExpected{}, expected, true);
         log_value(outstr, TagActual{}, actual, true);
 
@@ -194,9 +201,9 @@ expect_equal(const R1& expected, const R2& actual, const char* file, std::int32_
     size_t m = actual.size();
     if (n != m)
     {
-        ::std::stringstream outstr;
-        outstr << "error at " << file << ":" << line << " - " << message << ", expected sequence of size " << n
-               << " got sequence of size " << m;
+        std::stringstream outstr;
+        log_file_lineno_msg(outstr, file, line, message);
+        outstr << ", expected sequence of size " << n << " got sequence of size " << m;
         issue_error_message(outstr);
         return;
     }
@@ -206,7 +213,8 @@ expect_equal(const R1& expected, const R2& actual, const char* file, std::int32_
         if (!is_equal_val(expected[k], actual[k]))
         {
             std::stringstream outstr;
-            outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k;
+            log_file_lineno_msg(outstr, file, line, message);
+            outstr << ", at index " << k;
             log_value(outstr, TagExpected{}, expected[k], false);
             log_value(outstr, TagActual{}, actual[k], false);
 
@@ -233,8 +241,9 @@ expect_equal(Iterator1 expected_first, Iterator2 actual_first, Size n, const cha
     {
         if (!is_equal_val(*expected_first, *actual_first))
         {
-            ::std::stringstream outstr;
-            outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k;
+            std::stringstream outstr;
+            log_file_lineno_msg(outstr, file, line, message);
+            outstr << ", at index " << k;
             log_value(outstr, TagExpected{}, *expected_first, false);
             log_value(outstr, TagActual{}, *actual_first, false);
 


### PR DESCRIPTION
This PR enhances error logging in iterator comparisons by introducing streamability detection and structured log output.

- Added a compile-time trait to detect if a type can be streamed (in the namespace `TestUtils`).
- Introduced `TagExpected`/`TagActual` and `log_value` helpers for consistent logging (in the namespace `TestUtils`).
- Updated `expect_equal_val` and `expect_equal` to use the new logging helpers.

So now we can write in the test code something like
```C++
    std::vector<int> data;
    // ...
    auto it = data.begin();
    // ...
    EXPECT_EQ(data.begin(), it, "Error message");
```
Previously we would have had the compile errors in this use-case because iterator variables doesn't supports `operator<<` at all.