### PR TITLE
[oneDPL] A fix for oneDPL internal tuple and for oneDPL C++17 zip_view

### DIFF
--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -131,9 +131,9 @@ using tuplewrapper = oneapi::dpl::__internal::tuple<typename oneapi::dpl::__inte
 // __internal::make_tuple
 template <typename... T>
 constexpr oneapi::dpl::__internal::tuple<T...>
-make_tuple(T&&... args)
+make_tuple(T... args)
 {
-    return oneapi::dpl::__internal::tuple<T...>{std::forward<T>(args)...};
+    return oneapi::dpl::__internal::tuple<T...>{args...};
 }
 
 // __internal::make_tuplewrapper

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -131,9 +131,9 @@ using tuplewrapper = oneapi::dpl::__internal::tuple<typename oneapi::dpl::__inte
 // __internal::make_tuple
 template <typename... T>
 constexpr oneapi::dpl::__internal::tuple<T...>
-make_tuple(T... args)
+make_tuple(T&&... args)
 {
-    return oneapi::dpl::__internal::tuple<T...>{args...};
+    return oneapi::dpl::__internal::tuple<T...>{std::forward<T>(args)...};
 }
 
 // __internal::make_tuplewrapper

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -278,7 +278,7 @@ struct __value_holder
     __value_holder(_Up&& t) : value(::std::forward<_Up>(t))
     {
     }
-    std::remove_cv_t<std::remove_reference_t<_Tp>> value;
+    _Tp value;
 };
 
 // Necessary to make tuple trivially_copy_assignable. This type decided

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -278,7 +278,7 @@ struct __value_holder
     __value_holder(_Up&& t) : value(::std::forward<_Up>(t))
     {
     }
-    _Tp value;
+    std::remove_cv_t<std::remove_reference_t<_Tp>> value;
 };
 
 // Necessary to make tuple trivially_copy_assignable. This type decided

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -242,9 +242,7 @@ class zip_view
     using value_type = oneapi::dpl::__internal::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
     static constexpr ::std::size_t __num_ranges = sizeof...(_Ranges);
 
-    template <typename... _Rs>
-    explicit zip_view(_Rs&&... __args) : __m_ranges(oneapi::dpl::__internal::make_tuple(std::forward<_Rs>(__args)...))
-    {}
+    explicit zip_view(_Ranges... __args) : __m_ranges(__args...) {}
 
     auto
     size() const -> decltype(::std::get<0>(::std::declval<_tuple_ranges_t>()).size())

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -242,7 +242,9 @@ class zip_view
     using value_type = oneapi::dpl::__internal::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
     static constexpr ::std::size_t __num_ranges = sizeof...(_Ranges);
 
-    explicit zip_view(_Ranges... __args) : __m_ranges(oneapi::dpl::__internal::make_tuple(__args...)) {}
+    template <typename... _Rs>
+    explicit zip_view(_Rs&&... __args) : __m_ranges(oneapi::dpl::__internal::make_tuple(std::forward<_Rs>(__args)...))
+    {}
 
     auto
     size() const -> decltype(::std::get<0>(::std::declval<_tuple_ranges_t>()).size())


### PR DESCRIPTION
[oneDPL] A fix for oneDPL C++17 zip_view.

The following trivial example doesn't work:

```
    int a[10];
    std::ranges::subrange r1(a, a + 10);
    auto zip_view = make_zip_view(r1);

```

The PR suggests a fix for that.