### PR TITLE
Reduce-then-scan path for SYCL scan-by-segment implementations

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -83,12 +83,12 @@ __pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1
     temp[0] = init;
 
     transform(policy, first2, last2 - 1, _flags.get() + 1, _temp.get() + 1,
-              oneapi::dpl::__internal::__replace_if_fun<T, std::negate<FlagType>>(std::negate<FlagType>(), init));
+              oneapi::dpl::__internal::__replace_if_fun<T, std::negate<FlagType>>{std::negate<FlagType>{}, init});
 
     // scan key-flag tuples
     inclusive_scan(std::forward<Policy>(policy), make_zip_iterator(_temp.get(), _flags.get()),
                    make_zip_iterator(_temp.get(), _flags.get()) + n, make_zip_iterator(result, _flags.get()),
-                   oneapi::dpl::__internal::__segmented_scan_fun<ValueType, FlagType, Operator>(binary_op));
+                   oneapi::dpl::__internal::__segmented_scan_fun<ValueType, FlagType, Operator>{binary_op});
     return result + n;
 }
 

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -83,12 +83,12 @@ __pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1
     temp[0] = init;
 
     transform(policy, first2, last2 - 1, _flags.get() + 1, _temp.get() + 1,
-              internal::replace_if_fun<T, std::negate<FlagType>>(std::negate<FlagType>(), init));
+              oneapi::dpl::__internal::__replace_if_fun<T, std::negate<FlagType>>(std::negate<FlagType>(), init));
 
     // scan key-flag tuples
     inclusive_scan(std::forward<Policy>(policy), make_zip_iterator(_temp.get(), _flags.get()),
                    make_zip_iterator(_temp.get(), _flags.get()) + n, make_zip_iterator(result, _flags.get()),
-                   internal::segmented_scan_fun<ValueType, FlagType, Operator>(binary_op));
+                   oneapi::dpl::__internal::__segmented_scan_fun<ValueType, FlagType, Operator>(binary_op));
     return result + n;
 }
 

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -102,7 +102,7 @@ __pattern_exclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag,
                                     BinaryPredicate binary_pred, Operator binary_op)
 {
     return __internal::__pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result,
-                                                 init, binary_pred, binary_op, std::false_type{});
+                                                 init, binary_pred, binary_op, /*_Inclusive*/ std::false_type{});
 }
 
 #endif

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -82,92 +82,17 @@ __pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1
 
     temp[0] = init;
 
-    // TODO : add stencil form of replace_copy_if to oneDPL if the
-    // transform call here is difficult to understand and maintain.
-#if 1
     transform(policy, first2, last2 - 1, _flags.get() + 1, _temp.get() + 1,
-              internal::replace_if_fun<T, ::std::negate<FlagType>>(::std::negate<FlagType>(), init));
-#else
-    replace_copy_if(policy1, first2, last2 - 1, _flags.get() + 1, _temp.get() + 1, ::std::negate<FlagType>(), init);
-#endif
+              internal::replace_if_fun<T, std::negate<FlagType>>(std::negate<FlagType>(), init));
 
     // scan key-flag tuples
-    inclusive_scan(::std::forward<Policy>(policy), make_zip_iterator(_temp.get(), _flags.get()),
+    inclusive_scan(std::forward<Policy>(policy), make_zip_iterator(_temp.get(), _flags.get()),
                    make_zip_iterator(_temp.get(), _flags.get()) + n, make_zip_iterator(result, _flags.get()),
                    internal::segmented_scan_fun<ValueType, FlagType, Operator>(binary_op));
     return result + n;
 }
 
 #if _ONEDPL_BACKEND_SYCL
-template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
-          typename OutputIterator, typename T, typename BinaryPredicate, typename Operator>
-OutputIterator
-__pattern_exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy,
-                                         InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
-                                         OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
-                                         std::true_type /* has_known_identity*/)
-{
-    return __internal::__pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result,
-                                                 init, binary_pred, binary_op, std::false_type{});
-}
-
-template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
-          typename OutputIterator, typename T, typename BinaryPredicate, typename Operator>
-OutputIterator
-__pattern_exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
-                                         InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
-                                         BinaryPredicate binary_pred, Operator binary_op,
-                                         std::false_type /* has_known_identity*/)
-{
-
-    const auto n = ::std::distance(first1, last1);
-    typedef typename ::std::iterator_traits<OutputIterator>::value_type OutputType;
-    typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
-    typedef unsigned int FlagType;
-
-    InputIterator2 last2 = first2 + n;
-
-    // compute head flags
-    oneapi::dpl::__par_backend_hetero::__buffer<FlagType> _flags(n);
-    {
-        auto flag_buf = _flags.get_buffer();
-        auto flags = flag_buf.get_host_access(sycl::read_write);
-        flags[0] = 1;
-    }
-
-    transform(policy, first1, last1 - 1, first1 + 1, _flags.get() + 1,
-              oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
-
-    // shift input one to the right and initialize segments with init
-    oneapi::dpl::__par_backend_hetero::__buffer<OutputType> _temp(n);
-    {
-        auto temp_buf = _temp.get_buffer();
-        auto temp = temp_buf.get_host_access(sycl::read_write);
-
-        temp[0] = init;
-    }
-
-    auto policy1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<ExclusiveScan1>(policy);
-
-    // TODO : add stencil form of replace_copy_if to oneDPL if the
-    // transform call here is difficult to understand and maintain.
-#    if 1
-    transform(::std::move(policy1), first2, last2 - 1, _flags.get() + 1, _temp.get() + 1,
-              internal::replace_if_fun<T, ::std::negate<FlagType>>(::std::negate<FlagType>(), init));
-#    else
-    replace_copy_if(::std::move(policy1), first2, last2 - 1, _flags.get() + 1, _temp.get() + 1,
-                    ::std::negate<FlagType>(), init);
-#    endif
-
-    auto policy2 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<ExclusiveScan2>(std::forward<Policy>(policy));
-
-    // scan key-flag tuples
-    transform_inclusive_scan(std::move(policy2), make_zip_iterator(_temp.get(), _flags.get()),
-                             make_zip_iterator(_temp.get(), _flags.get()) + n, make_zip_iterator(result, _flags.get()),
-                             internal::segmented_scan_fun<ValueType, FlagType, Operator>(binary_op),
-                             oneapi::dpl::identity{}, oneapi::dpl::__internal::make_tuple(init, FlagType(1)));
-    return result + n;
-}
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename T, typename BinaryPredicate, typename Operator>
@@ -176,10 +101,8 @@ __pattern_exclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag,
                                     InputIterator1 last1, InputIterator2 first2, OutputIterator result, T init,
                                     BinaryPredicate binary_pred, Operator binary_op)
 {
-    return __internal::__pattern_exclusive_scan_by_segment_impl(
-        __tag, std::forward<Policy>(policy), first1, last1, first2, result, init, binary_pred, binary_op,
-        typename unseq_backend::__has_known_identity<
-            Operator, typename std::iterator_traits<InputIterator2>::value_type>::type{});
+    return __internal::__pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result,
+                                                 init, binary_pred, binary_op, std::false_type{});
 }
 
 #endif

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -102,7 +102,7 @@ __pattern_exclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag,
                                     BinaryPredicate binary_pred, Operator binary_op)
 {
     return __internal::__pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result,
-                                                 init, binary_pred, binary_op, /*_Inclusive*/ std::false_type{});
+                                                 binary_pred, binary_op, /*_Inclusive*/ std::false_type{}, init);
 }
 
 #endif

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -43,27 +43,6 @@ struct is_discard_iterator<Iter, ::std::enable_if_t<Iter::is_discard::value>> : 
 };
 
 // Used by: exclusive_scan_by_key
-// Lambda: [pred, &new_value](Ref1 a, Ref2 s) {return pred(s) ? new_value : a; });
-template <typename T, typename Predicate>
-struct replace_if_fun
-{
-    using result_of = T;
-
-    replace_if_fun(Predicate _pred, T _new_value) : pred(_pred), new_value(_new_value) {}
-
-    template <typename _T1, typename _T2>
-    T
-    operator()(_T1&& a, _T2&& s) const
-    {
-        return pred(s) ? new_value : a;
-    }
-
-  private:
-    Predicate pred;
-    const T new_value;
-};
-
-// Used by: exclusive_scan_by_key
 template <typename ValueType, typename FlagType, typename BinaryOp>
 struct scan_by_key_fun
 {
@@ -77,27 +56,6 @@ struct scan_by_key_fun
     {
         using ::std::get;
         return ::std::make_tuple(get<1>(y) ? get<0>(y) : binary_op(get<0>(x), get<0>(y)), get<1>(x) | get<1>(y));
-    }
-
-  private:
-    BinaryOp binary_op;
-};
-
-// Used by: reduce_by_key
-template <typename ValueType, typename FlagType, typename BinaryOp>
-struct segmented_scan_fun
-{
-    segmented_scan_fun(BinaryOp input) : binary_op(input) {}
-
-    template <typename _T1, typename _T2>
-    _T1
-    operator()(const _T1& x, const _T2& y) const
-    {
-        using ::std::get;
-        using x_t = ::std::tuple_element_t<0, _T1>;
-        auto new_x = get<1>(y) ? x_t(get<0>(y)) : x_t(binary_op(get<0>(x), get<0>(y)));
-        auto new_y = get<1>(x) | get<1>(y);
-        return _T1(new_x, new_y);
     }
 
   private:

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -75,7 +75,7 @@ __pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1
     transform(policy, first1, last1 - 1, first1 + 1, _mask.get() + 1,
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
-    inclusive_scan(::std::forward<Policy>(policy), make_zip_iterator(first2, _mask.get()),
+    inclusive_scan(std::forward<Policy>(policy), make_zip_iterator(first2, _mask.get()),
                    make_zip_iterator(first2, _mask.get()) + n, make_zip_iterator(result, _mask.get()),
                    internal::segmented_scan_fun<ValueType, FlagType, BinaryOperator>(binary_op));
 
@@ -86,67 +86,12 @@ __pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename BinaryPredicate, typename BinaryOperator>
 OutputIterator
-__pattern_inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy,
-                                         InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
-                                         OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op,
-                                         std::true_type /* has_known_identity */)
-{
-    using iter_value_t = typename ::std::iterator_traits<InputIterator2>::value_type;
-    iter_value_t identity = unseq_backend::__known_identity<BinaryOperator, iter_value_t>;
-    return __internal::__pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result,
-                                                 identity, binary_pred, binary_op, std::true_type{});
-}
-
-template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
-          typename OutputIterator, typename BinaryPredicate, typename BinaryOperator>
-OutputIterator
-__pattern_inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIterator1 first1,
-                                         InputIterator1 last1, InputIterator2 first2, OutputIterator result,
-                                         BinaryPredicate binary_pred, BinaryOperator binary_op,
-                                         std::false_type /* has_known_identity */)
-{
-
-    typedef unsigned int FlagType;
-    typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
-
-    const auto n = ::std::distance(first1, last1);
-
-    // Check for empty element ranges
-    if (n <= 0)
-        return result;
-
-    FlagType initial_mask = 1;
-
-    oneapi::dpl::__par_backend_hetero::__buffer<FlagType> _mask(n);
-    {
-        auto mask_buf = _mask.get_buffer();
-        auto mask = mask_buf.get_host_access(sycl::read_write);
-
-        mask[0] = initial_mask;
-    }
-
-    transform(policy, first1, last1 - 1, first1 + 1, _mask.get() + 1,
-              oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
-
-    auto policy1 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<InclusiveScan1>(std::forward<Policy>(policy));
-    transform_inclusive_scan(std::move(policy1), make_zip_iterator(first2, _mask.get()),
-                             make_zip_iterator(first2, _mask.get()) + n, make_zip_iterator(result, _mask.get()),
-                             internal::segmented_scan_fun<ValueType, FlagType, BinaryOperator>(binary_op),
-                             oneapi::dpl::identity{});
-    return result + n;
-}
-
-template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
-          typename OutputIterator, typename BinaryPredicate, typename BinaryOperator>
-OutputIterator
 __pattern_inclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag, Policy&& policy, InputIterator1 first1,
                                     InputIterator1 last1, InputIterator2 first2, OutputIterator result,
                                     BinaryPredicate binary_pred, BinaryOperator binary_op)
 {
-    return __internal::__pattern_inclusive_scan_by_segment_impl(
-        __tag, ::std::forward<Policy>(policy), first1, last1, first2, result, binary_pred, binary_op,
-        typename unseq_backend::__has_known_identity<
-            BinaryOperator, typename ::std::iterator_traits<InputIterator2>::value_type>::type{});
+    return __pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result, binary_pred,
+                                     binary_op, std::true_type{});
 }
 
 #endif

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -77,7 +77,7 @@ __pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1
 
     inclusive_scan(std::forward<Policy>(policy), make_zip_iterator(first2, _mask.get()),
                    make_zip_iterator(first2, _mask.get()) + n, make_zip_iterator(result, _mask.get()),
-                   internal::segmented_scan_fun<ValueType, FlagType, BinaryOperator>(binary_op));
+                   oneapi::dpl::__internal::__segmented_scan_fun<ValueType, FlagType, BinaryOperator>(binary_op));
 
     return result + n;
 }

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -91,7 +91,7 @@ __pattern_inclusive_scan_by_segment(__internal::__hetero_tag<_BackendTag> __tag,
                                     BinaryPredicate binary_pred, BinaryOperator binary_op)
 {
     return __pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result, binary_pred,
-                                     binary_op, std::true_type{});
+                                     binary_op, /*_Inclusive*/ std::true_type{});
 }
 
 #endif

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -77,7 +77,7 @@ __pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1
 
     inclusive_scan(std::forward<Policy>(policy), make_zip_iterator(first2, _mask.get()),
                    make_zip_iterator(first2, _mask.get()) + n, make_zip_iterator(result, _mask.get()),
-                   oneapi::dpl::__internal::__segmented_scan_fun<ValueType, FlagType, BinaryOperator>(binary_op));
+                   oneapi::dpl::__internal::__segmented_scan_fun<ValueType, FlagType, BinaryOperator>{binary_op});
 
     return result + n;
 }

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -137,7 +137,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     // Compute the sum of the segments. scanned_tail_flags values are not used.
     inclusive_scan(policy, make_zip_iterator(first2, _mask.get()), make_zip_iterator(first2, _mask.get()) + n,
                    make_zip_iterator(_scanned_values.get(), _scanned_tail_flags.get()),
-                   internal::segmented_scan_fun<ValueType, FlagType, BinaryOperator>(binary_op));
+                   oneapi::dpl::__internal::__segmented_scan_fun<ValueType, FlagType, BinaryOperator>(binary_op));
 
     // for example: _scanned_values     = { 1, 2, 3, 4, 1, 2, 3, 6, 1, 2, 3, 6, 0 }
 

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -137,7 +137,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     // Compute the sum of the segments. scanned_tail_flags values are not used.
     inclusive_scan(policy, make_zip_iterator(first2, _mask.get()), make_zip_iterator(first2, _mask.get()) + n,
                    make_zip_iterator(_scanned_values.get(), _scanned_tail_flags.get()),
-                   oneapi::dpl::__internal::__segmented_scan_fun<ValueType, FlagType, BinaryOperator>(binary_op));
+                   oneapi::dpl::__internal::__segmented_scan_fun<ValueType, FlagType, BinaryOperator>{binary_op});
 
     // for example: _scanned_values     = { 1, 2, 3, 4, 1, 2, 3, 6, 1, 2, 3, 6, 0 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -2181,6 +2181,36 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 }
 
 template <typename _BackendTag, typename _Policy, typename _InputIterator1, typename _InputIterator2,
+          typename _OutputIterator, typename _BinaryPredicate, typename _Operator, typename _Inclusive>
+_OutputIterator
+__pattern_scan_by_segment(__hetero_tag<_BackendTag>, _Policy&& __policy, _InputIterator1 __first1,
+                          _InputIterator1 __last1, _InputIterator2 __first2, _OutputIterator __result,
+                          _BinaryPredicate __binary_pred, _Operator __binary_op, _Inclusive)
+{
+    const auto __n = std::distance(__first1, __last1);
+
+    // Check for empty element ranges
+    if (__n <= 0)
+        return __result;
+
+    namespace __bknd = oneapi::dpl::__par_backend_hetero;
+
+    auto __keep_keys = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, _InputIterator1>();
+    auto __key_buf = __keep_keys(__first1, __last1);
+    auto __keep_values = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, _InputIterator2>();
+    auto __value_buf = __keep_values(__first2, __first2 + __n);
+    auto __keep_value_outputs =
+        oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, _OutputIterator>();
+    auto __value_output_buf = __keep_value_outputs(__result, __result + __n);
+    using _IterValueType = typename std::iterator_traits<_InputIterator2>::value_type;
+
+    __bknd::__parallel_scan_by_segment<_Inclusive::value>(
+        _BackendTag{}, std::forward<_Policy>(__policy), __key_buf.all_view(), __value_buf.all_view(),
+        __value_output_buf.all_view(), __binary_pred, __binary_op, unseq_backend::__no_init_value{});
+    return __result + __n;
+}
+
+template <typename _BackendTag, typename _Policy, typename _InputIterator1, typename _InputIterator2,
           typename _OutputIterator, typename _T, typename _BinaryPredicate, typename _Operator, typename _Inclusive>
 _OutputIterator
 __pattern_scan_by_segment(__hetero_tag<_BackendTag>, _Policy&& __policy, _InputIterator1 __first1,
@@ -2204,14 +2234,9 @@ __pattern_scan_by_segment(__hetero_tag<_BackendTag>, _Policy&& __policy, _InputI
     auto __value_output_buf = __keep_value_outputs(__result, __result + __n);
     using _IterValueType = typename std::iterator_traits<_InputIterator2>::value_type;
 
-    // Currently, this pattern requires a known identity for the binary operator.
-    static_assert(unseq_backend::__has_known_identity<_Operator, _IterValueType>::value,
-                  "Calls to __pattern_scan_by_segment require a known identity for the provided binary operator");
-    constexpr _IterValueType __identity = unseq_backend::__known_identity<_Operator, _IterValueType>;
-
     __bknd::__parallel_scan_by_segment<_Inclusive::value>(
         _BackendTag{}, std::forward<_Policy>(__policy), __key_buf.all_view(), __value_buf.all_view(),
-        __value_output_buf.all_view(), __binary_pred, __binary_op, __init, __identity);
+        __value_output_buf.all_view(), __binary_pred, __binary_op, unseq_backend::__init_value<_T>{__init});
     return __result + __n;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -2202,7 +2202,6 @@ __pattern_scan_by_segment(__hetero_tag<_BackendTag>, _Policy&& __policy, _InputI
     auto __keep_value_outputs =
         oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, _OutputIterator>();
     auto __value_output_buf = __keep_value_outputs(__result, __result + __n);
-    using _IterValueType = typename std::iterator_traits<_InputIterator2>::value_type;
 
     __bknd::__parallel_scan_by_segment<_Inclusive::value>(
         _BackendTag{}, std::forward<_Policy>(__policy), __key_buf.all_view(), __value_buf.all_view(),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2230,7 +2230,7 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
             oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
             oneapi::dpl::__ranges::zip_view(std::forward<_Range2>(__values), __mask_view),
             oneapi::dpl::__ranges::zip_view(std::forward<_Range3>(__out_values), __mask_view), __n,
-            oneapi::dpl::__internal::__no_op{}, oneapi::dpl::unseq_backend::__no_init_value<_ScanInitType>{},
+            oneapi::dpl::identity{}, oneapi::dpl::unseq_backend::__no_init_value<_ScanInitType>{},
             oneapi::dpl::__internal::__segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op},
             /*_Inclusive*/ std::true_type{})
             .wait();
@@ -2273,7 +2273,7 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
             oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
             oneapi::dpl::__ranges::zip_view(__temp_view, __mask_view),
             oneapi::dpl::__ranges::zip_view(std::forward<_Range3>(__out_values), __mask_view), __n,
-            oneapi::dpl::__internal::__no_op{},
+            oneapi::dpl::identity{},
             oneapi::dpl::unseq_backend::__init_value<_ScanInitType>{
                 oneapi::dpl::__internal::make_tuple(__init.__value, _FlagType(1))},
             oneapi::dpl::__internal::__segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op},

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2259,7 +2259,7 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
                 oneapi::dpl::__ranges::all_view<_OutputType, __par_backend_hetero::access_mode::read_write>(
                     __temp.get_buffer(), 1, __n - 1);
             oneapi::dpl::__internal::__replace_if_fun<typename _InitType::__value_type, std::negate<_FlagType>>
-                __replace_fun(std::negate<_FlagType>(), __init.__value);
+                __replace_fun{std::negate<_FlagType>{}, __init.__value};
             using _ReplaceTransform = oneapi::dpl::__internal::__transform_functor<decltype(__replace_fun)>;
             _ReplaceTransform __tf{__replace_fun};
             __parallel_for(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2190,8 +2190,6 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
                                     /*has_known_identity*/ std::false_type)
 {
     using _FlagType = unsigned int;
-    using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
-    using _OutputType = oneapi::dpl::__internal::__value_t<_Range3>;
 
     const auto __n = __keys.size();
 
@@ -2239,6 +2237,7 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
     }
     else
     {
+        using _OutputType = oneapi::dpl::__internal::__value_t<_Range3>;
         // shift input one to the right and initialize segments with init
         oneapi::dpl::__par_backend_hetero::__buffer<_OutputType> __temp(__n);
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2146,7 +2146,7 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
     {
         oneapi::dpl::unseq_backend::__no_init_value<oneapi::dpl::__internal::tuple<_FlagType, _ValueType>>
             __wrapped_init;
-        using _WriteOp = __write_scan_by_seg<decltype(__wrapped_init), _BinaryOperator>;
+        using _WriteOp = __write_scan_by_seg<__is_inclusive, decltype(__wrapped_init), _BinaryOperator>;
         return __parallel_transform_reduce_then_scan<sizeof(oneapi::dpl::__internal::tuple<_FlagType, _ValueType>),
                                                      _CustomName>(
             __q, __n,
@@ -2161,7 +2161,7 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
         // This is because init handling must occur on a per-segment basis and functions differently than the typical scan init.
         oneapi::dpl::unseq_backend::__init_value<oneapi::dpl::__internal::tuple<_FlagType, _ValueType>> __wrapped_init{
             {0, __init.__value}};
-        using _WriteOp = __write_scan_by_seg<decltype(__wrapped_init), _BinaryOperator>;
+        using _WriteOp = __write_scan_by_seg<__is_inclusive, decltype(__wrapped_init), _BinaryOperator>;
         return __parallel_transform_reduce_then_scan<sizeof(oneapi::dpl::__internal::tuple<_FlagType, _ValueType>),
                                                      _CustomName>(
             __q, __n,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2126,11 +2126,11 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
 // parallel_scan_by_segment - sync pattern
 //------------------------------------------------------------------------
 template <typename _CustomName, bool __is_inclusive, typename _Range1, typename _Range2, typename _Range3,
-          typename _BinaryPredicate, typename _BinaryOperator, typename _T>
+          typename _BinaryPredicate, typename _BinaryOperator, typename _InitType>
 auto
 __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, _Range2&& __values,
                                             _Range3&& __out_values, _BinaryPredicate __binary_pred,
-                                            _BinaryOperator __binary_op, [[maybe_unused]] _T __init, _T __identity)
+                                            _BinaryOperator __binary_op, [[maybe_unused]] _InitType __init)
 {
     using _GenReduceInput = __gen_red_by_seg_reduce_input<_BinaryPredicate>;
     using _ReduceOp = __scan_by_seg_op<_BinaryOperator>;
@@ -2138,8 +2138,6 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
     using _ScanInputTransform = __get_zeroth_element;
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
     std::size_t __n = __keys.size();
-    // __gen_red_by_seg_scan_input requires that __n > 1
-    assert(__n > 1);
     if constexpr (__is_inclusive)
     {
         oneapi::dpl::unseq_backend::__no_init_value<oneapi::dpl::__internal::tuple<std::size_t, _ValueType>>
@@ -2158,7 +2156,7 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
         // The init value is manually applied through the write functor in exclusive-scan-by-segment and we always pass __no_init_value.
         // This is because init handling must occur on a per-segment basis and functions differently than the typical scan init.
         oneapi::dpl::unseq_backend::__init_value<oneapi::dpl::__internal::tuple<std::size_t, _ValueType>>
-            __wrapped_init{{0, __init}};
+            __wrapped_init{{0, __init.__value}};
         using _WriteOp = __write_scan_by_seg<decltype(__wrapped_init), _BinaryOperator>;
         return __parallel_transform_reduce_then_scan<sizeof(oneapi::dpl::__internal::tuple<std::size_t, _ValueType>),
                                                      _CustomName>(
@@ -2171,25 +2169,188 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
     }
 }
 
+template <typename _ValueType, typename _FlagType, typename _BinaryOp>
+struct __segmented_scan_fun
+{
+    __segmented_scan_fun(_BinaryOp __input) : __binary_op(__input) {}
+
+    template <typename _T1, typename _T2>
+    _T1
+    operator()(const _T1& __x, const _T2& __y) const
+    {
+        using std::get;
+        using __x_t = std::tuple_element_t<0, _T1>;
+        auto __new_x =
+            std::get<1>(__y) ? __x_t(std::get<0>(__y)) : __x_t(__binary_op(std::get<0>(__x), std::get<0>(__y)));
+        auto __new_y = std::get<1>(__x) | std::get<1>(__y);
+        return _T1(__new_x, __new_y);
+    }
+
+  private:
+    _BinaryOp __binary_op;
+};
+
+template <typename _T, typename _Predicate>
+struct __replace_if_fun
+{
+    using __result_of = _T;
+
+    __replace_if_fun(_Predicate __pred, _T __new_value) : __pred(__pred), __new_value(__new_value) {}
+
+    template <typename _T1, typename _T2>
+    _T
+    operator()(_T1&& __a, _T2&& __s) const
+    {
+        return __pred(__s) ? __new_value : __a;
+    }
+
+  private:
+    _Predicate __pred;
+    const _T __new_value;
+};
+
+template <typename _CustomName>
+struct __scan_by_seg_fallback;
+
+template <typename _CustomName>
+struct __scan_by_seg_transform_wrapper1;
+
+template <typename _CustomName>
+struct __scan_by_seg_transform_wrapper2;
+
+template <typename _CustonName, bool __is_inclusive, typename _ExecutionPolicy, typename _Range1, typename _Range2,
+          typename _Range3, typename _BinaryPredicate, typename _BinaryOperator, typename _InitType>
+void
+__parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+                                    _Range1&& __keys, _Range2&& __values, _Range3&& __out_values,
+                                    _BinaryPredicate __binary_pred, _BinaryOperator __binary_op, _InitType __init,
+                                    /*has_known_identity*/ std::false_type)
+{
+    using _FlagType = unsigned int;
+    using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
+    using _OutputType = oneapi::dpl::__internal::__value_t<_Range3>;
+
+    const auto __n = __keys.size();
+
+    assert(__n > 0);
+
+    _FlagType __initial_mask = 1;
+
+    oneapi::dpl::__par_backend_hetero::__buffer<_FlagType> __mask(__n);
+    {
+        auto __mask_buf = __mask.get_buffer();
+        auto __mask_acc = __mask_buf.get_host_access(sycl::read_write);
+
+        __mask_acc[0] = __initial_mask;
+    }
+    auto __mask_view =
+        oneapi::dpl::__ranges::all_view<_FlagType, __par_backend_hetero::access_mode::read_write>(__mask.get_buffer());
+    if (__n > 1)
+    {
+        auto __mask_view_shifted =
+            oneapi::dpl::__ranges::all_view<_FlagType, __par_backend_hetero::access_mode::read_write>(
+                __mask.get_buffer(), 1, __n - 1);
+        using _NegateTransform =
+            oneapi::dpl::__internal::__transform_functor<oneapi::dpl::__internal::__not_pred<_BinaryPredicate>>;
+        _NegateTransform __tf{oneapi::dpl::__internal::__not_pred<_BinaryPredicate>(__binary_pred)};
+        auto __keys_shifted = oneapi::dpl::__ranges::drop_view_simple(__keys, 1);
+        __parallel_for(
+            oneapi::dpl::__internal::__device_backend_tag{},
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__scan_by_seg_transform_wrapper1>(__exec),
+            unseq_backend::walk_n_vectors_or_scalars<_NegateTransform>(__tf, static_cast<std::size_t>(__n - 1)),
+            __n - 1, __keys, __keys_shifted, __mask_view_shifted)
+            .wait();
+    }
+    if constexpr (__is_inclusive)
+    {
+        using _ScanInitType = oneapi::dpl::__internal::__value_t<decltype(oneapi::dpl::__ranges::zip_view(
+            std::forward<_Range2>(__values), __mask_view))>;
+        __parallel_transform_scan(
+            oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
+            oneapi::dpl::__ranges::zip_view(std::forward<_Range2>(__values), __mask_view),
+            oneapi::dpl::__ranges::zip_view(std::forward<_Range3>(__out_values), __mask_view), __n,
+            oneapi::dpl::__internal::__no_op{}, oneapi::dpl::unseq_backend::__no_init_value<_ScanInitType>{},
+            __segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op},
+            std::bool_constant<__is_inclusive>{})
+            .wait();
+    }
+    else
+    {
+        // shift input one to the right and initialize segments with init
+        oneapi::dpl::__par_backend_hetero::__buffer<_OutputType> __temp(__n);
+        {
+            auto __temp_buf = __temp.get_buffer();
+            auto __temp_acc = __temp_buf.get_host_access(sycl::read_write);
+
+            __temp_acc[0] = __init.__value;
+        }
+        auto __temp_view = oneapi::dpl::__ranges::all_view<_OutputType, __par_backend_hetero::access_mode::read_write>(
+            __temp.get_buffer());
+        if (__n > 1)
+        {
+            auto __mask_view_shifted =
+                oneapi::dpl::__ranges::all_view<_FlagType, __par_backend_hetero::access_mode::read_write>(
+                    __mask.get_buffer(), 1, __n - 1);
+            auto __temp_view_shifted =
+                oneapi::dpl::__ranges::all_view<_OutputType, __par_backend_hetero::access_mode::read_write>(
+                    __temp.get_buffer(), 1, __n - 1);
+            __replace_if_fun<typename _InitType::__value_type, std::negate<_FlagType>> __replace_fun(
+                std::negate<_FlagType>(), __init.__value);
+            using _ReplaceTransform = oneapi::dpl::__internal::__transform_functor<decltype(__replace_fun)>;
+            _ReplaceTransform __tf{__replace_fun};
+            __parallel_for(
+                oneapi::dpl::__internal::__device_backend_tag{},
+                oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__scan_by_seg_transform_wrapper2>(__exec),
+                unseq_backend::walk_n_vectors_or_scalars<_ReplaceTransform>(__tf, static_cast<std::size_t>(__n - 1)),
+                __n - 1, __values, __mask_view_shifted, __temp_view_shifted)
+                .wait();
+        }
+        using _ScanInitType =
+            oneapi::dpl::__internal::__value_t<decltype(oneapi::dpl::__ranges::zip_view(__temp_view, __mask_view))>;
+        __parallel_transform_scan(
+            oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
+            oneapi::dpl::__ranges::zip_view(__temp_view, __mask_view),
+            oneapi::dpl::__ranges::zip_view(std::forward<_Range3>(__out_values), __mask_view), __n,
+            oneapi::dpl::__internal::__no_op{},
+            oneapi::dpl::unseq_backend::__init_value<_ScanInitType>{
+                oneapi::dpl::__internal::make_tuple(__init.__value, _FlagType(1))},
+            __segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op}, std::true_type{})
+            .wait();
+    }
+}
+
 template <bool __is_inclusive, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
-          typename _BinaryPredicate, typename _BinaryOperator, typename _T>
+          typename _BinaryPredicate, typename _BinaryOperator, typename _InitType>
 void
 __parallel_scan_by_segment(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range1&& __keys,
                            _Range2&& __values, _Range3&& __out_values, _BinaryPredicate __binary_pred,
-                           _BinaryOperator __binary_op, _T __init, _T __identity)
+                           _BinaryOperator __binary_op, _InitType __init)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+    using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
+    assert(__keys.size() > 0);
 
-    sycl::queue __q_local = __exec.queue();
-
-    __parallel_scan_by_segment_reduce_then_scan<_CustomName, __is_inclusive>(
-        __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_values),
-        __binary_pred, __binary_op, __init, __identity)
-        .wait();
-
-    //__sycl_scan_by_segment_impl<_CustomName, __is_inclusive>()(
-    //    __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_values),
-    //    __binary_pred, __binary_op, __init, __identity);
+    if constexpr (std::is_trivially_copyable_v<_ValueType>)
+    {
+        sycl::queue __q_local = __exec.queue();
+        if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
+        {
+            __parallel_scan_by_segment_reduce_then_scan<_CustomName, __is_inclusive>(
+                __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
+                std::forward<_Range3>(__out_values), __binary_pred, __binary_op, __init)
+                .wait();
+            return;
+        }
+    }
+    // Implicit synchronization in this call. We need to wrap the policy as the implementation may still call
+    // reduce-then-scan and needs to avoid duplicate kernel names.
+    __parallel_scan_by_segment_fallback<_CustomName, __is_inclusive>(
+        oneapi::dpl::__internal::__device_backend_tag{},
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__scan_by_seg_fallback>(
+            std::forward<_ExecutionPolicy>(__exec)),
+        std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_values),
+        __binary_pred, __binary_op, __init,
+        oneapi::dpl::unseq_backend::__has_known_identity<_BinaryOperator, _ValueType>{});
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2132,18 +2132,22 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
                                             _Range3&& __out_values, _BinaryPredicate __binary_pred,
                                             _BinaryOperator __binary_op, [[maybe_unused]] _InitType __init)
 {
-    using _GenReduceInput = __gen_red_by_seg_reduce_input<_BinaryPredicate>;
+    using _GenReduceInput = __gen_scan_by_seg_reduce_input<_BinaryPredicate>;
     using _ReduceOp = __scan_by_seg_op<_BinaryOperator>;
     using _GenScanInput = __gen_scan_by_seg_scan_input<_BinaryPredicate>;
     using _ScanInputTransform = __get_zeroth_element;
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
     std::size_t __n = __keys.size();
+    // TODO: A bool type may be used here for a smaller footprint in registers / temp storage but results in IGC crashes
+    // during JIT time. The same occurs for uint8_t and uint16_t. uint32_t is used as a workaround until the underlying
+    // issue is resolved.
+    using _FlagType = std::uint32_t;
     if constexpr (__is_inclusive)
     {
-        oneapi::dpl::unseq_backend::__no_init_value<oneapi::dpl::__internal::tuple<std::size_t, _ValueType>>
+        oneapi::dpl::unseq_backend::__no_init_value<oneapi::dpl::__internal::tuple<_FlagType, _ValueType>>
             __wrapped_init;
         using _WriteOp = __write_scan_by_seg<decltype(__wrapped_init), _BinaryOperator>;
-        return __parallel_transform_reduce_then_scan<sizeof(oneapi::dpl::__internal::tuple<std::size_t, _ValueType>),
+        return __parallel_transform_reduce_then_scan<sizeof(oneapi::dpl::__internal::tuple<_FlagType, _ValueType>),
                                                      _CustomName>(
             __q, __n,
             oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__keys), std::forward<_Range2>(__values)),
@@ -2155,16 +2159,15 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
     {
         // The init value is manually applied through the write functor in exclusive-scan-by-segment and we always pass __no_init_value.
         // This is because init handling must occur on a per-segment basis and functions differently than the typical scan init.
-        oneapi::dpl::unseq_backend::__init_value<oneapi::dpl::__internal::tuple<std::size_t, _ValueType>>
-            __wrapped_init{{0, __init.__value}};
+        oneapi::dpl::unseq_backend::__init_value<oneapi::dpl::__internal::tuple<_FlagType, _ValueType>> __wrapped_init{
+            {0, __init.__value}};
         using _WriteOp = __write_scan_by_seg<decltype(__wrapped_init), _BinaryOperator>;
-        return __parallel_transform_reduce_then_scan<sizeof(oneapi::dpl::__internal::tuple<std::size_t, _ValueType>),
+        return __parallel_transform_reduce_then_scan<sizeof(oneapi::dpl::__internal::tuple<_FlagType, _ValueType>),
                                                      _CustomName>(
             __q, __n,
             oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__keys), std::forward<_Range2>(__values)),
             std::forward<_Range3>(__out_values), _GenReduceInput{__binary_pred}, _ReduceOp{__binary_op},
-            _GenScanInput{}, _ScanInputTransform{}, _WriteOp{__wrapped_init, __binary_op},
-            oneapi::dpl::unseq_backend::__no_init_value<oneapi::dpl::__internal::tuple<std::size_t, _ValueType>>{},
+            _GenScanInput{}, _ScanInputTransform{}, _WriteOp{__wrapped_init, __binary_op}, __wrapped_init,
             /*Inclusive*/ std::false_type{}, /*_IsUniquePattern=*/std::false_type{});
     }
 }
@@ -2199,7 +2202,7 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
     oneapi::dpl::__par_backend_hetero::__buffer<_FlagType> __mask(__n);
     {
         auto __mask_buf = __mask.get_buffer();
-        auto __mask_acc = __mask_buf.get_host_access(sycl::read_write);
+        auto __mask_acc = __mask_buf.get_host_access(sycl::write_only);
 
         __mask_acc[0] = __initial_mask;
     }
@@ -2231,7 +2234,7 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
             oneapi::dpl::__ranges::zip_view(std::forward<_Range3>(__out_values), __mask_view), __n,
             oneapi::dpl::__internal::__no_op{}, oneapi::dpl::unseq_backend::__no_init_value<_ScanInitType>{},
             oneapi::dpl::__internal::__segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op},
-            std::bool_constant<__is_inclusive>{})
+            /*_Inclusive*/ std::true_type{})
             .wait();
     }
     else
@@ -2240,7 +2243,7 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
         oneapi::dpl::__par_backend_hetero::__buffer<_OutputType> __temp(__n);
         {
             auto __temp_buf = __temp.get_buffer();
-            auto __temp_acc = __temp_buf.get_host_access(sycl::read_write);
+            auto __temp_acc = __temp_buf.get_host_access(sycl::write_only);
 
             __temp_acc[0] = __init.__value;
         }
@@ -2275,7 +2278,7 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
             oneapi::dpl::unseq_backend::__init_value<_ScanInitType>{
                 oneapi::dpl::__internal::make_tuple(__init.__value, _FlagType(1))},
             oneapi::dpl::__internal::__segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op},
-            std::true_type{})
+            /*_Inclusive*/ std::true_type{})
             .wait();
     }
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2144,35 +2144,16 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
     // issue is resolved.
     using _FlagType = std::uint32_t;
     using _PackedFlagValueType = oneapi::dpl::__internal::tuple<_FlagType, _ValueType>;
-    using _WrappedInitType =
-        std::conditional_t<__is_inclusive, oneapi::dpl::unseq_backend::__no_init_value<_PackedFlagValueType>,
-                           oneapi::dpl::unseq_backend::__init_value<_PackedFlagValueType>>;
-    if constexpr (__is_inclusive)
-    {
-        _WrappedInitType __wrapped_init;
-        using _WriteOp = __write_scan_by_seg<__is_inclusive, _WrappedInitType, _BinaryOperator>;
-        return __parallel_transform_reduce_then_scan<sizeof(_PackedFlagValueType), _CustomName>(
-            __q, __n,
-            oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__keys), std::forward<_Range2>(__values)),
-            std::forward<_Range3>(__out_values), _GenReduceInput{__binary_pred}, _ReduceOp{__binary_op},
-            _GenScanInput{}, _ScanInputTransform{}, _WriteOp{__wrapped_init, __binary_op}, __wrapped_init,
-            /*Inclusive*/ std::true_type{}, /*_IsUniquePattern=*/std::false_type{});
-    }
-    else
-    {
-        // The init value is manually applied through the write functor in exclusive-scan-by-segment and we always pass
-        // __no_init_value to the transform scan call. This is because init handling must occur on a per-segment basis
-        // and functions differently than the typical scan init which is only applied once in a single location.
-        _WrappedInitType __wrapped_init{{0, __init.__value}};
-        using _WriteOp = __write_scan_by_seg<__is_inclusive, _WrappedInitType, _BinaryOperator>;
-        return __parallel_transform_reduce_then_scan<sizeof(_PackedFlagValueType), _CustomName>(
-            __q, __n,
-            oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__keys), std::forward<_Range2>(__values)),
-            std::forward<_Range3>(__out_values), _GenReduceInput{__binary_pred}, _ReduceOp{__binary_op},
-            _GenScanInput{}, _ScanInputTransform{}, _WriteOp{__wrapped_init, __binary_op},
-            oneapi::dpl::unseq_backend::__no_init_value<_PackedFlagValueType>{},
-            /*Inclusive*/ std::false_type{}, /*_IsUniquePattern=*/std::false_type{});
-    }
+    // The init value is manually applied through the write functor in exclusive-scan-by-segment and we always pass
+    // __no_init_value to the transform scan call. This is because init handling must occur on a per-segment basis
+    // and functions differently than the typical scan init which is only applied once in a single location.
+    oneapi::dpl::unseq_backend::__no_init_value<_PackedFlagValueType> __placeholder_no_init{};
+    using _WriteOp = __write_scan_by_seg<__is_inclusive, _InitType, _BinaryOperator>;
+    return __parallel_transform_reduce_then_scan<sizeof(_PackedFlagValueType), _CustomName>(
+        __q, __n, oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__keys), std::forward<_Range2>(__values)),
+        std::forward<_Range3>(__out_values), _GenReduceInput{__binary_pred}, _ReduceOp{__binary_op}, _GenScanInput{},
+        _ScanInputTransform{}, _WriteOp{__init, __binary_op}, __placeholder_no_init,
+        /*Inclusive*/ std::bool_constant<__is_inclusive>{}, /*_IsUniquePattern=*/std::false_type{});
 }
 
 template <typename _CustomName>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -2169,46 +2169,6 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
     }
 }
 
-template <typename _ValueType, typename _FlagType, typename _BinaryOp>
-struct __segmented_scan_fun
-{
-    __segmented_scan_fun(_BinaryOp __input) : __binary_op(__input) {}
-
-    template <typename _T1, typename _T2>
-    _T1
-    operator()(const _T1& __x, const _T2& __y) const
-    {
-        using std::get;
-        using __x_t = std::tuple_element_t<0, _T1>;
-        auto __new_x =
-            std::get<1>(__y) ? __x_t(std::get<0>(__y)) : __x_t(__binary_op(std::get<0>(__x), std::get<0>(__y)));
-        auto __new_y = std::get<1>(__x) | std::get<1>(__y);
-        return _T1(__new_x, __new_y);
-    }
-
-  private:
-    _BinaryOp __binary_op;
-};
-
-template <typename _T, typename _Predicate>
-struct __replace_if_fun
-{
-    using __result_of = _T;
-
-    __replace_if_fun(_Predicate __pred, _T __new_value) : __pred(__pred), __new_value(__new_value) {}
-
-    template <typename _T1, typename _T2>
-    _T
-    operator()(_T1&& __a, _T2&& __s) const
-    {
-        return __pred(__s) ? __new_value : __a;
-    }
-
-  private:
-    _Predicate __pred;
-    const _T __new_value;
-};
-
 template <typename _CustomName>
 struct __scan_by_seg_fallback;
 
@@ -2270,7 +2230,7 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
             oneapi::dpl::__ranges::zip_view(std::forward<_Range2>(__values), __mask_view),
             oneapi::dpl::__ranges::zip_view(std::forward<_Range3>(__out_values), __mask_view), __n,
             oneapi::dpl::__internal::__no_op{}, oneapi::dpl::unseq_backend::__no_init_value<_ScanInitType>{},
-            __segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op},
+            oneapi::dpl::__internal::__segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op},
             std::bool_constant<__is_inclusive>{})
             .wait();
     }
@@ -2294,8 +2254,8 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
             auto __temp_view_shifted =
                 oneapi::dpl::__ranges::all_view<_OutputType, __par_backend_hetero::access_mode::read_write>(
                     __temp.get_buffer(), 1, __n - 1);
-            __replace_if_fun<typename _InitType::__value_type, std::negate<_FlagType>> __replace_fun(
-                std::negate<_FlagType>(), __init.__value);
+            oneapi::dpl::__internal::__replace_if_fun<typename _InitType::__value_type, std::negate<_FlagType>>
+                __replace_fun(std::negate<_FlagType>(), __init.__value);
             using _ReplaceTransform = oneapi::dpl::__internal::__transform_functor<decltype(__replace_fun)>;
             _ReplaceTransform __tf{__replace_fun};
             __parallel_for(
@@ -2314,7 +2274,8 @@ __parallel_scan_by_segment_fallback(oneapi::dpl::__internal::__device_backend_ta
             oneapi::dpl::__internal::__no_op{},
             oneapi::dpl::unseq_backend::__init_value<_ScanInitType>{
                 oneapi::dpl::__internal::make_tuple(__init.__value, _FlagType(1))},
-            __segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op}, std::true_type{})
+            oneapi::dpl::__internal::__segmented_scan_fun<_BinaryOperator, _FlagType, _BinaryOperator>{__binary_op},
+            std::true_type{})
             .wait();
     }
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -230,7 +230,7 @@ struct __write_scan_by_seg<unseq_backend::__no_init_value<_InitType>, _BinaryOp>
         // internal tuple and std::tuple. If the underlying type is not a tuple, then the type will just be passed
         // through.
         using _ConvertedTupleType =
-            typename oneapi::dpl::__internal::__get_tuple_type<std::decay_t<decltype(get<1>(__v))>,
+            typename oneapi::dpl::__internal::__get_tuple_type<std::decay_t<decltype(get<1>(get<0>(__v)))>,
                                                                std::decay_t<decltype(__out_rng[__id])>>::__type;
         __out_rng[__id] = static_cast<_ConvertedTupleType>(get<1>(get<0>(__v)));
     }
@@ -252,7 +252,7 @@ struct __write_scan_by_seg<unseq_backend::__init_value<_InitType>, _BinaryOp>
         // internal tuple and std::tuple. If the underlying type is not a tuple, then the type will just be passed
         // through.
         using _ConvertedTupleType =
-            typename oneapi::dpl::__internal::__get_tuple_type<std::decay_t<decltype(get<1>(__v))>,
+            typename oneapi::dpl::__internal::__get_tuple_type<std::decay_t<decltype(get<1>(get<0>(__v)))>,
                                                                std::decay_t<decltype(__out_rng[__id])>>::__type;
         // TODO: see if we can remove the two checks
         if (get<1>(__v) || __id == 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -217,6 +217,7 @@ struct __write_scan_by_seg
     using _TempData = __noop_temp_data;
     _InitType __init_value;
     _BinaryOp __binary_op;
+
     template <typename _OutRng, typename _ValueType>
     void
     operator()(_OutRng& __out_rng, std::size_t __id, const _ValueType& __v, const _TempData&) const
@@ -240,13 +241,10 @@ struct __write_scan_by_seg
             static_assert(
                 std::is_same_v<_InitType, oneapi::dpl::unseq_backend::__init_value<typename _InitType::__value_type>>,
                 "exclusive_scan_by_segment must have an initial element");
-            if (get<1>(__v))
-                __out_rng[__id] = static_cast<_ConvertedTupleType>(get<1>(__init_value.__value));
-            else
-            {
-                __out_rng[__id] =
-                    static_cast<_ConvertedTupleType>(__binary_op(get<1>(__init_value.__value), get<1>(get<0>(__v))));
-            }
+            __out_rng[__id] =
+                get<1>(__v)
+                    ? static_cast<_ConvertedTupleType>(get<1>(__init_value.__value))
+                    : static_cast<_ConvertedTupleType>(__binary_op(get<1>(__init_value.__value), get<1>(get<0>(__v))));
         }
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1332,7 +1332,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
                     if (__iters == 1)
                     {
-                        // fill with unused dummy values to avoid overruning input
+                        // fill with unused dummy values to avoid overrunning input
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
@@ -1361,7 +1361,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // If we are past the input range, then the previous value of v is passed to the sub-group scan.
                         // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
 
-                        // fill with unused dummy values to avoid overruning input
+                        // fill with unused dummy values to avoid overrunning input
                         std::uint32_t __load_id =
                             std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
 
@@ -1569,7 +1569,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 
                             std::size_t __remaining_elements =
                                 __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
-                            // fill with unused dummy values to avoid overruning input
+                            // fill with unused dummy values to avoid overrunning input
                             std::size_t __final_reduction_id =
                                 std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
                             __value = __tmp_ptr[__final_reduction_id];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -254,8 +254,7 @@ struct __write_scan_by_seg<unseq_backend::__init_value<_InitType>, _BinaryOp>
         using _ConvertedTupleType =
             typename oneapi::dpl::__internal::__get_tuple_type<std::decay_t<decltype(get<1>(get<0>(__v)))>,
                                                                std::decay_t<decltype(__out_rng[__id])>>::__type;
-        // TODO: see if we can remove the two checks
-        if (get<1>(__v) || __id == 0)
+        if (get<1>(__v))
             __out_rng[__id] = static_cast<_ConvertedTupleType>(get<1>(__init_value.__value));
         else
         {
@@ -770,6 +769,27 @@ struct __gen_red_by_seg_reduce_input
     _BinaryPred __binary_pred;
 };
 
+template <typename _BinaryPred>
+struct __gen_scan_by_seg_reduce_input
+{
+    using TempData = __noop_temp_data;
+    // Returns the following tuple:
+    // (new_seg_mask, value)
+    // bool new_seg_mask : true for a start of a new segment, false otherwise
+    // ValueType value   : Current element's value for reduction
+    template <typename _InRng>
+    auto
+    operator()(const _InRng& __in_rng, std::size_t __id, TempData&) const
+    {
+        const auto __in_keys = std::get<0>(__in_rng.tuple());
+        const auto __in_vals = std::get<1>(__in_rng.tuple());
+        using _ValueType = oneapi::dpl::__internal::__value_t<decltype(__in_vals)>;
+        const std::uint32_t __new_seg_mask = __id == 0 || !__binary_pred(__in_keys[__id - 1], __in_keys[__id]);
+        return oneapi::dpl::__internal::make_tuple(__new_seg_mask, _ValueType{__in_vals[__id]});
+    }
+    _BinaryPred __binary_pred;
+};
+
 // Generates input for a scan operation by applying a binary predicate to the keys of the input range.
 template <typename _BinaryPred>
 struct __gen_red_by_seg_scan_input
@@ -828,9 +848,9 @@ struct __gen_scan_by_seg_scan_input
 {
     using TempData = __noop_temp_data;
     // Returns the following tuple:
-    // (new_seg_mask, value)
-    // size_t new_seg_mask : 1 for a start of a new segment, 0 otherwise
-    // ValueType value     : Current element's value for reduction
+    // ((new_seg_mask, value), new_seg_mask)
+    // bool new_seg_mask : true for a start of a new segment, false otherwise
+    // ValueType value   : Current element's value for reduction
     template <typename _InRng>
     auto
     operator()(const _InRng& __in_rng, std::size_t __id, TempData&) const
@@ -838,10 +858,11 @@ struct __gen_scan_by_seg_scan_input
         const auto __in_keys = std::get<0>(__in_rng.tuple());
         const auto __in_vals = std::get<1>(__in_rng.tuple());
         using _ValueType = oneapi::dpl::__internal::__value_t<decltype(__in_vals)>;
-        // The first segment start (index 0) is not marked with a 1. This is because we need the first
-        // segment's key and value output index to be 0. We begin marking new segments only after the
-        // first.
-        const std::size_t __new_seg_mask = __id > 0 && !__binary_pred(__in_keys[__id - 1], __in_keys[__id]);
+        // Mark the first index as a new segment as well as an indexing corresponding to any key
+        // that does not satisfy the binary predicate with the previous key. The first tuple mask element
+        // is scanned over, and the third is a placeholder for exclusive_scan_by_segment to perfom init
+        // handling in the output write.
+        const std::uint32_t __new_seg_mask = __id == 0 || !__binary_pred(__in_keys[__id - 1], __in_keys[__id]);
         return oneapi::dpl::__internal::make_tuple(
             oneapi::dpl::__internal::make_tuple(__new_seg_mask, _ValueType{__in_vals[__id]}), __new_seg_mask);
     }
@@ -933,8 +954,7 @@ struct __scan_by_seg_op
         }
         // We are looking at elements from a previous segment, so no operation is performed
         // This scan over index is not needed.
-        return oneapi::dpl::__internal::make_tuple(get<0>(__lhs_tup) + get<0>(__rhs_tup),
-                                                   _OpReturnType{get<1>(__rhs_tup)});
+        return oneapi::dpl::__internal::make_tuple(std::uint32_t{1}, _OpReturnType{get<1>(__rhs_tup)});
     }
     _BinaryOp __binary_op;
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -847,7 +847,7 @@ struct __gen_scan_by_seg_scan_input
         using _ValueType = oneapi::dpl::__internal::__value_t<decltype(__in_vals)>;
         // Mark the first index as a new segment as well as an indexing corresponding to any key
         // that does not satisfy the binary predicate with the previous key. The first tuple mask element
-        // is scanned over, and the third is a placeholder for exclusive_scan_by_segment to perfom init
+        // is scanned over, and the third is a placeholder for exclusive_scan_by_segment to perform init
         // handling in the output write.
         const std::uint32_t __new_seg_mask = __id == 0 || !__binary_pred(__in_keys[__id - 1], __in_keys[__id]);
         return oneapi::dpl::__internal::make_tuple(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan_by_segment.h
@@ -360,22 +360,6 @@ struct __sycl_scan_by_segment_impl
     }
 };
 
-template <bool __is_inclusive, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
-          typename _BinaryPredicate, typename _BinaryOperator, typename _T>
-void
-__parallel_scan_by_segment(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range1&& __keys,
-                           _Range2&& __values, _Range3&& __out_values, _BinaryPredicate __binary_pred,
-                           _BinaryOperator __binary_op, _T __init, _T __identity)
-{
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
-    sycl::queue __q_local = __exec.queue();
-
-    __sycl_scan_by_segment_impl<_CustomName, __is_inclusive>()(
-        __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_values),
-        __binary_pred, __binary_op, __init, __identity);
-}
-
 } //namespace __par_backend_hetero
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -492,6 +492,15 @@ struct __gen_set_balanced_path;
 template <typename _SetOpCount, typename _TempData, typename _Compare>
 struct __gen_set_op_from_known_balanced_path;
 
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
+          typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename _KernelName>
+struct __parallel_reduce_then_scan_reduce_submitter;
+
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, typename _ReduceOp,
+          typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
+          typename _KernelName>
+struct __parallel_reduce_then_scan_scan_submitter;
+
 } // namespace oneapi::dpl::__par_backend_hetero
 
 template <typename _UnaryOp, typename _InitType>
@@ -626,6 +635,28 @@ template <typename _SetOpCount, typename _TempData, typename _Compare>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
     oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path, _SetOpCount, _TempData, _Compare)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Compare>
+{
+};
+
+// Submitters that capture member variables via *this into the kernel lambda must have device copyable specializations
+// if their members may not be trivially copyable.
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
+          typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename... _KernelName>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
+    oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_reduce_submitter, __max_inputs_per_item,
+    __is_inclusive, __is_unique_pattern_v, _GenReduceInput, _ReduceOp, _InitType, _KernelName...)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_GenReduceInput, _ReduceOp, _InitType>
+{
+};
+
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, typename _ReduceOp,
+          typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
+          typename... _KernelName>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
+    oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_scan_submitter, __max_inputs_per_item,
+    __is_inclusive, __is_unique_pattern_v, _ReduceOp, _GenScanInput, _ScanInputTransform, _WriteOp, _InitType,
+    _KernelName...)> : oneapi::dpl::__internal::__are_all_device_copyable<_ReduceOp, _GenScanInput, _ScanInputTransform,
+                                                                          _WriteOp, _InitType>
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -154,6 +154,9 @@ struct __parallel_reduce_by_segment_fallback_fn1;
 template <typename _BinaryPredicate>
 struct __parallel_reduce_by_segment_fallback_fn2;
 
+template <typename _ValueType, typename _FlagType, typename _BinaryOp>
+struct __segmented_scan_fun;
+
 } // namespace oneapi::dpl::__internal
 
 template <typename _Pred>
@@ -371,6 +374,13 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
 {
 };
 
+template <typename _ValueType, typename _FlagType, typename _BinaryOp>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__segmented_scan_fun, _ValueType,
+                                                       _FlagType, _BinaryOp)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryOp>
+{
+};
+
 namespace oneapi::dpl::__internal::__ranges
 {
 
@@ -422,6 +432,12 @@ struct __gen_red_by_seg_reduce_input;
 template <typename _BinaryPred>
 struct __gen_red_by_seg_scan_input;
 
+template <typename _BinaryPred>
+struct __gen_scan_by_seg_reduce_input;
+
+template <typename _BinaryPred>
+struct __gen_scan_by_seg_scan_input;
+
 template <typename _Predicate, typename _RangeTransform>
 struct __gen_mask;
 
@@ -443,6 +459,9 @@ struct __write_to_id_if_else;
 template <typename _BinaryPred>
 struct __write_red_by_seg;
 
+template <typename _InitWrapper, typename _BinaryOp>
+struct __write_scan_by_seg;
+
 template <typename _Assign>
 struct __write_multiple_to_id;
 
@@ -454,6 +473,9 @@ struct __leaf_sorter;
 
 template <typename _BinaryOp>
 struct __red_by_seg_op;
+
+template <typename _BinaryOp>
+struct __scan_by_seg_op;
 
 template <typename _SetOpCount, typename _Compare>
 struct __gen_set_balanced_path;
@@ -486,6 +508,20 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 
 template <typename _BinaryPred>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_red_by_seg_scan_input,
+                                                       _BinaryPred)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryPred>
+{
+};
+
+template <typename _BinaryPred>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
+    oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_reduce_input, _BinaryPred)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryPred>
+{
+};
+
+template <typename _BinaryPred>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_scan_input,
                                                        _BinaryPred)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryPred>
 {
@@ -531,6 +567,13 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 
+template <typename _InitWrapper, typename _BinaryOp>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_scan_by_seg,
+                                                       _InitWrapper, _BinaryOp)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_InitWrapper, _BinaryOp>
+{
+};
+
 template <typename _Assign>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_multiple_to_id,
                                                        _Assign)>
@@ -553,6 +596,12 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 
 template <typename _BinaryOp>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__red_by_seg_op, _BinaryOp)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryOp>
+{
+};
+
+template <typename _BinaryOp>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__scan_by_seg_op, _BinaryOp)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryOp>
 {
 };
@@ -775,9 +824,6 @@ struct replace_if_fun;
 template <typename ValueType, typename FlagType, typename BinaryOp>
 struct scan_by_key_fun;
 
-template <typename ValueType, typename FlagType, typename BinaryOp>
-struct segmented_scan_fun;
-
 template <typename Output1, typename Output2>
 class scatter_and_accumulate_fun;
 
@@ -800,13 +846,6 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::re
 
 template <typename ValueType, typename FlagType, typename BinaryOp>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::scan_by_key_fun, ValueType, FlagType,
-                                                       BinaryOp)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<BinaryOp>
-{
-};
-
-template <typename ValueType, typename FlagType, typename BinaryOp>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::segmented_scan_fun, ValueType, FlagType,
                                                        BinaryOp)>
     : oneapi::dpl::__internal::__are_all_device_copyable<BinaryOp>
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -157,6 +157,9 @@ struct __parallel_reduce_by_segment_fallback_fn2;
 template <typename _ValueType, typename _FlagType, typename _BinaryOp>
 struct __segmented_scan_fun;
 
+template <typename _T, typename _Predicate>
+struct __replace_if_fun;
+
 } // namespace oneapi::dpl::__internal
 
 template <typename _Pred>
@@ -378,6 +381,12 @@ template <typename _ValueType, typename _FlagType, typename _BinaryOp>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__segmented_scan_fun, _ValueType,
                                                        _FlagType, _BinaryOp)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryOp>
+{
+};
+
+template <typename _T, typename _Predicate>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__replace_if_fun, _T, _Predicate)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_T, _Predicate>
 {
 };
 
@@ -818,9 +827,6 @@ enum class search_algorithm;
 template <typename Comp, typename T, search_algorithm func>
 struct __custom_brick;
 
-template <typename T, typename Predicate>
-struct replace_if_fun;
-
 template <typename ValueType, typename FlagType, typename BinaryOp>
 struct scan_by_key_fun;
 
@@ -835,12 +841,6 @@ class transform_if_stencil_fun;
 template <typename Comp, typename T, oneapi::dpl::internal::search_algorithm func>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::__custom_brick, Comp, T, func)>
     : oneapi::dpl::__internal::__are_all_device_copyable<Comp, T>
-{
-};
-
-template <typename T, typename Predicate>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::internal::replace_if_fun, T, Predicate)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<T, Predicate>
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -468,7 +468,7 @@ struct __write_to_id_if_else;
 template <typename _BinaryPred>
 struct __write_red_by_seg;
 
-template <typename _InitWrapper, typename _BinaryOp>
+template <bool __is_inclusive, typename _InitWrapper, typename _BinaryOp>
 struct __write_scan_by_seg;
 
 template <typename _Assign>
@@ -576,9 +576,9 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 
-template <typename _InitWrapper, typename _BinaryOp>
+template <bool __is_inclusive, typename _InitWrapper, typename _BinaryOp>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_scan_by_seg,
-                                                       _InitWrapper, _BinaryOp)>
+                                                       __is_inclusive, _InitWrapper, _BinaryOp)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_InitWrapper, _BinaryOp>
 {
 };

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -21,8 +21,6 @@
 #include <cassert>
 #include <type_traits>
 
-#include "utils.h"
-
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -1031,8 +1031,6 @@ struct __count_fn_pred
 template <typename _ValueType, typename _FlagType, typename _BinaryOp>
 struct __segmented_scan_fun
 {
-    __segmented_scan_fun(_BinaryOp __input) : __binary_op(__input) {}
-
     template <typename _T1, typename _T2>
     _T1
     operator()(const _T1& __x, const _T2& __y) const
@@ -1044,7 +1042,6 @@ struct __segmented_scan_fun
         return _T1(__new_x, __new_y);
     }
 
-  private:
     _BinaryOp __binary_op;
 };
 
@@ -1053,16 +1050,13 @@ struct __replace_if_fun
 {
     using __result_of = _T;
 
-    __replace_if_fun(_Predicate __pred, _T __new_value) : __pred(__pred), __new_value(__new_value) {}
-
     template <typename _T1, typename _T2>
     _T
-    operator()(_T1&& __a, _T2&& __s) const
+    operator()(_T1&& __a, const _T2& __s) const
     {
-        return __pred(__s) ? __new_value : __a;
+        return __pred(__s) ? __new_value : std::forward<_T1>(__a);
     }
 
-  private:
     _Predicate __pred;
     const _T __new_value;
 };

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -1052,9 +1052,9 @@ struct __replace_if_fun
 
     template <typename _T1, typename _T2>
     _T
-    operator()(_T1&& __a, const _T2& __s) const
+    operator()(_T1&& __a, _T2&& __s) const
     {
-        return __pred(__s) ? __new_value : std::forward<_T1>(__a);
+        return __pred(std::forward<_T2>(__s)) ? __new_value : __a;
     }
 
     _Predicate __pred;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -17,7 +17,7 @@
 #define _ONEDPL_UTILS_H
 
 #include "onedpl_config.h"
-#include "tuple_impl.h" // Internal tuple and get specializations need by __segmented_scan_fun
+#include "tuple_impl.h" // Internal tuple and get specializations needed by __segmented_scan_fun
 
 #include <new>
 #include <tuple>

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -17,6 +17,7 @@
 #define _ONEDPL_UTILS_H
 
 #include "onedpl_config.h"
+#include "tuple_impl.h" // Internal tuple and get specializations need by __segmented_scan_fun
 
 #include <new>
 #include <tuple>
@@ -1026,6 +1027,45 @@ struct __count_fn_pred
     }
 };
 #endif
+
+template <typename _ValueType, typename _FlagType, typename _BinaryOp>
+struct __segmented_scan_fun
+{
+    __segmented_scan_fun(_BinaryOp __input) : __binary_op(__input) {}
+
+    template <typename _T1, typename _T2>
+    _T1
+    operator()(const _T1& __x, const _T2& __y) const
+    {
+        using std::get;
+        using __x_t = std::tuple_element_t<0, _T1>;
+        auto __new_x = get<1>(__y) ? __x_t(get<0>(__y)) : __x_t(__binary_op(get<0>(__x), get<0>(__y)));
+        auto __new_y = get<1>(__x) | get<1>(__y);
+        return _T1(__new_x, __new_y);
+    }
+
+  private:
+    _BinaryOp __binary_op;
+};
+
+template <typename _T, typename _Predicate>
+struct __replace_if_fun
+{
+    using __result_of = _T;
+
+    __replace_if_fun(_Predicate __pred, _T __new_value) : __pred(__pred), __new_value(__new_value) {}
+
+    template <typename _T1, typename _T2>
+    _T
+    operator()(_T1&& __a, _T2&& __s) const
+    {
+        return __pred(__s) ? __new_value : __a;
+    }
+
+  private:
+    _Predicate __pred;
+    const _T __new_value;
+};
 
 } // namespace __internal
 } // namespace dpl

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -58,10 +58,10 @@ test_device_copyable()
         sycl::is_device_copyable_v<
             oneapi::dpl::internal::scan_by_key_fun<int_device_copyable, int_device_copyable, noop_device_copyable>>,
         "scan_by_key_fun is not device copyable with device copyable types");
-    //segmented_scan_fun
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::internal::segmented_scan_fun<
+    //__segmented_scan_fun
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__segmented_scan_fun<
                       int_non_device_copyable, int_device_copyable, noop_device_copyable>>,
-                  "segmented_scan_fun is not device copyable with device copyable types");
+                  "__segmented_scan_fun is not device copyable with device copyable types");
     //scatter_and_accumulate_fun
     static_assert(sycl::is_device_copyable_v<
                       oneapi::dpl::internal::scatter_and_accumulate_fun<int_device_copyable, int_device_copyable>>,
@@ -172,6 +172,16 @@ test_device_copyable()
                       oneapi::dpl::__par_backend_hetero::__gen_red_by_seg_scan_input<binary_op_device_copyable>>,
                   "__gen_red_by_seg_scan_input is not device copyable with device copyable types");
 
+    //__gen_scan_by_seg_reduce_input
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_reduce_input<binary_op_device_copyable>>,
+                  "__gen_scan_by_seg_reduce_input is not device copyable with device copyable types");
+
+    //__gen_scan_by_seg_scan_input
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_scan_input<binary_op_device_copyable>>,
+                  "__gen_scan_by_seg_scan_input is not device copyable with device copyable types");
+
     //__gen_mask
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>,
                   "__gen_mask is not device copyable with device copyable types");
@@ -219,6 +229,11 @@ test_device_copyable()
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_red_by_seg<binary_op_device_copyable>>,
         "__write_red_by_seg is not device copyable with device copyable types");
 
+    //__write_scan_by_seg
+    static_assert(
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<int_device_copyable, binary_op_device_copyable>>,
+        "__write_scan_by_seg is not device copyable with device copyable types");
+
     //__write_multiple_to_id
     static_assert(sycl::is_device_copyable_v<
                       oneapi::dpl::__par_backend_hetero::__write_multiple_to_id<assign_device_copyable>>,
@@ -243,6 +258,11 @@ test_device_copyable()
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__red_by_seg_op<binary_op_device_copyable>>,
         "__red_by_seg_op is not device copyable with device copyable types");
+
+    //__scan_by_seg_op
+    static_assert(
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>>,
+        "__scan_by_seg_op is not device copyable with device copyable types");
 
     //__not_pred
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_device_copyable>>,
@@ -351,11 +371,11 @@ test_non_device_copyable()
         !sycl::is_device_copyable_v<oneapi::dpl::internal::scan_by_key_fun<int_non_device_copyable, int_device_copyable,
                                                                            noop_non_device_copyable>>,
         "scan_by_key_fun is device copyable with non device copyable types");
-    //segmented_scan_fun
+    //__segmented_scan_fun
     static_assert(
-        !sycl::is_device_copyable_v<oneapi::dpl::internal::segmented_scan_fun<int_device_copyable, int_device_copyable,
-                                                                              noop_non_device_copyable>>,
-        "segmented_scan_fun is device copyable with non device copyable types");
+        !sycl::is_device_copyable_v<oneapi::dpl::__internal::__segmented_scan_fun<int_device_copyable, int_device_copyable,
+                                                                                  noop_non_device_copyable>>,
+        "__segmented_scan_fun is device copyable with non device copyable types");
     //scatter_and_accumulate_fun
     static_assert(!sycl::is_device_copyable_v<
                       oneapi::dpl::internal::scatter_and_accumulate_fun<int_non_device_copyable, int_device_copyable>>,
@@ -449,10 +469,20 @@ test_non_device_copyable()
                       oneapi::dpl::__par_backend_hetero::__gen_red_by_seg_reduce_input<binary_op_non_device_copyable>>,
                   "__gen_red_by_seg_reduce_input is device copyable with non device copyable types");
 
-    //__gen_red_by_seg_reduce_input
+    //__gen_red_by_seg_scan_input
     static_assert(!sycl::is_device_copyable_v<
                       oneapi::dpl::__par_backend_hetero::__gen_red_by_seg_scan_input<binary_op_non_device_copyable>>,
                   "__gen_red_by_seg_scan_input is device copyable with non device copyable types");
+
+    //__gen_scan_by_seg_reduce_input
+    static_assert(!sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_reduce_input<binary_op_non_device_copyable>>,
+                  "__gen_scan_by_seg_reduce_input is device copyable with non device copyable types");
+
+    //__gen_scan_by_seg_scan_input
+    static_assert(!sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_scan_input<binary_op_non_device_copyable>>,
+                  "__gen_scan_by_seg_scan_input is device copyable with non device copyable types");
 
     //__gen_mask
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_non_device_copyable>>,
@@ -501,6 +531,11 @@ test_non_device_copyable()
                       oneapi::dpl::__par_backend_hetero::__write_red_by_seg<binary_op_non_device_copyable>>,
                   "__write_red_by_seg is device copyable with non device copyable types");
 
+    //__write_scan_by_seg
+    static_assert(!sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<int_non_device_copyable, binary_op_non_device_copyable>>,
+                  "__write_scan_by_seg is device copyable with non device copyable types");
+
     //__write_multiple_to_id
     static_assert(!sycl::is_device_copyable_v<
                       oneapi::dpl::__par_backend_hetero::__write_multiple_to_id<assign_non_device_copyable>>,
@@ -521,6 +556,11 @@ test_non_device_copyable()
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__red_by_seg_op<binary_op_non_device_copyable>>,
         "__red_by_seg_op is device copyable with non device copyable types");
+
+    //__scan_by_seg_op
+    static_assert(
+        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>>,
+        "__scan_by_seg_op is device copyable with non device copyable types");
 
     //__not_pred
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_non_device_copyable>>,

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -265,6 +265,28 @@ test_device_copyable()
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>>,
         "__scan_by_seg_op is not device copyable with device copyable types");
 
+    //__parallel_reduce_then_scan_reduce_submitter
+    static_assert(
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_reduce_submitter<
+            16, true, false,
+            oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_reduce_input<binary_op_device_copyable>,
+            oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>,
+            oneapi::dpl::unseq_backend::__no_init_value<int_device_copyable>,
+            oneapi::dpl::execution::DefaultKernelName>>,
+        "__parallel_reduce_then_scan_reduce_submitter is not device copyable with device copyable types");
+
+    //__parallel_reduce_then_scan_scan_submitter
+    static_assert(
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_scan_submitter<
+            16, true, false, oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>,
+            oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_scan_input<binary_op_device_copyable>,
+            oneapi::dpl::__par_backend_hetero::__get_zeroth_element,
+            oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<
+                true, oneapi::dpl::unseq_backend::__init_value<int_device_copyable>, binary_op_device_copyable>,
+            oneapi::dpl::unseq_backend::__no_init_value<int_device_copyable>,
+            oneapi::dpl::execution::DefaultKernelName>>,
+        "__parallel_reduce_then_scan_scan_submitter is not device copyable with device copyable types");
+
     //__not_pred
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_device_copyable>>,
                   "__not_pred is not device copyable with device copyable types");
@@ -562,6 +584,28 @@ test_non_device_copyable()
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>>,
         "__scan_by_seg_op is device copyable with non device copyable types");
+
+    //__parallel_reduce_then_scan_reduce_submitter
+    static_assert(
+        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_reduce_submitter<
+            16, true, false,
+            oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_reduce_input<binary_op_non_device_copyable>,
+            oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>,
+            oneapi::dpl::unseq_backend::__no_init_value<int_non_device_copyable>,
+            oneapi::dpl::execution::DefaultKernelName>>,
+        "__parallel_reduce_then_scan_reduce_submitter is device copyable with non device copyable types");
+
+    //__parallel_reduce_then_scan_scan_submitter
+    static_assert(
+        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_scan_submitter<
+            16, true, false, oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>,
+            oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_scan_input<binary_op_non_device_copyable>,
+            oneapi::dpl::__par_backend_hetero::__get_zeroth_element,
+            oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<
+                true, oneapi::dpl::unseq_backend::__init_value<int_non_device_copyable>, binary_op_non_device_copyable>,
+            oneapi::dpl::unseq_backend::__no_init_value<int_non_device_copyable>,
+            oneapi::dpl::execution::DefaultKernelName>>,
+        "__parallel_reduce_then_scan_scan_submitter is device copyable with non device copyable types");
 
     //__not_pred
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_non_device_copyable>>,

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -231,7 +231,8 @@ test_device_copyable()
 
     //__write_scan_by_seg
     static_assert(
-        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<int_device_copyable, binary_op_device_copyable>>,
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<true, int_device_copyable,
+                                                                                          binary_op_device_copyable>>,
         "__write_scan_by_seg is not device copyable with device copyable types");
 
     //__write_multiple_to_id
@@ -532,8 +533,8 @@ test_non_device_copyable()
                   "__write_red_by_seg is device copyable with non device copyable types");
 
     //__write_scan_by_seg
-    static_assert(!sycl::is_device_copyable_v<
-                      oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<int_non_device_copyable, binary_op_non_device_copyable>>,
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<
+                      true, int_non_device_copyable, binary_op_non_device_copyable>>,
                   "__write_scan_by_seg is device copyable with non device copyable types");
 
     //__write_multiple_to_id

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -49,10 +49,10 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::internal::__custom_brick<
                       noop_device_copyable, int_device_copyable, oneapi::dpl::internal::search_algorithm::lower_bound>>,
                   "__custom_brick is not device copyable with device copyable types");
-    //replace_if_fun
+    //__replace_if_fun
     static_assert(
-        sycl::is_device_copyable_v<oneapi::dpl::internal::replace_if_fun<int_device_copyable, noop_device_copyable>>,
-        "replace_if_fun is not device copyable with device copyable types");
+        sycl::is_device_copyable_v<oneapi::dpl::__internal::__replace_if_fun<int_device_copyable, noop_device_copyable>>,
+        "__replace_if_fun is not device copyable with device copyable types");
     //scan_by_key_fun
     static_assert(
         sycl::is_device_copyable_v<
@@ -362,10 +362,10 @@ test_non_device_copyable()
         !sycl::is_device_copyable_v<oneapi::dpl::internal::__custom_brick<
             noop_device_copyable, int_non_device_copyable, oneapi::dpl::internal::search_algorithm::lower_bound>>,
         "__custom_brick is device copyable with non device copyable types");
-    //replace_if_fun
+    //__replace_if_fun
     static_assert(!sycl::is_device_copyable_v<
-                      oneapi::dpl::internal::replace_if_fun<int_device_copyable, noop_non_device_copyable>>,
-                  "replace_if_fun is device copyable with non device copyable types");
+                      oneapi::dpl::__internal::__replace_if_fun<int_device_copyable, noop_non_device_copyable>>,
+                  "__replace_if_fun is device copyable with non device copyable types");
     //scan_by_key_fun
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::internal::scan_by_key_fun<int_non_device_copyable, int_device_copyable,


### PR DESCRIPTION
This PR adds a path for `inclusive_scan_by_segment` and `exclusive_scan_by_segment` using our reduce-then-scan infrastructure to improve performance. Additionally, some reorganization of existing "fallback" implementations is required 

Summary of changes:
- `__parallel_scan_by_segment_reduce_then_scan` and associated reduce-then-scan building blocks are added to implement scan-by-segment. The implementation is similar but unique from reduce-by-segment.
- The high level scan-by-segment fallback has been re-implemented at the parallel pattern level to consolidate the location of SYCL backend implementations.
- `__segmented_scan_fun` and `__replace_if_fun` have been moved to our general utilities as they are shared between implementations in `pstl/hetero/dpcpp` and `internal` directories.