### PR TITLE
Set algorithms, revert to set_a_write algorithm for small sizes

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1772,13 +1772,8 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _F
     typedef typename std::iterator_traits<_ForwardIterator1>::difference_type _Size1;
 
     const _Size1 __n1 = std::distance(__first1, __last1);
-    _Size1 __output_size = __n1;
-    if constexpr (_SetTag::__can_write_from_rng2_v)
-    {
-        const _Size1 __n2 = std::distance(__first2, __last2);
-        // one shot algorithm can write from set 1 or set 2, whereas old algorithm can only write from set 1.
-        __output_size = __n1 + __n2;
-    }
+    const _Size1 __n2 = std::distance(__first2, __last2);
+    const _Size1 __output_size = __n1 + __n2;
 
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator1>();
@@ -1792,16 +1787,10 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _F
 
     auto __result_size = __par_backend_hetero::__parallel_set_op(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                                                                  __buf1.all_view(), __buf2.all_view(),
-                                                                 __buf3.all_view(), __comp, __set_tag)
-                             .get();
+                                                                 __buf3.all_view(), __comp, __set_tag);
 
     return __result + __result_size;
 }
-
-template <typename Name>
-struct __set_intersection_scan_then_propagate
-{
-};
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _OutputIterator, typename _Compare>
@@ -1813,26 +1802,13 @@ __pattern_set_intersection(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
     // intersection is empty
     if (__first1 == __last1 || __first2 == __last2)
         return __result;
-    if (__par_backend_hetero::__can_set_op_write_from_set_b(_BackendTag{}, __exec))
-    {
-        return __pattern_hetero_set_op(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
-                                       __last2, __result, __comp, unseq_backend::_IntersectionTag<std::true_type>());
-    }
-    return __pattern_hetero_set_op(
-        __tag,
-        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_intersection_scan_then_propagate>(
-            std::forward<_ExecutionPolicy>(__exec)),
-        __first1, __last1, __first2, __last2, __result, __comp, unseq_backend::_IntersectionTag<std::false_type>());
+    return __pattern_hetero_set_op(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+                                       __last2, __result, __comp, unseq_backend::_IntersectionTag{});
 }
 
 //Dummy names to avoid kernel problems
 template <typename Name>
 struct __set_difference_copy_case_1
-{
-};
-
-template <typename Name>
-struct __set_difference_scan_then_propagate
 {
 };
 
@@ -1856,19 +1832,8 @@ __pattern_set_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first1, __last1, __result, oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{});
     }
-    if (__par_backend_hetero::__can_set_op_write_from_set_b(_BackendTag{}, __exec))
-    {
-        return __pattern_hetero_set_op(
-            __tag,
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_difference_scan_then_propagate>(
-                std::forward<_ExecutionPolicy>(__exec)),
-            __first1, __last1, __first2, __last2, __result, __comp, unseq_backend::_DifferenceTag<std::true_type>());
-    }
-    else
-    {
-        return __pattern_hetero_set_op(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
-                                       __last2, __result, __comp, unseq_backend::_DifferenceTag<std::false_type>());
-    }
+    return __pattern_hetero_set_op(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+                                       __last2, __result, __comp, oneapi::dpl::unseq_backend::_DifferenceTag{});
 }
 
 //Dummy names to avoid kernel problems
@@ -1879,11 +1844,6 @@ struct __set_union_copy_case_1
 
 template <typename Name>
 struct __set_union_copy_case_2
-{
-};
-
-template <typename Name>
-struct __set_union_scan_then_propagate
 {
 };
 
@@ -1917,34 +1877,8 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
             __first1, __last1, __result, oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{});
     }
 
-    if (__par_backend_hetero::__can_set_op_write_from_set_b(_BackendTag{}, __exec))
-    {
-        return __pattern_hetero_set_op(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
-                                       __last2, __result, __comp, unseq_backend::_UnionTag<std::true_type>());
-    }
-    else
-    {
-        using _ValueType = typename std::iterator_traits<_OutputIterator>::value_type;
-
-        // temporary buffer to store intermediate result
-        const auto __n2 = __last2 - __first2;
-        oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff(__n2);
-        auto __buf = __diff.get();
-
-        //1. Calc difference {2} \ {1}
-        const auto __n_diff =
-            oneapi::dpl::__internal::__pattern_hetero_set_op(
-                __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_scan_then_propagate>(__exec),
-                __first2, __last2, __first1, __last1, __buf, __comp, unseq_backend::_DifferenceTag<std::false_type>()) -
-            __buf;
-
-        //2. Merge {1} and the difference
-        return oneapi::dpl::__internal::__pattern_merge(
-            __tag,
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_2>(
-                std::forward<_ExecutionPolicy>(__exec)),
-            __first1, __last1, __buf, __buf + __n_diff, __result, __comp);
-    }
+    return __pattern_hetero_set_op(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+                                   __last2, __result, __comp, oneapi::dpl::unseq_backend::_UnionTag{});
 }
 
 //Dummy names to avoid kernel problems
@@ -1955,16 +1889,6 @@ struct __set_symmetric_difference_copy_case_1
 
 template <typename Name>
 struct __set_symmetric_difference_copy_case_2
-{
-};
-
-template <typename Name>
-struct __set_symmetric_difference_phase_1
-{
-};
-
-template <typename Name>
-struct __set_symmetric_difference_phase_2
 {
 };
 
@@ -2004,48 +1928,8 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first1, __last1, __result, oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{});
     }
-
-    if (__par_backend_hetero::__can_set_op_write_from_set_b(_BackendTag{}, __exec))
-    {
-        return __pattern_hetero_set_op(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
-                                       __last2, __result, __comp,
-                                       unseq_backend::_SymmetricDifferenceTag<std::true_type>());
-    }
-    else
-    {
-        typedef typename std::iterator_traits<_OutputIterator>::value_type _ValueType;
-
-        // temporary buffers to store intermediate result
-        const auto __n1 = __last1 - __first1;
-        oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff_1(__n1);
-        auto __buf_1 = __diff_1.get();
-        const auto __n2 = __last2 - __first2;
-        oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff_2(__n2);
-        auto __buf_2 = __diff_2.get();
-
-        //1. Calc difference {1} \ {2}
-        const auto __n_diff_1 =
-            oneapi::dpl::__internal::__pattern_hetero_set_op(
-                __tag,
-                oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_phase_1>(__exec),
-                __first1, __last1, __first2, __last2, __buf_1, __comp,
-                unseq_backend::_DifferenceTag<std::false_type>()) -
-            __buf_1;
-
-        //2. Calc difference {2} \ {1}
-        const auto __n_diff_2 =
-            oneapi::dpl::__internal::__pattern_hetero_set_op(
-                __tag,
-                oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_phase_2>(__exec),
-                __first2, __last2, __first1, __last1, __buf_2, __comp,
-                unseq_backend::_DifferenceTag<std::false_type>()) -
-            __buf_2;
-
-        //3. Merge the differences
-        return oneapi::dpl::__internal::__pattern_merge(__tag, std::forward<_ExecutionPolicy>(__exec), __buf_1,
-                                                        __buf_1 + __n_diff_1, __buf_2, __buf_2 + __n_diff_2, __result,
-                                                        __comp);
-    }
+    return __pattern_hetero_set_op(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+                                   __last2, __result, __comp, oneapi::dpl::unseq_backend::_SymmetricDifferenceTag{});
 }
 
 template <typename _Name>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1301,7 +1301,8 @@ struct __consider_write_a_alg
 template <>
 struct __consider_write_a_alg<oneapi::dpl::unseq_backend::_SymmetricDifferenceTag>
 {
-    static constexpr bool __value = false;
+    static constexpr std::size_t __threshold = 4096;
+    static constexpr bool __value = true;
 };
 
 // Selects the right implementation of set based on the size and platform

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1310,8 +1310,7 @@ struct __consider_write_a_alg
 template <>
 struct __consider_write_a_alg<oneapi::dpl::unseq_backend::_SymmetricDifferenceTag>
 {
-    static constexpr std::size_t __threshold = 4096;
-    static constexpr bool __value = true;
+    static constexpr bool __value = false;
 };
 
 // Selects the right implementation of set based on the size and platform

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1221,28 +1221,37 @@ __set_write_a_only_op(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Ran
 
     //1. Calc difference {1} \ {2}
     const std::size_t __n_diff_1 = oneapi::dpl::__par_backend_hetero::__set_op_impl<_CustomName>(__q, __rng1, __rng2, __tmp_rng1.all_view(), __comp, oneapi::dpl::unseq_backend::_DifferenceTag{});
-
+    
     //2. Calc difference {2} \ {1}
     const std::size_t __n_diff_2 = oneapi::dpl::__par_backend_hetero::__set_op_impl<__set_symmetric_difference_diff_wrapper<_CustomName>>(__q, std::forward<_Range2>(__rng2), std::forward<_Range1>(__rng1), __tmp_rng2.all_view(), __comp, oneapi::dpl::unseq_backend::_DifferenceTag{});
-
+    
     auto __keep_tmp3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, decltype(__buf_1)>();
     auto __keep_tmp4 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, decltype(__buf_2)>();
-    auto __tmp_rng3 = __keep_tmp3(__buf_1, __buf_1 + __n_diff_1);
-    auto __tmp_rng4 = __keep_tmp4(__buf_2, __buf_2 + __n_diff_2);
-
+    
     //3. Merge the differences
-    if (__n_diff_1 == 0)
+    if (__n_diff_1 == 0 && __n_diff_2 == 0)
+    {
+        // If both differences are empty, the result is empty
+        return 0;
+    }
+    else if (__n_diff_1 == 0)
     {
         // If the first difference is empty, just copy the second range to the result
+        auto __tmp_rng4 = __keep_tmp4(__buf_2, __buf_2 + __n_diff_2);
         oneapi::dpl::__par_backend_hetero::__parallel_copy_impl<__set_symmetric_difference_copy1_wrapper<_CustomName>>(__q, __n_diff_2, __tmp_rng4.all_view(), std::forward<_Range3>(__result)).wait();
         return __n_diff_2;
     }
     else if (__n_diff_2 == 0)
     {
         // If the second difference is empty, just copy the first range to the result
+        auto __tmp_rng3 = __keep_tmp3(__buf_1, __buf_1 + __n_diff_1);
         oneapi::dpl::__par_backend_hetero::__parallel_copy_impl<__set_symmetric_difference_copy1_wrapper<_CustomName>>(__q, __n_diff_1, __tmp_rng3.all_view(), std::forward<_Range3>(__result)).wait();
         return __n_diff_1;
     }
+
+    // Otherwise, merge the sequences together
+    auto __tmp_rng4 = __keep_tmp4(__buf_2, __buf_2 + __n_diff_2);
+    auto __tmp_rng3 = __keep_tmp3(__buf_1, __buf_1 + __n_diff_1);
 
     oneapi::dpl::__par_backend_hetero::__parallel_merge_impl<__set_symmetric_difference_merge_wrapper<_CustomName>>(__q, __tmp_rng3.all_view(), __tmp_rng4.all_view(), std::forward<_Range3>(__result), __comp).wait();
     return __n_diff_1 + __n_diff_2;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -221,6 +221,16 @@ class __scan_single_wg_dynamic_kernel;
 template <typename... Name>
 class __scan_copy_single_wg_kernel;
 
+template <typename _CustomName, typename _Index, typename _Range1, typename _Range2>
+__future<sycl::event>
+__parallel_copy_impl(sycl::queue& __q, _Index __count, _Range1&& __rng1, _Range2&& __rng2)
+{
+    auto __brick = oneapi::dpl::__internal::__pstl_assign{};
+    return oneapi::dpl::__par_backend_hetero::__parallel_for_impl<_CustomName>(__q,
+        unseq_backend::walk_n_vectors_or_scalars<decltype(__brick)>{std::move(__brick), static_cast<std::size_t>(__count)},
+        __count, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
+}
+
 //------------------------------------------------------------------------
 // parallel_transform_scan - async pattern
 //------------------------------------------------------------------------
@@ -1119,7 +1129,7 @@ __parallel_set_scan(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range
 
     return __par_backend_hetero::__parallel_transform_scan_base<_CustomName>(
         __q,
-        oneapi::dpl::__ranges::make_zip_view(
+        oneapi::dpl::__ranges::zip_view(
             std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
             oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
                 __mask_buf.get_buffer())),
@@ -1143,27 +1153,37 @@ __set_op_impl(sycl::queue&, _Range1&&, _Range2&&, _Range3&&, _Compare, _SetTag);
 template <typename _CustomName>
 struct __set_union_merge_wrapper;
 
+template <typename _CustomName>
+struct __set_union_copy_wrapper;
+
 template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare, typename _UseReduceThenScan>
 std::size_t
 __set_write_a_only_op(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
                                             _Compare __comp, oneapi::dpl::unseq_backend::_UnionTag, _UseReduceThenScan)
 {
-    std::cout<<"compound\n";
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range3>;
 
     // temporary buffer to store intermediate result
     const auto __n2 = __rng2.size();
     oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff(__n2);
     auto __buf = __diff.get();
-    auto __keep_tmp = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, decltype(__buf)>();
-    auto __tmp_rng1 = __keep_tmp(__buf, __buf + __n2);
-
+    auto __keep_tmp1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, decltype(__buf)>();
+    auto __tmp_rng1 = __keep_tmp1(__buf, __buf + __n2);
     //1. Calc difference {2} \ {1}
     const std::size_t __n_diff = oneapi::dpl::__par_backend_hetero::__set_op_impl<_CustomName>(__q, __rng2, __rng1, __tmp_rng1.all_view(), __comp,
-                                                    oneapi::dpl::unseq_backend::_DifferenceTag{});
+    oneapi::dpl::unseq_backend::_DifferenceTag{});
+
     //2. Merge {1} and the difference
-    auto __tmp_rng2 = __keep_tmp(__buf, __buf + __n_diff);
-    return std::get<0>(oneapi::dpl::__par_backend_hetero::__parallel_merge_impl<__set_union_merge_wrapper<_CustomName>>(__q, __rng1, __tmp_rng2.all_view(), __result, __comp).get());
+    if (__n_diff == 0)
+    {
+        oneapi::dpl::__par_backend_hetero::__parallel_copy_impl<__set_union_copy_wrapper<_CustomName>>(__q, __rng1.size(), std::forward<_Range1>(__rng1), std::forward<_Range3>(__result)).wait();
+        return __rng1.size();
+    }
+
+    auto __keep_tmp2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, decltype(__buf)>();
+    auto __tmp_rng2 = __keep_tmp2(__buf, __buf + __n_diff);
+    oneapi::dpl::__par_backend_hetero::__parallel_merge_impl<__set_union_merge_wrapper<_CustomName>>(__q, std::forward<_Range1>(__rng1), __tmp_rng2.all_view(), std::forward<_Range3>(__result), __comp).wait();
+    return __n_diff + __rng1.size();
 }
 
 template <typename _CustomName>
@@ -1171,6 +1191,12 @@ struct __set_symmetric_difference_diff_wrapper;
 
 template <typename _CustomName>
 struct __set_symmetric_difference_merge_wrapper;
+
+template <typename _CustomName>
+struct __set_symmetric_difference_copy1_wrapper;
+
+template <typename _CustomName>
+struct __set_symmetric_difference_copy2_wrapper;
 
 template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare, typename _UseReduceThenScan>
 std::size_t
@@ -1197,12 +1223,29 @@ __set_write_a_only_op(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Ran
     const std::size_t __n_diff_1 = oneapi::dpl::__par_backend_hetero::__set_op_impl<_CustomName>(__q, __rng1, __rng2, __tmp_rng1.all_view(), __comp, oneapi::dpl::unseq_backend::_DifferenceTag{});
 
     //2. Calc difference {2} \ {1}
-    const std::size_t __n_diff_2 = oneapi::dpl::__par_backend_hetero::__set_op_impl<__set_symmetric_difference_diff_wrapper<_CustomName>>(__q, __rng2, __rng1, __tmp_rng2.all_view(), __comp, oneapi::dpl::unseq_backend::_DifferenceTag{});
+    const std::size_t __n_diff_2 = oneapi::dpl::__par_backend_hetero::__set_op_impl<__set_symmetric_difference_diff_wrapper<_CustomName>>(__q, std::forward<_Range2>(__rng2), std::forward<_Range1>(__rng1), __tmp_rng2.all_view(), __comp, oneapi::dpl::unseq_backend::_DifferenceTag{});
+
+    auto __keep_tmp3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, decltype(__buf_1)>();
+    auto __keep_tmp4 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, decltype(__buf_2)>();
+    auto __tmp_rng3 = __keep_tmp3(__buf_1, __buf_1 + __n_diff_1);
+    auto __tmp_rng4 = __keep_tmp4(__buf_2, __buf_2 + __n_diff_2);
 
     //3. Merge the differences
-    auto __tmp_rng3 = __keep_tmp1(__buf_1, __buf_1 + __n_diff_1);
-    auto __tmp_rng4 = __keep_tmp2(__buf_2, __buf_2 + __n_diff_2);
-    return std::get<0>(oneapi::dpl::__par_backend_hetero::__parallel_merge_impl<__set_symmetric_difference_merge_wrapper<_CustomName>>(__q, __tmp_rng3.all_view(), __tmp_rng4.all_view(), __result, __comp).get());
+    if (__n_diff_1 == 0)
+    {
+        // If the first difference is empty, just copy the second range to the result
+        oneapi::dpl::__par_backend_hetero::__parallel_copy_impl<__set_symmetric_difference_copy1_wrapper<_CustomName>>(__q, __n_diff_2, __tmp_rng4.all_view(), std::forward<_Range3>(__result)).wait();
+        return __n_diff_2;
+    }
+    else if (__n_diff_2 == 0)
+    {
+        // If the second difference is empty, just copy the first range to the result
+        oneapi::dpl::__par_backend_hetero::__parallel_copy_impl<__set_symmetric_difference_copy1_wrapper<_CustomName>>(__q, __n_diff_1, __tmp_rng3.all_view(), std::forward<_Range3>(__result)).wait();
+        return __n_diff_1;
+    }
+
+    oneapi::dpl::__par_backend_hetero::__parallel_merge_impl<__set_symmetric_difference_merge_wrapper<_CustomName>>(__q, __tmp_rng3.all_view(), __tmp_rng4.all_view(), std::forward<_Range3>(__result), __comp).wait();
+    return __n_diff_1 + __n_diff_2;
 }
 
 template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare, typename _UseReduceThenScan>
@@ -1260,7 +1303,6 @@ __set_op_impl(sycl::queue& __q, _Range1&& __rng1,
     {
         if (__n1 + __n2 <= 1024 * 1024)
         {
-            std::cout<<"union compound rts\n";
             // use reduce then scan with set_a write
             return __set_write_a_only_op<_CustomName>(__q, std::forward<_Range1>(__rng1),
                                                             std::forward<_Range2>(__rng2),
@@ -1268,8 +1310,6 @@ __set_op_impl(sycl::queue& __q, _Range1&& __rng1,
         }
         else
         {
-            std::cout<<"union rts\n";
-
             return __parallel_set_write_a_b_op<reduce_then_scan_wrapper<_CustomName>>(__q, std::forward<_Range1>(__rng1),
                                                             std::forward<_Range2>(__rng2),
                                                             std::forward<_Range3>(__result), __comp, __set_tag).get();
@@ -1277,8 +1317,6 @@ __set_op_impl(sycl::queue& __q, _Range1&& __rng1,
     }
     else
     {
-        std::cout<<"union compound old\n";
-
         return __set_write_a_only_op<scan_then_propagate_wrapper<_CustomName>>(__q, std::forward<_Range1>(__rng1),
                                                         std::forward<_Range2>(__rng2),
                                                         std::forward<_Range3>(__result), __comp, __set_tag, std::false_type{});
@@ -1296,7 +1334,6 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolic
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
     sycl::queue __q_local = __exec.queue();
-    std::cout<<"set op\n";
     return __set_op_impl<_CustomName>(__q_local, std::forward<_Range1>(__rng1),
                                             std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp,
                                             __set_tag);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1288,6 +1288,22 @@ struct scan_then_propagate_wrapper
 {
 };
 
+
+
+template <typename _SetTag>
+struct __consider_write_a_alg
+{
+    static constexpr std::size_t __threshold = 1024 * 1024;
+    static constexpr bool __value = true;
+};
+
+// With complex compound alg, symmetric difference should always use single shot algorithm when available
+template <>
+struct __consider_write_a_alg<oneapi::dpl::unseq_backend::_SymmetricDifferenceTag>
+{
+    static constexpr bool __value = false;
+};
+
 // Selects the right implementation of set based on the size and platform
 template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _SetTag>
@@ -1301,19 +1317,19 @@ __set_op_impl(sycl::queue& __q, _Range1&& __rng1,
     //can we use reduce then scan?
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q))
     {
-        if (__n1 + __n2 <= 1024 * 1024)
+        if constexpr (__consider_write_a_alg<_SetTag>::__value)
         {
-            // use reduce then scan with set_a write
-            return __set_write_a_only_op<_CustomName>(__q, std::forward<_Range1>(__rng1),
-                                                            std::forward<_Range2>(__rng2),
-                                                            std::forward<_Range3>(__result), __comp, __set_tag, std::true_type{});
+            if (__n1 + __n2 <= __consider_write_a_alg<_SetTag>::__threshold)
+            {
+                // use reduce then scan with set_a write
+                return __set_write_a_only_op<_CustomName>(__q, std::forward<_Range1>(__rng1),
+                                                                std::forward<_Range2>(__rng2),
+                                                                std::forward<_Range3>(__result), __comp, __set_tag, std::true_type{});
+            }
         }
-        else
-        {
-            return __parallel_set_write_a_b_op<reduce_then_scan_wrapper<_CustomName>>(__q, std::forward<_Range1>(__rng1),
-                                                            std::forward<_Range2>(__rng2),
-                                                            std::forward<_Range3>(__result), __comp, __set_tag).get();
-        }
+        return __parallel_set_write_a_b_op<reduce_then_scan_wrapper<_CustomName>>(__q, std::forward<_Range1>(__rng1),
+                                                        std::forward<_Range2>(__rng2),
+                                                        std::forward<_Range3>(__result), __comp, __set_tag).get();
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1031,7 +1031,7 @@ __parallel_set_reduce_then_scan_set_a_write(sycl::queue& __q, _Range1&& __rng1, 
     const std::size_t __n = __rng1.size();
     return __parallel_transform_reduce_then_scan<sizeof(oneapi::dpl::__internal::__value_t<_Range1>), _CustomName>(
         __q, __n,
-        oneapi::dpl::__ranges::make_zip_view(
+        oneapi::dpl::__ranges::zip_view(
             std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
             oneapi::dpl::__ranges::all_view<std::int32_t, __par_backend_hetero::access_mode::read_write>(
                 __mask_buf.get_buffer())),
@@ -1077,7 +1077,7 @@ __parallel_set_write_a_b_op(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2
         ((sizeof(_In1ValueT) + sizeof(_In2ValueT)) / 2) * (__diagonal_spacing + 1) + sizeof(_TemporaryType);
     return __parallel_transform_reduce_then_scan<__bytes_per_work_item_iter, _CustomName>(
         __q, __num_diagonals,
-        oneapi::dpl::__ranges::make_zip_view(
+        oneapi::dpl::__ranges::zip_view(
             std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
             oneapi::dpl::__ranges::all_view<_TemporaryType, __par_backend_hetero::access_mode::read_write>(
                 __temp_diags.get_buffer())),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1008,13 +1008,13 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
 // This function is currently unused, but may be utilized for small sizes sets at some point in the future.
 template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
-          typename _IsOpDifference>
+          typename _SetTag>
 __future<sycl::event, __result_and_scratch_storage<oneapi::dpl::__internal::__difference_t<_Range3>>>
 __parallel_set_reduce_then_scan_set_a_write(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
-                                            _Compare __comp, _IsOpDifference)
+                                            _Compare __comp, _SetTag)
 {
     // fill in reduce then scan impl
-    using _GenMaskReduce = oneapi::dpl::__par_backend_hetero::__gen_set_mask<_IsOpDifference, _Compare>;
+    using _GenMaskReduce = oneapi::dpl::__par_backend_hetero::__gen_set_mask<_SetTag, _Compare>;
     using _MaskRangeTransform = oneapi::dpl::__par_backend_hetero::__extract_range_from_zip<2>;
     using _MaskPredicate = oneapi::dpl::__internal::__no_op;
     using _GenMaskScan = oneapi::dpl::__par_backend_hetero::__gen_mask<_MaskPredicate, _MaskRangeTransform>;
@@ -1028,9 +1028,8 @@ __parallel_set_reduce_then_scan_set_a_write(sycl::queue& __q, _Range1&& __rng1, 
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     oneapi::dpl::__par_backend_hetero::__buffer<std::int32_t> __mask_buf(__rng1.size());
-
     const std::size_t __n = __rng1.size();
-    return __parallel_transform_reduce_then_scan<sizeof(_Size), _CustomName>(
+    return __parallel_transform_reduce_then_scan<sizeof(oneapi::dpl::__internal::__value_t<_Range1>), _CustomName>(
         __q, __n,
         oneapi::dpl::__ranges::make_zip_view(
             std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
@@ -1046,7 +1045,7 @@ __parallel_set_reduce_then_scan_set_a_write(sycl::queue& __q, _Range1&& __rng1, 
 template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _SetTag>
 __future<sycl::event, __result_and_scratch_storage<oneapi::dpl::__internal::__difference_t<_Range3>>>
-__parallel_set_reduce_then_scan(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
+__parallel_set_write_a_b_op(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
                                 _Compare __comp, _SetTag)
 {
     constexpr std::uint16_t __diagonal_spacing = 32;
@@ -1136,34 +1135,171 @@ __parallel_set_scan(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range
         __copy_by_mask_op);
 }
 
+template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+          typename _SetTag>
+std::size_t
+__set_op_impl(sycl::queue&, _Range1&&, _Range2&&, _Range3&&, _Compare, _SetTag);
+                  
+template <typename _CustomName>
+struct __set_union_merge_wrapper;
+
+template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare, typename _UseReduceThenScan>
+std::size_t
+__set_write_a_only_op(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
+                                            _Compare __comp, oneapi::dpl::unseq_backend::_UnionTag, _UseReduceThenScan)
+{
+    std::cout<<"compound\n";
+    using _ValueType = oneapi::dpl::__internal::__value_t<_Range3>;
+
+    // temporary buffer to store intermediate result
+    const auto __n2 = __rng2.size();
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff(__n2);
+    auto __buf = __diff.get();
+    auto __keep_tmp = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, decltype(__buf)>();
+    auto __tmp_rng1 = __keep_tmp(__buf, __buf + __n2);
+
+    //1. Calc difference {2} \ {1}
+    const std::size_t __n_diff = oneapi::dpl::__par_backend_hetero::__set_op_impl<_CustomName>(__q, __rng2, __rng1, __tmp_rng1.all_view(), __comp,
+                                                    oneapi::dpl::unseq_backend::_DifferenceTag{});
+    //2. Merge {1} and the difference
+    auto __tmp_rng2 = __keep_tmp(__buf, __buf + __n_diff);
+    return std::get<0>(oneapi::dpl::__par_backend_hetero::__parallel_merge_impl<__set_union_merge_wrapper<_CustomName>>(__q, __rng1, __tmp_rng2.all_view(), __result, __comp).get());
+}
+
+template <typename _CustomName>
+struct __set_symmetric_difference_diff_wrapper;
+
+template <typename _CustomName>
+struct __set_symmetric_difference_merge_wrapper;
+
+template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare, typename _UseReduceThenScan>
+std::size_t
+__set_write_a_only_op(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
+                                            _Compare __comp, oneapi::dpl::unseq_backend::_SymmetricDifferenceTag, _UseReduceThenScan)
+{
+    using _ValueType = oneapi::dpl::__internal::__value_t<_Range3>;
+
+    // temporary buffers to store intermediate result
+    const auto __n1 = __rng1.size();
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff_1(__n1);
+    auto __buf_1 = __diff_1.get();
+    const auto __n2 = __rng2.size();
+    oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff_2(__n2);
+    auto __buf_2 = __diff_2.get();
+
+    auto __keep_tmp1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, decltype(__buf_1)>();
+    auto __keep_tmp2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, decltype(__buf_2)>();
+
+    auto __tmp_rng1 = __keep_tmp1(__buf_1, __buf_1 + __n1);
+    auto __tmp_rng2 = __keep_tmp2(__buf_2, __buf_2 + __n2);
+
+    //1. Calc difference {1} \ {2}
+    const std::size_t __n_diff_1 = oneapi::dpl::__par_backend_hetero::__set_op_impl<_CustomName>(__q, __rng1, __rng2, __tmp_rng1.all_view(), __comp, oneapi::dpl::unseq_backend::_DifferenceTag{});
+
+    //2. Calc difference {2} \ {1}
+    const std::size_t __n_diff_2 = oneapi::dpl::__par_backend_hetero::__set_op_impl<__set_symmetric_difference_diff_wrapper<_CustomName>>(__q, __rng2, __rng1, __tmp_rng2.all_view(), __comp, oneapi::dpl::unseq_backend::_DifferenceTag{});
+
+    //3. Merge the differences
+    auto __tmp_rng3 = __keep_tmp1(__buf_1, __buf_1 + __n_diff_1);
+    auto __tmp_rng4 = __keep_tmp2(__buf_2, __buf_2 + __n_diff_2);
+    return std::get<0>(oneapi::dpl::__par_backend_hetero::__parallel_merge_impl<__set_symmetric_difference_merge_wrapper<_CustomName>>(__q, __tmp_rng3.all_view(), __tmp_rng4.all_view(), __result, __comp).get());
+}
+
+template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare, typename _UseReduceThenScan>
+std::size_t
+__set_write_a_only_op(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
+                                            _Compare __comp, oneapi::dpl::unseq_backend::_IntersectionTag, _UseReduceThenScan)
+{
+    if constexpr (_UseReduceThenScan::value)
+        return __parallel_set_reduce_then_scan_set_a_write<_CustomName>(__q, std::forward<_Range1>(__rng1),
+                                            std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp,
+                                            oneapi::dpl::unseq_backend::_IntersectionTag{}).get();
+    else
+        return __parallel_set_scan<_CustomName>(__q, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                                                std::forward<_Range3>(__result), __comp,
+                                                oneapi::dpl::unseq_backend::_IntersectionTag{}).get();
+}
+
+template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare, typename _UseReduceThenScan>
+std::size_t
+__set_write_a_only_op(sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
+                                            _Compare __comp, oneapi::dpl::unseq_backend::_DifferenceTag, _UseReduceThenScan)
+{
+    if constexpr (_UseReduceThenScan::value)
+        return __parallel_set_reduce_then_scan_set_a_write<_CustomName>(__q, std::forward<_Range1>(__rng1),
+                                            std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp,
+                                            oneapi::dpl::unseq_backend::_DifferenceTag{}).get();
+    else
+        return __parallel_set_scan<_CustomName>(__q, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                                                std::forward<_Range3>(__result), __comp,
+                                                oneapi::dpl::unseq_backend::_DifferenceTag{}).get();
+}
+
+template <typename _CustomName>
+struct reduce_then_scan_wrapper
+{
+};
+
+template <typename _CustomName>
+struct scan_then_propagate_wrapper
+{
+};
+
+// Selects the right implementation of set based on the size and platform
+template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+          typename _SetTag>
+std::size_t
+__set_op_impl(sycl::queue& __q, _Range1&& __rng1,
+                  _Range2&& __rng2, _Range3&& __result, _Compare __comp, _SetTag __set_tag)
+{
+    size_t __n1 = __rng1.size();
+    size_t __n2 = __rng2.size();
+
+    //can we use reduce then scan?
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q))
+    {
+        if (__n1 + __n2 <= 1024 * 1024)
+        {
+            std::cout<<"union compound rts\n";
+            // use reduce then scan with set_a write
+            return __set_write_a_only_op<_CustomName>(__q, std::forward<_Range1>(__rng1),
+                                                            std::forward<_Range2>(__rng2),
+                                                            std::forward<_Range3>(__result), __comp, __set_tag, std::true_type{});
+        }
+        else
+        {
+            std::cout<<"union rts\n";
+
+            return __parallel_set_write_a_b_op<reduce_then_scan_wrapper<_CustomName>>(__q, std::forward<_Range1>(__rng1),
+                                                            std::forward<_Range2>(__rng2),
+                                                            std::forward<_Range3>(__result), __comp, __set_tag).get();
+        }
+    }
+    else
+    {
+        std::cout<<"union compound old\n";
+
+        return __set_write_a_only_op<scan_then_propagate_wrapper<_CustomName>>(__q, std::forward<_Range1>(__rng1),
+                                                        std::forward<_Range2>(__rng2),
+                                                        std::forward<_Range3>(__result), __comp, __set_tag, std::false_type{});
+    }
+}
+
+
+
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _SetTag>
-__future<sycl::event, __result_and_scratch_storage<oneapi::dpl::__internal::__difference_t<_Range3>>>
+std::size_t
 __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range1&& __rng1,
                   _Range2&& __rng2, _Range3&& __result, _Compare __comp, _SetTag __set_tag)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
     sycl::queue __q_local = __exec.queue();
-
-    if constexpr (_SetTag::__can_write_from_rng2_v)
-    {
-        return __parallel_set_reduce_then_scan<_CustomName>(__q_local, std::forward<_Range1>(__rng1),
-                                                            std::forward<_Range2>(__rng2),
-                                                            std::forward<_Range3>(__result), __comp, __set_tag);
-    }
-    else
-    {
-        return __parallel_set_scan<_CustomName>(__q_local, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                                                std::forward<_Range3>(__result), __comp, __set_tag);
-    }
-}
-
-template <typename _ExecutionPolicy>
-bool
-__can_set_op_write_from_set_b(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec)
-{
-    return oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__exec.queue());
+    std::cout<<"set op\n";
+    return __set_op_impl<_CustomName>(__q_local, std::forward<_Range1>(__rng1),
+                                            std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp,
+                                            __set_tag);
 }
 
 //------------------------------------------------------------------------
@@ -1405,8 +1541,8 @@ struct __parallel_find_or_nd_range_tuner<oneapi::dpl::__internal::__device_backe
                     const std::size_t __k = oneapi::dpl::__internal::__dpl_bit_ceil(
                         (std::size_t)std::ceil(__desired_iters_per_work_item / __iters_per_work_item));
                     // Proportionally reduce the number of work groups.
-                    __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                        __rng_n, __wgroup_size * __iters_per_work_item * __k);
+                    __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size *
+                                                                                         __iters_per_work_item * __k);
                 }
             }
         }
@@ -1790,8 +1926,8 @@ struct __is_radix_sort_usable_for_type
     static constexpr bool value =
 #if _ONEDPL_USE_RADIX_SORT
         (::std::is_arithmetic_v<_T> || ::std::is_same_v<sycl::half, _T>) &&
-            (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
-            __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
+        (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
+         __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
 #else
         false;
 #endif // _ONEDPL_USE_RADIX_SORT

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -272,7 +272,6 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
                                                                  std::forward<_Ranges>(__rngs)...);
 }
 
-
 } // namespace __par_backend_hetero
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -226,10 +226,9 @@ inline constexpr bool __has_pfor_brick_members_v = __has_pfor_brick_members<Bric
 
 //General version of parallel_for, one additional parameter - __count of iterations of loop __cgh.parallel_for,
 //for some algorithms happens that size of processing range is n, but amount of iterations is n/2.
-template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
+template <typename _CustomName, typename _Fp, typename _Index, typename... _Ranges>
 __future<sycl::event>
-__parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Fp __brick, _Index __count,
-               _Ranges&&... __rngs)
+__parallel_for_impl(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs)
 {
     static_assert(
         __has_pfor_brick_members_v<_Fp>,
@@ -239,13 +238,10 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
                __rngs.size())...}) > 0);
     assert(__count > 0);
 
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _ForKernelSmall =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__parallel_for_small_kernel<_CustomName>>;
     using _ForKernelLarge =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__parallel_for_large_kernel<_CustomName>>;
-
-    sycl::queue __q_local = __exec.queue();
 
     using __small_submitter = __parallel_for_small_submitter<_ForKernelSmall>;
     using __large_submitter = __parallel_for_large_submitter<_ForKernelLarge>;
@@ -255,13 +251,27 @@ __parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&&
     // then only compile the basic kernel as the two versions are effectively the same.
     if constexpr (__params_t::__iters_per_item > 1 || __params_t::__vector_size > 1)
     {
-        if (__count >= __large_submitter::template __estimate_best_start_size<_Fp, _Ranges...>(__q_local))
+        if (__count >= __large_submitter::template __estimate_best_start_size<_Fp, _Ranges...>(__q))
         {
-            return __large_submitter{}(__q_local, __brick, __count, std::forward<_Ranges>(__rngs)...);
+            return __large_submitter{}(__q, __brick, __count, std::forward<_Ranges>(__rngs)...);
         }
     }
-    return __small_submitter{}(__q_local, __brick, __count, std::forward<_Ranges>(__rngs)...);
+    return __small_submitter{}(__q, __brick, __count, std::forward<_Ranges>(__rngs)...);
 }
+
+//General version of parallel_for, one additional parameter - __count of iterations of loop __cgh.parallel_for,
+//for some algorithms happens that size of processing range is n, but amount of iterations is n/2.
+template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
+__future<sycl::event>
+__parallel_for(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Fp __brick, _Index __count,
+               _Ranges&&... __rngs)
+{
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+    sycl::queue __q_local = __exec.queue();
+    return oneapi::dpl::__par_backend_hetero::__parallel_for_impl<_CustomName>(__q_local, __brick, __count,
+                                                                 std::forward<_Ranges>(__rngs)...);
+}
+
 
 } // namespace __par_backend_hetero
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -482,18 +482,14 @@ __get_starting_size_limit_for_large_submitter<int>()
     return 16 * 1'048'576; // 16 MB
 }
 
-template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+
+template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _OutSizeLimit = std::false_type>
 __future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
-__parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range1&& __rng1,
+__parallel_merge_impl(sycl::queue& __q, _Range1&& __rng1,
                  _Range2&& __rng2, _Range3&& __rng3, _Compare __comp, _OutSizeLimit = {})
 {
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
     using __value_type = oneapi::dpl::__internal::__value_t<_Range3>;
-
-    sycl::queue __q_local = __exec.queue();
-
     const std::size_t __n = std::min<std::size_t>(__rng1.size() + __rng2.size(), __rng3.size());
     if (__n < __get_starting_size_limit_for_large_submitter<__value_type>())
     {
@@ -503,7 +499,7 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
         using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __merge_kernel_name<_CustomName, _WiIndex>>;
         return __parallel_merge_submitter<_OutSizeLimit, _WiIndex, _MergeKernelName>()(
-            __q_local, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2), std::forward<_Range3>(__rng3),
+            __q, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2), std::forward<_Range3>(__rng3),
             __comp);
     }
     else
@@ -516,7 +512,7 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
             using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
                 __merge_kernel_name_large<_CustomName, _WiIndex>>;
             return __parallel_merge_submitter_large<_OutSizeLimit, _WiIndex, _CustomName, _DiagonalsKernelName,
-                                                    _MergeKernelName>()(__q_local, std::forward<_Range1>(__rng1),
+                                                    _MergeKernelName>()(__q, std::forward<_Range1>(__rng1),
                                                                         std::forward<_Range2>(__rng2),
                                                                         std::forward<_Range3>(__rng3), __comp);
         }
@@ -528,11 +524,25 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
             using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
                 __merge_kernel_name_large<_CustomName, _WiIndex>>;
             return __parallel_merge_submitter_large<_OutSizeLimit, _WiIndex, _CustomName, _DiagonalsKernelName,
-                                                    _MergeKernelName>()(__q_local, std::forward<_Range1>(__rng1),
+                                                    _MergeKernelName>()(__q, std::forward<_Range1>(__rng1),
                                                                         std::forward<_Range2>(__rng2),
                                                                         std::forward<_Range3>(__rng3), __comp);
         }
     }
+}
+
+
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+          typename _OutSizeLimit = std::false_type>
+__future<sycl::event, std::shared_ptr<__result_and_scratch_storage_base>>
+__parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range1&& __rng1,
+                 _Range2&& __rng2, _Range3&& __rng3, _Compare __comp, _OutSizeLimit = {})
+{
+    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
+    sycl::queue __q_local = __exec.queue();
+    return __parallel_merge_impl<_CustomName>(__q_local, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                                                              std::forward<_Range3>(__rng3), __comp, _OutSizeLimit{});
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1626,8 +1626,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 inline bool
 __is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
 {
-    return true;//(__q.get_device().is_gpu() &&
-            //oneapi::dpl::__internal::__supports_sub_group_size(__q, __get_reduce_then_scan_reqd_sg_sz_host()));
+    return (__q.get_device().is_gpu() &&
+           oneapi::dpl::__internal::__supports_sub_group_size(__q, __get_reduce_then_scan_reqd_sg_sz_host()));
 }
 
 // General scan-like algorithm helpers

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -211,7 +211,7 @@ struct __write_red_by_seg
 // Writes multiple elements from temp data to the output range. The values to write are stored in `__temp_data` from a
 // previous operation, and must be written to the output range in the appropriate location. The zeroth element of `__v`
 // will contain the index of one past the last element to write, and the first element of `__v` will contain the number
-// of elements to write. Used for __parallel_set_reduce_then_scan.
+// of elements to write. Used for __parallel_set_write_a_b_op.
 template <typename _Assign>
 struct __write_multiple_to_id
 {
@@ -333,7 +333,7 @@ struct __gen_unique_mask
 
 // A mask generator for set operations (difference or intersection) to determine if an element from Set A should be
 // written to the output sequence based on its presence in Set B and the operation type (difference or intersection).
-template <typename _IsOpDifference, typename _Compare>
+template <typename _SetTag, typename _Compare>
 struct __gen_set_mask
 {
     template <typename _InRng>
@@ -351,9 +351,11 @@ struct __gen_set_mask
         auto __val_a = __set_a[__id];
 
         auto __res = oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a, __comp);
+        constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
+        
+        //initialization is true in case of difference operation; false - intersection.
+        bool bres = __is_difference;
 
-        bool bres =
-            _IsOpDifference::value; //initialization is true in case of difference operation; false - intersection.
         if (__res == __nb || __comp(__val_a, __set_b[__res]))
         {
             // there is no __val_a in __set_b, so __set_b in the difference {__set_a}/{__set_b};
@@ -375,7 +377,7 @@ struct __gen_set_mask
                 oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __val_b, __comp) -
                 oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, __val_b, __comp);
 
-            if constexpr (_IsOpDifference::value)
+            if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
             else
                 bres = __count_a_left <= __count_b; /*intersection*/
@@ -386,7 +388,7 @@ struct __gen_set_mask
     _Compare __comp;
 };
 
-// __parallel_set_reduce_then_scan
+// __parallel_set_write_a_b_op
 
 // Returns by reference: iterations consumed, and the number of elements copied to temp output.
 template <bool _CopyMatch, bool _CopyDiffSetA, bool _CopyDiffSetB, bool _CheckBounds, typename _InRng1,
@@ -514,21 +516,21 @@ template <typename _SetTag>
 struct __get_set_operation;
 
 template <>
-struct __get_set_operation<oneapi::dpl::unseq_backend::_IntersectionTag<std::true_type>> : public __set_intersection
+struct __get_set_operation<oneapi::dpl::unseq_backend::_IntersectionTag> : public __set_intersection
 {
 };
 
 template <>
-struct __get_set_operation<oneapi::dpl::unseq_backend::_DifferenceTag<std::true_type>> : public __set_difference
+struct __get_set_operation<oneapi::dpl::unseq_backend::_DifferenceTag> : public __set_difference
 {
 };
 template <>
-struct __get_set_operation<oneapi::dpl::unseq_backend::_UnionTag<std::true_type>> : public __set_union
+struct __get_set_operation<oneapi::dpl::unseq_backend::_UnionTag> : public __set_union
 {
 };
 
 template <>
-struct __get_set_operation<oneapi::dpl::unseq_backend::_SymmetricDifferenceTag<std::true_type>>
+struct __get_set_operation<oneapi::dpl::unseq_backend::_SymmetricDifferenceTag>
     : public __set_symmetric_difference
 {
 };
@@ -1624,8 +1626,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 inline bool
 __is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
 {
-    return (__q.get_device().is_gpu() &&
-            oneapi::dpl::__internal::__supports_sub_group_size(__q, __get_reduce_then_scan_reqd_sg_sz_host()));
+    return true;//(__q.get_device().is_gpu() &&
+            //oneapi::dpl::__internal::__supports_sub_group_size(__q, __get_reduce_then_scan_reqd_sg_sz_host()));
 }
 
 // General scan-like algorithm helpers

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1227,26 +1227,17 @@ struct __rotate_copy
 // brick_set_op for difference and intersection operations
 //------------------------------------------------------------------------
 
-template <typename _IsOneShot>
-struct _IntersectionTag : public ::std::false_type
-{
-    static constexpr bool __can_write_from_rng2_v = _IsOneShot::value;
-};
-template <typename _IsOneShot>
-struct _DifferenceTag : public ::std::true_type
-{
-    static constexpr bool __can_write_from_rng2_v = _IsOneShot::value;
-};
-template <typename _IsOneShot>
-struct _UnionTag : public std::true_type
-{
-    static constexpr bool __can_write_from_rng2_v = _IsOneShot::value;
-};
-template <typename _IsOneShot>
-struct _SymmetricDifferenceTag : public std::true_type
-{
-    static constexpr bool __can_write_from_rng2_v = _IsOneShot::value;
-};
+
+
+
+
+struct _IntersectionTag{};
+
+struct _DifferenceTag{};
+
+struct _UnionTag{};
+
+struct _SymmetricDifferenceTag{};
 
 template <typename _Compare, typename _Size1, typename _Size2, typename _IsOpDifference>
 class __brick_set_op
@@ -1276,7 +1267,8 @@ class __brick_set_op
 
         auto __res = __internal::__pstl_lower_bound(__b, _Size2(0), __nb, __val_a, __comp);
 
-        bool bres = _IsOpDifference(); //initialization in true in case of difference operation; false - intersection.
+        constexpr bool __is_difference = std::is_same_v<_IsOpDifference, oneapi::dpl::unseq_backend::_DifferenceTag>;
+        bool bres = __is_difference; //initialization in true in case of difference operation; false - intersection.
         if (__res == __nb || __comp(__val_a, __b[__b_beg + __res]))
         {
             // there is no __val_a in __b, so __b in the difference {__a}/{__b};
@@ -1298,7 +1290,7 @@ class __brick_set_op
                                      __res -
                                      __internal::__pstl_left_bound(__b, _Size2(0), _Size2(__res), __val_b, __comp);
 
-            if constexpr (_IsOpDifference::value)
+            if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
             else
                 bres = __count_a_left <= __count_b; /*intersection*/

--- a/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
+++ b/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
@@ -23,25 +23,25 @@
 #if TEST_DPCPP_BACKEND_PRESENT
 template <typename... _Args>
 auto
-std_set(oneapi::dpl::unseq_backend::_IntersectionTag<std::true_type>, _Args&&... args)
+std_set(oneapi::dpl::unseq_backend::_IntersectionTag, _Args&&... args)
 {
     return std::set_intersection(std::forward<_Args>(args)...);
 }
 template <typename... _Args>
 auto
-std_set(oneapi::dpl::unseq_backend::_DifferenceTag<std::true_type>, _Args&&... args)
+std_set(oneapi::dpl::unseq_backend::_DifferenceTag, _Args&&... args)
 {
     return std::set_difference(std::forward<_Args>(args)...);
 }
 template <typename... _Args>
 auto
-std_set(oneapi::dpl::unseq_backend::_SymmetricDifferenceTag<std::true_type>, _Args&&... args)
+std_set(oneapi::dpl::unseq_backend::_SymmetricDifferenceTag, _Args&&... args)
 {
     return std::set_symmetric_difference(std::forward<_Args>(args)...);
 }
 template <typename... _Args>
 auto
-std_set(oneapi::dpl::unseq_backend::_UnionTag<std::true_type>, _Args&&... args)
+std_set(oneapi::dpl::unseq_backend::_UnionTag, _Args&&... args)
 {
     return std::set_union(std::forward<_Args>(args)...);
 }
@@ -440,13 +440,13 @@ main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
     std::cout << "Test intersection" << std::endl;
-    test_variety_of_combinations_of_setops(oneapi::dpl::unseq_backend::_IntersectionTag<std::true_type>{});
+    test_variety_of_combinations_of_setops(oneapi::dpl::unseq_backend::_IntersectionTag{});
     std::cout << "Test difference" << std::endl;
-    test_variety_of_combinations_of_setops(oneapi::dpl::unseq_backend::_DifferenceTag<std::true_type>{});
+    test_variety_of_combinations_of_setops(oneapi::dpl::unseq_backend::_DifferenceTag{});
     std::cout << "Test union" << std::endl;
-    test_variety_of_combinations_of_setops(oneapi::dpl::unseq_backend::_UnionTag<std::true_type>{});
+    test_variety_of_combinations_of_setops(oneapi::dpl::unseq_backend::_UnionTag{});
     std::cout << "Test symmetric diff" << std::endl;
-    test_variety_of_combinations_of_setops(oneapi::dpl::unseq_backend::_SymmetricDifferenceTag<std::true_type>{});
+    test_variety_of_combinations_of_setops(oneapi::dpl::unseq_backend::_SymmetricDifferenceTag{});
     EXPECT_TRUE(test_right_biased_lower_bound(), "test for right biased lower bound");
     EXPECT_TRUE(test_find_balanced_path(), "test for find balanced path");
 #endif // TEST_DPCPP_BACKEND_PRESENT


### PR DESCRIPTION
This PR makes some infrastructure changes to allow a runtime decision based upon number of elements to select the set algorithm selected, in addition to limitations based upon platform and environment.

1) Relocate algorithm choice from hetero level to sycl backend and make ` __parallel_set_op` blocking. (temporarily required for type alignment, see #2300)
2) Create sycl backend entry points to call "merge" (`__parallel_merge_impl`) and "copy" (`__parallel_copy_impl`).
3) Add a threshold to switch algorithms from set_a_scan to balanced_path based upon set tag in `__set_op_impl` using `__consider_write_a_alg` 