### PR TITLE
Workaround icpx incompatibility issues with VS 17.14

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -257,6 +257,9 @@ jobs:
             build_type: release
             backend: tbb
             device_type: HOST
+            # TODO: replace with windows-latest once icpx 2025.2 is released.
+            # The latest updates of VS 2022 in newer images have compatibility issues with icpx 2025.1.
+            # windows-2019 uses VS 2019.
           - os: windows-2019
             cxx_compiler: icx
             std: 17

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -245,7 +245,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2019
             cxx_compiler: icx-cl
             std: 17
             build_type: release

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -245,7 +245,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-latest
             cxx_compiler: icx-cl
             std: 17
             build_type: release
@@ -257,7 +257,7 @@ jobs:
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: windows-latest
+          - os: windows-2019
             cxx_compiler: icx
             std: 17
             build_type: release


### PR DESCRIPTION
icpx 2025.1 and older have compatibility issues with VS 17.14, which was recently upgraded in the windows-2022 (windows-latest) image.