### PR TITLE
Release notes: correct sort issue description

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -44,7 +44,9 @@ Existing Issues
 See oneDPL Guide for other `restrictions and known limitations`_.
 
 - Incorrect results may be observed when calling ``sort`` with a device policy on Intel® Arc™ graphics 140V with data
-  sizes of 4-8 million elements.
+  sizes of 4-8 million elements on Windows.
+  That issue is resolved in
+  Intel® oneAPI DPC++/C++ Compiler 2025.1 or later and Intel® Graphics Driver 32.0.101.6647 or later.
 - ``histogram`` algorithm requires the output value type to be an integral type no larger than four bytes
   when used with a device policy on hardware that does not support 64-bit atomic operations.
 - ``histogram`` may provide incorrect results with device policies in a program built with ``-O0`` option and the driver
@@ -99,7 +101,9 @@ Known Issues and Limitations
 New in This Release
 ^^^^^^^^^^^^^^^^^^^
 - Incorrect results may be observed when calling ``sort`` with a device policy on Intel® Arc™ graphics 140V with data
-  sizes of 4-8 million elements.
+  sizes of 4-8 million elements on Windows.
+  That issue is resolved in
+  Intel® oneAPI DPC++/C++ Compiler 2025.1 or later and Intel® Graphics Driver 32.0.101.6647 or later.
 - ``sort``, ``stable_sort``, ``sort_by_key`` and ``stable_sort_by_key`` algorithms fail to compile
   when using Clang 17 and earlier versions, as well as compilers based on these versions,
   such as Intel® oneAPI DPC++/C++ Compiler 2023.2.0.

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -43,10 +43,6 @@ Existing Issues
 ^^^^^^^^^^^^^^^
 See oneDPL Guide for other `restrictions and known limitations`_.
 
-- Incorrect results may be observed when calling ``sort`` with a device policy on Intel® Arc™ graphics 140V with data
-  sizes of 4-8 million elements on Windows.
-  That issue is resolved in
-  Intel® oneAPI DPC++/C++ Compiler 2025.1 or later and Intel® Graphics Driver 32.0.101.6647 or later.
 - ``histogram`` algorithm requires the output value type to be an integral type no larger than four bytes
   when used with a device policy on hardware that does not support 64-bit atomic operations.
 - ``histogram`` may provide incorrect results with device policies in a program built with ``-O0`` option and the driver

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -98,7 +98,7 @@ New in This Release
 ^^^^^^^^^^^^^^^^^^^
 - Incorrect results may be observed when calling ``sort`` with a device policy on Intel® Arc™ graphics 140V with data
   sizes of 4-8 million elements on Windows.
-  That issue is resolved in
+  This issue is resolved in
   Intel® oneAPI DPC++/C++ Compiler 2025.1 or later and Intel® Graphics Driver 32.0.101.6647 or later.
 - ``sort``, ``stable_sort``, ``sort_by_key`` and ``stable_sort_by_key`` algorithms fail to compile
   when using Clang 17 and earlier versions, as well as compilers based on these versions,


### PR DESCRIPTION
That issue was observed on Windows only, with icpx 2025.0 and an old GPU driver presumably built in December 2024 - a combination of tools which did not fully support Intel® Core Ultra Series architecture. 

It is not observed with icpx 2025.1 (which introduced Intel® Core Ultra Series architecture support) and 32.0.101.6647 (released together with icpx 2025.1), as well as newer versions of these tools.

Let's remove the copy of the note for oneDPL 2022.9, where it is irrelevant, and update it for 2022.8. We can also remove the notes entirely, but I suggest providing an update to the original one to avoid confusion about sudden disappearance of the issue.