### PR TITLE
CI: fix fpga emulator

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -171,7 +171,7 @@ jobs:
           sudo apt-get install intel-oneapi-compiler-dpcpp-cpp -y
           # Avoid accidental use of a released version, keeping libpstloffload.so
           sudo rm -rf ${LINUX_ONEAPI_PATH}/dpl/latest/include
-      - name: Install Intel® oneAPI DPC++/C++ Compiler SYCL* with FPGA Emulator Runtime
+      - name: Install Intel® oneAPI DPC++/C++ Compiler with SYCL* FPGA Emulator Runtime
         if: (matrix.device_type == 'FPGA_EMU')
         run: |
           sudo apt-get install intel-oneapi-compiler-fpga -y

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -163,7 +163,12 @@ jobs:
       - name: Install Intel® oneAPI DPC++/C++ Compiler
         if: (matrix.cxx_compiler == 'icpx' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icx-cl' || matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'dpcpp-cl')
         run: |
-          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp -y
+          if [[ "${{ matrix.device_type }}" == "FPGA_EMU" ]]; then
+            # The latest major version of the compiler supporting fpga emulation packages
+            sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-2024.2 -y
+          else
+            sudo apt-get install intel-oneapi-compiler-dpcpp-cpp -y
+          fi
           # Avoid accidental use of a released version, keeping libpstloffload.so
           sudo rm -rf ${LINUX_ONEAPI_PATH}/dpl/latest/include
       - name: Install Intel® oneAPI DPC++/C++ Compiler SYCL* FPGA Emulator Runtime

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -161,17 +161,17 @@ jobs:
         run: |
           sudo apt-get install intel-oneapi-tbb-devel -y
       - name: Install Intel® oneAPI DPC++/C++ Compiler
-        if: (matrix.cxx_compiler == 'icpx' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icx-cl' || matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'dpcpp-cl')
+        if: ((matrix.cxx_compiler == 'icpx'  ||
+              matrix.cxx_compiler == 'icx'   ||
+              matrix.cxx_compiler == 'icx-cl'||
+              matrix.cxx_compiler == 'dpcpp' ||
+              matrix.cxx_compiler == 'dpcpp-cl') &&
+                matrix.device_type != 'FPGA_EMU')
         run: |
-          if [[ "${{ matrix.device_type }}" == "FPGA_EMU" ]]; then
-            # The latest major version of the compiler supporting fpga emulation packages
-            sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-2024.2 -y
-          else
-            sudo apt-get install intel-oneapi-compiler-dpcpp-cpp -y
-          fi
+          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp -y
           # Avoid accidental use of a released version, keeping libpstloffload.so
           sudo rm -rf ${LINUX_ONEAPI_PATH}/dpl/latest/include
-      - name: Install Intel® oneAPI DPC++/C++ Compiler SYCL* FPGA Emulator Runtime
+      - name: Install Intel® oneAPI DPC++/C++ Compiler SYCL* with FPGA Emulator Runtime
         if: (matrix.device_type == 'FPGA_EMU')
         run: |
           sudo apt-get install intel-oneapi-compiler-fpga -y

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -161,12 +161,12 @@ jobs:
         run: |
           sudo apt-get install intel-oneapi-tbb-devel -y
       - name: Install Intel® oneAPI DPC++/C++ Compiler
-        if: ((matrix.cxx_compiler == 'icpx'  ||
-              matrix.cxx_compiler == 'icx'   ||
-              matrix.cxx_compiler == 'icx-cl'||
-              matrix.cxx_compiler == 'dpcpp' ||
-              matrix.cxx_compiler == 'dpcpp-cl') &&
-                matrix.device_type != 'FPGA_EMU')
+        if: (matrix.device_type != 'FPGA_EMU' &&
+              (matrix.cxx_compiler == 'icpx'  ||
+               matrix.cxx_compiler == 'icx'   ||
+               matrix.cxx_compiler == 'icx-cl'||
+               matrix.cxx_compiler == 'dpcpp' ||
+               matrix.cxx_compiler == 'dpcpp-cl'))
         run: |
           sudo apt-get install intel-oneapi-compiler-dpcpp-cpp -y
           # Avoid accidental use of a released version, keeping libpstloffload.so


### PR DESCRIPTION
Let's use the latest version of icpx, which supporting the FPGA emulator.

`apt-get install intel-oneapi-compiler-fpga` package installs its own compatible icpx verison (2025.0) as a dependency. The latest compiler installed with `intel-oneapi-compiler-dpcpp-cpp`, which has recently been updated to 2025.2, is not compatible with that package.