### PR TITLE
Add checks with a single projection

### DIFF
--- a/test/parallel_api/ranges/std_ranges_equal.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_equal.pass.cpp
@@ -28,6 +28,8 @@ main()
     test_range_algo<1, int, data_in_in>{}(dpl_ranges::equal, equal_checker, binary_pred, proj, proj);
     test_range_algo<2, P2, data_in_in>{}(dpl_ranges::equal, equal_checker, binary_pred, &P2::x, &P2::x);
     test_range_algo<3, P2, data_in_in>{}(dpl_ranges::equal, equal_checker, binary_pred, &P2::proj, &P2::proj);
+    test_range_algo<4, int, data_in_in>{}(dpl_ranges::equal, equal_checker, binary_pred, proj);
+
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_find_end.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find_end.pass.cpp
@@ -30,11 +30,12 @@ main()
 
     //false result
     test_range_algo<1, int, data_in_in>{big_sz}(dpl_ranges::find_end, find_end_checker, binary_pred);
-    test_range_algo<2, int, data_in_in>{}(dpl_ranges::find_end, find_end_checker, binary_pred_const, proj, proj);
+    test_range_algo<2, int, data_in_in>{}(dpl_ranges::find_end, find_end_checker, binary_pred_const, proj);
+    test_range_algo<3, int, data_in_in>{}(dpl_ranges::find_end, find_end_checker, binary_pred_const, proj, proj);
 
-    test_range_algo<3, int, data_in_in>{}(dpl_ranges::find_end, find_end_checker, binary_pred, proj, proj);
-    test_range_algo<4, P2, data_in_in>{}(dpl_ranges::find_end, find_end_checker, binary_pred, &P2::x, &P2::x);
-    test_range_algo<5, P2, data_in_in>{}(dpl_ranges::find_end, find_end_checker, binary_pred, &P2::proj, &P2::proj);
+    test_range_algo<4, int, data_in_in>{}(dpl_ranges::find_end, find_end_checker, binary_pred, proj, proj);
+    test_range_algo<5, P2, data_in_in>{}(dpl_ranges::find_end, find_end_checker, binary_pred, &P2::x, &P2::x);
+    test_range_algo<6, P2, data_in_in>{}(dpl_ranges::find_end, find_end_checker, binary_pred, &P2::proj, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_find_first_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find_first_of.pass.cpp
@@ -27,13 +27,14 @@ main()
 
     test_range_algo<0, int, data_in_in>{medium_size}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred);
     test_range_algo<1, int, data_in_in>{}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred_const);
-    test_range_algo<2, int, data_in_in>{}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred, proj, proj);
-    test_range_algo<3, P2, data_in_in>{}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred, &P2::x, &P2::x);
-    test_range_algo<4, P2, data_in_in>{}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred, &P2::proj, &P2::proj);
+    test_range_algo<2, int, data_in_in>{}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred, proj);
+    test_range_algo<3, int, data_in_in>{}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred, proj, proj);
+    test_range_algo<4, P2, data_in_in>{}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred, &P2::x, &P2::x);
+    test_range_algo<5, P2, data_in_in>{}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred, &P2::proj, &P2::proj);
 
     //false result test case; data generator is a 'gen(i)', so std::identity produces 0, 1, 2, ...
     auto gen_negative = [](auto i) { return -i; };
-    test_range_algo<5, int, data_in_in, decltype(gen_negative)>{medium_size}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred);
+    test_range_algo<6, int, data_in_in, decltype(gen_negative)>{medium_size}(dpl_ranges::find_first_of, find_first_of_checker, binary_pred);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_merge.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_merge.pass.cpp
@@ -72,7 +72,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0, int, data_in_in_out_lim>{big_sz}(dpl_ranges::merge, merge_checker, std::ranges::less{}, std::identity{}, std::identity{});
+    test_range_algo<0, int, data_in_in_out_lim>{big_sz}(dpl_ranges::merge, merge_checker);
 
     test_range_algo<1, int, data_in_in_out_lim>{}(dpl_ranges::merge, merge_checker, std::ranges::less{}, proj, proj);
     test_range_algo<2, P2, data_in_in_out_lim>{}(dpl_ranges::merge, merge_checker, std::ranges::less{}, &P2::x, &P2::x);
@@ -82,7 +82,8 @@ main()
     test_range_algo<5, P2, data_in_in_out_lim>{}(dpl_ranges::merge, merge_checker, std::ranges::greater{}, &P2::x, &P2::x);
     test_range_algo<6, P2, data_in_in_out_lim>{}(dpl_ranges::merge, merge_checker, std::ranges::greater{}, &P2::proj, &P2::proj);
 
-    test_range_algo<7, int, data_in_in_out_lim>{}(dpl_ranges::merge, merge_checker);
+    test_range_algo<7, int, data_in_in_out_lim>{}(dpl_ranges::merge, merge_checker, std::ranges::less{});
+    test_range_algo<8, int, data_in_in_out_lim>{}(dpl_ranges::merge, merge_checker, std::ranges::less{}, proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_mismatch.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_mismatch.pass.cpp
@@ -26,9 +26,10 @@ main()
 
     test_range_algo<0, int, data_in_in>{big_sz}(dpl_ranges::mismatch, mismatch_checker, binary_pred);
     test_range_algo<1, int, data_in_in>{}(dpl_ranges::mismatch, mismatch_checker, binary_pred_const);
-    test_range_algo<2, int, data_in_in>{}(dpl_ranges::mismatch, mismatch_checker, binary_pred, proj, proj);
-    test_range_algo<3, P2, data_in_in>{}(dpl_ranges::mismatch, mismatch_checker, binary_pred, &P2::x, &P2::x);
-    test_range_algo<4, P2, data_in_in>{}(dpl_ranges::mismatch, mismatch_checker, binary_pred, &P2::proj, &P2::proj);
+    test_range_algo<2, int, data_in_in>{}(dpl_ranges::mismatch, mismatch_checker, binary_pred, proj);
+    test_range_algo<3, int, data_in_in>{}(dpl_ranges::mismatch, mismatch_checker, binary_pred, proj, proj);
+    test_range_algo<4, P2, data_in_in>{}(dpl_ranges::mismatch, mismatch_checker, binary_pred, &P2::x, &P2::x);
+    test_range_algo<5, P2, data_in_in>{}(dpl_ranges::mismatch, mismatch_checker, binary_pred, &P2::proj, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_transform.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_transform.pass.cpp
@@ -66,9 +66,10 @@ main()
     };
 
     test_range_algo<4, int, data_in_in_out_lim>{big_sz}(dpl_ranges::transform, transform_binary_checker, binary_f);
-    test_range_algo<5, int, data_in_in_out_lim>{}(dpl_ranges::transform, transform_binary_checker, binary_f, proj, proj);
-    test_range_algo<6, P2, data_in_in_out_lim>{}(dpl_ranges::transform, transform_binary_checker, binary_f, &P2::x, &P2::x);
-    test_range_algo<7, P2, data_in_in_out_lim>{}(dpl_ranges::transform, transform_binary_checker, binary_f, &P2::proj, &P2::proj);
+    test_range_algo<5, int, data_in_in_out_lim>{}(dpl_ranges::transform, transform_binary_checker, binary_f, proj);
+    test_range_algo<6, int, data_in_in_out_lim>{}(dpl_ranges::transform, transform_binary_checker, binary_f, proj, proj);
+    test_range_algo<7, P2, data_in_in_out_lim>{}(dpl_ranges::transform, transform_binary_checker, binary_f, &P2::x, &P2::x);
+    test_range_algo<8, P2, data_in_in_out_lim>{}(dpl_ranges::transform, transform_binary_checker, binary_f, &P2::proj, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);


### PR DESCRIPTION
Some tests of algorithms with two optional projections were missing checks when only one projection is passed.
It should be merged after #2316. 