### PR TITLE
Fix warning in the `std_ranges_transform_iota_sycl.pass.cpp`

### DIFF
--- a/test/parallel_api/ranges/std_ranges_transform_iota_sycl.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_transform_iota_sycl.pass.cpp
@@ -50,7 +50,7 @@ main()
 
     bProcessed = true;
 
-#endif //_ENABLE_STD_RANGES_TESTING
+#endif //_ENABLE_STD_RANGES_TESTING && TEST_DPCPP_BACKEND_PRESENT
 
     return TestUtils::done(bProcessed);
 }

--- a/test/parallel_api/ranges/std_ranges_transform_iota_sycl.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_transform_iota_sycl.pass.cpp
@@ -18,6 +18,8 @@
 std::int32_t
 main()
 {
+    bool bProcessed = false;
+
 #if _ENABLE_STD_RANGES_TESTING && TEST_DPCPP_BACKEND_PRESENT
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
@@ -46,7 +48,9 @@ main()
     dpl_ranges::transform(exec2, view2, view1, res, binary_f, proj, proj);
     EXPECT_EQ_N(expected.begin(), res.begin(), n, err_msg);
 
+    bProcessed = true;
+
 #endif //_ENABLE_STD_RANGES_TESTING
 
-    return TestUtils::done(_ENABLE_STD_RANGES_TESTING && TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(bProcessed);
 }


### PR DESCRIPTION
In this PR we fix warning:
```
warning : use of logical '&&' with constant operand [-Wconstant-logical-operand]
              return TestUtils::done(1 && 1);
```
This warning happens if  `_ENABLE_STD_RANGES_TESTING` and `TEST_DPCPP_BACKEND_PRESENT` are defined.