### PR TITLE
[Draft] Scan changes to improve numerical type requirements

### DIFF
--- a/include/oneapi/dpl/pstl/glue_numeric_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_impl.h
@@ -110,7 +110,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
                _ForwardIterator2 __result, _Tp __init)
 {
-    return transform_exclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __init,
+    return transform_exclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, std::move(__init),
                                     std::plus<_Tp>(), oneapi::dpl::identity{});
 }
 
@@ -120,7 +120,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
                _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op)
 {
-    return transform_exclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __init,
+    return transform_exclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, std::move(__init),
                                     __binary_op, oneapi::dpl::identity{});
 }
 #else
@@ -129,7 +129,7 @@ _ForwardIterator2
 exclusive_scan(oneapi::dpl::execution::sequenced_policy __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
                _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op)
 {
-    return transform_exclusive_scan(__exec, __first, __last, __result, __init, __binary_op, oneapi::dpl::identity{});
+    return transform_exclusive_scan(__exec, __first, __last, __result, std::move(__init), __binary_op, oneapi::dpl::identity{});
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
@@ -137,7 +137,7 @@ _ForwardIterator2
 exclusive_scan(oneapi::dpl::execution::unsequenced_policy __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
                _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op)
 {
-    return transform_exclusive_scan(__exec, __first, __last, __result, __init, __binary_op, oneapi::dpl::identity{});
+    return transform_exclusive_scan(__exec, __first, __last, __result, std::move(__init), __binary_op, oneapi::dpl::identity{});
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
@@ -145,7 +145,7 @@ _ForwardIterator2
 exclusive_scan(oneapi::dpl::execution::parallel_policy __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
                _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op)
 {
-    return transform_exclusive_scan(__exec, __first, __last, __result, __init, __binary_op, oneapi::dpl::identity{});
+    return transform_exclusive_scan(__exec, __first, __last, __result, std::move(__init), __binary_op, oneapi::dpl::identity{});
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
@@ -153,7 +153,7 @@ _ForwardIterator2
 exclusive_scan(oneapi::dpl::execution::parallel_unsequenced_policy __exec, _ForwardIterator1 __first,
                _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op)
 {
-    return transform_exclusive_scan(__exec, __first, __last, __result, __init, __binary_op, oneapi::dpl::identity{});
+    return transform_exclusive_scan(__exec, __first, __last, __result, std::move(__init), __binary_op, oneapi::dpl::identity{});
 }
 
 #    if _ONEDPL_BACKEND_SYCL
@@ -162,7 +162,7 @@ _ForwardIterator2
 exclusive_scan(const oneapi::dpl::execution::device_policy<PolicyParams...>& __exec, _ForwardIterator1 __first,
                _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op)
 {
-    return transform_exclusive_scan(__exec, __first, __last, __result, __init, __binary_op, oneapi::dpl::identity{});
+    return transform_exclusive_scan(__exec, __first, __last, __result, std::move(__init), __binary_op, oneapi::dpl::identity{});
 }
 
 #        if _ONEDPL_FPGA_DEVICE
@@ -172,7 +172,7 @@ _ForwardIterator2
 exclusive_scan(const oneapi::dpl::execution::fpga_policy<factor, KernelName>& __exec, _ForwardIterator1 __first,
                _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op)
 {
-    return transform_exclusive_scan(__exec, __first, __last, __result, __init, __binary_op, oneapi::dpl::identity{});
+    return transform_exclusive_scan(__exec, __first, __last, __result, std::move(__init), __binary_op, oneapi::dpl::identity{});
 }
 #        endif // _ONEDPL_FPGA_DEVICE
 #    endif     // _ONEDPL_BACKEND_SYCL
@@ -221,7 +221,7 @@ transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                             __first, __last, __result, __unary_op, __init, __binary_op,
+                                                             __first, __last, __result, __unary_op, std::move(__init), __binary_op,
                                                              /*inclusive=*/::std::false_type());
 }
 
@@ -237,7 +237,7 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                             __first, __last, __result, __unary_op, __init, __binary_op,
+                                                             __first, __last, __result, __unary_op, std::move(__init), __binary_op,
                                                              /*inclusive=*/::std::true_type());
 }
 

--- a/include/oneapi/dpl/pstl/glue_numeric_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_impl.h
@@ -206,7 +206,7 @@ inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIte
                _ForwardIterator2 __result, _BinaryOperation __binary_op, _Tp __init)
 {
     return transform_inclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __binary_op,
-                                    oneapi::dpl::identity{}, __init);
+                                    oneapi::dpl::identity{}, std::move(__init));
 }
 
 // [transform.exclusive.scan]
@@ -221,8 +221,8 @@ transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                             __first, __last, __result, __unary_op, std::move(__init), __binary_op,
-                                                             /*inclusive=*/::std::false_type());
+                                                             __first, __last, __result, __unary_op, std::move(__init),
+                                                             __binary_op, /*inclusive=*/::std::false_type());
 }
 
 // [transform.inclusive.scan]
@@ -237,8 +237,8 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first, __result);
 
     return oneapi::dpl::__internal::__pattern_transform_scan(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                             __first, __last, __result, __unary_op, std::move(__init), __binary_op,
-                                                             /*inclusive=*/::std::true_type());
+                                                             __first, __last, __result, __unary_op, std::move(__init),
+                                                             __binary_op, /*inclusive=*/::std::true_type());
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation,

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -289,6 +289,9 @@ __pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
     });
 }
 
+
+// For floating point types, we can be sure that types are default constructible and copyable, so we dont need to
+// support about move only types.
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator,
           class _UnaryOperation, class _Tp, class _BinaryOperation, class _Inclusive>
 ::std::enable_if_t<::std::is_floating_point_v<_Tp>, _OutputIterator>

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -236,7 +236,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-::std::enable_if_t<is_arithmetic_udop<_Tp, _BinaryOperation>::value, _OutputIterator>
+::std::enable_if_t<is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -177,11 +177,11 @@ __brick_transform_scan(_ForwardIterator __first, _ForwardIterator __last, _Outpu
     {
         // Copy the value pointed to by __first to avoid overwriting it when __result == __first
         _Tp __temp = *__first;
-        *__result = __init;
+        *__result = std::move(__init);
         _ONEDPL_PRAGMA_FORCEINLINE
-        __init = __binary_op(__init, __unary_op(__temp));
+        __init = __binary_op(std::move(__init), __unary_op(std::move(__temp)));
     }
-    return ::std::make_pair(__result, __init);
+    return ::std::make_pair(__result, std::move(__init));
 }
 
 // Inclusive form
@@ -191,13 +191,15 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
                        /*Inclusive*/ ::std::true_type, /*is_vector=*/::std::false_type) noexcept
 {
+    _OutputIterator __prev_result = __result;
     for (; __first != __last; ++__first, ++__result)
     {
         _ONEDPL_PRAGMA_FORCEINLINE
-        __init = __binary_op(__init, __unary_op(*__first));
-        *__result = __init;
+        __init = __binary_op(std::move(__init), __unary_op(*__first));
+        *__result = std::move(__init);
+        __prev_result = __result;
     }
-    return ::std::make_pair(__result, __init);
+    return ::std::make_pair(__result, *__prev_result);
 }
 
 // type is arithmetic and binary operation is a user defined operation.

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -220,7 +220,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 {
 #if _ONEDPL_UDS_PRESENT // PSTL_UDS_PRESENT
     // Check if _Tp is copy assignable and copy constructible, move only types are not supported with SIMD scan.
-    if constexpr (std::is_copy_assignable_v<_Tp> && std::is_copy_constructible_v<_Tp>) 
+    if constexpr (std::is_copy_assignable_v<_Tp> && std::is_copy_constructible_v<_Tp> && std::is_default_constructible_v<_Tp>)
     {
         if (_Inclusive() || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
         {

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -191,15 +191,16 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
                        /*Inclusive*/ ::std::true_type, /*is_vector=*/::std::false_type) noexcept
 {
-    _OutputIterator __prev_result = __result;
+    using _OutT = typename std::iterator_traits<_OutputIterator>::value_type;
+    _OutT __prev_result = std::move(__init);
     for (; __first != __last; ++__first, ++__result)
     {
         _ONEDPL_PRAGMA_FORCEINLINE
-        __init = __binary_op(std::move(__init), __unary_op(*__first));
+        __init = __binary_op(__prev_result, __unary_op(*__first));
         *__result = std::move(__init);
-        __prev_result = __result;
+        __prev_result = *__result;
     }
-    return ::std::make_pair(__result, *__prev_result);
+    return ::std::make_pair(__result, __prev_result);
 }
 
 // type is arithmetic and binary operation is a user defined operation.

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -227,18 +227,18 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
     }
 #endif
     // We need to call serial brick here to call function for inclusive and exclusive scan that depends on _Inclusive() value
-    return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
+    return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, std::move(__init), __binary_op, _Inclusive(),
                                               /*is_vector=*/::std::false_type());
 }
 
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-::std::enable_if_t<is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
+::std::enable_if_t<is_arithmetic_udop<_Tp, _BinaryOperation>::value, _OutputIterator>
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
 {
-    return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
+    return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, std::move(__init), __binary_op, _Inclusive(),
                                               /*is_vector=*/::std::false_type());
 }
 
@@ -251,7 +251,7 @@ __pattern_transform_scan(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _Fo
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
+    return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, std::move(__init), __binary_op, _Inclusive(),
                                               typename _Tag::__is_vector{})
         .first;
 }
@@ -270,17 +270,17 @@ __pattern_transform_scan(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
     return __internal::__except_handler([&]() {
         __par_backend::__parallel_transform_scan(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __last - __first,
-            [__first, __unary_op](_DifferenceType __i) mutable { return __unary_op(__first[__i]); }, __init,
+            [__first, __unary_op](_DifferenceType __i) mutable { return __unary_op(__first[__i]); }, std::move(__init),
             __binary_op,
             [__first, __unary_op, __binary_op](_DifferenceType __i, _DifferenceType __j, _Tp __init) {
                 // Execute serial __brick_transform_reduce, due to the explicit SIMD vectorization (reduction) requires a commutative operation for the guarantee of correct scan.
-                return __internal::__brick_transform_reduce(__first + __i, __first + __j, __init, __binary_op,
+                return __internal::__brick_transform_reduce(__first + __i, __first + __j, std::move(__init), __binary_op,
                                                             __unary_op,
                                                             /*__is_vector*/ ::std::false_type());
             },
             [__first, __unary_op, __binary_op, __result](_DifferenceType __i, _DifferenceType __j, _Tp __init) {
                 return __internal::__brick_transform_scan(__first + __i, __first + __j, __result + __i, __unary_op,
-                                                          __init, __binary_op, _Inclusive(), _IsVector{})
+                                                          std::move(__init), __binary_op, _Inclusive(), _IsVector{})
                     .second;
             });
         return __result + (__last - __first);

--- a/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_transform_scan.h
@@ -31,7 +31,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__omp_backend_tag, _Execution
                           _Tp __init, _Cp /* __combine */, _Rp /* __brick_reduce */, _Sp __scan)
 {
     // TODO: parallelize this function.
-    return __scan(_Index(0), __n, __init);
+    return __scan(_Index(0), __n, ::std::move(__init));
 }
 
 } // namespace __omp_backend

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -139,7 +139,7 @@ _Tp
 __parallel_transform_scan(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __n, _UnaryOp,
                           _Tp __init, _BinaryOp, _Reduce, _Scan __scan)
 {
-    return __scan(_Index(0), __n, __init);
+    return __scan(_Index(0), __n, std::move(__init));
 }
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -328,7 +328,7 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
             _Sp __scan)
 {
     if (__m == 1)
-        __scan(__i * __tilesize, __lastsize, __initial);
+        __scan(__i * __tilesize, __lastsize, std::move(__initial));
     else
     {
         const _Index __k = __split(__m);

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -328,7 +328,7 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
             _Sp __scan)
 {
     if (__m == 1)
-        __scan(__i * __tilesize, __lastsize, std::move(__initial));
+        __scan(__i * __tilesize, __lastsize, __initial);
     else
     {
         const _Index __k = __split(__m);
@@ -357,12 +357,13 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 // apex is called exactly once, after all calls to reduce and before all calls to scan.
 // For example, it's useful for allocating a __buffer used by scan but whose size is the sum of all reduction values.
 // T must have a trivial constructor and destructor.
+// T must be copy constructible.
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
 __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,
                        _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
 {
-    tbb::this_task_arena::isolate([=, &__combine, __initial = std::move(__initial)]() {
+    tbb::this_task_arena::isolate([=, &__combine]() {
         if (__n > 1)
         {
             _Index __p = tbb::this_task_arena::max_concurrency();
@@ -402,7 +403,7 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
             __apex(__sum);
         }
         if (__n)
-            __scan(_Index(0), __n, std::move(__initial));
+            __scan(_Index(0), __n, __initial);
     });
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -400,7 +400,7 @@ _Tp
 __parallel_transform_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __n, _Up __u,
                           _Tp __init, _Cp __combine, _Rp __brick_reduce, _Sp __scan)
 {
-    __trans_scan_body<_Index, _Up, _Tp, _Cp, _Rp, _Sp> __body(__u, __init, __combine, __brick_reduce, __scan);
+    __trans_scan_body<_Index, _Up, _Tp, _Cp, _Rp, _Sp> __body(__u, std::move(__init), __combine, __brick_reduce, __scan);
     auto __range = tbb::blocked_range<_Index>(0, __n);
     tbb::this_task_arena::isolate([__range, &__body]() { tbb::parallel_scan(__range, __body); });
     return __body.sum();

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -43,16 +43,18 @@ struct test_inclusive_scan_with_plus
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
     std::enable_if_t<!TestUtils::is_reverse_v<Iterator1> || std::is_same_v<Iterator1, Iterator2>>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, [[maybe_unused]] T init, T trash)
+               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, [[maybe_unused]] Init init1,
+               [[maybe_unused]] Init init2, T trash)
     {
         using namespace std;
         Iterator3 orr;
         // If the types are different, apply the init
-        constexpr bool use_init = !std::is_same_v<Iterator1, Iterator2>;
+        constexpr bool use_init = !std::is_same_v<Iterator1, Iterator2> && !std::is_same_v<Init, T>;
         if constexpr (use_init)
         {
-            inclusive_scan_serial(in_first, in_last, expected_first, std::plus<>{}, init);
-            orr = inclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first, std::plus<>{}, init);
+            inclusive_scan_serial(in_first, in_last, expected_first, std::plus<>{}, std::move(init1));
+            orr = inclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first, std::plus<>{},
+                                 std::move(init2));
         }
         else
         {
@@ -69,7 +71,7 @@ struct test_inclusive_scan_with_plus
     std::enable_if_t<TestUtils::is_reverse_v<Iterator1> && !std::is_same_v<Iterator1, Iterator2>>
     operator()(Policy&& /*exec*/, Iterator1 /*in_first*/, Iterator1 /*in_last*/, Iterator2 /*out_first*/,
                Iterator2 /*out_last*/, Iterator3 /*expected_first*/, Iterator3 /*expected_last*/, Size /*n*/,
-               T /*init*/, T /*trash*/)
+               Init /*init1*/, Init /*init2*/, T /*trash*/)
     {
     }
 };
@@ -78,14 +80,14 @@ template <typename In, typename Init, typename Out>
 struct test_exclusive_scan_with_plus
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
-    std::enable_if_t<!TestUtils::is_reverse_v<Iterator1> || std::is_same_v<Iterator1, Iterator2>>
+    std::enable_if_t<std::is_convertible_v<typename std::iterator_traits<Iterator1>::value_type, Init> && (!TestUtils::is_reverse_v<Iterator1> || std::is_same_v<Iterator1, Iterator2>)>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, T trash)
+               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, Init init1, Init init2, T trash)
     {
         using namespace std;
 
-        exclusive_scan_serial(in_first, in_last, expected_first, init);
-        auto orr = exclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first, init);
+        exclusive_scan_serial(in_first, in_last, expected_first, std::move(init1));
+        auto orr = exclusive_scan(std::forward<Policy>(exec), in_first, in_last, out_first, std::move(init2));
         EXPECT_TRUE(out_last == orr, "exclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from exclusive_scan");
         ::std::fill_n(out_first, n, trash);
@@ -96,7 +98,7 @@ struct test_exclusive_scan_with_plus
     std::enable_if_t<TestUtils::is_reverse_v<Iterator1> && !std::is_same_v<Iterator1, Iterator2>>
     operator()(Policy&& /*exec*/, Iterator1 /*in_first*/, Iterator1 /*in_last*/, Iterator2 /*out_first*/,
                Iterator2 /*out_last*/, Iterator3 /*expected_first*/, Iterator3 /*expected_last*/, Size /*n*/,
-               T /*init*/, T /*trash*/)
+               Init /*init1*/, Init /*init2*/, T /*trash*/)
     {
     }
 };
@@ -114,17 +116,35 @@ test_with_plus(Init init, Out trash, Convert convert)
 #ifdef _PSTL_TEST_INCLUSIVE_SCAN
 
         invoke_on_all_policies<0>()(test_inclusive_scan_with_plus<In, Init, Out>(), in.begin(), in.end(), out.begin(),
-                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
+                                    out.end(), expected.begin(), expected.end(), in.size(), init, init, trash);
         invoke_on_all_policies<1>()(test_inclusive_scan_with_plus<In, Init, Out>(), in.cbegin(), in.cend(), out.begin(),
-                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
+                                    out.end(), expected.begin(), expected.end(), in.size(), init, init, trash);
+        invoke_on_all_policies<2>()(test_inclusive_scan_with_plus<In, NoDefaultCtorWrapper<Init>, Out>(), in.begin(), in.end(), out.begin(),
+                                    out.end(), expected.begin(), expected.end(), in.size(), NoDefaultCtorWrapper<Init>{init}, NoDefaultCtorWrapper<Init>{init}, trash);
+        iterator_invoker<std::random_access_iterator_tag, /*reverse_iterator=*/std::false_type>()(
+            oneapi::dpl::execution::par_unseq, test_inclusive_scan_with_plus<In, MoveOnlyWrapper<Init>, Out>(), in.begin(), in.end(),
+            out.begin(), out.end(), expected.begin(), expected.end(), in.size(), MoveOnlyWrapper<Init>{init},
+            MoveOnlyWrapper<Init>{init}, trash);
 #endif
-
 #ifdef _PSTL_TEST_EXCLUSIVE_SCAN
 
+
         invoke_on_all_policies<2>()(test_exclusive_scan_with_plus<In, Init, Out>(), in.begin(), in.end(), out.begin(),
-                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
+                                    out.end(), expected.begin(), expected.end(), in.size(), init, init, trash);
         invoke_on_all_policies<3>()(test_exclusive_scan_with_plus<In, Init, Out>(), in.cbegin(), in.cend(), out.begin(),
-                                    out.end(), expected.begin(), expected.end(), in.size(), init, trash);
+                                    out.end(), expected.begin(), expected.end(), in.size(), init, init, trash);
+        
+        // For a vector of bool, converting from std::vector<bool>::reference to wrapped bools encounters issues 
+        // unrelated to move only or non default constructible types. Skip these tests in this instance.
+        if constexpr (!std::is_same_v<In, bool>)
+        {
+            invoke_on_all_policies<2>()(test_exclusive_scan_with_plus<In, NoDefaultCtorWrapper<Init>, Out>(), in.begin(), in.end(), out.begin(),
+                                        out.end(), expected.begin(), expected.end(), in.size(), NoDefaultCtorWrapper<Init>{init}, NoDefaultCtorWrapper<Init>{init}, trash);
+            iterator_invoker<std::random_access_iterator_tag, /*reverse_iterator=*/std::false_type>()(
+                oneapi::dpl::execution::par_unseq, test_exclusive_scan_with_plus<In, MoveOnlyWrapper<Init>, Out>(), in.begin(), in.end(),
+                out.begin(), out.end(), expected.begin(), expected.end(), in.size(), MoveOnlyWrapper<Init>{init},
+                MoveOnlyWrapper<Init>{init}, trash);
+        }
 #endif
     }
 

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -44,27 +44,27 @@ template <typename Type>
 struct test_transform_exclusive_scan
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
-              typename T, typename BinaryOp>
+              typename InitT, typename BinaryOp, typename T>
     ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
-               UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
+               UnaryOp unary_op, InitT init1, InitT init2, BinaryOp binary_op, T trash)
     {
         using namespace std;
 
-        transform_exclusive_scan(oneapi::dpl::execution::seq, first, last, expected_first, init, binary_op, unary_op);
-        auto orr2 = transform_exclusive_scan(std::forward<Policy>(exec), first, last, out_first, init, binary_op, unary_op);
+        transform_exclusive_scan(oneapi::dpl::execution::seq, first, last, expected_first, std::move(init1), binary_op, unary_op);
+        auto orr2 = transform_exclusive_scan(std::forward<Policy>(exec), first, last, out_first, std::move(init2), binary_op, unary_op);
         EXPECT_TRUE(out_last == orr2, "transform_exclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from transform_exclusive_scan");
         ::std::fill_n(out_first, n, trash);
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
-              typename T, typename BinaryOp>
+              typename InitT, typename BinaryOp, typename T>
     ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
-               UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
+               UnaryOp /* unary_op */, InitT /* init1 */, InitT /* init2 */, BinaryOp /* binary_op */, T /* trash */)
     {
     }
 };
@@ -73,27 +73,27 @@ template <typename Type>
 struct test_transform_inclusive_scan_init
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
-              typename T, typename BinaryOp>
+              typename InitT, typename BinaryOp, typename T>
     ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
-               UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
+               UnaryOp unary_op, InitT init1, InitT init2, BinaryOp binary_op, T trash)
     {
         using namespace std;
 
-        transform_inclusive_scan(oneapi::dpl::execution::seq, first, last, expected_first, binary_op, unary_op, init);
-        auto orr2 = transform_inclusive_scan(std::forward<Policy>(exec), first, last, out_first, binary_op, unary_op, init);
+        transform_inclusive_scan(oneapi::dpl::execution::seq, first, last, expected_first, binary_op, unary_op, std::move(init1));
+        auto orr2 = transform_inclusive_scan(std::forward<Policy>(exec), first, last, out_first, binary_op, unary_op, std::move(init2));
         EXPECT_TRUE(out_last == orr2, "transform_inclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from transform_inclusive_scan");
         ::std::fill_n(out_first, n, trash);
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
-              typename T, typename BinaryOp>
+              typename InitT, typename BinaryOp, typename T>
     ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
-               UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
+               UnaryOp /* unary_op */, InitT /* init1 */, InitT /* init2 */, BinaryOp /* binary_op */, T /* trash */)
     {
     }
 };
@@ -187,15 +187,22 @@ test(UnaryOp unary_op, Out init, BinaryOp binary_op, Out trash)
         transform_inclusive_scan_serial(in.cbegin(), in.cend(), out.fbegin(), unary_op, init, binary_op);
         check_and_reset(expected2.begin(), out.begin(), out.size(), trash);
         invoke_on_all_policies<1>()(test_transform_inclusive_scan_init<In>(), in.begin(), in.end(), out.begin(),
-                                    out.end(), expected2.begin(), expected2.end(), in.size(), unary_op, init,
+                                    out.end(), expected2.begin(), expected2.end(), in.size(), unary_op, init, init,
                                     binary_op, trash);
-        invoke_on_all_policies<2>()(test_transform_inclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
+        invoke_on_all_policies<2>()(test_transform_inclusive_scan_init<In>(), in.begin(), in.end(), out.begin(),
+                                    out.end(), expected2.begin(), expected2.end(), in.size(), unary_op,
+                                    NoDefaultCtorWrapper{init}, NoDefaultCtorWrapper{init}, binary_op, trash);
+        iterator_invoker<std::random_access_iterator_tag, /*reverse_iterator=*/std::false_type>()(
+            oneapi::dpl::execution::par_unseq, test_transform_inclusive_scan_init<In>(), in.begin(), in.end(),
+            out.begin(), out.end(), expected2.begin(), expected2.end(), in.size(), unary_op,
+            MoveOnlyWrapper<Out>{init}, MoveOnlyWrapper<Out>{init}, binary_op, trash);
+        invoke_on_all_policies<3>()(test_transform_inclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
                                     expected2.begin(), expected2.end(), in.size(), unary_op, init, binary_op, trash);
 #if !ONEDPL_FPGA_DEVICE
-        invoke_on_all_policies<3>()(test_transform_inclusive_scan_init<In>(), in.cbegin(), in.cend(), out.begin(),
-                                    out.end(), expected2.begin(), expected2.end(), in.size(), unary_op, init,
+        invoke_on_all_policies<4>()(test_transform_inclusive_scan_init<In>(), in.cbegin(), in.cend(), out.begin(),
+                                    out.end(), expected2.begin(), expected2.end(), in.size(), unary_op, init, init,
                                     binary_op, trash);
-        invoke_on_all_policies<4>()(test_transform_inclusive_scan<In>(), in.cbegin(), in.cend(), out.begin(),
+        invoke_on_all_policies<5>()(test_transform_inclusive_scan<In>(), in.cbegin(), in.cend(), out.begin(),
                                     out.end(), expected2.begin(), expected2.end(), in.size(), unary_op, init,
                                     binary_op, trash);
 #endif
@@ -203,16 +210,26 @@ test(UnaryOp unary_op, Out init, BinaryOp binary_op, Out trash)
 #ifdef _PSTL_TEST_TRANSFORM_EXCLUSIVE_SCAN
         transform_exclusive_scan_serial(in.cbegin(), in.cend(), out.fbegin(), unary_op, init, binary_op);
         check_and_reset(expected1.begin(), out.begin(), out.size(), trash);
-        invoke_on_all_policies<5>()(test_transform_exclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
-                                    expected1.begin(), expected1.end(), in.size(), unary_op, init, binary_op, trash);
+        invoke_on_all_policies<6>()(test_transform_exclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
+                                    expected1.begin(), expected1.end(), in.size(), unary_op, init, init, binary_op,
+                                    trash);
+        invoke_on_all_policies<7>()(test_transform_exclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
+                                    expected1.begin(), expected1.end(), in.size(), unary_op, NoDefaultCtorWrapper{init},
+                                    NoDefaultCtorWrapper{init}, binary_op, trash);
+        iterator_invoker<std::random_access_iterator_tag, /*reverse_iterator=*/std::false_type>()(
+            oneapi::dpl::execution::par_unseq, test_transform_exclusive_scan<In>(), in.begin(), in.end(), out.begin(),
+            out.end(), expected1.begin(), expected1.end(), in.size(), unary_op, MoveOnlyWrapper<Out>{init},
+            MoveOnlyWrapper<Out>{init}, binary_op, trash);
+
+
 #if !ONEDPL_FPGA_DEVICE
-        invoke_on_all_policies<6>()(test_transform_exclusive_scan<In>(), in.cbegin(), in.cend(), out.begin(),
-                                    out.end(), expected1.begin(), expected1.end(), in.size(), unary_op, init,
+        invoke_on_all_policies<8>()(test_transform_exclusive_scan<In>(), in.cbegin(), in.cend(), out.begin(),
+                                    out.end(), expected1.begin(), expected1.end(), in.size(), unary_op, init, init,
                                     binary_op, trash);
 #endif
         ::std::copy(in.begin(), in.end(), out.begin());
         invoke_on_all_policies<13>()(test_transform_exclusive_scan<In>(), out.begin(), out.end(), out.begin(), out.end(),
-                                    expected1.begin(), expected1.end(), in.size(), unary_op, init, binary_op, trash);
+                                    expected1.begin(), expected1.end(), in.size(), unary_op, init, init, binary_op, trash);
 #endif // _PSTL_TEST_TRANSFORM_EXCLUSIVE_SCAN
     }
 }
@@ -230,10 +247,10 @@ test_matrix(UnaryOp unary_op, Out init, BinaryOp binary_op, Out trash)
 
 #ifdef _PSTL_TEST_TRANSFORM_INCLUSIVE_SCAN
         invoke_on_all_policies<7>()(test_transform_inclusive_scan_init<In>(), in.begin(), in.end(), out.begin(),
-                                    out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op,
+                                    out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, init, binary_op,
                                     trash);
         invoke_on_all_policies<8>()(test_transform_inclusive_scan_init<In>(), in.cbegin(), in.cend(), out.begin(),
-                                    out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op,
+                                    out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, init, binary_op,
                                     trash);
         invoke_on_all_policies<9>()(test_transform_inclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
                                      expected.begin(), expected.end(), in.size(), unary_op, init, binary_op, trash);
@@ -244,9 +261,9 @@ test_matrix(UnaryOp unary_op, Out init, BinaryOp binary_op, Out trash)
 #ifdef _PSTL_TEST_TRANSFORM_EXCLUSIVE_SCAN
 #if !TEST_GCC10_EXCLUSIVE_SCAN_BROKEN
         invoke_on_all_policies<11>()(test_transform_exclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
-                                    expected.begin(), expected.end(), in.size(), unary_op, init, binary_op, trash);
+                                    expected.begin(), expected.end(), in.size(), unary_op, init, init, binary_op, trash);
         invoke_on_all_policies<12>()(test_transform_exclusive_scan<In>(), in.cbegin(), in.cend(), out.begin(),
-                                    out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op,
+                                    out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, init, binary_op,
                                     trash);
 #endif
 #endif

--- a/test/support/scan_serial_impl.h
+++ b/test/support/scan_serial_impl.h
@@ -24,10 +24,11 @@ template <class InputIterator, class OutputIterator, class T>
 OutputIterator
 exclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator result, T init)
 {
+    using _OutT = typename std::iterator_traits<OutputIterator>::value_type;
     for (; first != last; ++first, ++result)
     {
-        auto res = init;
-        init = init + *first;
+        _OutT res = std::move(init);
+        init = T{res + *first};
         *result = res;
     }
     return result;
@@ -37,10 +38,11 @@ template <class InputIterator, class OutputIterator, class T, class BinaryOperat
 OutputIterator
 exclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator result, T init, BinaryOperation binary_op)
 {
+    using _OutT = typename std::iterator_traits<OutputIterator>::value_type;
     for (; first != last; ++first, ++result)
     {
-        auto res = init;
-        init = binary_op(init, *first);
+        _OutT res = std::move(init);
+        init = binary_op(res, *first);
         *result = res;
     }
     return result;
@@ -68,10 +70,13 @@ template <class InputIterator, class OutputIterator, class BinaryOperation, clas
 OutputIterator
 inclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator result, BinaryOperation binary_op, T init)
 {
+    using _OutT = typename std::iterator_traits<OutputIterator>::value_type;
+    _OutT __prev_ele = std::move(init);
     for (; first != last; ++first, ++result)
     {
-        init = binary_op(init, *first);
-        *result = init;
+        init = binary_op(__prev_ele, *first);
+        *result = std::move(init);
+        __prev_ele = *result;
     }
     return result;
 }

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1248,7 +1248,7 @@ struct MoveOnlyWrapper {
     // Default constructor
     MoveOnlyWrapper() = delete;
 
-    MoveOnlyWrapper(_T v) : value(v) {}
+    MoveOnlyWrapper(const _T& v) : value(v) {}
 
     operator _T() const { return value; }
 
@@ -1288,7 +1288,7 @@ struct NoDefaultCtorWrapper {
     // Default constructor
     NoDefaultCtorWrapper() = delete;
 
-    NoDefaultCtorWrapper(_T v) : value(v) {}
+    NoDefaultCtorWrapper(const _T& v) : value(v) {}
 
     operator _T() const { return value; }
 


### PR DESCRIPTION
Currently draft as some things are polished.

Currently targets dev/dhoeflin/numerical_type_requirements until #2327 is merged, to make cleaner diff. This PR branches off that one to make use of the same utilities.

This PR removes copy assignment and copy constructible requirements from scalar init types used in `[transform_](in/ex)clusive_scan` APIs.  

It also adds tests to confirm this for host policies, and adds tests to confirm no default construction requirements are imposed across all policies. 

Notes:
- openMP SIMD vectorization requires default constructible, copy assignment and copy construction, so vectorization is turned off where these are not satisfied. There may be a way to improve this in the future, but for now we just turn it off. 
- There is a scan tbb implementation specific to floating point types which does not support move only types.  All types which satisfy `std::is_floating_point_v<T>` should be copyable, and default constructible, so we do not attempt to support move only or non default constructible types within that implementation.
- omp backend does NOT try to parallelize scan... This is outside the scope of this PR but likely should be addressed.