### PR TITLE
Fix broken tests

### DIFF
--- a/test/parallel_api/iterator/input_data_sweep.h
+++ b/test/parallel_api/iterator/input_data_sweep.h
@@ -45,7 +45,7 @@ struct get_expected_op
     }
 };
 
-static auto noop = [](auto i) { return i; };
+inline constexpr auto noop = [](auto i) { return i; };
 
 template <int __recurse, int __reverses, bool __read = true, bool __reset_read = true, bool __write = true,
           bool __check_write = true, bool __usable_as_perm_map = true, bool __usable_as_perm_src = true,

--- a/test/parallel_api/iterator/input_data_sweep.h
+++ b/test/parallel_api/iterator/input_data_sweep.h
@@ -45,6 +45,8 @@ struct get_expected_op
     }
 };
 
+static auto noop = [](auto i) { return i; };
+
 template <int __recurse, int __reverses, bool __read = true, bool __reset_read = true, bool __write = true,
           bool __check_write = true, bool __usable_as_perm_map = true, bool __usable_as_perm_src = true,
           bool __is_reversible = true, typename Policy, typename InputIterator1, typename InputIterator2,
@@ -152,7 +154,6 @@ wrap_recurse(Policy&& exec, InputIterator1 first, InputIterator1 last, InputIter
 #    endif // _ONEDPL_DEBUG_SYCL
         oneapi::dpl::discard_iterator discard{};
         // iterate through all wrappers and recurse - 1
-        auto noop = oneapi::dpl::identity{};
 
         if constexpr (__is_reversible)
         { // std::reverse_iterator(it)

--- a/test/parallel_api/iterator/input_data_sweep.h
+++ b/test/parallel_api/iterator/input_data_sweep.h
@@ -20,7 +20,6 @@
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
 #include _PSTL_TEST_HEADER(iterator)
-#include _PSTL_TEST_HEADER(functional) // for oneapi::dpl::identity
 
 #include "support/utils_invoke.h"
 


### PR DESCRIPTION
This PR fixes broken tests in the `input_data_sweep` suite by centralizing the no-op identity function and removing a conflicting local definition.

- Introduce a global `noop` generic lambda
- Remove the local `noop` alias to `oneapi::dpl::identity`
- Ensure consistency of the identity operation across recursive test wrappers

The errors has been introduced in the PR https://github.com/uxlfoundation/oneDPL/pull/2294