### PR TITLE
Add documentation for transform_iterator pitfall

### DIFF
--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -84,17 +84,17 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
   .. note::
      When using ``transform_iterator`` with base iterators that return prvalues (temporary objects) upon dereferencing
      (such as ``counting_iterator`` or ``zip_iterator``), care must be taken with the transform functor. Functors that
-     return references to their input arguments (like ``oneapi::dpl::identity``) will create dangling references when
-     applied to prvalues, resulting in undefined behavior. Instead, in situations like these, use functors that return
-     values by copy:
+     return references they accepted as input reference arguments (like ``oneapi::dpl::identity`` or ``std::identity``)
+     will create dangling references when applied to prvalues, resulting in undefined behavior. Instead, in these
+     situations, use functors that return values by copy:
 
      .. code:: cpp
 
        //  DANGEROUS: identity returns reference to prvalue (dangling reference)
-       auto bad_transform = dpl::make_transform_iterator(counting_iter, dpl::identity{});
+       auto bad_transform = dpl::make_transform_iterator(dpl::counting_iter<int>{0}, dpl::identity{});
        
        //  SAFE: custom functor returns by value
-       auto safe_transform = dpl::make_transform_iterator(counting_iter, [](auto x) { return x; });
+       auto safe_transform = dpl::make_transform_iterator(dpl::counting_iter<int>{0}, [](auto x) { return x; });
 
   The ``transform_iterator`` class provides the following constructors:
 

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -6,8 +6,8 @@ Iterators
 The definitions of the iterators are available through the ``<oneapi/dpl/iterator>``
 header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
-* ``counting_iterator``: a random-access iterator-like type whose dereferenced result is an integer
-  counter prvalue. Instances of a ``counting_iterator`` provide read-only dereference operations. The counter of an
+* ``counting_iterator``: a random-access iterator-like type whose dereferenced result is an prvalue integer
+  counter. Instances of a ``counting_iterator`` provide read-only dereference operations. The counter of an
   ``counting_iterator`` instance changes according to the arithmetic of the random-access iterator type:
 
   .. code:: cpp
@@ -19,8 +19,8 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
     auto sum = dpl::reduce(dpl::execution::dpcpp_default,
                            count_a, count_b, init); // sum is (0 + 0 + 1 + ... + 9) = 45
 
-* ``zip_iterator``: an iterator constructed with one or more iterators as input. The result of
-  ``zip_iterator`` dereferencing is a temporary tuple-like object of an unspecified type that holds the values
+* ``zip_iterator``: an iterator constructed with one or more iterators as input. The result of dereferencing
+  ``zip_iterator`` is a temporary tuple-like object of an unspecified type that holds the values
   returned by dereferencing the member iterators, which the ``zip_iterator`` wraps. Arithmetic operations
   performed on a ``zip_iterator`` instance are also applied to each of the member iterators.
 

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -7,7 +7,7 @@ The definitions of the iterators are available through the ``<oneapi/dpl/iterato
 header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
 * ``counting_iterator``: a random-access iterator-like type whose dereferenced value is an integer
-  counter. Instances of a ``counting_iterator`` provide read-only dereference operations. The counter of an
+  counter (prvalue). Instances of a ``counting_iterator`` provide read-only dereference operations. The counter of an
   ``counting_iterator`` instance changes according to the arithmetic of the random-access iterator type:
 
   .. code:: cpp
@@ -80,6 +80,21 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
   The unary functor provided to a ``transform_iterator`` should have a ``const``-qualified call operator which accepts
   the reference type of the base iterator as argument. The functor's call operator should not have any side effects and
   should not modify the state of the functor object.
+
+  .. note::
+     When using ``transform_iterator`` with base iterators that return prvalues (temporary objects) upon dereferencing
+     (such as ``counting_iterator`` or ``zip_iterator``), care must be taken with the transform functor. Functors that
+     return references to their input arguments (like ``oneapi::dpl::identity``) will create dangling references when
+     applied to prvalues, resulting in undefined behavior. Instead, in situations like these, use functors that return
+     values by copy:
+
+     .. code:: cpp
+
+       //  DANGEROUS: identity returns reference to prvalue (dangling reference)
+       auto bad_transform = dpl::make_transform_iterator(counting_iter, dpl::identity{});
+       
+       //  SAFE: custom functor returns by value
+       auto safe_transform = dpl::make_transform_iterator(counting_iter, [](auto x) { return x; });
 
   The ``transform_iterator`` class provides the following constructors:
 

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -6,8 +6,8 @@ Iterators
 The definitions of the iterators are available through the ``<oneapi/dpl/iterator>``
 header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
-* ``counting_iterator``: a random-access iterator-like type whose dereferenced value is an integer
-  counter (prvalue). Instances of a ``counting_iterator`` provide read-only dereference operations. The counter of an
+* ``counting_iterator``: a random-access iterator-like type whose dereferenced result is an integer
+  counter prvalue. Instances of a ``counting_iterator`` provide read-only dereference operations. The counter of an
   ``counting_iterator`` instance changes according to the arithmetic of the random-access iterator type:
 
   .. code:: cpp
@@ -20,7 +20,7 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
                            count_a, count_b, init); // sum is (0 + 0 + 1 + ... + 9) = 45
 
 * ``zip_iterator``: an iterator constructed with one or more iterators as input. The result of
-  ``zip_iterator`` dereferencing is a tuple-like object of an unspecified type that holds the values
+  ``zip_iterator`` dereferencing is a temporary tuple-like object of an unspecified type that holds the values
   returned by dereferencing the member iterators, which the ``zip_iterator`` wraps. Arithmetic operations
   performed on a ``zip_iterator`` instance are also applied to each of the member iterators.
 


### PR DESCRIPTION
Add some documentation to `transform_iterator` to warn of a potential pitfall with a dangling reference when using functors similar to `oneapi::dpl::identity` in combination with source iterators returning a prvalue.