### PR TITLE
Rename the name of execution policy parameter in tests

### DIFF
--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -29,9 +29,9 @@ class Kernel;
 #if TEST_DPCPP_BACKEND_PRESENT
 
 template<typename Policy>
-void test_policy_instance(Policy&& policy)
+void test_policy_instance(Policy&& exec)
 {
-    sycl::queue queue = policy.queue();
+    sycl::queue queue = exec.queue();
 
     auto __max_work_group_size = queue.get_device().template get_info<sycl::info::device::max_work_group_size>();
     EXPECT_TRUE(__max_work_group_size > 0, "policy: wrong work group size");
@@ -42,7 +42,7 @@ void test_policy_instance(Policy&& policy)
     static ::std::vector<int> a(n);
 
     ::std::fill(a.begin(), a.end(), 0);
-    std::fill(std::forward<Policy>(policy), a.begin(), a.end(), -1);
+    std::fill(std::forward<Policy>(exec), a.begin(), a.end(), -1);
 #if _PSTL_SYCL_TEST_USM
     queue.wait_and_throw();
 #endif

--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
@@ -107,16 +107,16 @@ generate_data(KeyIt keys_begin, ValIt vals_begin, Size keys_n, Size vals_n, std:
 
 template<typename Policy, typename KeyIt, typename ValIt, typename Size, typename... Compare>
 void
-call_sort(Policy&& policy, KeyIt keys_begin, ValIt vals_begin, Size n, StableSortTag, Compare... compare)
+call_sort(Policy&& exec, KeyIt keys_begin, ValIt vals_begin, Size n, StableSortTag, Compare... compare)
 {
-    oneapi::dpl::stable_sort_by_key(std::forward<Policy>(policy), keys_begin, keys_begin + n, vals_begin, compare...);
+    oneapi::dpl::stable_sort_by_key(std::forward<Policy>(exec), keys_begin, keys_begin + n, vals_begin, compare...);
 }
 
 template<typename Policy, typename KeyIt, typename ValIt, typename Size, typename... Compare>
 void
-call_sort(Policy&& policy, KeyIt keys_begin, ValIt vals_begin, Size n, UnstableSortTag, Compare... compare)
+call_sort(Policy&& exec, KeyIt keys_begin, ValIt vals_begin, Size n, UnstableSortTag, Compare... compare)
 {
-    oneapi::dpl::sort_by_key(std::forward<Policy>(policy), keys_begin, keys_begin + n, vals_begin, compare...);
+    oneapi::dpl::sort_by_key(std::forward<Policy>(exec), keys_begin, keys_begin + n, vals_begin, compare...);
 }
 
 template<typename KeyIt, typename ValIt, typename Size, typename Compare = std::less<>>
@@ -176,7 +176,7 @@ check_sort(const KeyIt& keys_begin, const ValIt& vals_begin,
 
 template<typename KeyT, typename ValT, typename Size, typename Policy, typename StabilityTag, typename... Compare>
 void
-test_with_std_policy(Policy&& policy, Size n, StabilityTag stability_tag, Compare... compare)
+test_with_std_policy(Policy&& exec, Size n, StabilityTag stability_tag, Compare... compare)
 {
     Size keys_n = n;
     Size vals_n = n + 5; // to test that the remaining values are not touched
@@ -186,7 +186,7 @@ test_with_std_policy(Policy&& policy, Size n, StabilityTag stability_tag, Compar
     std::vector<KeyT> keys(origin_keys);
     std::vector<ValT> vals(origin_vals);
 
-    call_sort(std::forward<Policy>(policy), keys.begin(), vals.begin(), keys_n, stability_tag, compare...);
+    call_sort(std::forward<Policy>(exec), keys.begin(), vals.begin(), keys_n, stability_tag, compare...);
     check_sort(keys.begin(), vals.begin(), origin_keys.begin(), origin_vals.begin(), keys_n, vals_n, stability_tag, compare...);
 }
 

--- a/test/parallel_api/iterator/input_data_sweep_counting_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_counting_iter.pass.cpp
@@ -29,26 +29,26 @@
 
 template <typename T, int __recurse, typename Policy>
 void
-test(Policy&& policy, T trash, size_t n, const std::string& type_text)
+test(Policy&& exec, T trash, size_t n, const std::string& type_text)
 {
     if constexpr (std::is_integral_v<T>)
     {
-        if (TestUtils::has_types_support<T>(policy.queue().get_device()))
+        if (TestUtils::has_types_support<T>(exec.queue().get_device()))
         {
 
-            TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(policy.queue(), n);
+            TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec.queue(), n);
             oneapi::dpl::counting_iterator<int> counting(0);
             oneapi::dpl::counting_iterator<T> my_counting(0);
             //counting_iterator
             wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/false, /*__write=*/false,
                          /*__check_write=*/false, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
-                         /*__is_reversible=*/true>(std::forward<Policy>(policy), my_counting, my_counting + n, counting, copy_out.get_data(),
+                         /*__is_reversible=*/true>(std::forward<Policy>(exec), my_counting, my_counting + n, counting, copy_out.get_data(),
                                                    my_counting, copy_out.get_data(), counting, trash,
                                                    std::string("counting_iterator<") + type_text + std::string(">"));
         }
         else
         {
-            TestUtils::unsupported_types_notifier(policy.queue().get_device());
+            TestUtils::unsupported_types_notifier(exec.queue().get_device());
         }
     }
 }

--- a/test/parallel_api/iterator/input_data_sweep_host_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_host_iter.pass.cpp
@@ -29,24 +29,24 @@
 
 template <typename T, int __recurse, typename Policy>
 void
-test(Policy&& policy, T trash, size_t n, const std::string& type_text)
+test(Policy&& exec, T trash, size_t n, const std::string& type_text)
 {
-    if (TestUtils::has_types_support<T>(policy.queue().get_device()))
+    if (TestUtils::has_types_support<T>(exec.queue().get_device()))
     {
 
-        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(policy.queue(), n);
+        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec.queue(), n);
         auto copy_from = oneapi::dpl::counting_iterator<int>(0);
         // host iterator
         std::vector<T> host_iter(n);
         wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
                      /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/false,
-                     /*__is_reversible=*/true>(std::forward<Policy>(policy), host_iter.begin(), host_iter.end(), copy_from,
+                     /*__is_reversible=*/true>(std::forward<Policy>(exec), host_iter.begin(), host_iter.end(), copy_from,
                                                copy_out.get_data(), host_iter.begin(), copy_out.get_data(), copy_from,
                                                trash, std::string("host_iterator<") + type_text + std::string(">"));
     }
     else
     {
-        TestUtils::unsupported_types_notifier(policy.queue().get_device());
+        TestUtils::unsupported_types_notifier(exec.queue().get_device());
     }
 }
 

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -29,25 +29,25 @@
 
 template <typename T, int __recurse, typename Policy>
 void
-test(Policy&& policy, T trash, size_t n, const std::string& type_text)
+test(Policy&& exec, T trash, size_t n, const std::string& type_text)
 {
-    if (TestUtils::has_types_support<T>(policy.queue().get_device()))
+    if (TestUtils::has_types_support<T>(exec.queue().get_device()))
     {
-        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(policy.queue(), n);
+        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec.queue(), n);
         oneapi::dpl::counting_iterator<int> counting(0);
         // sycl iterator
         sycl::buffer<T> buf(n);
         //test all modes / wrappers
         wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
                      /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
-                     /*__is_reversible=*/false>(std::forward<Policy>(policy), oneapi::dpl::begin(buf), oneapi::dpl::end(buf), counting,
+                     /*__is_reversible=*/false>(std::forward<Policy>(exec), oneapi::dpl::begin(buf), oneapi::dpl::end(buf), counting,
                                                 copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(),
                                                 counting, trash,
                                                 std::string("sycl_iterator<") + type_text + std::string(">"));
     }
     else
     {
-        TestUtils::unsupported_types_notifier(policy.queue().get_device());
+        TestUtils::unsupported_types_notifier(exec.queue().get_device());
     }
 }
 

--- a/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
@@ -29,15 +29,15 @@
 
 template <typename T, int __recurse, typename Policy>
 void
-test_usm_shared_alloc(Policy&& policy, T trash, size_t n, const std::string& type_text)
+test_usm_shared_alloc(Policy&& exec, T trash, size_t n, const std::string& type_text)
 {
-    if (TestUtils::has_types_support<T>(policy.queue().get_device()))
+    if (TestUtils::has_types_support<T>(exec.queue().get_device()))
     {
         //std::vector using usm shared allocator
-        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(policy.queue(), n);
+        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec.queue(), n);
         oneapi::dpl::counting_iterator<int> counting(0);
         // usm_shared allocator std::vector
-        sycl::usm_allocator<T, sycl::usm::alloc::shared> q_alloc{policy.queue()};
+        sycl::usm_allocator<T, sycl::usm::alloc::shared> q_alloc{exec.queue()};
         std::vector<T, decltype(q_alloc)> shared_data_vec(n, q_alloc);
         //test all modes / wrappers
 
@@ -48,27 +48,27 @@ test_usm_shared_alloc(Policy&& policy, T trash, size_t n, const std::string& typ
             /*__check_write=*/true, /*__usable_as_perm_map=*/true,
             /*__usable_as_perm_src=*/
             TestUtils::__vector_impl_distinguishes_usm_allocator_from_default_v<decltype(shared_data_vec.begin())>,
-            /*__is_reversible=*/true>(std::forward<Policy>(policy), shared_data_vec.begin(), shared_data_vec.end(), counting,
+            /*__is_reversible=*/true>(std::forward<Policy>(exec), shared_data_vec.begin(), shared_data_vec.end(), counting,
                                       copy_out.get_data(), shared_data_vec.begin(), copy_out.get_data(), counting,
                                       trash, std::string("usm_shared_alloc_vector<") + type_text + std::string(">"));
     }
     else
     {
-        TestUtils::unsupported_types_notifier(policy.queue().get_device());
+        TestUtils::unsupported_types_notifier(exec.queue().get_device());
     }
 }
 
 template <typename T, int __recurse, typename Policy>
 void
-test_usm_host_alloc(Policy&& policy, T trash, size_t n, const std::string& type_text)
+test_usm_host_alloc(Policy&& exec, T trash, size_t n, const std::string& type_text)
 {
-    if (TestUtils::has_types_support<T>(policy.queue().get_device()))
+    if (TestUtils::has_types_support<T>(exec.queue().get_device()))
     {
         //std::vector using usm host allocator
-        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(policy.queue(), n);
+        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec.queue(), n);
         oneapi::dpl::counting_iterator<int> counting(0);
         // usm_host allocator std::vector
-        sycl::usm_allocator<T, sycl::usm::alloc::host> q_alloc{policy.queue()};
+        sycl::usm_allocator<T, sycl::usm::alloc::host> q_alloc{exec.queue()};
         std::vector<T, decltype(q_alloc)> host_data_vec(n, q_alloc);
         //test all modes / wrappers
 
@@ -78,13 +78,13 @@ test_usm_host_alloc(Policy&& policy, T trash, size_t n, const std::string& type_
             __recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
             /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/
             TestUtils::__vector_impl_distinguishes_usm_allocator_from_default_v<decltype(host_data_vec.begin())>,
-            /*__is_reversible=*/true>(std::forward<Policy>(policy), host_data_vec.begin(), host_data_vec.end(), counting, copy_out.get_data(),
+            /*__is_reversible=*/true>(std::forward<Policy>(exec), host_data_vec.begin(), host_data_vec.end(), counting, copy_out.get_data(),
                                       host_data_vec.begin(), copy_out.get_data(), counting, trash,
                                       std::string("usm_host_alloc_vector<") + type_text + std::string(">"));
     }
     else
     {
-        TestUtils::unsupported_types_notifier(policy.queue().get_device());
+        TestUtils::unsupported_types_notifier(exec.queue().get_device());
     }
 }
 #endif //TEST_DPCPP_BACKEND_PRESENT

--- a/test/parallel_api/iterator/input_data_sweep_usm_device.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_device.pass.cpp
@@ -29,23 +29,23 @@
 
 template <typename T, int __recurse, typename Policy>
 void
-test(Policy&& policy, T trash, size_t n, const std::string& type_text)
+test(Policy&& exec, T trash, size_t n, const std::string& type_text)
 {
-    if (TestUtils::has_types_support<T>(policy.queue().get_device()))
+    if (TestUtils::has_types_support<T>(exec.queue().get_device()))
     {
-        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(policy.queue(), n);
+        TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec.queue(), n);
         oneapi::dpl::counting_iterator<int> counting(0);
         // usm_device
-        TestUtils::usm_data_transfer<sycl::usm::alloc::device, T> device_data(policy.queue(), n);
+        TestUtils::usm_data_transfer<sycl::usm::alloc::device, T> device_data(exec.queue(), n);
         auto usm_device = device_data.get_data();
         //test all modes / wrappers
-        wrap_recurse<__recurse, 0>(std::forward<Policy>(policy), usm_device, usm_device + n, counting, copy_out.get_data(), usm_device,
+        wrap_recurse<__recurse, 0>(std::forward<Policy>(exec), usm_device, usm_device + n, counting, copy_out.get_data(), usm_device,
                                    copy_out.get_data(), counting, trash,
                                    std::string("usm_device<") + type_text + std::string(">"));
     }
     else
     {
-        TestUtils::unsupported_types_notifier(policy.queue().get_device());
+        TestUtils::unsupported_types_notifier(exec.queue().get_device());
     }
 }
 

--- a/test/parallel_api/iterator/input_data_sweep_usm_shared.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_shared.pass.cpp
@@ -29,26 +29,26 @@
 
 template <typename T, int __recurse, typename Policy>
 void
-test(Policy&& policy, T trash, size_t n, const std::string& type_text)
+test(Policy&& exec, T trash, size_t n, const std::string& type_text)
 {
-    if (TestUtils::has_types_support<T>(policy.queue().get_device()))
+    if (TestUtils::has_types_support<T>(exec.queue().get_device()))
     {
 
         { //usm shared ptr
-            TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(policy.queue(), n);
+            TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec.queue(), n);
             oneapi::dpl::counting_iterator<int> counting(0);
             // usm_shared
-            TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> shared_data(policy.queue(), n);
+            TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> shared_data(exec.queue(), n);
             auto usm_shared = shared_data.get_data();
             //test all modes / wrappers
-            wrap_recurse<__recurse, 0>(std::forward<Policy>(policy), usm_shared, usm_shared + n, counting, copy_out.get_data(), usm_shared,
+            wrap_recurse<__recurse, 0>(std::forward<Policy>(exec), usm_shared, usm_shared + n, counting, copy_out.get_data(), usm_shared,
                                     copy_out.get_data(), counting, trash,
                                     std::string("usm_shared<") + type_text + std::string(">"));
         }
     }
     else
     {
-        TestUtils::unsupported_types_notifier(policy.queue().get_device());
+        TestUtils::unsupported_types_notifier(exec.queue().get_device());
     }
 }
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1002,27 +1002,27 @@ using __is_able_to_create_new_policy =
 #if TEST_DPCPP_BACKEND_PRESENT
 template <typename _NewKernelName, typename Policy, ::std::enable_if_t<__is_able_to_create_new_policy<Policy>::value, int> = 0>
 auto
-create_new_policy(Policy&& policy)
+create_new_policy(Policy&& exec)
 {
-    return TestUtils::make_new_policy<_NewKernelName>(std::forward<Policy>(policy));
+    return TestUtils::make_new_policy<_NewKernelName>(std::forward<Policy>(exec));
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 template <typename _NewKernelName, typename Policy, ::std::enable_if_t<!__is_able_to_create_new_policy<Policy>::value, int> = 0>
 auto
-create_new_policy(Policy&& policy)
+create_new_policy(Policy&& exec)
 {
-    return std::forward<Policy>(policy);
+    return std::forward<Policy>(exec);
 }
 
 template <int idx, typename Policy>
 auto
-create_new_policy_idx(Policy&& policy)
+create_new_policy_idx(Policy&& exec)
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    return create_new_policy<TestUtils::new_kernel_name<Policy, idx>>(std::forward<Policy>(policy));
+    return create_new_policy<TestUtils::new_kernel_name<Policy, idx>>(std::forward<Policy>(exec));
 #else
-    return std::forward<Policy>(policy);
+    return std::forward<Policy>(exec);
 #endif
 }
 

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -89,22 +89,22 @@ make_fpga_policy(Arg&& arg)
 template <typename _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_Policy, int> = 0>
 auto
-make_new_policy(_Policy&& __policy)
-    -> decltype(TestUtils::make_device_policy<_NewKernelName>(::std::forward<_Policy>(__policy)))
+make_new_policy(_Policy&& __exec)
+    -> decltype(TestUtils::make_device_policy<_NewKernelName>(::std::forward<_Policy>(__exec)))
 {
-    return TestUtils::make_device_policy<_NewKernelName>(std::forward<_Policy>(__policy));
+    return TestUtils::make_device_policy<_NewKernelName>(std::forward<_Policy>(__exec));
 }
 
 #if ONEDPL_FPGA_DEVICE
 template <typename _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_Policy, int> = 0>
 auto
-make_new_policy(_Policy&& __policy)
+make_new_policy(_Policy&& __exec)
     -> decltype(TestUtils::make_fpga_policy<::std::decay_t<_Policy>::unroll_factor, _NewKernelName>(
-        ::std::forward<_Policy>(__policy)))
+        ::std::forward<_Policy>(__exec)))
 {
     return TestUtils::make_fpga_policy<std::decay_t<_Policy>::unroll_factor, _NewKernelName>(
-        std::forward<_Policy>(__policy));
+        std::forward<_Policy>(__exec));
 }
 #endif
 


### PR DESCRIPTION
This PR renames the execution policy parameter from `policy` to `exec` across test utilities and test cases for consistency.

- Renamed function parameters and forwarded variables from `policy` to `exec` in test helper headers.
- Updated all test implementations to use `exec` when invoking queue-based operations and wrappers.
- Ensured stable and unstable sort helpers use the new parameter name.

## Justification
Previously in tests we had `Policy&& policy` and `Policy&& exec` together:
 - `Policy&& exec` - 373 entries in tests;
 - `Policy&& policy` -  14 (16) entries in tests.