### PR TITLE
Update a known issue for range-based count_if

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -60,7 +60,7 @@ See oneDPL Guide for other `restrictions and known limitations`_.
 - With libstdc++ version 10, the compilation error *SYCL kernel cannot use exceptions* occurs
   when calling the range-based ``adjacent_find``, ``is_sorted`` or ``is_sorted_until`` algorithms with device policies.
 - The range-based ``count_if`` may produce incorrect results on Intel® Data Center GPU Max Series when the driver version
-  is "Rolling 2507.12" and newer.
+  is *Rolling 2507.12* or *Rolling 2507.17*. Other *Rolling* and *LTS* versions are unaffected.
 
 New in 2022.8.0
 ===============

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -59,8 +59,6 @@ See oneDPL Guide for other `restrictions and known limitations`_.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
 - With libstdc++ version 10, the compilation error *SYCL kernel cannot use exceptions* occurs
   when calling the range-based ``adjacent_find``, ``is_sorted`` or ``is_sorted_until`` algorithms with device policies.
-- The range-based ``count_if`` may produce incorrect results on Intel® Data Center GPU Max Series when the driver version
-  is *Rolling 2507.12* or *Rolling 2507.17*. Other *Rolling* and *LTS* versions are unaffected.
 
 New in 2022.8.0
 ===============


### PR DESCRIPTION
The issue does not reproduce with other Rolling or LTS versions of the GPU driver.

This addition complements the existing known issue for the 2022.9 release.
Let's update the 2022.9 section of [the release notes](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpcpp-library-release-notes.html) if it's expected to be revised in the next release.
If not, it would be more appropriate to add this to the oneDPL 2022.10 section instead.

Upd. Agreed to remove the note entirely as outdated - the mentioned Rolling driver version is no longer supported. 