### PR TITLE
Remove cpp20 requirement to include <version>

### DIFF
--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -18,14 +18,11 @@
 // The oneAPI Specification version this implementation is compliant with
 #define ONEDPL_SPEC_VERSION 104
 
-#if _ONEDPL___cplusplus >= 202002L && __has_include(<version>)
+#if __has_include(<version>)
 #    include <version> // The standard C++20 header
 #    define _ONEDPL_STD_FEATURE_MACROS_PRESENT 1
-// Clang 15 and older do not support range adaptors, see https://bugs.llvm.org/show_bug.cgi?id=44833
-#    define _ONEDPL_CPP20_RANGES_PRESENT ((__cpp_lib_ranges >= 201911L) && !(__clang__ && __clang_major__ < 16))
 #else
 #    define _ONEDPL_STD_FEATURE_MACROS_PRESENT 0
-#    define _ONEDPL_CPP20_RANGES_PRESENT 0
 #endif
 
 #ifndef _PSTL_VERSION

--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -21,8 +21,11 @@
 #if __has_include(<version>)
 #    include <version> // The standard C++20 header
 #    define _ONEDPL_STD_FEATURE_MACROS_PRESENT 1
+// Clang 15 and older do not support range adaptors, see https://bugs.llvm.org/show_bug.cgi?id=44833
+#    define _ONEDPL_CPP20_RANGES_PRESENT ((__cpp_lib_ranges >= 201911L) && !(__clang__ && __clang_major__ < 16))
 #else
 #    define _ONEDPL_STD_FEATURE_MACROS_PRESENT 0
+#    define _ONEDPL_CPP20_RANGES_PRESENT 0
 #endif
 
 #ifndef _PSTL_VERSION

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -271,12 +271,15 @@
     (_ONEDPL___cplusplus >= 202002L && (_MSC_VER >= 1921 || _GLIBCXX_RELEASE >= 10))
 
 #if _ONEDPL_STD_FEATURE_MACROS_PRESENT
+// Clang 15 and older do not support range adaptors, see https://bugs.llvm.org/show_bug.cgi?id=44833
+#    define _ONEDPL_CPP20_RANGES_PRESENT ((__cpp_lib_ranges >= 201911L) && !(__clang__ && __clang_major__ < 16))
 #    define _ONEDPL_CPP20_CONCEPTS_PRESENT (__cpp_concepts >= 201907L && __cpp_lib_concepts >= 202002L)
 #    define _ONEDPL_CPP23_TUPLE_LIKE_COMMON_REFERENCE_PRESENT                                                          \
         (_ONEDPL___cplusplus >= 202302L && __cpp_lib_tuple_like >= 202207L)
 #    define _ONEDPL_CPP23_RANGES_ZIP_PRESENT (_ONEDPL___cplusplus >= 202302L && __cpp_lib_ranges_zip >= 202110L)
 #    define _ONEDPL_CPP26_DEFAULT_VALUE_TYPE_PRESENT (__cpp_lib_algorithm_default_value_type >= 202403L)
 #else
+#    define _ONEDPL_CPP20_RANGES_PRESENT 0
 #    define _ONEDPL_CPP20_CONCEPTS_PRESENT 0
 #    define _ONEDPL_CPP23_TUPLE_LIKE_COMMON_REFERENCE_PRESENT 0
 #    define _ONEDPL_CPP23_RANGES_ZIP_PRESENT 0

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -271,15 +271,12 @@
     (_ONEDPL___cplusplus >= 202002L && (_MSC_VER >= 1921 || _GLIBCXX_RELEASE >= 10))
 
 #if _ONEDPL_STD_FEATURE_MACROS_PRESENT
-// Clang 15 and older do not support range adaptors, see https://bugs.llvm.org/show_bug.cgi?id=44833
-#    define _ONEDPL_CPP20_RANGES_PRESENT ((__cpp_lib_ranges >= 201911L) && !(__clang__ && __clang_major__ < 16))
 #    define _ONEDPL_CPP20_CONCEPTS_PRESENT (__cpp_concepts >= 201907L && __cpp_lib_concepts >= 202002L)
 #    define _ONEDPL_CPP23_TUPLE_LIKE_COMMON_REFERENCE_PRESENT                                                          \
         (_ONEDPL___cplusplus >= 202302L && __cpp_lib_tuple_like >= 202207L)
 #    define _ONEDPL_CPP23_RANGES_ZIP_PRESENT (_ONEDPL___cplusplus >= 202302L && __cpp_lib_ranges_zip >= 202110L)
 #    define _ONEDPL_CPP26_DEFAULT_VALUE_TYPE_PRESENT (__cpp_lib_algorithm_default_value_type >= 202403L)
 #else
-#    define _ONEDPL_CPP20_RANGES_PRESENT 0
 #    define _ONEDPL_CPP20_CONCEPTS_PRESENT 0
 #    define _ONEDPL_CPP23_TUPLE_LIKE_COMMON_REFERENCE_PRESENT 0
 #    define _ONEDPL_CPP23_RANGES_ZIP_PRESENT 0


### PR DESCRIPTION
Some compilers (like gcc 10.5)  provide <version>, but do not set `__cplusplus >= 202002L`.  
By not attempting to include <version>, we miss out on these macros, and also decline to attempt to define many features like concepts, etc.  which may exist in an implementation that does not set `__cplusplus >= 202002L`.  

Specifically, this PR fixes a divergence from TBB prior to this change where they are using concepts (checking the version macros explicitly, with no dependence on `__cplusplus`, and therefore requiring `std::input_iterator` concept for inputs to parallel for.  

We have a workaround for `zip_forward_iterator` to help it satisfy that concept which does not get applied because we try to limit the scope of that workaround to only where it is required.
  
https://github.com/uxlfoundation/oneDPL/blob/ef406d231043c7b1df49ebf781ee5cde3624138e/include/oneapi/dpl/pstl/tuple_impl.h#L829-L840

This divergence from TBB for gcc 10 causes a build errors for the tbb backend because we need the workaround and do not apply it.