### PR TITLE
Fix performance issue of `parallel_find_or` - 3-Kernels approach

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1450,7 +1450,7 @@ struct __parallel_find_or_impl_one_wg<__or_tag_check, __internal::__optional_ker
             __cgh.parallel_for<KernelName...>(
                 sycl::nd_range</*dim=*/1>(sycl::range</*dim=*/1>(__wgroup_size), sycl::range</*dim=*/1>(__wgroup_size)),
                 [=](sycl::nd_item</*dim=*/1> __item) {
-                    auto __local_idx = __item.get_local_id(0);
+                    const std::size_t __local_idx = __item.get_local_id(0);
 
                     // 1. Set initial value to local found state
                     __FoundStateType __found_local = __init_value;


### PR DESCRIPTION
This PR addresses a performance issue in the `parallel_find_or` implementation by modernizing the synchronization approach and removing manual buffer management. The changes replace the previous synchronization mechanism that relied on SYCL buffer destruction with an explicit event-based waiting pattern.

- Replaces manual SYCL buffer management with `__result_and_scratch_storage` utility class
- Introduces explicit initialization of the result value from the first work-item instead of relying on host initialization
- Changes from implicit synchronization (buffer destruction) to explicit event-based synchronization

Alternative variant implemented in [https://github.com/uxlfoundation/oneDPL/pull/2349 based on 2-kernels approach.](https://github.com/uxlfoundation/oneDPL/pull/2358).