### PR TITLE
Use SYCL USM host memory to writeback from device memory in `__parallel_find_or`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1517,8 +1517,7 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
                 __result_storage.template __get_scratch_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
             __cgh.single_task<KernelNameInit...>([__scratch_acc, __init_value]() {
-                auto __scratch_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(
-                    __scratch_acc, __scratch_storage_size);
+                auto __scratch_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__scratch_acc);
                 *__scratch_ptr = __init_value;
             });
         });
@@ -1561,8 +1560,8 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
                     // Set local found state value value to global atomic
                     if (__local_idx == 0 && __found_local != __init_value)
                     {
-                        auto __scratch_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(
-                            __scratch_acc, __scratch_storage_size);
+                        auto __scratch_ptr =
+                            __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__scratch_acc);
 
                         __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
                             *__scratch_ptr);
@@ -1577,9 +1576,9 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
             auto __res_acc = __result_storage.template __get_result_acc<sycl::access_mode::write>(__cgh);
             __cgh.depends_on(__event);
             __cgh.single_task<KernelNameWriteBack...>([__scratch_acc, __res_acc]() {
-                auto __scratch_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(
-                    __scratch_acc, __scratch_storage_size);
-                auto __res_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc);
+                auto __scratch_ptr = __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__scratch_acc);
+                auto __res_ptr =
+                    __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__res_acc, __scratch_storage_size);
                 *__res_ptr = *__scratch_ptr;
             });
         });


### PR DESCRIPTION
Performance can be further improved in `__parallel_find_or`, particularly for discrete GPU devices, by writing single element results in device memory back to the host through USM host memory instead of going through a memcpy operation.

This improves performance in two ways:

- Works around a driver bug where level-zero memcpy operations are taking several hundred microseconds for single element transfers.
- We have observed that USM host memory performs better than memcpy operations for single element transfers to-and-from the device, so this change is a general performance optimization as opposed to being a temporary workaround.

If USM host memory is not supported, there will be small overhead from additional device transfers but this is likely negligible. 