### PR TITLE
Remove default constructible requirement from result_and_scratch_storage

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -60,9 +60,8 @@ struct __temp_data_array
     _ValueT
     get_and_destroy(std::uint16_t __idx)
     {
-        _ValueT __ele = std::move(__data[__idx].__v);
-        __data[__idx].__destroy();
-        return __ele;
+        oneapi::dpl::__internal::__scoped_destroyer<_ValueT> __destroy_when_leaving_scope{__data[__idx]};
+        return __data[__idx].__v;
     }
 
     oneapi::dpl::__internal::__lazy_ctor_storage<_ValueT> __data[elements];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -60,6 +60,8 @@ struct __temp_data_array
     _ValueT
     get_and_destroy(std::uint16_t __idx)
     {
+        // Setting up temporary value to be destroyed as this function exits. The __scoped_destroyer calls destroy when
+        // it leaves scope.
         oneapi::dpl::__internal::__scoped_destroyer<_ValueT> __destroy_when_leaving_scope{__data[__idx]};
         return __data[__idx].__v;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -667,9 +667,15 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
         }
         else if (__supports_USM_device)
         {
-            _T __tmp;
-            __q.memcpy(&__tmp, __scratch_buf.get() + __scratch_n + _Idx, 1 * sizeof(_T)).wait();
-            return __tmp;
+            static_assert(sycl::is_device_copyable_v<_T>,
+                          "The type _T must be device copyable to use __result_and_scratch_storage.");
+            // Avoid default constructor for _T, we know that _T is device copyable and therefore a copy construction
+            // is equivalent to a bitwise copy
+            _T* __tmp = static_cast<_T*>(malloc(sizeof(_T)));
+            __q.memcpy(__tmp, __scratch_buf.get() + __scratch_n + _Idx, 1 * sizeof(_T)).wait();
+            _T __return_tmp = std::move(*__tmp);
+            free(__tmp);
+            return __return_tmp;
         }
         else
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -672,7 +672,7 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
             // Avoid default constructor for _T, we know that _T is device copyable and therefore a copy construction
             // is equivalent to a bitwise copy.  We may treat *__tmp as if it has been constructed.
             oneapi::dpl::__internal::__lazy_ctor_storage<_T> __lazy_ctor_storage;
-            __q.memcpy(&(__lazy_ctor_storage.__v), __scratch_buf.get() + __scratch_n + _Idx, 1 * sizeof(_T)).wait();
+            __q.memcpy(&__lazy_ctor_storage.__v, __scratch_buf.get() + __scratch_n + _Idx, 1 * sizeof(_T)).wait();
 
             // Setting up _T to be destroyed as this function exits. _T being device copyable provides that it has a
             // public non deleted destructor.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -670,10 +670,14 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
             static_assert(sycl::is_device_copyable_v<_T>,
                           "The type _T must be device copyable to use __result_and_scratch_storage.");
             // Avoid default constructor for _T, we know that _T is device copyable and therefore a copy construction
-            // is equivalent to a bitwise copy
+            // is equivalent to a bitwise copy.  We may treat *__tmp as if it has been constructed.
             _T* __tmp = static_cast<_T*>(malloc(sizeof(_T)));
             __q.memcpy(__tmp, __scratch_buf.get() + __scratch_n + _Idx, 1 * sizeof(_T)).wait();
             _T __return_tmp = std::move(*__tmp);
+            
+            // Calling explicit destructor to properly clean up after move and before free.
+            // _T being device copyable provides that it has a public non deleted destructor
+            __tmp->~_T();
             free(__tmp);
             return __return_tmp;
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -518,6 +518,9 @@ struct __result_and_scratch_storage_base
 template <typename _T, std::size_t _NResults = 1>
 struct __result_and_scratch_storage : __result_and_scratch_storage_base
 {
+    static_assert(sycl::is_device_copyable_v<_T>,
+                  "The type _T must be device copyable to use __result_and_scratch_storage.");
+
   private:
     using __sycl_buffer_t = sycl::buffer<_T, 1>;
 
@@ -667,10 +670,8 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
         }
         else if (__supports_USM_device)
         {
-            static_assert(sycl::is_device_copyable_v<_T>,
-                          "The type _T must be device copyable to use __result_and_scratch_storage.");
-            // Avoid default constructor for _T, we know that _T is device copyable and therefore a copy construction
-            // is equivalent to a bitwise copy.  We may treat *__tmp as if it has been constructed.
+            // Avoid default constructor for _T. We know that _T is device copyable and therefore a copy construction
+            // is equivalent to a bitwise copy. We may treat __lazy_ctor_storage.__v as constructed after the memcpy.
             oneapi::dpl::__internal::__lazy_ctor_storage<_T> __lazy_ctor_storage;
             __q.memcpy(&__lazy_ctor_storage.__v, __scratch_buf.get() + __scratch_n + _Idx, 1 * sizeof(_T)).wait();
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -673,7 +673,7 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
             // is equivalent to a bitwise copy.  We may treat *__tmp as if it has been constructed.
             oneapi::dpl::__internal::__lazy_ctor_storage<_T> __lazy_ctor_storage;
             __q.memcpy(&(__lazy_ctor_storage.__v), __scratch_buf.get() + __scratch_n + _Idx, 1 * sizeof(_T)).wait();
-            
+
             // Setting up _T to be destroyed as this function exits. _T being device copyable provides that it has a
             // public non deleted destructor.
             oneapi::dpl::__internal::__scoped_destroyer<_T> __destroy_when_leaving_scope{__lazy_ctor_storage};

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -675,8 +675,8 @@ struct __result_and_scratch_storage : __result_and_scratch_storage_base
             oneapi::dpl::__internal::__lazy_ctor_storage<_T> __lazy_ctor_storage;
             __q.memcpy(&__lazy_ctor_storage.__v, __scratch_buf.get() + __scratch_n + _Idx, 1 * sizeof(_T)).wait();
 
-            // Setting up _T to be destroyed as this function exits. _T being device copyable provides that it has a
-            // public non deleted destructor.
+            // Setting up _T to be destroyed as this function exits. The __scoped_destroyer calls destroy when it
+            // leaves scope. _T being device copyable provides that it has a public non deleted destructor.
             oneapi::dpl::__internal::__scoped_destroyer<_T> __destroy_when_leaving_scope{__lazy_ctor_storage};
             return __lazy_ctor_storage.__v;
         }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -888,9 +888,7 @@ union __lazy_ctor_storage
     __lazy_ctor_storage() {}
 
     // empty destructor since we should be explicitly destroying any constructed data
-    ~__lazy_ctor_storage()
-    {
-    }
+    ~__lazy_ctor_storage() {}
 
     template <typename _U>
     void

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -898,6 +898,10 @@ union __lazy_ctor_storage
     {
         __v.~_Tp();
     }
+    // empty destructor since we should be explicitly destroying any constructed data
+    ~__lazy_ctor_storage()
+    {
+    }
 };
 
 // Scoped destroyer for __lazy_ctor_storage. It can be used to destroy the storage when it goes out of scope.

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -887,6 +887,11 @@ union __lazy_ctor_storage
     _Tp __v;
     __lazy_ctor_storage() {}
 
+    // empty destructor since we should be explicitly destroying any constructed data
+    ~__lazy_ctor_storage()
+    {
+    }
+
     template <typename _U>
     void
     __setup(_U&& init)
@@ -897,10 +902,6 @@ union __lazy_ctor_storage
     __destroy()
     {
         __v.~_Tp();
-    }
-    // empty destructor since we should be explicitly destroying any constructed data
-    ~__lazy_ctor_storage()
-    {
     }
 };
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -903,7 +903,8 @@ union __lazy_ctor_storage
     }
 };
 
-// Scoped destroyer for __lazy_ctor_storage. It can be used to destroy the storage when it goes out of scope.
+// Scoped destroyer for __lazy_ctor_storage. It can be used to destroy the a __lazy_ctor_storage when it goes out of
+// scope.
 // Note: Should only be used *after* the storage has been initialized with __setup or some other method to ensure that
 //       data is not destroyed before it is initialized. This is relevant for exception handling which may change the
 //       control flow unexpectedly.

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -915,7 +915,6 @@ struct __scoped_destroyer
     }
 };
 
-
 // To implement __min_nested_type_size, a general utility with an internal tuple
 // specialization, we need to forward declare our internal tuple first as tuple_impl.h
 // already includes this header.

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -900,6 +900,22 @@ union __lazy_ctor_storage
     }
 };
 
+// Scoped destroyer for __lazy_ctor_storage. It can be used to destroy the storage when it goes out of scope.
+// Note: Should only be used *after* the storage has been initialized with __setup or some other method to ensure that
+//       data is not destroyed before it is initialized. This is relevant for exception handling which may change the
+//       control flow unexpectedly.
+template <typename _DataType>
+struct __scoped_destroyer
+{
+    oneapi::dpl::__internal::__lazy_ctor_storage<_DataType>& ___lazy_ctor_storage_ref;
+    ~__scoped_destroyer()
+    {
+        // Explicitly call destructor of __lazy_ctor_storage
+        ___lazy_ctor_storage_ref.__destroy();
+    }
+};
+
+
 // To implement __min_nested_type_size, a general utility with an internal tuple
 // specialization, we need to forward declare our internal tuple first as tuple_impl.h
 // already includes this header.

--- a/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
@@ -19,6 +19,7 @@
 #include _PSTL_TEST_HEADER(numeric)
 
 #include "support/utils.h"
+#include "support/utils_device_copyable.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
@@ -53,6 +53,11 @@ test_long_form(T init, BinaryOp binary_op, F f)
 
         invoke_on_all_policies<0>()(test_long_reduce<T>(), in.begin(), in.end(), init, binary_op, expected);
         invoke_on_all_policies<1>()(test_long_reduce<T>(), in.cbegin(), in.cend(), init, binary_op, expected);
+        if constexpr (std::is_same_v<BinaryOp, std::plus<T>>)
+        {
+            invoke_on_all_policies<2>()(test_long_reduce<T>(), in.begin(), in.end(), NoDefaultCtorWrapper<T>{init},
+                                        std::plus<NoDefaultCtorWrapper<T>>{}, NoDefaultCtorWrapper<T>{expected});
+        }
     }
 }
 

--- a/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
@@ -19,6 +19,7 @@
 #include _PSTL_TEST_HEADER(numeric)
 
 #include "support/utils.h"
+#include "support/utils_device_copyable.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
@@ -147,6 +147,22 @@ test_by_type(T init, BinaryOperation1 opB1, BinaryOperation2 opB2, UnaryOp opU, 
                                     in2.cbegin(), in2.cbegin() + n, init, opB1, opB2);
         invoke_on_all_policies<4>()(test_2_iters<T>(), in1.cbegin(), in1.cbegin() + n, init, opB1, opU);
 #endif
+        if constexpr (std::is_same_v<BinaryOperation1, std::plus<T>>)
+        {
+            if constexpr (std::is_same_v<BinaryOperation2, std::multiplies<T>>)
+            {
+                invoke_on_all_policies<5>()(
+                    test_3_iters_custom_ops<NoDefaultCtorWrapper<T>>(), in1.begin(), in1.begin() + n, in2.begin(),
+                    in2.begin() + n, NoDefaultCtorWrapper<T>{init}, std::plus<NoDefaultCtorWrapper<T>>{},
+                    std::multiplies<NoDefaultCtorWrapper<T>>{});
+            }
+            if constexpr (std::is_same_v<UnaryOp, std::negate<T>>)
+            {
+                invoke_on_all_policies<5>()(test_2_iters<NoDefaultCtorWrapper<T>>(), in1.begin(), in1.begin() + n,
+                                            NoDefaultCtorWrapper<T>{init}, std::plus<NoDefaultCtorWrapper<T>>{},
+                                            std::negate<NoDefaultCtorWrapper<T>>{});
+            }
+        }
     }
 }
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1282,6 +1282,12 @@ struct NoDefaultCtorWrapper {
     {
         return NoDefaultCtorWrapper{a.value * b.value};
     } 
+
+    // non-trivial destructor for testing
+    ~NoDefaultCtorWrapper()
+    {
+        value.~_T();
+    }
 };
 
 } /* namespace TestUtils */

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1243,6 +1243,47 @@ struct Pow2
     }
 };
 
+template <typename _T>
+struct NoDefaultCtorWrapper {
+    _T value;
+
+    // Default constructor
+    NoDefaultCtorWrapper() = delete;
+
+    NoDefaultCtorWrapper(_T v) : value(v) {}
+
+    operator _T() const { return value; }
+
+    // Move constructor
+    NoDefaultCtorWrapper(NoDefaultCtorWrapper&&) = default;
+
+    // Move assignment operator
+    NoDefaultCtorWrapper& operator=(NoDefaultCtorWrapper&&) = default;
+
+    // Deleted copy constructor and copy assignment operator
+    NoDefaultCtorWrapper(const NoDefaultCtorWrapper&) = default;
+    NoDefaultCtorWrapper& operator=(const NoDefaultCtorWrapper&) = default;
+    
+    NoDefaultCtorWrapper operator-() const
+    {
+        return NoDefaultCtorWrapper{-value};
+    }
+
+    friend bool operator==(const NoDefaultCtorWrapper& a, const NoDefaultCtorWrapper& b)
+    {
+        return a.value == b.value;
+    } 
+    friend NoDefaultCtorWrapper operator+(const NoDefaultCtorWrapper& a, const NoDefaultCtorWrapper& b)
+    {
+        return NoDefaultCtorWrapper{a.value + b.value};
+    } 
+
+    friend NoDefaultCtorWrapper operator*(const NoDefaultCtorWrapper& a, const NoDefaultCtorWrapper& b)
+    {
+        return NoDefaultCtorWrapper{a.value * b.value};
+    } 
+};
+
 } /* namespace TestUtils */
 
 #endif // _UTILS_H

--- a/test/support/utils_device_copyable.h
+++ b/test/support/utils_device_copyable.h
@@ -263,6 +263,12 @@ template <>
 struct sycl::is_device_copyable<TestUtils::range_device_copyable> : std::true_type
 {
 };
+
+template <typename T>
+struct sycl::is_device_copyable<TestUtils::NoDefaultCtorWrapper<T>> : sycl::is_device_copyable<T>
+{
+};
+
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 #endif // _UTILS_DEVICE_COPYABLE_H


### PR DESCRIPTION
This PR removes the default constructor requirement from the SYCL backend's `result_and_scratch_storage` utility.

To do this, we require the type to be device copyable (which already was the case), but also provides that a bitwise copy is equivalent to copy construction.

This was split off from #2327.