### PR TITLE
Move only type support for [transform_]reduce for host backends

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -97,7 +97,8 @@ Difference with Standard C++ Parallel Algorithms
   ``transform_inclusive_scan``, and ``transform_exclusive_scan``, the initial value type must be ``MoveAssignable``
   in addition to the existing ``MoveConstructible`` requirement. While this is not required by the C++ standard, it is
   necessary for reasonable (non-recursive) implementations and is consistent with other standard library implementations
-  in practice.
+  in practice. Insufficient type requirements for numeric algorithms are discussed in detail in
+  https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0571r2.html.
 * For the following algorithms, ``par_unseq`` and ``unseq`` policies do not result in SIMD execution:
   ``includes``, ``inplace_merge``, ``merge``, ``set_difference``, ``set_intersection``,
   ``set_symmetric_difference``, ``set_union``, ``stable_partition``, ``unique``.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -93,6 +93,11 @@ Difference with Standard C++ Parallel Algorithms
   the execution will remain serial for other iterator types.
 * Function objects passed in to algorithms executed with device policies must provide ``const``-qualified ``operator()``.
   The `SYCL specification`_ states that writing to such an object during a SYCL kernel is undefined behavior.
+* For algorithms ``reduce``, ``transform_reduce``, ``inclusive_scan``, ``exclusive_scan``,
+  ``transform_inclusive_scan``, and ``transform_exclusive_scan``, the initial value type must be ``MoveAssignable``
+  in addition to the existing ``MoveConstructible`` requirement. While this is not required by the C++ standard, it is
+  necessary for reasonable (non-recursive) implementations and is consistent with other standard library implementations
+  in practice.
 * For the following algorithms, ``par_unseq`` and ``unseq`` policies do not result in SIMD execution:
   ``includes``, ``inplace_merge``, ``merge``, ``set_difference``, ``set_intersection``,
   ``set_symmetric_difference``, ``set_union``, ``stable_partition``, ``unique``.
@@ -166,9 +171,12 @@ Known Limitations
 * ``reduce_by_segment``, when used with C++ standard aligned policies, imposes limitations on the value type.
   Firstly, it must satisfy the ``DefaultConstructible`` requirements.
   Secondly, a default-constructed instance of that type should act as the identity element for the binary reduction function.
-* The initial value type for ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
-  ``inclusive_scan_by_segment``, ``reduce``, ``reduce_by_segment``, ``transform_reduce``, ``transform_exclusive_scan``,
-  ``transform_inclusive_scan`` should satisfy the ``MoveAssignable`` and the ``CopyConstructible`` requirements.
+* The initial value type for ``reduce_by_segment``, ``exclusive_scan_by_segment``, and ``inclusive_scan_by_segment``
+  should satisfy the ``MoveAssignable`` and the ``CopyConstructible`` requirements.
+* The initial value type for ``reduce``, ``transform_reduce``, should satisfy the ``CopyConstructible`` and the
+``CopyAssignable`` requirements when used with device execution policies.
+* The initial value type for ``exclusive_scan``, ``inclusive_scan``,  ``transform_exclusive_scan``,
+  ``transform_inclusive_scan`` should satisfy the ``CopyConstructible`` and the ``CopyAssignable`` requirements.
 * For ``max_element``, ``min_element``, ``minmax_element``, ``partial_sort``, ``partial_sort_copy``, ``sort``, ``stable_sort``
   the dereferenced value type of the provided iterators should satisfy the ``DefaultConstructible`` requirements.
 * For ``remove``, ``remove_if``, ``unique`` the dereferenced value type of the provided

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -146,7 +146,7 @@ reduce_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterat
 
     wait_for_all(std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
+        __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, std::move(__init), __binary_op,
         oneapi::dpl::identity{});
     return ret_val;
 }
@@ -167,7 +167,7 @@ template <class _ExecutionPolicy, class _ForwardIt, class _T, class... _Events,
 auto
 reduce_async(_ExecutionPolicy&& __exec, _ForwardIt __first, _ForwardIt __last, _T __init, _Events&&... __dependencies)
 {
-    return reduce_async(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, ::std::plus<_T>(),
+    return reduce_async(::std::forward<_ExecutionPolicy>(__exec), __first, __last, std::move(__init), ::std::plus<_T>(),
                         ::std::forward<_Events>(__dependencies)...);
 }
 
@@ -200,7 +200,7 @@ transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _Forward
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     return oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __init, __binary_op1,
+        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, std::move(__init), __binary_op1,
         __binary_op2);
 }
 
@@ -215,7 +215,7 @@ transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIt __first, _ForwardIt
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     return oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op, __unary_op);
+        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, std::move(__init), __binary_op, __unary_op);
 }
 
 template <class _ExecutionPolicy, class _ForwardIt1, class _ForwardIt2, class _T, class... _Events,
@@ -225,7 +225,7 @@ transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _Forward
                        _T __init, _Events&&... __dependencies)
 {
     using _ValueType = typename ::std::iterator_traits<_ForwardIt1>::value_type;
-    return transform_reduce_async(::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __init,
+    return transform_reduce_async(::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, std::move(__init),
                                   ::std::plus<_T>(), ::std::multiplies<_ValueType>(),
                                   ::std::forward<_Events>(__dependencies)...);
 }

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -200,8 +200,8 @@ transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _Forward
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     return oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, std::move(__init), __binary_op1,
-        __binary_op2);
+        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, std::move(__init),
+        __binary_op1, __binary_op2);
 }
 
 template <class _ExecutionPolicy, class _ForwardIt, class _T, class _BinaryOp, class _UnaryOp, class... _Events,
@@ -215,7 +215,8 @@ transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIt __first, _ForwardIt
 
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     return oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, std::move(__init), __binary_op, __unary_op);
+        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, std::move(__init), __binary_op,
+        __unary_op);
 }
 
 template <class _ExecutionPolicy, class _ForwardIt1, class _ForwardIt2, class _T, class... _Events,
@@ -225,8 +226,8 @@ transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, _Forward
                        _T __init, _Events&&... __dependencies)
 {
     using _ValueType = typename ::std::iterator_traits<_ForwardIt1>::value_type;
-    return transform_reduce_async(::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, std::move(__init),
-                                  ::std::plus<_T>(), ::std::multiplies<_ValueType>(),
+    return transform_reduce_async(::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+                                  std::move(__init), ::std::plus<_T>(), ::std::multiplies<_ValueType>(),
                                   ::std::forward<_Events>(__dependencies)...);
 }
 

--- a/include/oneapi/dpl/internal/serial_numeric_impl.h
+++ b/include/oneapi/dpl/internal/serial_numeric_impl.h
@@ -31,15 +31,15 @@ _Tp
 reduce(_InputIterator __first, _InputIterator __last, _Tp __init, _BinaryOp __b)
 {
     for (; __first != __last; ++__first)
-        __init = __b(__init, *__first);
-    return __init;
+        __init = __b(std::move(__init), *__first);
+    return std::move(__init);
 }
 
 template <class _InputIterator, class _Tp>
 _Tp
 reduce(_InputIterator __first, _InputIterator __last, _Tp __init)
 {
-    return oneapi::dpl::reduce(__first, __last, __init, ::std::plus<_Tp>());
+    return oneapi::dpl::reduce(__first, __last, std::move(__init), ::std::plus<_Tp>());
 }
 
 template <class _InputIterator>

--- a/include/oneapi/dpl/pstl/glue_numeric_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_impl.h
@@ -40,7 +40,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
 reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
        _BinaryOperation __binary_op)
 {
-    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
+    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), __first, __last, std::move(__init), __binary_op,
                             oneapi::dpl::identity{});
 }
 
@@ -48,8 +48,8 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
 reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init)
 {
-    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, std::plus<_Tp>(),
-                            oneapi::dpl::identity{});
+    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), __first, __last, std::move(__init),
+                            std::plus<_Tp>(), oneapi::dpl::identity{});
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator>
@@ -74,7 +74,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Forward
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     return oneapi::dpl::__internal::__pattern_transform_reduce(
-        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __init,
+        __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, std::move(__init),
         ::std::plus<_InputType>(), ::std::multiplies<_InputType>());
 }
 
@@ -87,8 +87,8 @@ transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Forward
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first1, __first2);
 
     return oneapi::dpl::__internal::__pattern_transform_reduce(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                               __first1, __last1, __first2, __init, __binary_op1,
-                                                               __binary_op2);
+                                                               __first1, __last1, __first2, std::move(__init),
+                                                               __binary_op1, __binary_op2);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation>
@@ -99,7 +99,8 @@ transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIt
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     return oneapi::dpl::__internal::__pattern_transform_reduce(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                               __first, __last, __init, __binary_op, __unary_op);
+                                                               __first, __last, std::move(__init), __binary_op,
+                                                               __unary_op);
 }
 
 // [exclusive.scan]

--- a/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
@@ -39,8 +39,8 @@ template <typename _ExecutionPolicy, typename _Range, typename _Tp, typename _Bi
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
 reduce(_ExecutionPolicy&& __exec, _Range&& __rng, _Tp __init, _BinaryOperation __binary_op)
 {
-    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), std::forward<_Range>(__rng), std::move(__init), __binary_op,
-                            oneapi::dpl::identity{});
+    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), std::forward<_Range>(__rng), std::move(__init),
+                            __binary_op, oneapi::dpl::identity{});
 }
 
 template <typename _ExecutionPolicy, typename _Range, typename _Tp>

--- a/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
@@ -39,7 +39,7 @@ template <typename _ExecutionPolicy, typename _Range, typename _Tp, typename _Bi
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
 reduce(_ExecutionPolicy&& __exec, _Range&& __rng, _Tp __init, _BinaryOperation __binary_op)
 {
-    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), std::forward<_Range>(__rng), __init, __binary_op,
+    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), std::forward<_Range>(__rng), std::move(__init), __binary_op,
                             oneapi::dpl::identity{});
 }
 
@@ -47,7 +47,7 @@ template <typename _ExecutionPolicy, typename _Range, typename _Tp>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
 reduce(_ExecutionPolicy&& __exec, _Range&& __rng, _Tp __init)
 {
-    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), std::forward<_Range>(__rng), __init,
+    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), std::forward<_Range>(__rng), std::move(__init),
                             std::plus<_Tp>(), oneapi::dpl::identity{});
 }
 
@@ -69,7 +69,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
     return oneapi::dpl::__internal::__ranges::__pattern_transform_reduce(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
-        views::all_read(::std::forward<_Range2>(__rng2)), __init, ::std::plus<_ValueType>(),
+        views::all_read(::std::forward<_Range2>(__rng2)), std::move(__init), ::std::plus<_ValueType>(),
         ::std::multiplies<_ValueType>());
 }
 
@@ -83,7 +83,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, 
 
     return oneapi::dpl::__internal::__ranges::__pattern_transform_reduce(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range1>(__rng1)),
-        views::all_read(::std::forward<_Range2>(__rng2)), __init, __binary_op1, __binary_op2);
+        views::all_read(::std::forward<_Range2>(__rng2)), std::move(__init), __binary_op1, __binary_op2);
 }
 
 template <typename _ExecutionPolicy, typename _Range, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
@@ -95,7 +95,7 @@ transform_reduce(_ExecutionPolicy&& __exec, _Range&& __rng, _Tp __init, _BinaryO
 
     return oneapi::dpl::__internal::__ranges::__pattern_transform_reduce(
         __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), views::all_read(::std::forward<_Range>(__rng)),
-        __init, __binary_op, __unary_op);
+        std::move(__init), __binary_op, __unary_op);
 }
 
 // [exclusive.scan]

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -371,8 +371,8 @@ __brick_adjacent_difference(_RandomAccessIterator1 __first, _RandomAccessIterato
 
     auto __n = __last - __first;
     *__d_first = *__first;
-    return __unseq_backend::__simd_walk_n(
-        __n - 1, [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) { __z = __op(__x, __y); },
+    return __unseq_backend::__simd_walk_n(__n - 1, 
+        [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) { __z = __op(__x, __y); },
         __first + 1, __first, __d_first + 1);
 }
 

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -44,7 +44,7 @@ __brick_transform_reduce(_ForwardIterator1 __first1, _ForwardIterator1 __last1, 
                          _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2,
                          /*is_vector=*/::std::false_type) noexcept
 {
-    return ::std::inner_product(__first1, __last1, __first2, __init, __binary_op1, __binary_op2);
+    return ::std::inner_product(__first1, __last1, __first2, std::move(__init), __binary_op1, __binary_op2);
 }
 
 template <class _RandomAccessIterator1, class _RandomAccessIterator2, class _Tp, class _BinaryOperation1,
@@ -57,7 +57,7 @@ __brick_transform_reduce(_RandomAccessIterator1 __first1, _RandomAccessIterator1
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType;
     return __unseq_backend::__simd_transform_reduce(
-        __last1 - __first1, __init, __binary_op1,
+        __last1 - __first1, std::move(__init), __binary_op1,
         [=, &__binary_op2](_DifferenceType __i) { return __binary_op2(__first1[__i], __first2[__i]); });
 }
 
@@ -70,7 +70,7 @@ __pattern_transform_reduce(_Tag, _ExecutionPolicy&&, _ForwardIterator1 __first1,
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    return __brick_transform_reduce(__first1, __last1, __first2, __init, __binary_op1, __binary_op2,
+    return __brick_transform_reduce(__first1, __last1, __first2, std::move(__init), __binary_op1, __binary_op2,
                                     typename _Tag::__is_vector{});
 }
 
@@ -89,12 +89,12 @@ __pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
             [__first1, __first2, __binary_op2](_RandomAccessIterator1 __i) mutable {
                 return __binary_op2(*__i, *(__first2 + (__i - __first1)));
             },
-            __init,
+            std::move(__init),
             __binary_op1, // Combine
             [__first1, __first2, __binary_op1, __binary_op2](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j,
                                                              _Tp __init) -> _Tp {
-                return __internal::__brick_transform_reduce(__i, __j, __first2 + (__i - __first1), __init, __binary_op1,
-                                                            __binary_op2, _IsVector{});
+                return __internal::__brick_transform_reduce(__i, __j, __first2 + (__i - __first1), std::move(__init),
+                                                            __binary_op1, __binary_op2, _IsVector{});
             });
     });
 }
@@ -110,7 +110,7 @@ __brick_transform_reduce(_ForwardIterator __first, _ForwardIterator __last, _Tp 
 {
     for (; __first != __last; ++__first)
     {
-        __init = __binary_op(__init, __unary_op(*__first));
+        __init = __binary_op(std::move(__init), __unary_op(*__first));
     }
     return __init;
 }
@@ -123,8 +123,8 @@ __brick_transform_reduce(_RandomAccessIterator __first, _RandomAccessIterator __
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     return __unseq_backend::__simd_transform_reduce(
-        __last - __first, __init, __binary_op,
-        [=, &__unary_op](_DifferenceType __i) { return __unary_op(__first[__i]); });
+        __last - __first, std::move(__init), __binary_op,
+        [=, &__unary_op](_DifferenceType __i) { return _Tp{__unary_op(__first[__i])}; });
 }
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation,
@@ -135,7 +135,7 @@ __pattern_transform_reduce(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, _
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    return __internal::__brick_transform_reduce(__first, __last, __init, __binary_op, __unary_op,
+    return __internal::__brick_transform_reduce(__first, __last, std::move(__init), __binary_op, __unary_op,
                                                 typename _Tag::__is_vector{});
 }
 
@@ -151,9 +151,11 @@ __pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
     return __internal::__except_handler([&]() {
         return __par_backend::__parallel_transform_reduce(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-            [__unary_op](_RandomAccessIterator __i) mutable { return __unary_op(*__i); }, __init, __binary_op,
+            [__unary_op](_RandomAccessIterator __i) mutable { return __unary_op(*__i); }, std::move(__init),
+            __binary_op,
             [__unary_op, __binary_op](_RandomAccessIterator __i, _RandomAccessIterator __j, _Tp __init) {
-                return __internal::__brick_transform_reduce(__i, __j, __init, __binary_op, __unary_op, _IsVector{});
+                return __internal::__brick_transform_reduce(__i, __j, std::move(__init), __binary_op, __unary_op,
+                                                            _IsVector{});
             });
     });
 }
@@ -369,8 +371,8 @@ __brick_adjacent_difference(_RandomAccessIterator1 __first, _RandomAccessIterato
 
     auto __n = __last - __first;
     *__d_first = *__first;
-    return __unseq_backend::__simd_walk_n(__n - 1,
-        [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) { __z = __op(__x, __y); },
+    return __unseq_backend::__simd_walk_n(
+        __n - 1, [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) { __z = __op(__x, __y); },
         __first + 1, __first, __d_first + 1);
 }
 

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -124,7 +124,7 @@ __brick_transform_reduce(_RandomAccessIterator __first, _RandomAccessIterator __
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     return __unseq_backend::__simd_transform_reduce(
         __last - __first, std::move(__init), __binary_op,
-        [=, &__unary_op](_DifferenceType __i) { return _Tp{__unary_op(__first[__i])}; });
+        [=, &__unary_op](_DifferenceType __i) { return __unary_op(__first[__i]); });
 }
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation,

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -92,8 +92,8 @@ __pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
             std::move(__init),
             __binary_op1, // Combine
             [__first1, __first2, __binary_op1, __binary_op2](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j,
-                                                             _Tp __init) -> _Tp {
-                return __internal::__brick_transform_reduce(__i, __j, __first2 + (__i - __first1), std::move(__init),
+                                                             _Tp __init_) -> _Tp {
+                return __internal::__brick_transform_reduce(__i, __j, __first2 + (__i - __first1), std::move(__init_),
                                                             __binary_op1, __binary_op2, _IsVector{});
             });
     });
@@ -153,8 +153,8 @@ __pattern_transform_reduce(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec,
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             [__unary_op](_RandomAccessIterator __i) mutable { return __unary_op(*__i); }, std::move(__init),
             __binary_op,
-            [__unary_op, __binary_op](_RandomAccessIterator __i, _RandomAccessIterator __j, _Tp __init) {
-                return __internal::__brick_transform_reduce(__i, __j, std::move(__init), __binary_op, __unary_op,
+            [__unary_op, __binary_op](_RandomAccessIterator __i, _RandomAccessIterator __j, _Tp __init_) {
+                return __internal::__brick_transform_reduce(__i, __j, std::move(__init_), __binary_op, __unary_op,
                                                             _IsVector{});
             });
     });

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -371,7 +371,7 @@ __brick_adjacent_difference(_RandomAccessIterator1 __first, _RandomAccessIterato
 
     auto __n = __last - __first;
     *__d_first = *__first;
-    return __unseq_backend::__simd_walk_n(__n - 1, 
+    return __unseq_backend::__simd_walk_n(__n - 1,
         [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) { __z = __op(__x, __y); },
         __first + 1, __first, __d_first + 1);
 }

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -112,7 +112,7 @@ _Tp
 __parallel_transform_reduce(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __first,
                             _Index __last, _UnaryOp, _Tp __init, _BinaryOp, _Reduce __reduce)
 {
-    return __reduce(__first, __last, __init);
+    return __reduce(__first, __last, std::move(__init));
 }
 
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -451,7 +451,7 @@ template <typename _Tp, typename _BinaryOperation>
 inline constexpr bool is_arithmetic_plus_v = is_arithmetic_plus<_Tp, _BinaryOperation>::value;
 
 template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
-::std::enable_if_t<is_arithmetic_plus_v<_Tp, _BinaryOperation>, _Tp>
+::std::enable_if_t<is_arithmetic_plus_v<_Tp, _BinaryOperation> && std::is_copy_constructible_v<_Tp>, _Tp>
 __simd_transform_reduce(_DifferenceType __n, _Tp __init, _BinaryOperation, _UnaryOperation __f) noexcept
 {
     _ONEDPL_PRAGMA_SIMD_REDUCTION(+ : __init)
@@ -496,7 +496,7 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
         // combiner
         for (_Size __i = 0; __i < __block_size; ++__i)
         {
-            __init = __binary_op(__init, __lane[__i]);
+            __init = __binary_op(std::move(__init), __lane[__i]);
         }
         // destroyer
         _ONEDPL_PRAGMA_SIMD
@@ -509,10 +509,10 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
     {
         for (_Size __i = 0; __i < __n; ++__i)
         {
-            __init = __binary_op(__init, __f(__i));
+            __init = __binary_op(std::move(__init), __f(__i));
         }
     }
-    return __init;
+    return std::move(__init);
 }
 
 // Exclusive scan for "+" and arithmetic types

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -902,10 +902,6 @@ union __lazy_ctor_storage
     {
         __v.~_Tp();
     }
-    // empty destructor since we should be explicitly destroying any constructed data
-    ~__lazy_ctor_storage()
-    {
-    }
 };
 
 // Scoped destroyer for __lazy_ctor_storage. It can be used to destroy the a __lazy_ctor_storage when it goes out of

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -902,6 +902,10 @@ union __lazy_ctor_storage
     {
         __v.~_Tp();
     }
+    // empty destructor since we should be explicitly destroying any constructed data
+    ~__lazy_ctor_storage()
+    {
+    }
 };
 
 // Scoped destroyer for __lazy_ctor_storage. It can be used to destroy the a __lazy_ctor_storage when it goes out of

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -888,7 +888,9 @@ union __lazy_ctor_storage
     _Tp __v;
     __lazy_ctor_storage() {}
 
-    // empty destructor since we should be explicitly destroying any constructed data
+    // Empty destructor, we must explicitly manage destruction of data constructed.
+    // A defaulted destructor of a union would not automatically call destructors of the variant __v, but also does not
+    // support non-trivial destructors for _Tp. This allows us to support non-trivial destructors for _Tp.
     ~__lazy_ctor_storage() {}
 
     template <typename _U>

--- a/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
@@ -30,7 +30,7 @@ struct test_long_reduce
     void
     operator()(Policy&& exec, Iterator first, Iterator last, T init, BinaryOp binary, T expected)
     {
-        T result_r = std::reduce(std::forward<Policy>(exec), first, last, init, binary);
+        T result_r = std::reduce(std::forward<Policy>(exec), first, last, std::move(init), binary);
         EXPECT_EQ(expected, result_r, "bad result from reduce(exec, first, last, init, binary_op)");
     }
 };
@@ -42,7 +42,7 @@ test_long_form(T init, BinaryOp binary_op, F f)
     // Try sequences of various lengths
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        T expected(init);
+        T expected(std::move(init));
         Sequence<T> in(n, [n, f](size_t k) { return f((std::int32_t(k ^ n) % 1000 - 500)); });
         for (size_t k = 0; k < n; ++k)
             expected = binary_op(expected, in[k]);
@@ -58,6 +58,10 @@ test_long_form(T init, BinaryOp binary_op, F f)
         {
             invoke_on_all_policies<2>()(test_long_reduce<T>(), in.begin(), in.end(), NoDefaultCtorWrapper<T>{init},
                                         std::plus<NoDefaultCtorWrapper<T>>{}, NoDefaultCtorWrapper<T>{expected});
+            // Test with MoveOnlyWrapper on host policies
+            iterator_invoker<std::random_access_iterator_tag, /*reverse_iterator=*/std::false_type>()(
+                oneapi::dpl::execution::par_unseq, test_long_reduce<T>(), in.begin(), in.end(),
+                MoveOnlyWrapper<T>{init}, std::plus<MoveOnlyWrapper<T>>{}, MoveOnlyWrapper<T>{expected});
         }
     }
 }

--- a/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
@@ -42,7 +42,7 @@ test_long_form(T init, BinaryOp binary_op, F f)
     // Try sequences of various lengths
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        T expected(std::move(init));
+        T expected(init);
         Sequence<T> in(n, [n, f](size_t k) { return f((std::int32_t(k ^ n) % 1000 - 500)); });
         for (size_t k = 0; k < n; ++k)
             expected = binary_op(expected, in[k]);

--- a/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
@@ -71,9 +71,9 @@ class MyClass
 
 template <typename T>
 void
-CheckResults(const T& expected, const T& in, const char* msg)
+CheckResults(T expected, T in, const char* msg)
 {
-    EXPECT_TRUE(Equal(expected, in), msg);
+    EXPECT_TRUE(Equal(std::move(expected), std::move(in)), msg);
 }
 
 // We need to check correctness only for "int" (for example) except cases
@@ -105,11 +105,11 @@ struct test_3_iters_custom_ops
               typename BinaryOperation2>
     void
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 /* last2 */,
-               T init, BinaryOperation1 opB1, BinaryOperation2 opB2)
+               T init1, T init2, BinaryOperation1 opB1, BinaryOperation2 opB2)
     {
-        auto expectedB = ::std::inner_product(first1, last1, first2, init, opB1, opB2);
-        T resRA = std::transform_reduce(std::forward<Policy>(exec), first1, last1, first2, init, opB1, opB2);
-        CheckResults(expectedB, resRA, "wrong result with tranform_reduce (3 iterators, custom predicates)");
+        auto expectedB = ::std::inner_product(first1, last1, first2, std::move(init1), opB1, opB2);
+        T resRA = std::transform_reduce(std::forward<Policy>(exec), first1, last1, first2, std::move(init2), opB1, opB2);
+        CheckResults(std::move(expectedB), std::move(resRA), "wrong result with tranform_reduce (3 iterators, custom predicates)");
     }
 };
 
@@ -119,11 +119,11 @@ struct test_2_iters
     template <typename Policy, typename InputIterator1, typename T, typename BinaryOperation,
               typename UnaryOp>
     void
-    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, T init, BinaryOperation opB, UnaryOp opU)
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, T init1, T init2, BinaryOperation opB, UnaryOp opU)
     {
-        auto expectedU = transform_reduce_serial(first1, last1, init, opB, opU);
-        T resRA = std::transform_reduce(std::forward<Policy>(exec), first1, last1, init, opB, opU);
-        CheckResults(expectedU, resRA, "wrong result with tranform_reduce (2 iterators)");
+        auto expectedU = transform_reduce_serial(first1, last1, std::move(init1), opB, opU);
+        T resRA = std::transform_reduce(std::forward<Policy>(exec), first1, last1, std::move(init2), opB, opU);
+        CheckResults(std::move(expectedU), std::move(resRA), "wrong result with tranform_reduce (2 iterators)");
     }
 };
 
@@ -138,15 +138,15 @@ test_by_type(T init, BinaryOperation1 opB1, BinaryOperation2 opB2, UnaryOp opU, 
     for (::std::size_t n = 0; n < maxSize; n = n < 16 ? n + 1 : size_t(3.1415 * n))
     {
         invoke_on_all_policies<0>()(test_3_iters_custom_ops<T>(), in1.begin(), in1.begin() + n,
-                                    in2.begin(), in2.begin() + n, init, opB1, opB2);
-        invoke_on_all_policies<1>()(test_2_iters<T>(), in1.begin(), in1.begin() + n, init, opB1, opU);
+                                    in2.begin(), in2.begin() + n, init, init, opB1, opB2);
+        invoke_on_all_policies<1>()(test_2_iters<T>(), in1.begin(), in1.begin() + n, init, init, opB1, opU);
 #if !ONEDPL_FPGA_DEVICE
         invoke_on_all_policies<2>()(test_3_iters_default_ops<T>(), in1.begin(), in1.begin() + n,
                                     in2.begin(), in2.begin() + n, init);
 
         invoke_on_all_policies<3>()(test_3_iters_custom_ops<T>(), in1.cbegin(), in1.cbegin() + n,
-                                    in2.cbegin(), in2.cbegin() + n, init, opB1, opB2);
-        invoke_on_all_policies<4>()(test_2_iters<T>(), in1.cbegin(), in1.cbegin() + n, init, opB1, opU);
+                                    in2.cbegin(), in2.cbegin() + n, init, init, opB1, opB2);
+        invoke_on_all_policies<4>()(test_2_iters<T>(), in1.cbegin(), in1.cbegin() + n, init, init, opB1, opU);
 #endif
         if constexpr (std::is_same_v<BinaryOperation1, std::plus<T>>)
         {
@@ -154,14 +154,25 @@ test_by_type(T init, BinaryOperation1 opB1, BinaryOperation2 opB2, UnaryOp opU, 
             {
                 invoke_on_all_policies<5>()(
                     test_3_iters_custom_ops<NoDefaultCtorWrapper<T>>(), in1.begin(), in1.begin() + n, in2.begin(),
-                    in2.begin() + n, NoDefaultCtorWrapper<T>{init}, std::plus<NoDefaultCtorWrapper<T>>{},
-                    std::multiplies<NoDefaultCtorWrapper<T>>{});
+                    in2.begin() + n, NoDefaultCtorWrapper<T>{init}, NoDefaultCtorWrapper<T>{init},
+                    std::plus<NoDefaultCtorWrapper<T>>{}, std::multiplies<NoDefaultCtorWrapper<T>>{});
+
+                iterator_invoker<std::random_access_iterator_tag, /*reverse_iterator=*/std::false_type>()(
+                    oneapi::dpl::execution::par_unseq, test_3_iters_custom_ops<T>(), in1.begin(), in1.begin() + n,
+                    in2.begin(), in2.begin() + n, MoveOnlyWrapper<T>{init}, MoveOnlyWrapper<T>{init},
+                    std::plus<MoveOnlyWrapper<T>>{}, std::multiplies<MoveOnlyWrapper<T>>{});
             }
             if constexpr (std::is_same_v<UnaryOp, std::negate<T>>)
             {
                 invoke_on_all_policies<5>()(test_2_iters<NoDefaultCtorWrapper<T>>(), in1.begin(), in1.begin() + n,
-                                            NoDefaultCtorWrapper<T>{init}, std::plus<NoDefaultCtorWrapper<T>>{},
+                                            NoDefaultCtorWrapper<T>{init}, NoDefaultCtorWrapper<T>{init},
+                                            std::plus<NoDefaultCtorWrapper<T>>{},
                                             std::negate<NoDefaultCtorWrapper<T>>{});
+
+                iterator_invoker<std::random_access_iterator_tag, /*reverse_iterator=*/std::false_type>()(
+                    oneapi::dpl::execution::par_unseq, test_2_iters<T>(), in1.begin(), in1.begin() + n,
+                    MoveOnlyWrapper<T>{init}, MoveOnlyWrapper<T>{init}, std::plus<MoveOnlyWrapper<T>>{},
+                    std::negate<MoveOnlyWrapper<T>>{});
             }
         }
     }

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1271,16 +1271,16 @@ struct MoveOnlyWrapper {
     friend bool operator==(const MoveOnlyWrapper& a, const MoveOnlyWrapper& b)
     {
         return a.value == b.value;
-    } 
+    }
     friend MoveOnlyWrapper operator+(const MoveOnlyWrapper& a, const MoveOnlyWrapper& b)
     {
         return MoveOnlyWrapper{a.value + b.value};
-    } 
+    }
 
     friend MoveOnlyWrapper operator*(const MoveOnlyWrapper& a, const MoveOnlyWrapper& b)
     {
         return MoveOnlyWrapper{a.value * b.value};
-    } 
+    }
 };
 
 template <typename _T>

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1244,6 +1244,46 @@ struct Pow2
 };
 
 template <typename _T>
+struct MoveOnlyWrapper {
+    _T value;
+
+    // Default constructor
+    MoveOnlyWrapper() = delete;
+
+    MoveOnlyWrapper(_T v) : value(v) {}
+
+    operator _T() const { return value; }
+
+    // Move constructor
+    MoveOnlyWrapper(MoveOnlyWrapper&&) = default;
+
+    // Move assignment operator
+    MoveOnlyWrapper& operator=(MoveOnlyWrapper&&) = default;
+
+    // Deleted copy constructor and copy assignment operator
+    MoveOnlyWrapper(const MoveOnlyWrapper&) = delete;
+    MoveOnlyWrapper& operator=(const MoveOnlyWrapper&) = delete;
+
+    MoveOnlyWrapper operator-() const
+    {
+        return MoveOnlyWrapper{-value};
+    }
+    friend bool operator==(const MoveOnlyWrapper& a, const MoveOnlyWrapper& b)
+    {
+        return a.value == b.value;
+    } 
+    friend MoveOnlyWrapper operator+(const MoveOnlyWrapper& a, const MoveOnlyWrapper& b)
+    {
+        return MoveOnlyWrapper{a.value + b.value};
+    } 
+
+    friend MoveOnlyWrapper operator*(const MoveOnlyWrapper& a, const MoveOnlyWrapper& b)
+    {
+        return MoveOnlyWrapper{a.value * b.value};
+    } 
+};
+
+template <typename _T>
 struct NoDefaultCtorWrapper {
     _T value;
 


### PR DESCRIPTION
This PR adds support within [transform_]reduce for types with only move constructor and move assignment operator (no copy assignment or construction) for host backends (tbb and omp).

It adds host policy tests for move only types within [transform_]reduce.pass.  

This is part of the resolution for #1955. 