### PR TITLE
[Draft] Dynamic Selection proposal for extra resource type

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -215,6 +215,7 @@ class auto_tune_policy
     using resource_type = decltype(unwrap(std::declval<wrapped_resource_t>()));
     using wait_type = typename Backend::wait_type;
     using selection_type = auto_tune_selection_type;
+    using extra_resource_type = ExtraResourceType;
 
     auto_tune_policy(deferred_initialization_t) {}
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -168,7 +168,7 @@ class auto_tune_policy
 	scratch_space_t scratch_space;
 
         auto_tune_selection_type(const policy_t& p, resource_with_index_t r, std::shared_ptr<tuner_t> t, extra_resource_t er)
-            : policy_(p), resource_(r), tuner_(::std::move(t)), extra_resource_(::std::move(er))
+            : policy_(p), resource_(r), tuner_(::std::move(t)), extra_resource_(er)
         {
         }
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/backend_traits.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/backend_traits.h
@@ -125,16 +125,6 @@ struct has_reset
     static constexpr bool value = decltype(test<ResourceType>(0))::value;
 };
 
-template <typename ResourceType>
-struct has_cleanup
-{
-    template <typename T>
-    static auto test(int) -> decltype(std::declval<T>().cleanup(), std::true_type{});
-    template <typename>
-    static auto test(...) -> std::false_type;
-    static constexpr bool value = decltype(test<ResourceType>(0))::value;
-};
-
 } //namespace internal
 
 template <typename ResourceType>
@@ -143,8 +133,6 @@ struct extra_resource_traits
     static constexpr bool has_initialize_v = internal::has_initialize<ResourceType>::value; 
 
     static constexpr bool has_reset_v = internal::has_reset<ResourceType>::value;
-
-    static constexpr bool has_cleanup_v = internal::has_cleanup<ResourceType>::value;
 };
 
 } // namespace experimental

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/backend_traits.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/backend_traits.h
@@ -100,6 +100,53 @@ using selection_scratch_t = typename scratch_trait_t_impl<Backend, backend_trait
 
 } //namespace backend_traits
 
+
+namespace internal
+{
+template <typename ResourceType>
+struct has_initialize
+{
+    template <typename T>
+    static auto test(int) -> decltype(std::declval<T>().initialize(), std::true_type{});
+
+    template <typename>
+    static auto test(...) -> std::false_type;
+
+    static constexpr bool value = decltype(test<ResourceType>(0))::value;
+};
+
+template <typename ResourceType>
+struct has_reset
+{
+    template <typename T>
+    static auto test(int) -> decltype(std::declval<T>().reset(), std::true_type{});
+    template <typename>
+    static auto test(...) -> std::false_type;
+    static constexpr bool value = decltype(test<ResourceType>(0))::value;
+};
+
+template <typename ResourceType>
+struct has_cleanup
+{
+    template <typename T>
+    static auto test(int) -> decltype(std::declval<T>().cleanup(), std::true_type{});
+    template <typename>
+    static auto test(...) -> std::false_type;
+    static constexpr bool value = decltype(test<ResourceType>(0))::value;
+};
+
+} //namespace internal
+
+template <typename ResourceType>
+struct extra_resource_traits
+{
+    static constexpr bool has_initialize_v = internal::has_initialize<ResourceType>::value; 
+
+    static constexpr bool has_reset_v = internal::has_reset<ResourceType>::value;
+
+    static constexpr bool has_cleanup_v = internal::has_cleanup<ResourceType>::value;
+};
+
 } // namespace experimental
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
@@ -82,19 +82,6 @@ class backend_base
         }
     }
 
-    ~backend_base()
-    {
-        if constexpr (oneapi::dpl::experimental::extra_resource_traits<extra_resource_t>::has_cleanup_v)
-        {
-            for (auto& e : extra_resources_)
-            {
-                e.cleanup();
-            }
-        }
-        extra_resources_.~extra_resource_container_t();
-        resources_.~resource_container_t();
-    }
-
     auto
     get_submission_group()
     {
@@ -105,7 +92,7 @@ class backend_base
         return static_cast<Backend*>(this)->get_resources_impl();
     }
 
-    std::enable_if<has_extra_resources_v, extra_resource_container_t>
+    extra_resource_container_t
     get_extra_resources() const
     {
         return extra_resources_;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
@@ -156,9 +156,17 @@ class backend_base
     auto
     submit_impl(SelectionHandle s, Function&& f, Args&&... args)
     {
-      static_cast<Backend*>(this)->instrument_before_impl(s);
-      auto w = std::forward<Function>(f)(oneapi::dpl::experimental::unwrap(s), std::forward<Args>(args)...);
-	    return static_cast<Backend*>(this)->instrument_after_impl(s, w);
+        static_cast<Backend*>(this)->instrument_before_impl(s);
+        if constexpr (has_extra_resources_v)
+        {
+            auto w = std::forward<Function>(f)(oneapi::dpl::experimental::unwrap(s), s.get_extra_resource(), std::forward<Args>(args)...);
+            return static_cast<Backend*>(this)->instrument_after_impl(s, w);
+        }
+        else
+        {
+            auto w = std::forward<Function>(f)(oneapi::dpl::experimental::unwrap(s), std::forward<Args>(args)...);
+            return static_cast<Backend*>(this)->instrument_after_impl(s, w);
+        }
     }
 
     template<typename WaitType>

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
@@ -91,6 +91,8 @@ class backend_base
                 e.cleanup();
             }
         }
+        extra_resources_.~extra_resource_container_t();
+        resources_.~resource_container_t();
     }
 
     auto

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -61,7 +61,7 @@ class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType,
         ExtraResourceType extra_;
 
       public:
-        dl_selection_handle_t(const Policy& p, std::shared_ptr<resource_t> r, ExtraResourceType extra) : policy_(p), resource_(std::move(r)), extra_(std::move(extra)) {}
+        dl_selection_handle_t(const Policy& p, std::shared_ptr<resource_t> r, ExtraResourceType extra) : policy_(p), resource_(std::move(r)), extra_(extra) {}
 	///using scratch_space_t = typename backend_traits::selection_scratch_t<Backend,execution_info::task_time_t>; //REMOVE???
 	///scratch_space_t scratch_space; //REMOVE???
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -180,7 +180,10 @@ class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType,
                 {
                     least_load = v;
                     least_loaded = r;
-                    extra_resource = selector_->get_extra_resource(i);
+                    if constexpr(base_t::has_extra_resources_v)
+                    {
+                        extra_resource = selector_->get_extra_resource(i);
+                    }
                 }
             }
             return selection_type{dynamic_load_policy<ResourceType, ExtraResourceType, Backend>(*this), least_loaded, extra_resource};

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -27,17 +27,19 @@ namespace experimental
 {
 
 #if _DS_BACKEND_SYCL != 0
-template <typename ResourceType = sycl::queue, typename Backend = default_backend<ResourceType>>
+template <typename ResourceType = sycl::queue, typename ExtraResourceType = oneapi::dpl::experimental::empty_extra_resource, typename Backend = default_backend<ResourceType, ExtraResourceType>>
 #else
-template <typename ResourceType, typename Backend = default_backend<ResourceType>>
+template <typename ResourceType, typename ExtraResourceType = oneapi::dpl::experimental::empty_extra_resource, typename Backend = default_backend<ResourceType, ExtraResourceType>>
 #endif
-class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType, Backend>, ResourceType, Backend>
+class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType, ExtraResourceType, Backend>, ResourceType, ExtraResourceType, Backend>
 {
   protected:
-    using base_t = policy_base<dynamic_load_policy<ResourceType, Backend>, ResourceType, Backend>;
+    using base_t = policy_base<dynamic_load_policy<ResourceType, ExtraResourceType, Backend>, ResourceType, ExtraResourceType, Backend>;
     using resource_container_size_t = typename base_t::resource_container_size_t;
 
     using execution_resource_t = typename base_t::execution_resource_t;
+    using extra_resource_container_t = typename base_t::extra_resource_container_t;
+    using extra_resource_t = ExtraResourceType;
     using load_t = int;
 
     struct resource_t
@@ -54,9 +56,10 @@ class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType,
     {
         Policy policy_;
         std::shared_ptr<resource_t> resource_;
+        std::shared_ptr<ExtraResourceType> extra_;
 
       public:
-        dl_selection_handle_t(const Policy& p, std::shared_ptr<resource_t> r) : policy_(p), resource_(std::move(r)) {}
+        dl_selection_handle_t(const Policy& p, std::shared_ptr<resource_t> r, std::shared_ptr<ExtraResourceType> extra) : policy_(p), resource_(std::move(r)), extra_(std::move(extra)) {}
 	///using scratch_space_t = typename backend_traits::selection_scratch_t<Backend,execution_info::task_time_t>; //REMOVE???
 	///scratch_space_t scratch_space; //REMOVE???
 
@@ -65,6 +68,12 @@ class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType,
         unwrap()
         {
             return ::oneapi::dpl::experimental::unwrap(resource_->e_);
+        }
+
+        std::shared_ptr<ExtraResourceType>
+        get_extra_resource()
+        {
+            return extra_;
         }
 
         Policy
@@ -92,32 +101,56 @@ class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType,
     {
         resource_container_t resources_;
         std::mutex m_;
+        extra_resource_container_t extra_resources_;
+        auto
+        get_extra_resource(std::size_t i) const
+        {
+            if constexpr (base_t::has_extra_resources_v)
+            {
+                return base_t::extra_resources_[i];
+            }
+            else
+            {
+                return std::make_shared<oneapi::dpl::experimental::empty_extra_resource>();
+            }
+        }
     };
 
     std::shared_ptr<selector_t> selector_;
 
   public:
-    using selection_type = dl_selection_handle_t<dynamic_load_policy<ResourceType, Backend>>;
+    using selection_type = dl_selection_handle_t<dynamic_load_policy<ResourceType, ExtraResourceType, Backend>>;
     using resource_type = typename base_t::resource_type;
     using wait_type = typename Backend::wait_type; //TODO: Get from policy_base instead?
 
     dynamic_load_policy() { base_t::initialize(); }
     dynamic_load_policy(deferred_initialization_t) {}
     dynamic_load_policy(const std::vector<resource_type>& u) { base_t::initialize(u); }
+    dynamic_load_policy(const std::vector<resource_type>& u, const std::vector<extra_resource_t>& v) { base_t::initialize(u, v); }
 
     void
     initialize_impl()
     {
         if (!selector_)
-	{
-	    selector_ = std::make_shared<selector_t>();
-	}
-	auto u = base_t::get_resources();
-	selector_->resources_.clear();
-    for (auto x : u)
+        {
+            selector_ = std::make_shared<selector_t>();
+        }
+        auto u = base_t::get_resources();
+        selector_->resources_.clear();
+        for (auto x : u)
+        {
+            selector_->resources_.push_back(std::make_shared<resource_t>(x));
+        }
+        if constexpr (base_t::has_extra_resources_v)
+        {
+            auto er = base_t::get_extra_resources();
+            selector_->extra_resources_.clear();
+            selector_->extra_resources_.reserve(er.size());
+            for (const auto& e : er)
             {
-                selector_->resources_.push_back(std::make_shared<resource_t>(x));
+                selector_->extra_resources_.push_back(std::make_shared<extra_resource_t>(e));
             }
+        }
 
     }
 
@@ -129,19 +162,23 @@ class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType,
 	     if (selector_)
         {
             std::shared_ptr<resource_t> least_loaded;
+            std::shared_ptr<ExtraResourceType> extra_resource;
+
             int least_load = std::numeric_limits<load_t>::max();
 
             std::lock_guard<std::mutex> l(selector_->m_);
-            for (auto r : selector_->resources_)
+            for (std::size_t i = 0; i < selector_->resources_.size(); ++i)
             {
+                auto& r = selector_->resources_[i];
                 load_t v = r->load_.load();
                 if (!least_loaded || v < least_load)
                 {
                     least_load = v;
-                    least_loaded = ::std::move(r);
+                    least_loaded = r;
+                    extra_resource = selector_->get_extra_resource(i);
                 }
             }
-            return selection_type{dynamic_load_policy<ResourceType, Backend>(*this), least_loaded};
+            return selection_type{dynamic_load_policy<ResourceType, ExtraResourceType, Backend>(*this), least_loaded, extra_resource};
         }
         else
         {

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
@@ -39,6 +39,7 @@ class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceT
     struct selector_t 
     {
         typename base_t::resource_container_t resources_;
+        typename base_t::extra_resource_container_t extra_resources_;
         std::size_t index_ = 0;
 
         auto
@@ -46,7 +47,7 @@ class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceT
         {
             if constexpr (base_t::has_extra_resources_v)
             {
-                return base_t::extra_resources_[index_];
+                return extra_resources_[index_];
             }
             else
             {
@@ -61,6 +62,7 @@ class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceT
     using resource_type = typename base_t::resource_type;
     using typename base_t::selection_type;
     using wait_type = typename Backend::wait_type; //TODO: Get from policy_base instead?
+    using extra_resource_type = ExtraResourceType;
 
     fixed_resource_policy(::std::size_t index = 0) 
     { 
@@ -71,7 +73,13 @@ class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceT
     fixed_resource_policy(const std::vector<resource_type>& u, ::std::size_t index = 0) 
     { 
         base_t::initialize(u); 
-	selector_->index_ = index;
+        selector_->index_ = index;
+    }
+
+    fixed_resource_policy(const std::vector<resource_type>& u, const std::vector<ExtraResourceType>& v, std::size_t index = 0) 
+    { 
+        base_t::initialize(u, v); 
+        selector_->index_ = index;
     }
 
     void 
@@ -84,6 +92,16 @@ class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceT
 	auto u = base_t::get_resources();
         selector_->resources_ = u;
         selector_->index_ = 0;
+        if constexpr (base_t::has_extra_resources_v)
+        {
+            auto er = base_t::get_extra_resources();
+            selector_->extra_resources_.clear();
+            selector_->extra_resources_.reserve(er.size());
+            for (const auto& e : er)
+            {
+                selector_->extra_resources_.push_back(ExtraResourceType{e});
+            }
+        }
     }
 
     template <typename... Args>

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/policy_base.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/policy_base.h
@@ -33,11 +33,11 @@ class policy_base
     using resource_container_t = typename backend_t::resource_container_t;
     using resource_container_size_t = typename resource_container_t::size_type;
     using execution_resource_t = typename backend_t::execution_resource_t;
-    using extra_resource_container_t = typename backend_t::extra_resource_container_t;
     using wrapped_resource_t = execution_resource_t;
     static constexpr bool has_extra_resources_v = backend_t::has_extra_resources_v;
 
   public:
+    using extra_resource_container_t = typename backend_t::extra_resource_container_t;
     using resource_type = decltype(unwrap(std::declval<wrapped_resource_t>()));
     using extra_resource_t = ExtraResourceType;
     using selection_type = basic_selection_handle_t<Policy, execution_resource_t, ExtraResourceType>;
@@ -53,10 +53,13 @@ class policy_base
         throw std::logic_error("get_resources called before initialization");
     }
 
-    std::enable_if_t<!has_extra_resources_v, extra_resource_container_t>
+    extra_resource_container_t
     get_extra_resources() const
     {
-        if (backend_) return backend_->get_extra_resources();
+        if (backend_) 
+        {
+            return backend_->get_extra_resources();
+        }
         throw std::logic_error("get_extra_resources called before initialization");
     }
 
@@ -73,6 +76,14 @@ class policy_base
         if (!backend_) backend_ = std::make_shared<backend_t>(u);
         static_cast<Policy*>(this)->initialize_impl();
     }
+
+    void 
+    initialize(const std::vector<resource_type>& u, const std::vector<ExtraResourceType>& v) 
+    {
+        if (!backend_) backend_ = std::make_shared<backend_t>(u, v);
+        static_cast<Policy*>(this)->initialize_impl();
+    }
+
 
     template <typename... Args>
     auto

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/policy_base.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/policy_base.h
@@ -25,7 +25,7 @@ namespace dpl
 namespace experimental 
 {
 
-template <typename Policy, typename ResourceType, typename Backend>
+template <typename Policy, typename ResourceType, typename ExtraResourceType, typename Backend>
 class policy_base 
 {
   protected:
@@ -33,11 +33,14 @@ class policy_base
     using resource_container_t = typename backend_t::resource_container_t;
     using resource_container_size_t = typename resource_container_t::size_type;
     using execution_resource_t = typename backend_t::execution_resource_t;
+    using extra_resource_container_t = typename backend_t::extra_resource_container_t;
     using wrapped_resource_t = execution_resource_t;
+    static constexpr bool has_extra_resources_v = backend_t::has_extra_resources_v;
 
   public:
     using resource_type = decltype(unwrap(std::declval<wrapped_resource_t>()));
-    using selection_type = basic_selection_handle_t<Policy, execution_resource_t>;
+    using extra_resource_t = ExtraResourceType;
+    using selection_type = basic_selection_handle_t<Policy, execution_resource_t, ExtraResourceType>;
 
   protected:
     std::shared_ptr<backend_t> backend_;
@@ -48,6 +51,13 @@ class policy_base
     {
         if (backend_) return backend_->get_resources();
         throw std::logic_error("get_resources called before initialization");
+    }
+
+    std::enable_if_t<!has_extra_resources_v, extra_resource_container_t>
+    get_extra_resources() const
+    {
+        if (backend_) return backend_->get_extra_resources();
+        throw std::logic_error("get_extra_resources called before initialization");
     }
 
     void 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
@@ -22,7 +22,7 @@ struct policy_traits
 {
     using selection_type = typename std::decay_t<Policy>::selection_type; //selection type
     using resource_type = typename std::decay_t<Policy>::resource_type;   //resource type
-
+    using extra_resource_type = typename std::decay_t<Policy>::extra_resource_type; //extra resource type
     using wait_type = typename std::decay_t<Policy>::wait_type; //wait_type
 };
 
@@ -31,6 +31,10 @@ using selection_t = typename policy_traits<Policy>::selection_type;
 
 template <typename Policy>
 using resource_t = typename policy_traits<Policy>::resource_type;
+
+template <typename Policy>
+using extra_resource_t = typename policy_traits<Policy>::extra_resource_type;
+
 
 template <typename Policy>
 using wait_t = typename policy_traits<Policy>::wait_type;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/scoring_policy_defs.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/scoring_policy_defs.h
@@ -17,19 +17,44 @@ namespace dpl
 {
 namespace experimental
 {
-template <typename Policy, typename Resource>
+
+class empty_extra_resource
+{
+    // This class is used to indicate that no extra resource is needed.
+    // It can be used as a template parameter for default_backend.
+};
+
+struct no_extra_resources
+{
+    using type = void;
+    std::size_t
+    size() const noexcept
+    {
+        return 0;
+    }
+};
+
+template <typename Policy, typename Resource, typename ExtraResourceType = oneapi::dpl::experimental::empty_extra_resource>
 class basic_selection_handle_t
 {
     Policy p_;
     Resource e_;
+    ExtraResourceType r_;
 
   public:
-    explicit basic_selection_handle_t(const Policy& p, Resource e = Resource{}) : p_(p), e_(std::move(e)) {}
+    explicit basic_selection_handle_t(const Policy& p, Resource e = Resource{}, ExtraResourceType r = ExtraResourceType{}) : p_(p), e_(std::move(e)), r_(std::move(r)) {}
     auto
     unwrap()
     {
         return oneapi::dpl::experimental::unwrap(e_);
     }
+
+    ExtraResourceType
+    get_extra_resource()
+    {
+        return r_;
+    }
+
     Policy
     get_policy()
     {

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -23,7 +23,6 @@
 #include <utility>
 #include <algorithm>
 
-
 namespace oneapi
 {
 namespace dpl
@@ -31,22 +30,22 @@ namespace dpl
 namespace experimental
 {
 
-template< >
-class default_backend<sycl::queue> : public backend_base<sycl::queue, default_backend<sycl::queue>>
+template <typename _ExtraResource>
+class default_backend<sycl::queue, _ExtraResource>
+    : public backend_base<sycl::queue, _ExtraResource, default_backend<sycl::queue, _ExtraResource>>
 {
   public:
     using resource_type = sycl::queue;
     using wait_type = sycl::event;
-    template<typename ...Req>
-    struct scratch_t 
+    template <typename... Req>
+    struct scratch_t
     {
     };
 
-    
-    template<>
-    struct scratch_t<execution_info::task_time_t> 
+    template <>
+    struct scratch_t<execution_info::task_time_t>
     {
-	    sycl::event my_start_event;
+        sycl::event my_start_event;
     };
 
     using execution_resource_t = resource_type;
@@ -60,8 +59,10 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
     class async_waiter_base
     {
       public:
-        virtual void report() const = 0;
-        virtual bool is_complete() const = 0;
+        virtual void
+        report() const = 0;
+        virtual bool
+        is_complete() const = 0;
         virtual ~async_waiter_base() = default;
     };
 
@@ -171,8 +172,8 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
         sgroup_ptr_ = std::make_unique<submission_group>(global_rank_);
     }
 
-    template <typename NativeUniverseVector>
-    default_backend(const NativeUniverseVector& v)
+    template <typename NativeUniverseVector, typename ExtraResourceVector = oneapi::dpl::experimental::no_extra_resources>
+    default_backend(const NativeUniverseVector& v, const ExtraResourceVector& r = {})
     {
         bool profiling = true;
         global_rank_.reserve(v.size());
@@ -188,7 +189,7 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
         sgroup_ptr_ = std::make_unique<submission_group>(global_rank_);
     }
 
-/*
+    /*
     //trait to check for scratch_space 
     template<typename T, typename = void>
     struct has_scratch_space : std::false_type {};
@@ -196,74 +197,77 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
     template<typename T>
     struct has_scratch_space<T, std::void_t<decltype(std::declval<T>().scratch_space)>>::true_type {};
 */
-    template <typename SelectionHandle> 
+    template <typename SelectionHandle>
     void
     instrument_before_impl(SelectionHandle s)
     {
-        if constexpr (report_value_v<SelectionHandle, execution_info::task_time_t, report_duration>) 
-        {
+        if constexpr (report_value_v<SelectionHandle, execution_info::task_time_t, report_duration>)
+        {
 #ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
-        auto q = unwrap(s);
-        if (!q.get_device().has(sycl::aspect::ext_oneapi_queue_profiling_tag)) 
+            auto q = unwrap(s);
+            if (!q.get_device().has(sycl::aspect::ext_oneapi_queue_profiling_tag))
             {
                 std::cout << "Cannot time kernels without enabling profiling on queue\n";
-            ///TODO: THROW???
+                 ///TODO: THROW???
             }
-           if constexpr (internal::scratch_space_member<SelectionHandle>::value)
-		s.scratch_space.my_start_event = sycl::ext::oneapi::experimental::submit_profiling_tag(q); //starting timestamp
+            if constexpr (internal::scratch_space_member<SelectionHandle>::value)
+                s.scratch_space.my_start_event =
+                    sycl::ext::oneapi::experimental::submit_profiling_tag(q); //starting timestamp
 #else
-           std::cout << "task_time reporting not supported with this configuration " << std::endl;
+            std::cout << "task_time reporting not supported with this configuration " << std::endl;
 #endif
-       }
-       if constexpr (report_info_v<SelectionHandle, execution_info::task_submission_t>)
-           report(s, execution_info::task_submission);
-       }
-
-       template <typename SelectionHandle, typename WaitType>
-       auto
-       instrument_after_impl(SelectionHandle s, WaitType e1)
-       {
-           constexpr bool report_task_completion = report_info_v<SelectionHandle, execution_info::task_completion_t>;
-           constexpr bool report_task_time = report_value_v<SelectionHandle, execution_info::task_time_t, report_duration>;
-       if constexpr (report_task_completion || report_task_time)
-       {
-           async_waiter<SelectionHandle> waiter{e1, std::make_shared<SelectionHandle>(s)};
-           if constexpr (report_task_time && is_profiling_enabled)
-           {
-               async_waiter_list.add_waiter(new async_waiter(waiter));
-           }
-
-           if (report_task_time && !is_profiling_enabled)
-           {
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
-           if constexpr (internal::scratch_space_member<SelectionHandle>::value)
-           {
-               auto q = unwrap(s);
-               sycl::event q_end = sycl::ext::oneapi::experimental::submit_profiling_tag(q); //ending timestamp
-               //get raw nano number
-               uint64_t time_taken_nanoseconds =
-               q_end.template get_profiling_info<sycl::info::event_profiling::command_start>() -
-               s.scratch_space.my_start_event.template get_profiling_info<sycl::info::event_profiling::command_end>();
-               //convert nanoseconds to milliseconds
-               report_duration time_taken_milliseconds = 
-               std::chrono::duration_cast<report_duration>(std::chrono::nanoseconds(time_taken_nanoseconds));
-
-               s.report(execution_info::task_time, time_taken_milliseconds);
-            }
-#endif
-           }
-           if constexpr (report_task_completion)
-               s.report(execution_info::task_completion);
-          
-               return waiter;
-           }
-
-           return async_waiter{e1, std::make_shared<SelectionHandle>(s)};
+        }
+        if constexpr (report_info_v<SelectionHandle, execution_info::task_submission_t>)
+            report(s, execution_info::task_submission);
     }
 
+    template <typename SelectionHandle, typename WaitType>
+    auto
+    instrument_after_impl(SelectionHandle s, WaitType e1)
+    {
+        constexpr bool report_task_completion = report_info_v<SelectionHandle, execution_info::task_completion_t>;
+        constexpr bool report_task_time = report_value_v<SelectionHandle, execution_info::task_time_t, report_duration>;
+        if constexpr (report_task_completion || report_task_time)
+        {
+            async_waiter<SelectionHandle> waiter{e1, std::make_shared<SelectionHandle>(s)};
+            if (report_task_time && is_profiling_enabled)
+            {
+                async_waiter_list.add_waiter(new async_waiter(waiter));
+            }
 
+            if (report_task_time && !is_profiling_enabled)
+            {
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+                if constexpr (internal::scratch_space_member<SelectionHandle>::value)
+                {
+                    auto q = unwrap(s);
+                    if constexpr (oneapi::dpl::experimental::extra_resource_traits<_ExtraResource>::has_reset_v)
+                    {
+                        s.get_extra_resource().reset();
+                    }
+                    sycl::event q_end = sycl::ext::oneapi::experimental::submit_profiling_tag(q); //ending timestamp
+                                                                                                  //get raw nano number
+                        uint64_t time_taken_nanoseconds =
+                            q_end.template get_profiling_info<sycl::info::event_profiling::command_start>() -
+                            s.scratch_space.my_start_event
+                                .template get_profiling_info<sycl::info::event_profiling::command_end>();
+                                 //convert nanoseconds to milliseconds
+                        report_duration time_taken_milliseconds = std::chrono::duration_cast<report_duration>(
+                            std::chrono::nanoseconds(time_taken_nanoseconds));
 
-/*
+                    s.report(execution_info::task_time, time_taken_milliseconds);
+                }
+#endif
+            }
+            if constexpr (report_task_completion)
+                s.report(execution_info::task_completion);
+            return waiter;
+        }
+
+        return async_waiter{e1, std::make_shared<SelectionHandle>(s)};
+    }
+
+    /*
     template <typename SelectionHandle>
     void
     instrument_before_impl(SelectionHandle s)

--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
@@ -22,13 +22,13 @@ int
 test_auto_initialization(const std::vector<sycl::queue>& u)
 {
     // initialize
-    oneapi::dpl::experimental::auto_tune_policy<sycl::queue, oneapi::dpl::experimental::default_backend<sycl::queue>> p{u};
+    oneapi::dpl::experimental::auto_tune_policy<sycl::queue, oneapi::dpl::experimental::empty_extra_resource, oneapi::dpl::experimental::default_backend<sycl::queue, oneapi::dpl::experimental::empty_extra_resource>> p{u};
     auto u2 = oneapi::dpl::experimental::get_resources(p);
     EXPECT_TRUE(std::equal(std::begin(u2), std::end(u2), std::begin(u)),
                 "ERROR: provided resources and queried resources are not equal\n");
 
     // deferred initialization
-    oneapi::dpl::experimental::auto_tune_policy<sycl::queue, oneapi::dpl::experimental::default_backend<sycl::queue>> p2{oneapi::dpl::experimental::deferred_initialization};
+    oneapi::dpl::experimental::auto_tune_policy<sycl::queue, oneapi::dpl::experimental::empty_extra_resource, oneapi::dpl::experimental::default_backend<sycl::queue, oneapi::dpl::experimental::empty_extra_resource>> p2{oneapi::dpl::experimental::deferred_initialization};
     try
     {
         auto u3 = oneapi::dpl::experimental::get_resources(p2);
@@ -447,7 +447,7 @@ main()
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
 #if !ONEDPL_FPGA_DEVICE || !ONEDPL_FPGA_EMULATOR
-    using policy_t = oneapi::dpl::experimental::auto_tune_policy<sycl::queue, oneapi::dpl::experimental::default_backend<sycl::queue>>;
+    using policy_t = oneapi::dpl::experimental::auto_tune_policy<sycl::queue, oneapi::dpl::experimental::empty_extra_resource, oneapi::dpl::experimental::default_backend<sycl::queue, oneapi::dpl::experimental::empty_extra_resource>>;
     std::vector<sycl::queue> u1;
     std::vector<sycl::queue> u2;
     constexpr bool use_event_profiling = true;

--- a/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
@@ -72,7 +72,7 @@ main()
         // should always pick first when waiting on sync in each iteration
 
         // select extra resource
-        auto ef = [v](int i) { return v[i % v.size()]; };
+        auto ef = [v](int i) { return v[0]; };
 
         constexpr bool just_call_submit = false;
         constexpr bool call_select_before_submit = true;

--- a/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
 #if !ONEDPL_FPGA_DEVICE || !ONEDPL_FPGA_EMULATOR
-    using policy_t = oneapi::dpl::experimental::dynamic_load_policy<sycl::queue, oneapi::dpl::experimental::default_backend<sycl::queue>>;
+    using policy_t = oneapi::dpl::experimental::dynamic_load_policy<sycl::queue, oneapi::dpl::experimental::empty_extra_resource, oneapi::dpl::experimental::default_backend<sycl::queue, oneapi::dpl::experimental::empty_extra_resource>>;
     std::vector<sycl::queue> u;
     build_dl_universe(u);
 

--- a/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
@@ -19,7 +19,7 @@ main()
     bool bProcessed = false;
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
-    using policy_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, oneapi::dpl::experimental::default_backend<sycl::queue>>;
+    using policy_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, oneapi::dpl::experimental::empty_extra_resource, oneapi::dpl::experimental::default_backend<sycl::queue, oneapi::dpl::experimental::empty_extra_resource>>;
     std::vector<sycl::queue> u;
     build_universe(u);
     if (!u.empty())

--- a/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
@@ -20,11 +20,23 @@ main()
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
     using policy_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, oneapi::dpl::experimental::empty_extra_resource, oneapi::dpl::experimental::default_backend<sycl::queue, oneapi::dpl::experimental::empty_extra_resource>>;
+    using policy_with_extra_resources_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, int, oneapi::dpl::experimental::default_backend<sycl::queue, int>>;
+
     std::vector<sycl::queue> u;
     build_universe(u);
+
+    std::vector<int> v;
+    for (int i = 0; i < u.size(); ++i)
+    {
+        v.push_back(i);
+    }
+
     if (!u.empty())
     {
+        
         auto f = [u](int, int offset = 0) { return u[offset]; };
+
+        auto ef = [v](int, int offset = 0) { return v[offset]; };
 
         constexpr bool just_call_submit = false;
         constexpr bool call_select_before_submit = true;
@@ -35,6 +47,8 @@ main()
         EXPECT_EQ(0, (test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f)), "");
         EXPECT_EQ(0, (test_submit_and_wait<just_call_submit, policy_t>(u, f)), "");
         EXPECT_EQ(0, (test_submit_and_wait<call_select_before_submit, policy_t>(u, f)), "");
+        EXPECT_EQ(0, (test_extra_resource_submit_and_wait<just_call_submit, policy_with_extra_resources_t>(u, v, f, ef)), "");
+        EXPECT_EQ(0, (test_extra_resource_submit_and_wait<call_select_before_submit, policy_with_extra_resources_t>(u, v, f, ef)), "");
         EXPECT_EQ(0, (test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f)), "");
         EXPECT_EQ(0, (test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f)), "");
 

--- a/test/parallel_api/dynamic_selection/sycl/test_round_robin_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_round_robin_policy_sycl.pass.cpp
@@ -21,7 +21,7 @@ main()
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
     //using policy_t = oneapi::dpl::experimental::round_robin_policy<oneapi::dpl::experimental::sycl_backend>;
-    using policy_t = oneapi::dpl::experimental::round_robin_policy<sycl::queue, oneapi::dpl::experimental::default_backend<sycl::queue>>;
+    using policy_t = oneapi::dpl::experimental::round_robin_policy<sycl::queue, oneapi::dpl::experimental::empty_extra_resource, oneapi::dpl::experimental::default_backend<sycl::queue, oneapi::dpl::experimental::empty_extra_resource>>;
     std::vector<sycl::queue> u;
     build_universe(u);
     if (!u.empty())

--- a/test/parallel_api/dynamic_selection/sycl/test_round_robin_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_round_robin_policy_sycl.pass.cpp
@@ -22,14 +22,24 @@ main()
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
     //using policy_t = oneapi::dpl::experimental::round_robin_policy<oneapi::dpl::experimental::sycl_backend>;
     using policy_t = oneapi::dpl::experimental::round_robin_policy<sycl::queue, oneapi::dpl::experimental::empty_extra_resource, oneapi::dpl::experimental::default_backend<sycl::queue, oneapi::dpl::experimental::empty_extra_resource>>;
+    using policy_with_extra_resources_t = oneapi::dpl::experimental::round_robin_policy<sycl::queue, int, oneapi::dpl::experimental::default_backend<sycl::queue, int>>;
+
     std::vector<sycl::queue> u;
     build_universe(u);
+
+    std::vector<int> v;
+    for (int i = 0; i < u.size(); ++i)
+    {
+        v.push_back(i);
+    }
+
     if (!u.empty())
     {
         auto n = u.size();
         std::cout << "UNIVERSE SIZE " << n << std::endl;
 
         auto f = [u, n](int i) { return u[(i - 1) % n]; };
+        auto ef = [v, n](int i) { return v[(i - 1) % n]; };
 
         constexpr bool just_call_submit = false;
         constexpr bool call_select_before_submit = true;
@@ -40,6 +50,8 @@ main()
         EXPECT_EQ(0, (test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f)), "");
         EXPECT_EQ(0, (test_submit_and_wait<just_call_submit, policy_t>(u, f)), "");
         EXPECT_EQ(0, (test_submit_and_wait<call_select_before_submit, policy_t>(u, f)), "");
+        EXPECT_EQ(0, (test_extra_resource_submit_and_wait<just_call_submit, policy_with_extra_resources_t>(u, v, f, ef)), "");
+        EXPECT_EQ(0, (test_extra_resource_submit_and_wait<call_select_before_submit, policy_with_extra_resources_t>(u, v, f, ef)), "");
         EXPECT_EQ(0, (test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f)), "");
         EXPECT_EQ(0, (test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f)), "");
 

--- a/test/support/test_dynamic_load_utils.h
+++ b/test/support/test_dynamic_load_utils.h
@@ -402,17 +402,14 @@ template <bool call_select_before_submit, typename Policy, typename UniverseCont
 int
 test_extra_resource_submit_and_wait(UniverseContainer u, ExtraUniverseContainer v, ResourceFunction&& f, ExtraResourceFunction&& ef)
 {
-    //std::cout<<"testing extra resource..., vsize:"<<v.size()<<"\n";
     using my_policy_t = Policy;
     my_policy_t p{u, v};
-    //std::cout<<"initialized\n";
     const int N = 6;
     std::atomic<int> ecount = 0;
     bool pass = true;
 
     if constexpr (call_select_before_submit)
     {
-//        std::cout<<"call before submit\n";
         for (int i = 1; i <= N; ++i)
         {
             auto test_resource = f(i);
@@ -438,7 +435,6 @@ test_extra_resource_submit_and_wait(UniverseContainer u, ExtraUniverseContainer 
     }
     else
     {
-//        std::cout<<" submit and wait\n";
         for (int i = 1; i <= N; ++i)
         {
             auto test_resource = f(i);
@@ -449,7 +445,6 @@ test_extra_resource_submit_and_wait(UniverseContainer u, ExtraUniverseContainer 
                     if (e != test_resource || ex != test_extra_resource)
                     {
                         std::cout<<"ERROR: did not select expected resources\n";
-                        //std::cout<<" ex: "<<ex<<" test_extra_resource: "<<test_extra_resource<<"\n";
                         pass = false;
                     }
                     ecount += i;
@@ -472,7 +467,7 @@ test_extra_resource_submit_and_wait(UniverseContainer u, ExtraUniverseContainer 
         std::cout << "ERROR: did not select expected resources\n";
         return 1;
     }
-    std::cout << "submit_and_wait: OK\n";
+    std::cout << "test_extra_resource_submit_and_wait: OK\n";
     return 0;
 }
 #endif // TEST_DYNAMIC_SELECTION_AVAILABLE

--- a/test/support/test_dynamic_selection_utils.h
+++ b/test/support/test_dynamic_selection_utils.h
@@ -365,5 +365,78 @@ test_submit_and_wait(UniverseContainer u, ResourceFunction&& f)
     return 0;
 }
 
+template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ExtraUniverseContainer, typename ResourceFunction, typename ExtraResourceFunction>
+int
+test_extra_resource_submit_and_wait(UniverseContainer u, ExtraUniverseContainer v, ResourceFunction&& f, ExtraResourceFunction&& ef)
+{
+    using my_policy_t = Policy;
+    my_policy_t p{u, v};
+    const int N = 100;
+    std::atomic<int> ecount = 0;
+    bool pass = true;
+
+    if constexpr (call_select_before_submit)
+    {
+        for (int i = 1; i <= N; ++i)
+        {
+            auto test_resource = f(i);
+            auto test_extra_resource = ef(i);
+            auto func = [&pass, test_resource, test_extra_resource, &ecount,
+                         i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e, typename oneapi::dpl::experimental::policy_traits<Policy>::extra_resource_type ex) {
+                if (e != test_resource || ex != test_extra_resource)
+                {
+                    pass = false;
+                }
+                ecount += i;
+                return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+            };
+            auto s = oneapi::dpl::experimental::select(p, func);
+            oneapi::dpl::experimental::submit_and_wait(s, func);
+            int count = ecount.load();
+            if (count != i * (i + 1) / 2)
+            {
+                std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+                return 1;
+            }
+        }
+    }
+    else
+    {
+        for (int i = 1; i <= N; ++i)
+        {
+            auto test_resource = f(i);
+            auto test_extra_resource = ef(i);
+            oneapi::dpl::experimental::submit_and_wait(
+                p, [&pass, &ecount, test_resource,
+                    test_extra_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e, typename oneapi::dpl::experimental::policy_traits<Policy>::extra_resource_type ex) {
+                    if (e != test_resource || ex != test_extra_resource)
+                    {
+                        std::cout<<"ERROR: did not select expected resources\n";
+                        pass = false;
+                    }
+                    ecount += i;
+                    if constexpr (std::is_same_v<
+                                      typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
+                        return e;
+                    else
+                        return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+                });
+            int count = ecount.load();
+            if (count != i * (i + 1) / 2)
+            {
+                std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+                return 1;
+            }
+        }
+    }
+    if (!pass)
+    {
+        std::cout << "ERROR: did not select expected resources\n";
+        return 1;
+    }
+    std::cout << "test_extra_resource_submit_and_wait: OK\n";
+    return 0;
+}
+
 
 #endif /* _ONEDPL_TEST_DYNAMIC_SELECTION_UTILS_H */


### PR DESCRIPTION
Work in progress draft for adding an extra resource type to pair with a resource, which defaults to empty.

Allows passing in a vector of extra_resources to match the main resources, which can define any of 3 functions:
1) `initialize()` - called once per extra resource during creation of the backend if defined
2) `reset()` - called once per selection to "reset" the extra resource during `instrument_before_impl()` if defined
3) `clean_up()` - called once per extra resource when backend is destroyed if defined


Selection handle contain a function `get_extra_resource()` which provide the `extra_resource_t` object associated with the selected resource.

If a extra resources are provided, it is passed as the second argument to the provided submit function, otherwise it is not.

So far, this only tests the case without extra resources provided.  We need to test the case with extra resources as well.

(I also removed some strange formatting / unicode characters, they were causing warnings and made code difficult to read)