### PR TITLE
Adjust clang format to c++20 for concepts, etc.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 BasedOnStyle: LLVM
 
-Standard: c++17
+Standard: c++20
 
 IndentWidth: 4
 ColumnLimit: 120


### PR DESCRIPTION
To get concepts / requires clauses etc. to work with clang format we need to adjust the standard in our .clang-format file.

Currently causing strange formatting in #2359.
