### PR TITLE
Including utils.h to make definition of NoDefaultCtorWrapper available.

### DIFF
--- a/test/support/utils_device_copyable.h
+++ b/test/support/utils_device_copyable.h
@@ -17,6 +17,7 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT
 #include "utils_sycl_defs.h"
+#include "utils.h"
 #include <iostream>
 #include <type_traits>
 #include <cstddef>


### PR DESCRIPTION
#2354 introduces a test utility `NoDefaultCtorWrapper` in `test/support/utils.h` and uses the utility in `test/support/utils_device_copyable.h`. This PR includes `utils.h` in `utils_device_copyable.h` so the definition is available to resolve the compilation failure of `test/parallel_api/iterator/indirectly_device_accessible.pass.cpp`.