### PR TITLE
Dynamic Selection Adding ResourceAdapter to support queue*

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
@@ -187,7 +187,7 @@ class default_backend : public default_backend_impl<std::decay_t<decltype(std::d
     default_backend()
     {
     }
-    default_backend(const std::vector<ResourceType>& r, ResourceAdapter adapt = oneapi::dpl::identity{}) : base_t(r, adapt)
+    default_backend(const std::vector<ResourceType>& r, ResourceAdapter adapt = {}) : base_t(r, adapt)
     {
     }
 };

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
@@ -33,6 +33,10 @@ namespace experimental
 template<typename ResourceType, typename Backend>
 class backend_base
 {
+  static_assert(std::is_same_v<
+                  std::decay_t<decltype(std::declval<Backend::resource_adapter_t>()(std::declval<Backend::execution_resource_t>()))>,
+                  Backend::base_resource_t>,
+                "BaseResourceType does not match ResourceAdapter called with ResourceType");
   public:
     using resource_type = ResourceType;
     using execution_resource_t = resource_type;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
@@ -21,6 +21,7 @@
 #include "oneapi/dpl/internal/dynamic_selection_traits.h"
 #include "oneapi/dpl/internal/dynamic_selection_impl/scoring_policy_defs.h"
 #include "oneapi/dpl/internal/dynamic_selection_impl/backend_traits.h"
+#include "oneapi/dpl/functional"
 
 namespace oneapi
 {
@@ -176,7 +177,7 @@ public:
     ResourceAdapter __adapter;
 };
 
-template <typename ResourceType, typename ResourceAdapter = std::identity>
+template <typename ResourceType, typename ResourceAdapter = oneapi::dpl::identity>
 class default_backend : public default_backend_impl<std::decay_t<decltype(std::declval<ResourceAdapter>()(std::declval<ResourceType>()))>, ResourceType, ResourceAdapter>
 {
   public:
@@ -186,7 +187,7 @@ class default_backend : public default_backend_impl<std::decay_t<decltype(std::d
     default_backend()
     {
     }
-    default_backend(const std::vector<ResourceType>& r, ResourceAdapter adapt = std::identity{}) : base_t(r, adapt)
+    default_backend(const std::vector<ResourceType>& r, ResourceAdapter adapt = oneapi::dpl::identity{}) : base_t(r, adapt)
     {
     }
 };

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
@@ -33,10 +33,11 @@ namespace experimental
 template<typename ResourceType, typename Backend>
 class backend_base
 {
-  static_assert(std::is_same_v<
-                  std::decay_t<decltype(std::declval<Backend::resource_adapter_t>()(std::declval<Backend::execution_resource_t>()))>,
-                  Backend::base_resource_t>,
-                "BaseResourceType does not match ResourceAdapter called with ResourceType");
+    static_assert(std::is_same_v<std::decay_t<decltype(std::declval<Backend::resource_adapter_t>()(
+                                     std::declval<Backend::execution_resource_t>()))>,
+                                 Backend::base_resource_t>,
+                  "BaseResourceType does not match ResourceAdapter called with ResourceType");
+
   public:
     using resource_type = ResourceType;
     using execution_resource_t = resource_type;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/default_backend.h
@@ -172,9 +172,9 @@ public:
     using my_base = backend_base<ResourceType, default_backend_impl<BaseResourceType, ResourceType, ResourceAdapter>>;
 
     default_backend_impl() : my_base() {}
-    default_backend_impl(const std::vector<ResourceType>& u, ResourceAdapter adapter) : my_base(u), __adapter(adapter) {}
+    default_backend_impl(const std::vector<ResourceType>& u, ResourceAdapter adapter_) : my_base(u), adapter(adapter_) {}
   private:
-    ResourceAdapter __adapter;
+    ResourceAdapter adapter;
 };
 
 template <typename ResourceType, typename ResourceAdapter = oneapi::dpl::identity>

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -12,6 +12,7 @@
 
 #include <mutex>
 #include "oneapi/dpl/internal/dynamic_selection_impl/policy_base.h"
+#include "oneapi/dpl/functional"
 
 #if _DS_BACKEND_SYCL != 0
 #    include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
@@ -27,9 +28,9 @@ namespace experimental
 {
 
 #if _DS_BACKEND_SYCL != 0
-template <typename ResourceType = sycl::queue, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
+template <typename ResourceType = sycl::queue, typename ResourceAdapter = oneapi::dpl::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #else
-template <typename ResourceType, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
+template <typename ResourceType, typename ResourceAdapter = oneapi::dpl::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #endif
 class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType, ResourceAdapter, Backend>, ResourceType, Backend>
 {
@@ -103,7 +104,7 @@ class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType,
 
     dynamic_load_policy() { base_t::initialize(); }
     dynamic_load_policy(deferred_initialization_t) {}
-    dynamic_load_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = std::identity{}) { base_t::initialize(u, adapter); }
+    dynamic_load_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = oneapi::dpl::identity{}) { base_t::initialize(u, adapter); }
 
     void
     initialize_impl()

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -104,7 +104,7 @@ class dynamic_load_policy : public policy_base<dynamic_load_policy<ResourceType,
 
     dynamic_load_policy() { base_t::initialize(); }
     dynamic_load_policy(deferred_initialization_t) {}
-    dynamic_load_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = oneapi::dpl::identity{}) { base_t::initialize(u, adapter); }
+    dynamic_load_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = {}) { base_t::initialize(u, adapter); }
 
     void
     initialize_impl()

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
@@ -11,6 +11,7 @@
 #define _ONEDPL_FIXED_RESOURCE_POLICY_H
 
 #include "oneapi/dpl/internal/dynamic_selection_impl/policy_base.h"
+#include "oneapi/dpl/functional"
 
 #if _DS_BACKEND_SYCL != 0
 #    include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
@@ -26,9 +27,9 @@ namespace experimental
 {
 
 #if _DS_BACKEND_SYCL != 0
-template <typename ResourceType = sycl::queue, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
+template <typename ResourceType = sycl::queue, typename ResourceAdapter = oneapi::dpl::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #else
-template <typename ResourceType, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
+template <typename ResourceType, typename ResourceAdapter = oneapi::dpl::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #endif
 class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceType, ResourceAdapter, Backend>, ResourceType, Backend> 
 {
@@ -55,7 +56,7 @@ class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceT
     	selector_->index_ = index;
     }
     fixed_resource_policy(deferred_initialization_t) {}
-    fixed_resource_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = std::identity{}, ::std::size_t index = 0) 
+    fixed_resource_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = oneapi::dpl::identity{}, ::std::size_t index = 0) 
     { 
         base_t::initialize(u, adapter); 
         selector_->index_ = index;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
@@ -58,7 +58,7 @@ class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceT
     fixed_resource_policy(const std::vector<resource_type>& u, ::std::size_t index = 0) 
     { 
         base_t::initialize(u); 
-	selector_->index_ = index;
+        selector_->index_ = index;
     }
 
     void 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
@@ -26,14 +26,14 @@ namespace experimental
 {
 
 #if _DS_BACKEND_SYCL != 0
-template <typename ResourceType = sycl::queue, typename Backend = default_backend<ResourceType>>
+template <typename ResourceType = sycl::queue, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #else
-template <typename ResourceType, typename Backend = default_backend<ResourceType>>
+template <typename ResourceType, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #endif
-class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceType, Backend>, ResourceType, Backend> 
+class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceType, ResourceAdapter, Backend>, ResourceType, Backend> 
 {
   protected:
-    using base_t = policy_base<fixed_resource_policy<ResourceType, Backend>, ResourceType, Backend>;
+    using base_t = policy_base<fixed_resource_policy<ResourceType, ResourceAdapter, Backend>, ResourceType, Backend>;
     using resource_container_size_t = typename base_t::resource_container_size_t;
 
     struct selector_t 
@@ -52,12 +52,12 @@ class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceT
     fixed_resource_policy(::std::size_t index = 0) 
     { 
         base_t::initialize(); 
-	selector_->index_ = index;
+    	selector_->index_ = index;
     }
     fixed_resource_policy(deferred_initialization_t) {}
-    fixed_resource_policy(const std::vector<resource_type>& u, ::std::size_t index = 0) 
+    fixed_resource_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = std::identity{}, ::std::size_t index = 0) 
     { 
-        base_t::initialize(u); 
+        base_t::initialize(u, adapter); 
         selector_->index_ = index;
     }
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
@@ -56,7 +56,7 @@ class fixed_resource_policy : public policy_base<fixed_resource_policy<ResourceT
     	selector_->index_ = index;
     }
     fixed_resource_policy(deferred_initialization_t) {}
-    fixed_resource_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = oneapi::dpl::identity{}, ::std::size_t index = 0) 
+    fixed_resource_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = {}, ::std::size_t index = 0) 
     { 
         base_t::initialize(u, adapter); 
         selector_->index_ = index;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/policy_base.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/policy_base.h
@@ -57,10 +57,11 @@ class policy_base
         static_cast<Policy*>(this)->initialize_impl();
     }
 
+    template <typename... Args>
     void 
-    initialize(const std::vector<resource_type>& u) 
+    initialize(const std::vector<resource_type>& u, Args... args) 
     {
-        if (!backend_) backend_ = std::make_shared<backend_t>(u);
+        if (!backend_) backend_ = std::make_shared<backend_t>(u, args...);
         static_cast<Policy*>(this)->initialize_impl();
     }
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy.h
@@ -26,14 +26,14 @@ namespace experimental
 {
 
 #if _DS_BACKEND_SYCL != 0
-template <typename ResourceType = sycl::queue, typename Backend = default_backend<ResourceType>>
+template <typename ResourceType = sycl::queue, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #else
-template <typename ResourceType, typename Backend = default_backend<ResourceType>>
+template <typename ResourceType, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #endif
-class round_robin_policy : public policy_base<round_robin_policy<ResourceType, Backend>, ResourceType, Backend> 
+class round_robin_policy : public policy_base<round_robin_policy<ResourceType, ResourceAdapter, Backend>, ResourceType, Backend> 
 {
   protected:
-    using base_t = policy_base<round_robin_policy<ResourceType, Backend>, ResourceType, Backend>;
+    using base_t = policy_base<round_robin_policy<ResourceType, ResourceAdapter, Backend>, ResourceType, Backend>;
     using resource_container_size_t = typename base_t::resource_container_size_t;
 
     struct selector_t 
@@ -52,7 +52,7 @@ class round_robin_policy : public policy_base<round_robin_policy<ResourceType, B
 
     round_robin_policy() { base_t::initialize(); }
     round_robin_policy(deferred_initialization_t) {}
-    round_robin_policy(const std::vector<resource_type>& u) { base_t::initialize(u); }
+    round_robin_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = std::identity{}) { base_t::initialize(u, adapter); }
 
     void 
     initialize_impl() 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy.h
@@ -11,6 +11,7 @@
 #define _ONEDPL_ROUND_ROBIN_POLICY_H
 
 #include "oneapi/dpl/internal/dynamic_selection_impl/policy_base.h"
+#include "oneapi/dpl/functional"
 
 #if _DS_BACKEND_SYCL != 0
 #    include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
@@ -26,9 +27,9 @@ namespace experimental
 {
 
 #if _DS_BACKEND_SYCL != 0
-template <typename ResourceType = sycl::queue, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
+template <typename ResourceType = sycl::queue, typename ResourceAdapter = oneapi::dpl::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #else
-template <typename ResourceType, typename ResourceAdapter = std::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
+template <typename ResourceType, typename ResourceAdapter = oneapi::dpl::identity, typename Backend = default_backend<ResourceType, ResourceAdapter>>
 #endif
 class round_robin_policy : public policy_base<round_robin_policy<ResourceType, ResourceAdapter, Backend>, ResourceType, Backend> 
 {
@@ -52,7 +53,7 @@ class round_robin_policy : public policy_base<round_robin_policy<ResourceType, R
 
     round_robin_policy() { base_t::initialize(); }
     round_robin_policy(deferred_initialization_t) {}
-    round_robin_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = std::identity{}) { base_t::initialize(u, adapter); }
+    round_robin_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = oneapi::dpl::identity{}) { base_t::initialize(u, adapter); }
 
     void 
     initialize_impl() 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy.h
@@ -53,7 +53,7 @@ class round_robin_policy : public policy_base<round_robin_policy<ResourceType, R
 
     round_robin_policy() { base_t::initialize(); }
     round_robin_policy(deferred_initialization_t) {}
-    round_robin_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = oneapi::dpl::identity{}) { base_t::initialize(u, adapter); }
+    round_robin_policy(const std::vector<resource_type>& u, ResourceAdapter adapter = {}) { base_t::initialize(u, adapter); }
 
     void 
     initialize_impl() 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -359,7 +359,7 @@ class default_backend_impl<sycl::queue, ResourceType, ResourceAdapter> : public 
     // it is the user's responsibilty to initialize the resources
     template <typename T = ResourceAdapter>
     void
-    initialize_default_resources(std::enable_if_t<!std::is_same_v<T, std::identity>, int> = 0)
+    initialize_default_resources(std::enable_if_t<std::is_same_v<T, std::identity>, int> = 0)
     {
         bool profiling = true;
         auto prop_list = sycl::property_list{};

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -50,6 +50,8 @@ class default_backend_impl<sycl::queue, ResourceType, ResourceAdapter> : public 
 
     using execution_resource_t = resource_type;
     using resource_container_t = std::vector<execution_resource_t>;
+    using resource_adapter_t = ResourceAdapter;
+    using base_resource_t = sycl::queue;
 
   private:
     using base_t = backend_base<ResourceType, default_backend_impl<sycl::queue, ResourceType, ResourceAdapter>>;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -31,8 +31,9 @@ namespace dpl
 namespace experimental
 {
 
-template<typename ResourceType, typename ResourceAdapter>
-class default_backend_impl<sycl::queue, ResourceType, ResourceAdapter> : public backend_base<ResourceType, default_backend_impl<sycl::queue, ResourceType, ResourceAdapter>>
+template <typename ResourceType, typename ResourceAdapter>
+class default_backend_impl<sycl::queue, ResourceType, ResourceAdapter>
+    : public backend_base<ResourceType, default_backend_impl<sycl::queue, ResourceType, ResourceAdapter>>
 {
   public:
     using resource_type = ResourceType;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -23,7 +23,6 @@
 #include <utility>
 #include <algorithm>
 
-
 namespace oneapi
 {
 namespace dpl
@@ -37,22 +36,22 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
   public:
     using resource_type = sycl::queue;
     using wait_type = sycl::event;
-    template<typename ...Req>
-    struct scratch_t 
+    template <typename... Req>
+    struct scratch_t
     {
     };
 
-    
-    template<>
-    struct scratch_t<execution_info::task_time_t> 
+    template <>
+    struct scratch_t<execution_info::task_time_t>
     {
-	    sycl::event my_start_event;
+        sycl::event my_start_event;
     };
 
     using execution_resource_t = resource_type;
     using resource_container_t = std::vector<execution_resource_t>;
 
   private:
+    using base_t = backend_base<sycl::queue, default_backend<sycl::queue>>;
     static inline bool is_profiling_enabled = false;
     using report_clock_type = std::chrono::steady_clock;
     using report_duration = std::chrono::milliseconds;
@@ -60,8 +59,10 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
     class async_waiter_base
     {
       public:
-        virtual void report() const = 0;
-        virtual bool is_complete() const = 0;
+        virtual void
+        report() const = 0;
+        virtual bool
+        is_complete() const = 0;
         virtual ~async_waiter_base() = default;
     };
 
@@ -168,24 +169,22 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
     default_backend()
     {
         initialize_default_resources();
-        sgroup_ptr_ = std::make_unique<submission_group>(global_rank_);
+        sgroup_ptr_ = std::make_unique<submission_group>(this->resources_);
     }
 
     template <typename NativeUniverseVector>
-    default_backend(const NativeUniverseVector& v)
+    default_backend(const NativeUniverseVector& v) : base_t(v)
     {
         bool profiling = true;
-        global_rank_.reserve(v.size());
-        for (auto e : v)
+        for (auto e : this->get_resources())
         {
-            global_rank_.push_back(e);
             if (!e.template has_property<sycl::property::queue::enable_profiling>())
             {
                 profiling = false;
             }
         }
         is_profiling_enabled = profiling;
-        sgroup_ptr_ = std::make_unique<submission_group>(global_rank_);
+        sgroup_ptr_ = std::make_unique<submission_group>(this->get_resources());
     }
 
 /*
@@ -196,72 +195,71 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
     template<typename T>
     struct has_scratch_space<T, std::void_t<decltype(std::declval<T>().scratch_space)>>::true_type {};
 */
-    template <typename SelectionHandle> 
+    template <typename SelectionHandle>
     void
     instrument_before_impl(SelectionHandle s)
     {
-        if constexpr (report_value_v<SelectionHandle, execution_info::task_time_t, report_duration>) 
-        {
+        if constexpr (report_value_v<SelectionHandle, execution_info::task_time_t, report_duration>)
+        {
 #ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
-        auto q = unwrap(s);
-        if (!q.get_device().has(sycl::aspect::ext_oneapi_queue_profiling_tag)) 
+            auto q = unwrap(s);
+            if (!q.get_device().has(sycl::aspect::ext_oneapi_queue_profiling_tag))
             {
                 std::cout << "Cannot time kernels without enabling profiling on queue\n";
-            ///TODO: THROW???
+                 ///TODO: THROW???
             }
-           if constexpr (internal::scratch_space_member<SelectionHandle>::value)
-		s.scratch_space.my_start_event = sycl::ext::oneapi::experimental::submit_profiling_tag(q); //starting timestamp
+            if constexpr (internal::scratch_space_member<SelectionHandle>::value)
+                s.scratch_space.my_start_event =
+                    sycl::ext::oneapi::experimental::submit_profiling_tag(q); //starting timestamp
 #else
-           std::cout << "task_time reporting not supported with this configuration " << std::endl;
+            std::cout << "task_time reporting not supported with this configuration " << std::endl;
 #endif
-       }
-       if constexpr (report_info_v<SelectionHandle, execution_info::task_submission_t>)
-           report(s, execution_info::task_submission);
-       }
-
-       template <typename SelectionHandle, typename WaitType>
-       auto
-       instrument_after_impl(SelectionHandle s, WaitType e1)
-       {
-           constexpr bool report_task_completion = report_info_v<SelectionHandle, execution_info::task_completion_t>;
-           constexpr bool report_task_time = report_value_v<SelectionHandle, execution_info::task_time_t, report_duration>;
-       if constexpr (report_task_completion || report_task_time)
-       {
-           async_waiter<SelectionHandle> waiter{e1, std::make_shared<SelectionHandle>(s)};
-           if constexpr (report_task_time && is_profiling_enabled)
-           {
-               async_waiter_list.add_waiter(new async_waiter(waiter));
-           }
-
-           if (report_task_time && !is_profiling_enabled)
-           {
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
-           if constexpr (internal::scratch_space_member<SelectionHandle>::value)
-           {
-               auto q = unwrap(s);
-               sycl::event q_end = sycl::ext::oneapi::experimental::submit_profiling_tag(q); //ending timestamp
-               //get raw nano number
-               uint64_t time_taken_nanoseconds =
-               q_end.template get_profiling_info<sycl::info::event_profiling::command_start>() -
-               s.scratch_space.my_start_event.template get_profiling_info<sycl::info::event_profiling::command_end>();
-               //convert nanoseconds to milliseconds
-               report_duration time_taken_milliseconds = 
-               std::chrono::duration_cast<report_duration>(std::chrono::nanoseconds(time_taken_nanoseconds));
-
-               s.report(execution_info::task_time, time_taken_milliseconds);
-            }
-#endif
-           }
-           if constexpr (report_task_completion)
-               s.report(execution_info::task_completion);
-          
-               return waiter;
-           }
-
-           return async_waiter{e1, std::make_shared<SelectionHandle>(s)};
+        }
+        if constexpr (report_info_v<SelectionHandle, execution_info::task_submission_t>)
+            report(s, execution_info::task_submission);
     }
 
+    template <typename SelectionHandle, typename WaitType>
+    auto
+    instrument_after_impl(SelectionHandle s, WaitType e1)
+    {
+        constexpr bool report_task_completion = report_info_v<SelectionHandle, execution_info::task_completion_t>;
+        constexpr bool report_task_time = report_value_v<SelectionHandle, execution_info::task_time_t, report_duration>;
+        if constexpr (report_task_completion || report_task_time)
+        {
+            async_waiter<SelectionHandle> waiter{e1, std::make_shared<SelectionHandle>(s)};
+            if (report_task_time && is_profiling_enabled)
+            {
+                async_waiter_list.add_waiter(new async_waiter(waiter));
+            }
 
+            if (report_task_time && !is_profiling_enabled)
+            {
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+                if constexpr (internal::scratch_space_member<SelectionHandle>::value)
+                {
+                    auto q = unwrap(s);
+                    sycl::event q_end = sycl::ext::oneapi::experimental::submit_profiling_tag(q); //ending timestamp
+                                                                                                  //get raw nano number
+                        uint64_t time_taken_nanoseconds =
+                            q_end.template get_profiling_info<sycl::info::event_profiling::command_start>() -
+                            s.scratch_space.my_start_event
+                                .template get_profiling_info<sycl::info::event_profiling::command_end>();
+                                 //convert nanoseconds to milliseconds
+                        report_duration time_taken_milliseconds = std::chrono::duration_cast<report_duration>(
+                            std::chrono::nanoseconds(time_taken_nanoseconds));
+
+                    s.report(execution_info::task_time, time_taken_milliseconds);
+                }
+#endif
+            }
+            if constexpr (report_task_completion)
+                s.report(execution_info::task_completion);
+            return waiter;
+        }
+
+        return async_waiter{e1, std::make_shared<SelectionHandle>(s)};
+    }
 
 /*
     template <typename SelectionHandle>
@@ -335,16 +333,11 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
     }
 */
     auto
-    get_submission_group()
+    get_submission_group_impl()
     {
         return *sgroup_ptr_;
     }
 
-    auto
-    get_resources_impl()
-    {
-        return global_rank_;
-    }
 
     void
     lazy_report()
@@ -356,7 +349,6 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
     }
 
   private:
-    resource_container_t global_rank_;
     std::unique_ptr<submission_group> sgroup_ptr_;
 
     void
@@ -379,7 +371,7 @@ class default_backend<sycl::queue> : public backend_base<sycl::queue, default_ba
         }
         for (auto& x : devices)
         {
-            global_rank_.push_back(sycl::queue{x, prop_list});
+            this->resources_.push_back(sycl::queue{x, prop_list});
         }
     }
 };

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -15,6 +15,7 @@
 
 #include "oneapi/dpl/internal/dynamic_selection_impl/scoring_policy_defs.h"
 #include "oneapi/dpl/internal/dynamic_selection_impl/default_backend.h"
+#include "oneapi/dpl/functional"
 
 #include <chrono>
 #include <ratio>
@@ -169,7 +170,7 @@ class default_backend_impl<sycl::queue, ResourceType, ResourceAdapter> : public 
     operator=(const default_backend_impl&) = delete;
 
     template <typename T = ResourceAdapter>
-    default_backend_impl(std::enable_if_t<std::is_same_v<T, std::identity>, int> = 0)
+    default_backend_impl(std::enable_if_t<std::is_same_v<T, oneapi::dpl::identity>, int> = 0)
     {
         initialize_default_resources();
         sgroup_ptr_ = std::make_unique<submission_group>(this->resources_, __adapter);
@@ -355,11 +356,11 @@ class default_backend_impl<sycl::queue, ResourceType, ResourceAdapter> : public 
     std::unique_ptr<submission_group> sgroup_ptr_;
 
 
-    // We can only default initialize adapter is std::identity. If a non base resource is provided with an adapter, then
+    // We can only default initialize adapter is oneapi::dpl::identity. If a non base resource is provided with an adapter, then
     // it is the user's responsibilty to initialize the resources
     template <typename T = ResourceAdapter>
     void
-    initialize_default_resources(std::enable_if_t<std::is_same_v<T, std::identity>, int> = 0)
+    initialize_default_resources(std::enable_if_t<std::is_same_v<T, oneapi::dpl::identity>, int> = 0)
     {
         bool profiling = true;
         auto prop_list = sycl::property_list{};

--- a/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
@@ -15,6 +15,25 @@
 #include "support/utils.h"
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
 
+template <typename CustomName, typename Policy, typename ResourceContainer, typename FunctionType, typename FunctionType2, typename... Args>
+int run_dynamic_load_policy_tests(const ResourceContainer& resources, const FunctionType& f, const FunctionType2& f2, Args&&... args)
+{
+    int result = 0;
+    constexpr bool just_call_submit = false;
+    constexpr bool call_select_before_submit = true;
+
+    result += test_dl_initialization<Policy, ResourceContainer>(resources, std::forward<Args>(args)...);
+    result += test_select<Policy, ResourceContainer, const FunctionType2&, false>(resources, f2, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_event<just_call_submit, Policy>(resources, f2, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_event<call_select_before_submit, Policy>(resources, f2, std::forward<Args>(args)...);
+    result += test_submit_and_wait<just_call_submit, Policy>(resources, f2, std::forward<Args>(args)...);
+    result += test_submit_and_wait<call_select_before_submit, Policy>(resources, f2, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_group<just_call_submit, TestUtils::unique_kernel_name<CustomName, 0>, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_group<call_select_before_submit, TestUtils::unique_kernel_name<CustomName, 1>, Policy>(resources, f, std::forward<Args>(args)...);
+
+    return result;
+}
+
 static inline void
 build_dl_universe(std::vector<sycl::queue>& u)
 {
@@ -41,6 +60,10 @@ build_dl_universe(std::vector<sycl::queue>& u)
 }
 #endif
 
+struct queue_load;
+struct queue_ptr_load;
+
+
 int
 main()
 {
@@ -48,7 +71,6 @@ main()
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
 #if !ONEDPL_FPGA_DEVICE || !ONEDPL_FPGA_EMULATOR
-    using policy_t = oneapi::dpl::experimental::dynamic_load_policy<sycl::queue, oneapi::dpl::experimental::default_backend<sycl::queue>>;
     std::vector<sycl::queue> u;
     build_dl_universe(u);
 
@@ -57,23 +79,32 @@ main()
     //If building the universe is not a success, return
     if (n != 0)
     {
+        // Test with direct sycl::queue resources
+        using policy_t = oneapi::dpl::experimental::dynamic_load_policy<sycl::queue, std::identity, oneapi::dpl::experimental::default_backend<sycl::queue>>;
+        
         // should be similar to round_robin when waiting on policy
         auto f = [u](int i) { return u[i % u.size()]; };
-
         auto f2 = [u](int) { return u[0]; };
         // should always pick first when waiting on sync in each iteration
 
-        constexpr bool just_call_submit = false;
-        constexpr bool call_select_before_submit = true;
+        std::cout << "\nRunning dynamic load tests for sycl::queue ...\n";
+        EXPECT_EQ(0, (run_dynamic_load_policy_tests<queue_load, policy_t>(u, f, f2)), "");
 
-        EXPECT_EQ(0, (test_dl_initialization(u)), "");
-        EXPECT_EQ(0, (test_select<policy_t, decltype(u), decltype(f2)&, false>(u, f2)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f2)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f2)), "");
-        EXPECT_EQ(0, (test_submit_and_wait<just_call_submit, policy_t>(u, f2)), "");
-        EXPECT_EQ(0, (test_submit_and_wait<call_select_before_submit, policy_t>(u, f2)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f)), "");
+        // Test with sycl::queue* resources and dereference adapter
+        auto deref_op = [](auto pointer){return *pointer;};
+        using policy_pointer_t = oneapi::dpl::experimental::dynamic_load_policy<sycl::queue*, decltype(deref_op), oneapi::dpl::experimental::default_backend<sycl::queue*, decltype(deref_op)>>;
+        
+        std::vector<sycl::queue*> u_ptrs;
+        u_ptrs.reserve(u.size());
+        for (auto& e: u)
+        {
+            u_ptrs.push_back(&e);
+        }
+        auto f_ptrs = [u_ptrs](int i) { return u_ptrs[i % u_ptrs.size()]; };
+        auto f2_ptrs = [u_ptrs](int) { return u_ptrs[0]; };
+
+        std::cout << "\nRunning dynamic load tests for sycl::queue* ...\n";
+        EXPECT_EQ(0, (run_dynamic_load_policy_tests<queue_ptr_load, policy_pointer_t>(u_ptrs, f_ptrs, f2_ptrs, deref_op)), "");
 
         bProcessed = true;
     }

--- a/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
@@ -10,6 +10,7 @@
 #include "support/test_config.h"
 
 #include "oneapi/dpl/dynamic_selection"
+#include "oneapi/dpl/functional"
 #include <iostream>
 #include "support/test_dynamic_load_utils.h"
 #include "support/utils.h"
@@ -80,7 +81,7 @@ main()
     if (n != 0)
     {
         // Test with direct sycl::queue resources
-        using policy_t = oneapi::dpl::experimental::dynamic_load_policy<sycl::queue, std::identity, oneapi::dpl::experimental::default_backend<sycl::queue>>;
+        using policy_t = oneapi::dpl::experimental::dynamic_load_policy<sycl::queue, oneapi::dpl::identity, oneapi::dpl::experimental::default_backend<sycl::queue>>;
         
         // should be similar to round_robin when waiting on policy
         auto f = [u](int i) { return u[i % u.size()]; };

--- a/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
@@ -10,6 +10,7 @@
 #include "support/test_config.h"
 
 #include "oneapi/dpl/dynamic_selection"
+#include "oneapi/dpl/functional"
 #include "support/test_dynamic_selection_utils.h"
 #include "support/utils.h"
 
@@ -43,7 +44,7 @@ main()
     if (!u.empty())
     {
         // Test with direct sycl::queue resources
-        using policy_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, std::identity, oneapi::dpl::experimental::default_backend<sycl::queue, std::identity>>;
+        using policy_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, oneapi::dpl::identity, oneapi::dpl::experimental::default_backend<sycl::queue, oneapi::dpl::identity>>;
         auto f = [u](int, int offset = 0) { return u[offset]; };
         
         std::cout<<"\nRunning tests for sycl::queue ...\n";

--- a/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
@@ -19,16 +19,17 @@ main()
     bool bProcessed = false;
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
-    using policy_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, oneapi::dpl::experimental::default_backend<sycl::queue>>;
+    using policy_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, std::identity, oneapi::dpl::experimental::default_backend<sycl::queue, std::identity>>;
     std::vector<sycl::queue> u;
     build_universe(u);
     if (!u.empty())
     {
         auto f = [u](int, int offset = 0) { return u[offset]; };
 
+        
         constexpr bool just_call_submit = false;
         constexpr bool call_select_before_submit = true;
-
+        
         EXPECT_EQ(0, (test_initialization<policy_t, sycl::queue>(u)), "");
         EXPECT_EQ(0, (test_select<policy_t, decltype(u), decltype(f)&, false>(u, f)), "");
         EXPECT_EQ(0, (test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f)), "");
@@ -37,6 +38,26 @@ main()
         EXPECT_EQ(0, (test_submit_and_wait<call_select_before_submit, policy_t>(u, f)), "");
         EXPECT_EQ(0, (test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f)), "");
         EXPECT_EQ(0, (test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f)), "");
+        
+        auto deref_op = [](auto pointer){return *pointer;};
+        using policy_pointer_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue*, decltype(deref_op), oneapi::dpl::experimental::default_backend<sycl::queue*, decltype(deref_op)>>;
+        
+        std::vector<sycl::queue*> u_ptrs;
+        u_ptrs.reserve(u.size());
+        for (auto& e: u)
+        {
+            u_ptrs.push_back(&e);
+        }
+        auto f_ptrs = [u_ptrs](int, int offset = 0) { return u_ptrs[offset]; };
+
+        EXPECT_EQ(0, (test_initialization<policy_pointer_t, sycl::queue*>(u_ptrs, deref_op)), "");
+        EXPECT_EQ(0, (test_select<policy_pointer_t, decltype(u_ptrs), decltype(f_ptrs)&, false>(u_ptrs, f_ptrs, deref_op)), "");
+        EXPECT_EQ(0, (test_submit_and_wait_on_event<just_call_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
+        EXPECT_EQ(0, (test_submit_and_wait_on_event<call_select_before_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
+        EXPECT_EQ(0, (test_submit_and_wait<just_call_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
+        EXPECT_EQ(0, (test_submit_and_wait<call_select_before_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
+        EXPECT_EQ(0, (test_submit_and_wait_on_group<just_call_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
+        EXPECT_EQ(0, (test_submit_and_wait_on_group<call_select_before_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
 
         bProcessed = true;
     }

--- a/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_fixed_resource_policy_sycl.pass.cpp
@@ -13,32 +13,43 @@
 #include "support/test_dynamic_selection_utils.h"
 #include "support/utils.h"
 
+template <typename Policy, typename ResourceContainer, typename FunctionType, typename... Args>
+int run_fixed_resource_policy_tests(const ResourceContainer& resources, const FunctionType& f, Args&&... args)
+{
+    int result = 0;
+    constexpr bool just_call_submit = false;
+    constexpr bool call_select_before_submit = true;
+    
+    result += test_initialization<Policy, typename ResourceContainer::value_type>(resources, std::forward<Args>(args)...);
+    result += test_select<Policy, ResourceContainer, const FunctionType&, false>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_event<just_call_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_event<call_select_before_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait<just_call_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait<call_select_before_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_group<just_call_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_group<call_select_before_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    
+    return result;
+}
+
 int
 main()
 {
     bool bProcessed = false;
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
-    using policy_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, std::identity, oneapi::dpl::experimental::default_backend<sycl::queue, std::identity>>;
     std::vector<sycl::queue> u;
     build_universe(u);
     if (!u.empty())
     {
+        // Test with direct sycl::queue resources
+        using policy_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue, std::identity, oneapi::dpl::experimental::default_backend<sycl::queue, std::identity>>;
         auto f = [u](int, int offset = 0) { return u[offset]; };
-
         
-        constexpr bool just_call_submit = false;
-        constexpr bool call_select_before_submit = true;
+        std::cout<<"\nRunning tests for sycl::queue ...\n";
+        EXPECT_EQ(0, (run_fixed_resource_policy_tests<policy_t>(u, f)), "");
         
-        EXPECT_EQ(0, (test_initialization<policy_t, sycl::queue>(u)), "");
-        EXPECT_EQ(0, (test_select<policy_t, decltype(u), decltype(f)&, false>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait<just_call_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait<call_select_before_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f)), "");
-        
+        // Test with sycl::queue* resources and dereference adapter
         auto deref_op = [](auto pointer){return *pointer;};
         using policy_pointer_t = oneapi::dpl::experimental::fixed_resource_policy<sycl::queue*, decltype(deref_op), oneapi::dpl::experimental::default_backend<sycl::queue*, decltype(deref_op)>>;
         
@@ -50,14 +61,8 @@ main()
         }
         auto f_ptrs = [u_ptrs](int, int offset = 0) { return u_ptrs[offset]; };
 
-        EXPECT_EQ(0, (test_initialization<policy_pointer_t, sycl::queue*>(u_ptrs, deref_op)), "");
-        EXPECT_EQ(0, (test_select<policy_pointer_t, decltype(u_ptrs), decltype(f_ptrs)&, false>(u_ptrs, f_ptrs, deref_op)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_event<just_call_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_event<call_select_before_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
-        EXPECT_EQ(0, (test_submit_and_wait<just_call_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
-        EXPECT_EQ(0, (test_submit_and_wait<call_select_before_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_group<just_call_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_group<call_select_before_submit, policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
+        std::cout<<"\nRunning tests for sycl::queue* ...\n";
+        EXPECT_EQ(0, (run_fixed_resource_policy_tests<policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
 
         bProcessed = true;
     }

--- a/test/parallel_api/dynamic_selection/sycl/test_round_robin_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_round_robin_policy_sycl.pass.cpp
@@ -14,14 +14,31 @@
 #include "oneapi/dpl/dynamic_selection"
 #include "support/test_dynamic_selection_utils.h"
 
+template <typename Policy, typename ResourceContainer, typename FunctionType, typename... Args>
+int run_round_robin_policy_tests(const ResourceContainer& resources, const FunctionType& f, Args&&... args)
+{
+    int result = 0;
+    constexpr bool just_call_submit = false;
+    constexpr bool call_select_before_submit = true;
+    
+    result += test_initialization<Policy, typename ResourceContainer::value_type>(resources, std::forward<Args>(args)...);
+    result += test_select<Policy, ResourceContainer, const FunctionType&, false>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_event<just_call_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_event<call_select_before_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait<just_call_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait<call_select_before_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_group<just_call_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    result += test_submit_and_wait_on_group<call_select_before_submit, Policy>(resources, f, std::forward<Args>(args)...);
+    
+    return result;
+}
+
 int
 main()
 {
     bool bProcessed = false;
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
-    //using policy_t = oneapi::dpl::experimental::round_robin_policy<oneapi::dpl::experimental::sycl_backend>;
-    using policy_t = oneapi::dpl::experimental::round_robin_policy<sycl::queue, oneapi::dpl::experimental::default_backend<sycl::queue>>;
     std::vector<sycl::queue> u;
     build_universe(u);
     if (!u.empty())
@@ -29,19 +46,27 @@ main()
         auto n = u.size();
         std::cout << "UNIVERSE SIZE " << n << std::endl;
 
+        // Test with direct sycl::queue resources
+        using policy_t = oneapi::dpl::experimental::round_robin_policy<sycl::queue, std::identity, oneapi::dpl::experimental::default_backend<sycl::queue>>;
         auto f = [u, n](int i) { return u[(i - 1) % n]; };
 
-        constexpr bool just_call_submit = false;
-        constexpr bool call_select_before_submit = true;
+        std::cout << "\nRunning round robin tests for sycl::queue ...\n";
+        EXPECT_EQ(0, (run_round_robin_policy_tests<policy_t>(u, f)), "");
 
-        EXPECT_EQ(0, (test_initialization<policy_t, sycl::queue>(u)), "");
-        EXPECT_EQ(0, (test_select<policy_t, decltype(u), decltype(f)&, false>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait<just_call_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait<call_select_before_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f)), "");
-        EXPECT_EQ(0, (test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f)), "");
+        // Test with sycl::queue* resources and dereference adapter
+        auto deref_op = [](auto pointer){return *pointer;};
+        using policy_pointer_t = oneapi::dpl::experimental::round_robin_policy<sycl::queue*, decltype(deref_op), oneapi::dpl::experimental::default_backend<sycl::queue*, decltype(deref_op)>>;
+        
+        std::vector<sycl::queue*> u_ptrs;
+        u_ptrs.reserve(u.size());
+        for (auto& e: u)
+        {
+            u_ptrs.push_back(&e);
+        }
+        auto f_ptrs = [u_ptrs, n](int i) { return u_ptrs[(i - 1) % n]; };
+
+        std::cout << "\nRunning round robin tests for sycl::queue* ...\n";
+        EXPECT_EQ(0, (run_round_robin_policy_tests<policy_pointer_t>(u_ptrs, f_ptrs, deref_op)), "");
 
         bProcessed = true;
     }

--- a/test/parallel_api/dynamic_selection/sycl/test_round_robin_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_round_robin_policy_sycl.pass.cpp
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include "oneapi/dpl/dynamic_selection"
+#include "oneapi/dpl/functional"
 #include "support/test_dynamic_selection_utils.h"
 
 template <typename Policy, typename ResourceContainer, typename FunctionType, typename... Args>
@@ -47,7 +48,7 @@ main()
         std::cout << "UNIVERSE SIZE " << n << std::endl;
 
         // Test with direct sycl::queue resources
-        using policy_t = oneapi::dpl::experimental::round_robin_policy<sycl::queue, std::identity, oneapi::dpl::experimental::default_backend<sycl::queue>>;
+        using policy_t = oneapi::dpl::experimental::round_robin_policy<sycl::queue, oneapi::dpl::identity, oneapi::dpl::experimental::default_backend<sycl::queue>>;
         auto f = [u, n](int i) { return u[(i - 1) % n]; };
 
         std::cout << "\nRunning round robin tests for sycl::queue ...\n";

--- a/test/support/test_dynamic_load_utils.h
+++ b/test/support/test_dynamic_load_utils.h
@@ -11,6 +11,7 @@
 #define _ONEDPL_TEST_DYNAMIC_LOAD_UTILS_H
 
 #include "support/test_config.h"
+#include "oneapi/dpl/functional"
 
 #include <thread>
 #include <chrono>
@@ -117,9 +118,9 @@ test_select(UniverseContainer u, ResourceFunction&& f, Args&&... args)
     return 0;
 }
 
-template <bool call_select_before_submit, typename CustomName, typename Policy, typename UniverseContainer, typename ResourceFunction, typename ResourceAdapter = std::identity>
+template <bool call_select_before_submit, typename CustomName, typename Policy, typename UniverseContainer, typename ResourceFunction, typename ResourceAdapter = oneapi::dpl::identity>
 int
-test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, ResourceAdapter adapter = std::identity{})
+test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, ResourceAdapter adapter = oneapi::dpl::identity{})
 {
     using my_policy_t = Policy;
 

--- a/test/support/test_dynamic_load_utils.h
+++ b/test/support/test_dynamic_load_utils.h
@@ -120,7 +120,7 @@ test_select(UniverseContainer u, ResourceFunction&& f, Args&&... args)
 
 template <bool call_select_before_submit, typename CustomName, typename Policy, typename UniverseContainer, typename ResourceFunction, typename ResourceAdapter = oneapi::dpl::identity>
 int
-test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, ResourceAdapter adapter = oneapi::dpl::identity{})
+test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, ResourceAdapter adapter = {})
 {
     using my_policy_t = Policy;
 

--- a/test/support/test_dynamic_load_utils.h
+++ b/test/support/test_dynamic_load_utils.h
@@ -29,11 +29,12 @@ template <typename Policy, int idx>
 using new_kernel_name = unique_kernel_name<std::decay_t<Policy>, idx>;
 } // namespace TestUtils
 
+template <typename Policy, typename UniverseContainer, typename... Args>
 int
-test_dl_initialization(const std::vector<sycl::queue>& u)
+test_dl_initialization(const UniverseContainer& u, Args&&... args)
 {
     // initialize
-    oneapi::dpl::experimental::dynamic_load_policy<sycl::queue> p{u}; //TODO:Remove need for type specification
+    Policy p{u, std::forward<Args>(args)...}; //TODO:Remove need for type specification
     auto u2 = oneapi::dpl::experimental::get_resources(p);
     if (!std::equal(std::begin(u2), std::end(u2), std::begin(u)))
     {
@@ -42,7 +43,7 @@ test_dl_initialization(const std::vector<sycl::queue>& u)
     }
 
     // deferred initialization
-    oneapi::dpl::experimental::dynamic_load_policy<sycl::queue> p2{oneapi::dpl::experimental::deferred_initialization};
+    Policy p2{oneapi::dpl::experimental::deferred_initialization};
     try
     {
         auto u3 = oneapi::dpl::experimental::get_resources(p2);
@@ -55,7 +56,7 @@ test_dl_initialization(const std::vector<sycl::queue>& u)
     catch (...)
     {
     }
-    p2.initialize(u);
+    p2.initialize(u, std::forward<Args>(args)...);
     auto u3 = oneapi::dpl::experimental::get_resources(p);
     if (!std::equal(std::begin(u3), std::end(u3), std::begin(u)))
     {
@@ -67,12 +68,12 @@ test_dl_initialization(const std::vector<sycl::queue>& u)
     return 0;
 }
 
-template <typename Policy, typename UniverseContainer, typename ResourceFunction, bool AutoTune = false>
+template <typename Policy, typename UniverseContainer, typename ResourceFunction, bool AutoTune = false, typename... Args>
 int
-test_select(UniverseContainer u, ResourceFunction&& f)
+test_select(UniverseContainer u, ResourceFunction&& f, Args&&... args)
 {
     using my_policy_t = Policy;
-    my_policy_t p{u};
+    my_policy_t p{u, std::forward<Args>(args)...};
 
     const int N = 100;
     std::atomic<int> ecount = 0;
@@ -116,12 +117,14 @@ test_select(UniverseContainer u, ResourceFunction&& f)
     return 0;
 }
 
-template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+template <bool call_select_before_submit, typename CustomName, typename Policy, typename UniverseContainer, typename ResourceFunction, typename ResourceAdapter = std::identity>
 int
-test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f)
+test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, ResourceAdapter adapter = std::identity{})
 {
     using my_policy_t = Policy;
-    my_policy_t p{u};
+
+    // This doesnt test the default initializer for policy when adapter isn't provided, but other tests do.
+    my_policy_t p{u, adapter};
 
     // Do a matrix multiply operation with each work item processing a row of the result matrix
 
@@ -169,11 +172,11 @@ test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f)
                 }
                 if (target == 0)
                 {
-                    auto e2 = e.submit([&](sycl::handler& cgh) {
+                    auto e2 = adapter(e).submit([&](sycl::handler& cgh) {
                         auto accessorA = bufferA.get_access<sycl::access::mode::read>(cgh);
                         auto accessorB = bufferB.get_access<sycl::access::mode::read>(cgh);
                         auto accessorResultMatrix = bufferResultMatrix.get_access<sycl::access::mode::write>(cgh);
-                        cgh.parallel_for<TestUtils::unique_kernel_name<class load2, 0>>(
+                        cgh.parallel_for<TestUtils::unique_kernel_name<CustomName, 0>>(
                             sycl::range<1>(rows_c), [=](sycl::item<1> row_c) {
                                 for (size_t col_c = 0; col_c < cols_c; ++col_c)
                                 {
@@ -190,7 +193,7 @@ test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f)
                 }
                 else
                 {
-                    auto e2 = e.submit([&](sycl::handler&) {});
+                    auto e2 = adapter(e).submit([&](sycl::handler&) {});
                     return e2;
                 }
             };
@@ -215,11 +218,11 @@ test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f)
                     }
                     if (target == 0)
                     {
-                        auto e2 = e.submit([&](sycl::handler& cgh) {
+                        auto e2 = adapter(e).submit([&](sycl::handler& cgh) {
                             auto accessorA = bufferA.get_access<sycl::access::mode::read>(cgh);
                             auto accessorB = bufferB.get_access<sycl::access::mode::read>(cgh);
                             auto accessorResultMatrix = bufferResultMatrix.get_access<sycl::access::mode::write>(cgh);
-                            cgh.parallel_for<TestUtils::unique_kernel_name<class load1, 0>>(
+                            cgh.parallel_for<TestUtils::unique_kernel_name<CustomName, 1>>(
                                 sycl::range<1>(rows_c), [=](sycl::item<1> row_c) {
                                     for (size_t col_c = 0; col_c < cols_c; ++col_c)
                                     {
@@ -236,7 +239,7 @@ test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f)
                     }
                     else
                     {
-                        auto e2 = e.submit([&](sycl::handler&) {
+                        auto e2 = adapter(e).submit([&](sycl::handler&) {
                             // for(int i=0;i<1;i++);
                         });
                         return e2;
@@ -256,12 +259,12 @@ test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f)
     return 0;
 }
 
-template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction, typename... Args>
 int
-test_submit_and_wait_on_event(UniverseContainer u, ResourceFunction&& f)
+test_submit_and_wait_on_event(UniverseContainer u, ResourceFunction&& f, Args&&... args)
 {
     using my_policy_t = Policy;
-    my_policy_t p{u};
+    my_policy_t p{u, std::forward<Args>(args)...};
 
     const int N = 6;
     bool pass = true;
@@ -326,12 +329,12 @@ test_submit_and_wait_on_event(UniverseContainer u, ResourceFunction&& f)
     return 0;
 }
 
-template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction, typename... Args>
 int
-test_submit_and_wait(UniverseContainer u, ResourceFunction&& f)
+test_submit_and_wait(UniverseContainer u, ResourceFunction&& f, Args&&... args)
 {
     using my_policy_t = Policy;
-    my_policy_t p{u};
+    my_policy_t p{u, std::forward<Args>(args)...};
 
     const int N = 6;
     std::atomic<int> ecount = 0;

--- a/test/support/test_dynamic_selection_utils.h
+++ b/test/support/test_dynamic_selection_utils.h
@@ -64,13 +64,13 @@ build_universe(std::vector<sycl::queue>& u)
 }
 
 #endif // TEST_DYNAMIC_SELECTION_AVAILABLE
-template <typename Policy, typename T>
+template <typename Policy, typename T, typename... Args>
 int
-test_initialization(const std::vector<T>& u)
+test_initialization(const std::vector<T>& u, Args... args)
 {
     // initialize
     using my_policy_t = Policy;
-    my_policy_t p{u};
+    my_policy_t p{u, args...};
     auto u2 = oneapi::dpl::experimental::get_resources(p);
     if (!std::equal(std::begin(u2), std::end(u2), std::begin(u)))
     {
@@ -92,7 +92,7 @@ test_initialization(const std::vector<T>& u)
     catch (...)
     {
     }
-    p2.initialize(u);
+    p2.initialize(u, args...);
     auto u3 = oneapi::dpl::experimental::get_resources(p);
     if (!std::equal(std::begin(u3), std::end(u3), std::begin(u)))
     {
@@ -104,12 +104,12 @@ test_initialization(const std::vector<T>& u)
     return 0;
 }
 
-template <typename Policy, typename UniverseContainer, typename ResourceFunction, bool AutoTune = false>
+template <typename Policy, typename UniverseContainer, typename ResourceFunction, bool AutoTune, typename... Args>
 int
-test_select(UniverseContainer u, ResourceFunction&& f)
+test_select(UniverseContainer u, ResourceFunction&& f, Args... args)
 {
     using my_policy_t = Policy;
-    my_policy_t p{u};
+    my_policy_t p{u, args...};
 
     const int N = 100;
     std::atomic<int> ecount = 0;
@@ -153,12 +153,12 @@ test_select(UniverseContainer u, ResourceFunction&& f)
     return 0;
 }
 
-template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction, typename... Args>
 int
-test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f)
+test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, Args... args)
 {
     using my_policy_t = Policy;
-    my_policy_t p{u};
+    my_policy_t p{u, args...};
 
     int N = 100;
     std::atomic<int> ecount = 0;
@@ -216,12 +216,12 @@ test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f)
     return 0;
 }
 
-template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction, typename... Args>
 int
-test_submit_and_wait_on_event(UniverseContainer u, ResourceFunction&& f)
+test_submit_and_wait_on_event(UniverseContainer u, ResourceFunction&& f, Args... args)
 {
     using my_policy_t = Policy;
-    my_policy_t p{u};
+    my_policy_t p{u, args...};
 
     const int N = 100;
     bool pass = true;
@@ -294,12 +294,12 @@ test_submit_and_wait_on_event(UniverseContainer u, ResourceFunction&& f)
     return 0;
 }
 
-template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+template <bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction, typename... Args>
 int
-test_submit_and_wait(UniverseContainer u, ResourceFunction&& f)
+test_submit_and_wait(UniverseContainer u, ResourceFunction&& f, Args... args)
 {
     using my_policy_t = Policy;
-    my_policy_t p{u};
+    my_policy_t p{u, args...};
 
     const int N = 100;
     std::atomic<int> ecount = 0;


### PR DESCRIPTION
This PR allows users to provide a `resource_adapter` alongside a `resource` where the resulting `base_resource = resource_adapter(resource)` defines the default backend implementation.

This enables a use case where a user may want a resource to contain more or even a different variant as compared to the core base resource which defines a backend implementation.

The motivating use case is using `sycl::queue*` as the resource type alongside an adapter which dereferences.  This allows less overhead copying pointers rather than full queues.  It also allows the pointer to be used as a unique identifier to do things like look up a memory space in a global map.

Alternatively, you could envision a resource being provided which is a `std::pair<sycl::queue, usm_pointer>`, and an adapter functor `std::get<0>` to solve a similar use case (without the potential benefit of reducing overhead).