### PR TITLE
Remove extra declarations from sort tests

### DIFF
--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
@@ -38,9 +38,6 @@
 struct StableSortTag{};
 struct UnstableSortTag{};
 
-class TagUSM;
-class TagBuffer;
-
 struct Particle
 {
     float mass = 0;


### PR DESCRIPTION
`TagUSM` and `TagBuffer` are already declared in this file. 