### PR TITLE
Fix universal references by reordering template args

### DIFF
--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -522,11 +522,10 @@ void
 __for_loop_impl(_ExecutionPolicy&& __exec, _Ip __start, _Ip __finish, _Fp&& __f, _Sp __stride,
                 ::std::tuple<_Rest...>&& __t, ::std::index_sequence<_Is...>)
 {
-    oneapi::dpl::__internal::__pattern_for_loop(
-        ::std::forward<_ExecutionPolicy>(__exec), __start, __finish, __f, __stride,
-        oneapi::dpl::__internal::__use_vectorization<_Ip>(__exec),
-        oneapi::dpl::__internal::__use_parallelization<_Ip>(__exec),
-        ::std::get<_Is>(::std::move(__t))...);
+    oneapi::dpl::__internal::__pattern_for_loop(::std::forward<_ExecutionPolicy>(__exec), __start, __finish, __f,
+                                                __stride, oneapi::dpl::__internal::__use_vectorization<_Ip>(__exec),
+                                                oneapi::dpl::__internal::__use_parallelization<_Ip>(__exec),
+                                                ::std::get<_Is>(::std::move(__t))...);
 }
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Fp, typename _Sp, typename... _Rest,
@@ -535,11 +534,10 @@ void
 __for_loop_n_impl(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Fp&& __f, _Sp __stride,
                   ::std::tuple<_Rest...>&& __t, ::std::index_sequence<_Is...>)
 {
-    oneapi::dpl::__internal::__pattern_for_loop_n(
-        ::std::forward<_ExecutionPolicy>(__exec), __start, __n, __f, __stride,
-        oneapi::dpl::__internal::__use_vectorization<_Ip>(__exec),
-        oneapi::dpl::__internal::__use_parallelization<_Ip>(__exec),
-        ::std::get<_Is>(::std::move(__t))...);
+    oneapi::dpl::__internal::__pattern_for_loop_n(::std::forward<_ExecutionPolicy>(__exec), __start, __n, __f, __stride,
+                                                  oneapi::dpl::__internal::__use_vectorization<_Ip>(__exec),
+                                                  oneapi::dpl::__internal::__use_parallelization<_Ip>(__exec),
+                                                  ::std::get<_Is>(::std::move(__t))...);
 }
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Sp, typename... _Rest>

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -502,14 +502,14 @@ struct __use_par_vec_helper
 };
 
 // Special versions for for_loop: handles both iterators and integral types(treated as random access iterators)
-template <typename _ExecutionPolicy, typename _Ip>
+template <typename _Ip, typename _ExecutionPolicy>
 auto
 __use_vectorization(_ExecutionPolicy&& __exec)
 {
     return __use_par_vec_helper<_Ip>::__use_vector(::std::forward<_ExecutionPolicy>(__exec));
 }
 
-template <typename _ExecutionPolicy, typename _Ip>
+template <typename _Ip, typename _ExecutionPolicy>
 auto
 __use_parallelization(_ExecutionPolicy&& __exec)
 {
@@ -524,8 +524,8 @@ __for_loop_impl(_ExecutionPolicy&& __exec, _Ip __start, _Ip __finish, _Fp&& __f,
 {
     oneapi::dpl::__internal::__pattern_for_loop(
         ::std::forward<_ExecutionPolicy>(__exec), __start, __finish, __f, __stride,
-        oneapi::dpl::__internal::__use_vectorization<_ExecutionPolicy, _Ip>(__exec),
-        oneapi::dpl::__internal::__use_parallelization<_ExecutionPolicy, _Ip>(__exec),
+        oneapi::dpl::__internal::__use_vectorization<_Ip>(__exec),
+        oneapi::dpl::__internal::__use_parallelization<_Ip>(__exec),
         ::std::get<_Is>(::std::move(__t))...);
 }
 
@@ -537,8 +537,8 @@ __for_loop_n_impl(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Fp&& __f, 
 {
     oneapi::dpl::__internal::__pattern_for_loop_n(
         ::std::forward<_ExecutionPolicy>(__exec), __start, __n, __f, __stride,
-        oneapi::dpl::__internal::__use_vectorization<_ExecutionPolicy, _Ip>(__exec),
-        oneapi::dpl::__internal::__use_parallelization<_ExecutionPolicy, _Ip>(__exec),
+        oneapi::dpl::__internal::__use_vectorization<_Ip>(__exec),
+        oneapi::dpl::__internal::__use_parallelization<_Ip>(__exec),
         ::std::get<_Is>(::std::move(__t))...);
 }
 


### PR DESCRIPTION
This PR resolves an issue where because of the ordering of template arguments, we were using non-forwarded policy arguments, with a specified type for the arguments which may not match the incoming value category of policy.
Reordering the template arguments allows us to properly use forwarding / universal references for the policy again in these helpers.

Branched off from https://github.com/uxlfoundation/oneDPL/pull/2369/files#r2260684243