### PR TITLE
Fix forwarded value captured policy 

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3396,9 +3396,12 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         //{1} < {2}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
-            [=] { __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result, __copy_range); },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result + __n1, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first1, __last1, __result, __copy_range);
+            },
+            [=] {
+                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first2, __last2, __result + __n1,
+                                                  __copy_range);
             });
         return __result + __n1 + __n2;
     }
@@ -3411,9 +3414,12 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         //{2} < {1}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
-            [=] { __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result, __copy_range); },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result + __n2, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first2, __last2, __result, __copy_range);
+            },
+            [=] {
+                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first1, __last1, __result + __n2,
+                                                  __copy_range);
             });
         return __result + __n1 + __n2;
     }
@@ -3427,11 +3433,12 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first1; left_bound_seq_1)
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __left_bound_seq_1, __res_or, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first1, __left_bound_seq_1, __res_or,
+                                                  __copy_range);
             },
             [=, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, __exec, __left_bound_seq_1, __last1, __first2, __last2, __result, __comp,
+                    __tag, std::move(__exec), __left_bound_seq_1, __last1, __first2, __last2, __result, __comp,
                     [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; }, __set_union_op);
             });
         return __result;
@@ -3447,11 +3454,12 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first2; left_bound_seq_2)
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __left_bound_seq_2, __res_or, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first2, __left_bound_seq_2, __res_or,
+                                                  __copy_range);
             },
             [=, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, __exec, __first1, __last1, __left_bound_seq_2, __last2, __result, __comp,
+                    __tag, std::move(__exec), __first1, __last1, __left_bound_seq_2, __last2, __result, __comp,
                     [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; }, __set_union_op);
             });
         return __result;

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3400,8 +3400,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
                 __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result, __copy_range);
             },
             [=, &__exec] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result + __n1,
-                                                  __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result + __n1, __copy_range);
             });
         return __result + __n1 + __n2;
     }
@@ -3418,8 +3417,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
                 __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result, __copy_range);
             },
             [=, &__exec] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result + __n2,
-                                                  __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result + __n2, __copy_range);
             });
         return __result + __n1 + __n2;
     }
@@ -3433,8 +3431,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first1; left_bound_seq_1)
             [=, &__exec] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __left_bound_seq_1, __res_or,
-                                                  __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __left_bound_seq_1, __res_or, __copy_range);
             },
             [=, &__exec, &__result] {
                 __result = __internal::__parallel_set_op(
@@ -3454,8 +3451,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first2; left_bound_seq_2)
             [=, &__exec] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __left_bound_seq_2, __res_or,
-                                                  __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __left_bound_seq_2, __res_or, __copy_range);
             },
             [=, &__exec, &__result] {
                 __result = __internal::__parallel_set_op(

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3397,11 +3397,11 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
                                                   __result, __copy_range);
             },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
                                                   __result + __n1, __copy_range);
             });
         return __result + __n1 + __n2;
@@ -3416,11 +3416,11 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
                                                   __result, __copy_range);
             },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
                                                   __result + __n2, __copy_range);
             });
         return __result + __n1 + __n2;
@@ -3435,12 +3435,12 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first1; left_bound_seq_1)
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first1,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1,
                                                   __left_bound_seq_1, __res_or, __copy_range);
             },
             [=, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, ::std::forward<_ExecutionPolicy>(__exec), __left_bound_seq_1, __last1, __first2, __last2,
+                    __tag, __exec, __left_bound_seq_1, __last1, __first2, __last2,
                     __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; },
                     __set_union_op);
             });
@@ -3457,12 +3457,12 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first2; left_bound_seq_2)
             [=] {
-                __internal::__pattern_walk2_brick(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first2,
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2,
                                                   __left_bound_seq_2, __res_or, __copy_range);
             },
             [=, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __left_bound_seq_2, __last2,
+                    __tag, __exec, __first1, __last1, __left_bound_seq_2, __last2,
                     __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; },
                     __set_union_op);
             });

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3396,13 +3396,9 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         //{1} < {2}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            [=] { __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result, __copy_range); },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
-                                                  __result, __copy_range);
-            },
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
-                                                  __result + __n1, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result + __n1, __copy_range);
             });
         return __result + __n1 + __n2;
     }
@@ -3415,13 +3411,9 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         //{2} < {1}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            [=] { __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result, __copy_range); },
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2,
-                                                  __result, __copy_range);
-            },
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1,
-                                                  __result + __n2, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result + __n2, __copy_range);
             });
         return __result + __n1 + __n2;
     }
@@ -3435,14 +3427,12 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first1; left_bound_seq_1)
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first1,
-                                                  __left_bound_seq_1, __res_or, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __left_bound_seq_1, __res_or, __copy_range);
             },
             [=, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, __exec, __left_bound_seq_1, __last1, __first2, __last2,
-                    __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; },
-                    __set_union_op);
+                    __tag, __exec, __left_bound_seq_1, __last1, __first2, __last2, __result, __comp,
+                    [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; }, __set_union_op);
             });
         return __result;
     }
@@ -3457,14 +3447,12 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first2; left_bound_seq_2)
             [=] {
-                __internal::__pattern_walk2_brick(__tag, __exec, __first2,
-                                                  __left_bound_seq_2, __res_or, __copy_range);
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __left_bound_seq_2, __res_or, __copy_range);
             },
             [=, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, __exec, __first1, __last1, __left_bound_seq_2, __last2,
-                    __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; },
-                    __set_union_op);
+                    __tag, __exec, __first1, __last1, __left_bound_seq_2, __last2, __result, __comp,
+                    [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; }, __set_union_op);
             });
         return __result;
     }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3396,11 +3396,11 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         //{1} < {2}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first1, __last1, __result, __copy_range);
+            [=, &__exec] {
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result, __copy_range);
             },
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first2, __last2, __result + __n1,
+            [=, &__exec] {
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result + __n1,
                                                   __copy_range);
             });
         return __result + __n1 + __n2;
@@ -3414,11 +3414,11 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         //{2} < {1}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first2, __last2, __result, __copy_range);
+            [=, &__exec] {
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __last2, __result, __copy_range);
             },
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first1, __last1, __result + __n2,
+            [=, &__exec] {
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __last1, __result + __n2,
                                                   __copy_range);
             });
         return __result + __n1 + __n2;
@@ -3432,13 +3432,13 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first1; left_bound_seq_1)
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first1, __left_bound_seq_1, __res_or,
+            [=, &__exec] {
+                __internal::__pattern_walk2_brick(__tag, __exec, __first1, __left_bound_seq_1, __res_or,
                                                   __copy_range);
             },
-            [=, &__result] {
+            [=, &__exec, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, std::move(__exec), __left_bound_seq_1, __last1, __first2, __last2, __result, __comp,
+                    __tag, __exec, __left_bound_seq_1, __last1, __first2, __last2, __result, __comp,
                     [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; }, __set_union_op);
             });
         return __result;
@@ -3453,13 +3453,13 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
         __par_backend::__parallel_invoke(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec),
             //do parallel copying of [first2; left_bound_seq_2)
-            [=] {
-                __internal::__pattern_walk2_brick(__tag, std::move(__exec), __first2, __left_bound_seq_2, __res_or,
+            [=, &__exec] {
+                __internal::__pattern_walk2_brick(__tag, __exec, __first2, __left_bound_seq_2, __res_or,
                                                   __copy_range);
             },
-            [=, &__result] {
+            [=, &__exec, &__result] {
                 __result = __internal::__parallel_set_op(
-                    __tag, std::move(__exec), __first1, __last1, __left_bound_seq_2, __last2, __result, __comp,
+                    __tag, __exec, __first1, __last1, __left_bound_seq_2, __last2, __result, __comp,
                     [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; }, __set_union_op);
             });
         return __result;


### PR DESCRIPTION
In this PR we switch from forwarding after a capture by value to a capture by reference and then pass through.

Forwarding doesn't make sense here as the type may no longer match.
 
branched off from 
https://github.com/uxlfoundation/oneDPL/pull/2369/files#r2254402955
