### PR TITLE
Fix temporary buffer data type in `__pattern_set_union` and `__pattern_set_symmetric_difference` for `__hetero_tag`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1924,7 +1924,10 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
     }
     else
     {
-        using _ValueType = typename std::iterator_traits<_OutputIterator>::value_type;
+        // We should use a temporary buffer here to store the intermediate result,
+        // which is the difference {2} \ {1}. The buffer should have the same data type
+        // as the elements in the second sequence.
+        using _ValueType = typename std::iterator_traits<_ForwardIterator2>::value_type;
 
         // temporary buffer to store intermediate result
         const auto __n2 = __last2 - __first2;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -2016,14 +2016,15 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
     }
     else
     {
-        typedef typename std::iterator_traits<_OutputIterator>::value_type _ValueType;
+        typedef typename std::iterator_traits<_ForwardIterator1>::value_type _ValueType1;
+        typedef typename std::iterator_traits<_ForwardIterator2>::value_type _ValueType2;
 
         // temporary buffers to store intermediate result
         const auto __n1 = __last1 - __first1;
-        oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff_1(__n1);
+        oneapi::dpl::__par_backend_hetero::__buffer<_ValueType1> __diff_1(__n1);
         auto __buf_1 = __diff_1.get();
         const auto __n2 = __last2 - __first2;
-        oneapi::dpl::__par_backend_hetero::__buffer<_ValueType> __diff_2(__n2);
+        oneapi::dpl::__par_backend_hetero::__buffer<_ValueType2> __diff_2(__n2);
         auto __buf_2 = __diff_2.get();
 
         //1. Calc difference {1} \ {2}


### PR DESCRIPTION
This PR fixes a data type issue in some pattern implementations for heterogeneous execution tags:
-  `__pattern_set_union`;
- `__pattern_set_symmetric_difference`.

The change corrects the temporary buffer's data type to match the second sequence's element type rather than the output iterator's value type.

- Corrected temporary buffer data type from output iterator's value type to second sequence's value type
- Added explanatory comment describing the purpose of the temporary buffer

This issue has been found and fixed together with @dmitriy-sobolev

### Reproducer
```C++
struct A1
{
    int field_a;
    operator int() const { return field_a; }
};
struct A2
{
    int field_b;
    operator int() const { return field_b; }
};
 
auto __comp = [](auto&& __val1, auto&& __val2){
    // compare A1 and A2 by their fields field_a, field_b
};
 
// run iterator algorithms on two sets {A1} and {A2} -> set{int};

std::vector<A1> __dataA1 = { {1}, {2}, {3 }};
std::vector<A2> __dataA2 = { {2}, {5} }};
std::vector<int> __res(__dataA1.size() + __dataA2.size());

std::set_union(dpcpp_default,
               __dataA1.begin(), __dataA1.end(),
               __dataA2.begin(), __dataA2.end(),
               __res.begin();
```

### References
https://en.cppreference.com/w/cpp/algorithm/set_union.html
https://en.cppreference.com/w/cpp/algorithm/set_symmetric_difference.html