### PR TITLE
Improve reporting of issues in the range algorithm tests

### DIFF
--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -211,9 +211,9 @@ private:
         static_assert(std::is_same_v<decltype(res), decltype(checker(r_in, args...))>, "Wrong return type");
 
         using Algo = decltype(algo);
-        auto bres = ret_in_val(expected_res, expected_view.begin()) == ret_in_val(res, r_in.begin());
-        EXPECT_TRUE(bres, (std::string("wrong return value from algo with ranges: ") + typeid(Algo).name() +
-                typeid(decltype(tr_in(std::declval<Container&>()()))).name()).c_str());
+        EXPECT_EQ(ret_in_val(expected_res, expected_view.begin()), ret_in_val(res, r_in.begin()),
+                  (std::string("wrong return value from algo with ranges: ") + typeid(Algo).name() +
+                   typeid(decltype(tr_in(std::declval<Container&>()()))).name()).c_str());
 
         //check result
         auto n = std::ranges::size(expected_view);
@@ -250,11 +250,11 @@ private:
         //check result
         static_assert(std::is_same_v<decltype(res), decltype(checker(tr_in(A), tr_out(B), args...))>, "Wrong return type");
 
-        auto bres_in = ret_in_val(expected_res, src_view.begin()) == ret_in_val(res, tr_in(A).begin());
-        EXPECT_TRUE(bres_in, (std::string("wrong return value from algo with input range: ") + typeid(Algo).name()).c_str());
+        EXPECT_EQ(ret_in_val(expected_res, src_view.begin()), ret_in_val(res, tr_in(A).begin()),
+                  (std::string("wrong return value from algo with input range: ") + typeid(Algo).name()).c_str());
 
-        auto bres_out = ret_out_val(expected_res, exp_view.begin()) == ret_out_val(res, tr_out(B).begin());
-        EXPECT_TRUE(bres_out, (std::string("wrong return value from algo with output range: ") + typeid(Algo).name()).c_str());
+        EXPECT_EQ(ret_out_val(expected_res, exp_view.begin()), ret_out_val(res, tr_out(B).begin()),
+                  (std::string("wrong return value from algo with output range: ") + typeid(Algo).name()).c_str());
 
         //check result
         auto n = std::ranges::size(exp_view);
@@ -323,10 +323,18 @@ private:
         auto res = algo(CLONE_TEST_POLICY(exec), tr_in(A), tr_in(B), args...);
 
         static_assert(std::is_same_v<decltype(res), decltype(checker(tr_in(A), tr_in(B), args...))>, "Wrong return type");
-
-        auto bres_in = ret_in_val(expected_res, src_view1.begin()) == ret_in_val(res, tr_in(A).begin());
-        EXPECT_TRUE(bres_in, (std::string("wrong return value from algo: ") + typeid(decltype(algo)).name() +
-            typeid(decltype(tr_in(std::declval<Container&>()()))).name()).c_str());
+        if constexpr (!std::is_same_v<decltype(res), bool>)
+        {
+            EXPECT_EQ(ret_in_val(expected_res, src_view1.begin()), ret_in_val(res, tr_in(A).begin()),
+                      (std::string("wrong return value from algo: ") + typeid(decltype(algo)).name() +
+                       typeid(decltype(tr_in(std::declval<Container&>()()))).name()).c_str());
+        }
+        else
+        {
+            EXPECT_EQ(expected_res, res,
+                      (std::string("wrong return value from algo: ") + typeid(decltype(algo)).name() +
+                       typeid(decltype(tr_in(std::declval<Container&>()()))).name()).c_str());
+        }
     }
 
     struct TransformOp
@@ -367,14 +375,14 @@ private:
 
         static_assert(std::is_same_v<decltype(res), decltype(checker(tr_in(A), tr_in(B), tr_out(C), args...))>, "Wrong return type");
 
-        auto bres_in1 = ret_in_val(expected_res, src_view1.begin()) == ret_in_val(res, tr_in(A).begin());
-        EXPECT_TRUE(bres_in1, (std::string("wrong return value from algo with input range 1: ") + typeid(Algo).name()).c_str());
+        EXPECT_EQ(ret_in_val(expected_res, src_view1.begin()), ret_in_val(res, tr_in(A).begin()),
+                  (std::string("wrong return value from algo with input range 1: ") + typeid(Algo).name()).c_str());
 
-        auto bres_in2 = ret_in_val(expected_res, src_view2.begin()) == ret_in_val(res, tr_in(B).begin());
-        EXPECT_TRUE(bres_in2, (std::string("wrong return value from algo with input range 2: ") + typeid(Algo).name()).c_str());
+        EXPECT_EQ(ret_in_val(expected_res, src_view2.begin()), ret_in_val(res, tr_in(B).begin()),
+                  (std::string("wrong return value from algo with input range 2: ") + typeid(Algo).name()).c_str());
 
-        auto bres_out = ret_out_val(expected_res, expected_view.begin()) == ret_out_val(res, tr_out(C).begin());
-        EXPECT_TRUE(bres_out, (std::string("wrong return value from algo with output range: ") + typeid(Algo).name()).c_str());
+        EXPECT_EQ(ret_out_val(expected_res, expected_view.begin()), ret_out_val(res, tr_out(C).begin()),
+                  (std::string("wrong return value from algo with output range: ") + typeid(Algo).name()).c_str());
 
         //check result
         auto n = std::ranges::size(expected_view);
@@ -457,7 +465,7 @@ struct host_subrange_impl
 
     using type = ViewType;
     ViewType view;
-    T* mem = NULL;
+    T* mem = nullptr;
 
     std::allocator<T> alloc;
 
@@ -496,7 +504,7 @@ struct host_vector
 {
     using type = std::vector<T>;
     type vec;
-    T* p = NULL;
+    T* p = nullptr;
 
     template<typename Policy>
     host_vector(Policy&&, T* data, int n): vec(data, data + n), p(data) {}
@@ -526,7 +534,7 @@ struct usm_vector
     using type = std::vector<T, shared_allocator>;
 
     std::vector<T, shared_allocator> vec;
-    T* p = NULL;
+    T* p = nullptr;
 
     template<typename Policy>
     usm_vector(Policy&& exec, T* data, int n): vec(data, data + n, shared_allocator(exec.queue())), p(data)
@@ -560,7 +568,7 @@ struct usm_subrange_impl
     using type = ViewType;
 
     shared_allocator alloc;
-    T* p = NULL;
+    T* p = nullptr;
     ViewType view;
 
     template<typename Policy>

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -165,7 +165,17 @@ template <typename TStream, typename Tag, typename TValue>
 
     if constexpr (IsOutputStreamable<TValue, decltype(os)>::value)
     {
-        os << value;
+        if constexpr (std::is_same_v<bool, std::decay_t<TValue>>)
+        {
+            if (value)
+                os << "true";
+            else
+                os << "false";
+        }
+        else
+        {
+            os << value;
+        }
     }
     else
     {


### PR DESCRIPTION
Reporting Improvements:
- `EXPECT_EQ` will provide the current and the expected values instead of just true/false with `EXPECT_TRUE`.
- `bool` values will be reported as true/false.

Additional modernization/safety improvement:
- `nullptr` instead of `NULL`.

These changes were added by @SergeyKopienko during the development of some range-based algorithms, and were shown as quite useful while analyzing issues. 