### PR TITLE
Pass views by value to make_zip_view

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -281,9 +281,9 @@ class zip_view
 
 template <typename... _Ranges>
 auto
-make_zip_view(_Ranges&&... args) -> decltype(zip_view<_Ranges...>(::std::forward<_Ranges>(args)...))
+make_zip_view(_Ranges... args)
 {
-    return zip_view<_Ranges...>(::std::forward<_Ranges>(args)...);
+    return zip_view<_Ranges...>(args...);
 }
 
 // a custom view, over a pair of "passed directly" iterators


### PR DESCRIPTION
This is a draft to investigate the purpose better. This change was initially added in #2320, but it does not seem related, so it was moved into a separate PR.

The assumed purpose is that [zip_view ](https://en.cppreference.com/w/cpp/ranges/zip_view/zip_view.html)'s constructor expects views as input types, but `make_zip_view` may preserve a reference of a view type due to the perfect forwarding, which is not a view anymore. See https://godbolt.org/z/s8zv1c756 as an example of an effect of preserving a reference. Views are lightweight objects, so let's pass them by copy.