### PR TITLE
Fixing same mangled name with comma compilation

### DIFF
--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -388,7 +388,7 @@ struct invoke_on_all_hetero_policies
 
 #if TEST_CHECK_COMPILATION_WITH_COMMA_OP_DELETED_ITERS
             // Check compilation of the kernel with comma operator deleted iterators. Use policy wrapped with unique
-            // identifier to differenciate from other calls, but, preserve the policy for other two calls.
+            // identifier to differentiate from other calls, but, preserve the policy for other two calls.
             TestUtils::check_compilation_no_comma(CLONE_TEST_POLICY_IDX(my_policy, 0), op, rest...);
 #endif
 


### PR DESCRIPTION
#2369 introduced an issue with same mangled name as we did not wrap the policy, but sent in an example with different iterator types.  This caused compilation errors on APIs when unnamed lambdas are disabled.

This PR fixes the issue by cloning and wrapping the policy we send in for check_compilation_no_comma.
