### PR TITLE
Fix return types in `oneapi::dpl::__internal::__ranges::__pattern_minmax_element` and `oneapi::dpl::__internal::__ranges::__pattern_mismatch`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1046,7 +1046,7 @@ __pattern_minmax(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R&& __r,
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Pred, typename _Proj1,
           typename _Proj2>
-std::pair<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>>
+std::pair<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>>
 __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred,
                    _Proj1 __proj1, _Proj2 __proj2)
 {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1015,7 +1015,7 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
 template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
-std::pair<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_R>>
+std::pair<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_R>>
 __pattern_minmax_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp,
                          _Proj __proj)
 {


### PR DESCRIPTION
This PR fix the return types of two pattern functions in the oneAPI DPL library to use `borrowed_iterator_t` instead of `iterator_t` for C++20 ranges compliance.

- Updated return types from `std::ranges::iterator_t` to `std::ranges::borrowed_iterator_t` in two function signatures
- Ensures proper iterator borrowing semantics for range-based algorithms

From issue #2394