### PR TITLE
Fix testing temp range type for device policies

### DIFF
--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -237,7 +237,7 @@ struct test
 
 private:
 
-    template <typename Policy, typename T>
+    template <typename T>
     using TmpContainerType = std::array<T,0>;
 
     // Test dangling iterators in return types for call with temporary data
@@ -252,7 +252,7 @@ private:
 
             // Check dangling with temporary containers in implementation
             using res_ret_t = decltype(algo(CLONE_TEST_POLICY_IDX(exec, idx),
-                                            std::declval<TmpContainerType<decltype(exec), T>>(),
+                                            std::declval<TmpContainerType<T>>(),
                                             args...));
 
             if constexpr (!std::is_fundamental_v<res_ret_t>)
@@ -275,8 +275,8 @@ private:
 
             // Check dangling with temporary containers in implementation
             using res_ret_t = decltype(algo(CLONE_TEST_POLICY_IDX(exec, idx),
-                                            std::declval<TmpContainerType<decltype(exec), T>>(),
-                                            std::declval<TmpContainerType<decltype(exec), T>>(),
+                                            std::declval<TmpContainerType<T>>(),
+                                            std::declval<TmpContainerType<T>>(),
                                             args...));
 
             if constexpr (!std::is_fundamental_v<res_ret_t>)
@@ -299,9 +299,9 @@ private:
 
             // Check dangling with temporary containers in implementation
             using res_ret_t = decltype(algo(CLONE_TEST_POLICY_IDX(exec, idx),
-                                            std::declval<TmpContainerType<decltype(exec), T>>(),
-                                            std::declval<TmpContainerType<decltype(exec), T>>(),
-                                            std::declval<TmpContainerType<decltype(exec), T>>(),
+                                            std::declval<TmpContainerType<T>>(),
+                                            std::declval<TmpContainerType<T>>(),
+                                            std::declval<TmpContainerType<T>>(),
                                             args...));
 
             if constexpr (!std::is_fundamental_v<res_ret_t>)

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -238,7 +238,7 @@ struct test
 private:
 
     template <typename Policy, typename T>
-    using TmpContainerType = std::array<T,10>;
+    using TmpContainerType = std::array<T,0>;
 
     // Test dangling iterators in return types for call with temporary data
     template <int idx, typename Policy, typename Algo, typename ...Args>

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -237,14 +237,8 @@ struct test
 
 private:
 
-  template <typename Policy, typename T>
-  using TmpContainerType =
-#if TEST_DPCPP_BACKEND_PRESENT
-      std::conditional_t<oneapi::dpl::__internal::__is_host_execution_policy<Policy>::value, std::vector<T>,
-                         std::vector<T, sycl::usm_allocator<T, sycl::usm::alloc::shared>>>;
-#else
-      std::vector<T>;
-#endif
+    template <typename Policy, typename T>
+    using TmpContainerType = std::array<T,10>;
 
     // Test dangling iterators in return types for call with temporary data
     template <int idx, typename Policy, typename Algo, typename ...Args>


### PR DESCRIPTION
#2389 added tests for dangling iterators when APIs are called with temporary ranges.  

`std::vector` is not device copyable, so it does not make sense to pass it as a temporary range, even to test for dangling iterator returns.  
`std::array` is sycl device copyable and can be used in a similar way.   With this, we can use the same type for both device and host policies.  

This removes the static assertion when `auto` is used as the return type for range functional structs.  It was due to a real issue with the device copyability of `std::vector`, but is suppressed when replacing `auto` with an explicit return type.  This explicit return type seems like it allowed the compiler to short circuit within a `decltype` context without compiling the rest of the call stack, since it has an explicit return type.  Skipping this compilation allowed it to skip the `static_assert` which checks for device copyability.  

In reality `auto` is perfectly fine to use as the return, but had errors wrongly attributed to it.  Removing `auto` merely suppressed an unrelated error.  
I tested reintroducing auto to the return type of the functional range operators without issue locally with after this PR.