### PR TITLE
Implement P2248R8: Enable list-initialization for algorithms

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_defs.h
@@ -64,7 +64,8 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator,
+          class _Tp = typename std::iterator_traits<_ForwardIterator>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
@@ -104,7 +105,8 @@ adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardItera
 
 // [alg.count]
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator,
+          class _Tp = typename std::iterator_traits<_ForwardIterator>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<
     _ExecutionPolicy, typename ::std::iterator_traits<_ForwardIterator>::difference_type>
 count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
@@ -126,12 +128,14 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
        _ForwardIterator2 __s_last);
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size,
+          class _Tp = typename std::iterator_traits<_ForwardIterator>::value_type, class _BinaryPredicate>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count,
          const _Tp& __value, _BinaryPredicate __pred);
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size,
+          class _Tp = typename std::iterator_traits<_ForwardIterator>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count,
          const _Tp& __value);
@@ -189,33 +193,39 @@ transform_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIter
 
 // [alg.replace]
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate,
+          class _Tp = typename std::iterator_traits<_ForwardIterator>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
            const _Tp& __new_value);
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator,
+          class _Tp = typename std::iterator_traits<_ForwardIterator>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value,
         const _Tp& __new_value);
 
-template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate,
+          class _Tp = typename std::iterator_traits<_ForwardIterator2>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
                 _ForwardIterator2 __result, _UnaryPredicate __pred, const _Tp& __new_value);
 
-template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2,
+          class _Tp = typename std::iterator_traits<_ForwardIterator2>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
              const _Tp& __old_value, const _Tp& __new_value);
 
 // [alg.fill]
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator,
+          class _Tp = typename std::iterator_traits<_ForwardIterator>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size,
+          class _Tp = typename std::iterator_traits<_ForwardIterator>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, const _Tp& __value);
 
@@ -235,7 +245,8 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 remove_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
                _ForwardIterator2 __result, _Predicate __pred);
 
-template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2,
+          class _Tp = typename std::iterator_traits<_ForwardIterator1>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 remove_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
             const _Tp& __value);
@@ -244,7 +255,8 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 remove_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred);
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+template <class _ExecutionPolicy, class _ForwardIterator,
+          class _Tp = typename std::iterator_traits<_ForwardIterator>::value_type>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 remove(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
@@ -97,6 +97,85 @@ test_fill_by_type(::std::size_t n)
 #endif
 }
 
+void test_empty_list_initialization_for_fill()
+{
+    {
+        std::vector<int> v{3,6,5,4,3,7,8,0,2,4};
+        oneapi::dpl::fill(oneapi::dpl::execution::seq, v.begin(), v.end(), {});
+        EXPECT_TRUE(std::count(v.begin(), v.end(), 0) == v.size(), "a sequence is not filled properly by oneapi::dpl::fill with `seq` policy");
+    }
+    {
+        std::vector<int> v{3,6,5,4,3,7,8,0,2,4};
+        oneapi::dpl::fill(oneapi::dpl::execution::unseq, v.begin(), v.end(), {});
+        EXPECT_TRUE(std::count(v.begin(), v.end(), 0) == v.size(), "a sequence is not filled properly by oneapi::dpl::fill with `unseq` policy");
+    }
+
+    {
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{6},{5},{4},{3},{7},{8},{2},{1},{4}};
+            oneapi::dpl::fill(oneapi::dpl::execution::par, v_custom.begin(), v_custom.end(), {});
+            EXPECT_TRUE(std::count(v_custom.begin(), v_custom.end(), TestUtils::DefaultInitializedToOne{}) == v_custom.size(),
+                        "a sequence is not filled properly by oneapi::dpl::fill with `par` policy");
+        }
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{6},{5},{4},{3},{7},{8},{2},{1},{4}};
+            oneapi::dpl::fill(oneapi::dpl::execution::par_unseq, v_custom.begin(), v_custom.end(), {});
+            EXPECT_TRUE(std::count(v_custom.begin(), v_custom.end(), TestUtils::DefaultInitializedToOne{}) == v_custom.size(),
+                        "a sequence is not filled properly by oneapi::dpl::fill with `par_unseq` policy");
+        }
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    std::vector<int> v{3,6,5,4,3,7,8,0,2,4};
+    sycl::buffer<int> buf(v);
+    auto it = oneapi::dpl::fill(oneapi::dpl::execution::dpcpp_default, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), {});
+    EXPECT_TRUE(std::count(v.begin(), v.end(), 0) == v.size(), "a sequence is not filled properly by oneapi::dpl::fill with `device_policy` policy");
+#endif
+}
+
+void test_empty_list_initialization_for_fill_n()
+{
+    constexpr std::size_t fill_number = 6;
+    {
+        std::vector<int> v{3,6,5,4,3,7,8,0,2,4};
+        auto it = oneapi::dpl::fill_n(oneapi::dpl::execution::seq, v.begin(), fill_number, {});
+        auto count = std::count(v.begin(), v.begin() + fill_number, 0);
+        EXPECT_TRUE(it == (v.begin() + fill_number), "an incorrect iterator returned from oneapi::dpl::fill_n with `seq` policy");
+        EXPECT_TRUE(count == fill_number, "a sequence is not filled properly by oneapi::dpl::fill_n with `seq` policy");
+    }
+    {
+        std::vector<int> v{3,6,5,4,3,7,8,0,2,4};
+        auto it = oneapi::dpl::fill_n(oneapi::dpl::execution::unseq, v.begin(), fill_number, {});
+        auto count = std::count(v.begin(), v.begin() + fill_number, 0);
+        EXPECT_TRUE(it == (v.begin() + fill_number), "an incorrect iterator returned from oneapi::dpl::fill_n with `unseq` policy");
+        EXPECT_TRUE(count == fill_number, "a sequence is not filled properly by oneapi::dpl::fill_n with `unseq` policy");
+    }
+
+    {
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{6},{5},{4},{3},{7},{8},{2},{1},{4}};
+            auto it = oneapi::dpl::fill_n(oneapi::dpl::execution::par, v_custom.begin(), fill_number, {});
+            auto count = std::count(v_custom.begin(), v_custom.begin() + fill_number, TestUtils::DefaultInitializedToOne{1});
+            EXPECT_TRUE(it == (v_custom.begin() + fill_number), "an incorrect iterator returned from oneapi::dpl::fill_n with `par` policy");
+            EXPECT_TRUE(count == fill_number, "a sequence is not filled properly by oneapi::dpl::fill_n with `par` policy");
+        }
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{6},{5},{4},{3},{7},{8},{2},{1},{4}};
+            auto it = oneapi::dpl::fill_n(oneapi::dpl::execution::par_unseq, v_custom.begin(), fill_number, {});
+            auto count = std::count(v_custom.begin(), v_custom.begin() + fill_number, TestUtils::DefaultInitializedToOne{1});
+            EXPECT_TRUE(it == (v_custom.begin() + fill_number), "an incorrect iterator returned from oneapi::dpl::fill_n with `par_unseq` policy");
+            EXPECT_TRUE(count == fill_number, "a sequence is not filled properly by oneapi::dpl::fill_n with `par_unseq` policy");
+        }
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    std::vector<int> v{3,6,5,4,3,7,8,0,2,4};
+    sycl::buffer<int> buf(v);
+    auto it = oneapi::dpl::fill_n(oneapi::dpl::execution::dpcpp_default, oneapi::dpl::begin(buf), fill_number, {});
+    auto count = std::count(v.begin(), v.begin() + fill_number, 0);
+    EXPECT_TRUE(it.get_idx() == fill_number, "an incorrect iterator returned from oneapi::dpl::fill_n with `device_policy` policy");
+    EXPECT_TRUE(count == fill_number, "a sequence is not filled properly by oneapi::dpl::fill_n with `device_policy` policy");
+#endif
+}
+
 int
 main()
 {
@@ -107,6 +186,9 @@ main()
         test_fill_by_type<std::int32_t>(n);
         test_fill_by_type<float64_t>(n);
     }
+
+    test_empty_list_initialization_for_fill();
+    test_empty_list_initialization_for_fill_n();
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
@@ -105,6 +105,54 @@ struct test_non_const
     }
 };
 
+void test_empty_list_initialization()
+{
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> expected{3,6,4,7,8,3,4};
+        auto it = oneapi::dpl::remove(oneapi::dpl::execution::seq, v.begin(), v.end(), {});
+        EXPECT_TRUE(it == v.begin() + 7, "not all empty list-initialized values are properly removed by oneapi::dpl::remove with `seq` policy");
+        v.erase(it, v.end());
+        EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::remove with empty list-initialized value and with `seq` policy");
+    }
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> expected{3,6,4,7,8,3,4};
+        auto it = oneapi::dpl::remove(oneapi::dpl::execution::unseq, v.begin(), v.end(), {});
+        EXPECT_TRUE(it == v.begin() + 7, "not all empty list-initialized values are properly removed by oneapi::dpl::remove with `unseq` policy");
+        v.erase(it, v.end());
+        EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::remove with empty list-initialized value and with `unseq` policy");
+    }
+
+    {
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{1},{3},{1},{8},{2},{0},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{3},{5},{3},{8},{2},{0}};
+            auto it = oneapi::dpl::remove(oneapi::dpl::execution::par, v_custom.begin(), v_custom.end(), {});
+            EXPECT_TRUE(it == v_custom.begin() + 6, "not all empty list-initialized values are properly removed by oneapi::dpl::remove with `par` policy");
+            v_custom.erase(it, v_custom.end());
+            EXPECT_TRUE(v_custom == expected_custom, "wrong effect from calling oneapi::dpl::remove with empty list-initialized value and with `par` policy");
+        }
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{1},{3},{1},{8},{2},{0},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{3},{5},{3},{8},{2},{0}};
+            auto it = oneapi::dpl::remove(oneapi::dpl::execution::par_unseq, v_custom.begin(), v_custom.end(), {});
+            EXPECT_TRUE(it == v_custom.begin() + 6, "not all empty list-initialized values are properly removed by oneapi::dpl::remove with `par_unseq` policy");
+            v_custom.erase(it, v_custom.end());
+            EXPECT_TRUE(v_custom == expected_custom, "wrong effect from calling oneapi::dpl::remove with empty list-initialized value and with `par_unseq` policy");
+        }
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+    std::vector<int> expected{3,6,4,7,8,3,4};
+    sycl::buffer<int> buf(v);
+    auto it = oneapi::dpl::remove(oneapi::dpl::execution::dpcpp_default, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), {});
+    EXPECT_TRUE(it.get_idx() == 7, "not all empty list-initialized values are properly removed by oneapi::dpl::remove with `device_policy` policy");
+    v.erase(v.begin() + it.get_idx(), v.end());
+    EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::remove with empty list-initialized value and with `device_policy` policy");
+#endif
+}
+
 int
 main()
 {
@@ -132,6 +180,8 @@ main()
     );
     EXPECT_TRUE(MemoryChecker::alive_objects() == 0, "wrong effect from remove,remove_if: number of ctor and dtor calls is not equal");
 #endif
+
+    test_empty_list_initialization();
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -156,6 +156,82 @@ struct test_non_const
     }
 };
 
+void test_empty_list_initialization_for_replace()
+{
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+        oneapi::dpl::replace(oneapi::dpl::execution::seq, v.begin(), v.end(), 3, {});
+        EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::replace with empty list-initialized value and with `seq` policy");
+    }
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+        oneapi::dpl::replace(oneapi::dpl::execution::unseq, v.begin(), v.end(), 3, {});
+        EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::replace with empty list-initialized value and with `unseq` policy");
+    }
+
+    {
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{3},{3},{1},{8},{2},{3},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{1},{1},{5},{1},{1},{1},{8},{2},{1},{1}};
+            oneapi::dpl::replace(oneapi::dpl::execution::par, v_custom.begin(), v_custom.end(), {3}, {});
+            EXPECT_TRUE(v_custom == expected_custom, "wrong effect from calling oneapi::dpl::replace with empty list-initialized value and with `par` policy");
+        }
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{3},{3},{1},{8},{2},{3},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{1},{1},{5},{1},{1},{1},{8},{2},{1},{1}};
+            oneapi::dpl::replace(oneapi::dpl::execution::par_unseq, v_custom.begin(), v_custom.end(), {3}, {});
+            EXPECT_TRUE(v_custom == expected_custom, "wrong effect from calling oneapi::dpl::replace with empty list-initialized value and with `par_unseq` policy");
+        }
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+    std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+    sycl::buffer<int> buf(v);
+    oneapi::dpl::replace(oneapi::dpl::execution::dpcpp_default, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), 3, {});
+    EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::replace with empty list-initialized value and with `device_policy` policy");
+#endif
+}
+
+void test_empty_list_initialization_for_replace_if()
+{
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+        oneapi::dpl::replace_if(oneapi::dpl::execution::seq, v.begin(), v.end(), [](auto x) { return x == 3; }, {});
+        EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::replace_if with empty list-initialized value and with `seq` policy");
+    }
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+        oneapi::dpl::replace_if(oneapi::dpl::execution::unseq, v.begin(), v.end(), [](auto x) { return x == 3; }, {});
+        EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::replace_if with empty list-initialized value and with `unseq` policy");
+    }
+
+    {
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{3},{3},{1},{8},{2},{3},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{1},{1},{5},{1},{1},{1},{8},{2},{1},{1}};
+            oneapi::dpl::replace_if(oneapi::dpl::execution::par, v_custom.begin(), v_custom.end(), [](auto x) { return x == TestUtils::DefaultInitializedToOne{3}; }, {});
+            EXPECT_TRUE(v_custom == expected_custom, "wrong effect from calling oneapi::dpl::replace_if with empty list-initialized value and with `par` policy");
+        }
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{3},{3},{1},{8},{2},{3},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{1},{1},{5},{1},{1},{1},{8},{2},{1},{1}};
+            oneapi::dpl::replace_if(oneapi::dpl::execution::par_unseq, v_custom.begin(), v_custom.end(), [](auto x) { return x == TestUtils::DefaultInitializedToOne{3}; }, {});
+            EXPECT_TRUE(v_custom == expected_custom, "wrong effect from calling oneapi::dpl::replace_if with empty list-initialized value and with `par_unseq` policy");
+        }
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+    std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+    sycl::buffer<int> buf(v);
+    oneapi::dpl::replace_if(oneapi::dpl::execution::dpcpp_default, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), [](auto x) { return x == 3; }, {});
+    EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::replace_if with empty list-initialized value and with `device_policy` policy");
+#endif
+}
+
 int
 main()
 {
@@ -169,6 +245,9 @@ main()
 #ifdef _PSTL_TEST_REPLACE_IF
     test_algo_basic_single<std::int16_t>(run_for_rnd_fw<test_non_const<std::int16_t>>());
 #endif
+
+    test_empty_list_initialization_for_replace();
+    test_empty_list_initialization_for_replace_if();
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
@@ -109,6 +109,94 @@ struct test_non_const
     }
 };
 
+void test_empty_list_initialization_for_replace_copy()
+{
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> dest(v.size());
+        std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+        oneapi::dpl::replace_copy(oneapi::dpl::execution::seq, v.begin(), v.end(), dest.begin(), 3, {});
+        EXPECT_TRUE(dest == expected, "wrong effect from calling oneapi::dpl::replace_copy with empty list-initialized value and with `seq` policy");
+    }
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> dest(v.size());
+        std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+        oneapi::dpl::replace_copy(oneapi::dpl::execution::unseq, v.begin(), v.end(), dest.begin(), 3, {});
+        EXPECT_TRUE(dest == expected, "wrong effect from calling oneapi::dpl::replace_copy with empty list-initialized value and with `unseq` policy");
+    }
+
+    {
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{3},{3},{1},{8},{2},{3},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> dest_custom(v_custom.size());
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{1},{1},{5},{1},{1},{1},{8},{2},{1},{1}};
+            oneapi::dpl::replace_copy(oneapi::dpl::execution::par, v_custom.begin(), v_custom.end(), dest_custom.begin(), {3}, {});
+            EXPECT_TRUE(dest_custom == expected_custom, "wrong effect from calling oneapi::dpl::replace_copy with empty list-initialized value and with `par` policy");
+        }
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{3},{3},{1},{8},{2},{3},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> dest_custom(v_custom.size());
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{1},{1},{5},{1},{1},{1},{8},{2},{1},{1}};
+            oneapi::dpl::replace_copy(oneapi::dpl::execution::par_unseq, v_custom.begin(), v_custom.end(), dest_custom.begin(), {3}, {});
+            EXPECT_TRUE(dest_custom == expected_custom, "wrong effect from calling oneapi::dpl::replace_copy with empty list-initialized value and with `par` policy");
+        }
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+    std::vector<int> dest(v.size());
+    std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+    sycl::buffer<int> buf(v);
+    sycl::buffer<int> dest_buf(v);
+    oneapi::dpl::replace_copy(oneapi::dpl::execution::dpcpp_default, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), oneapi::dpl::begin(dest_buf), 3, {});
+    EXPECT_TRUE(dest == expected, "wrong effect from calling oneapi::dpl::replace_copy with empty list-initialized value and with `device_policy` policy");
+#endif
+}
+
+void test_empty_list_initialization_for_replace_copy_if()
+{
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> dest(v.size());
+        std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+        oneapi::dpl::replace_copy_if(oneapi::dpl::execution::seq, v.begin(), v.end(), dest.begin(), [](auto x) { return x == 3; }, {});
+        EXPECT_TRUE(dest == expected, "wrong effect from calling oneapi::dpl::replace_copy_if with empty list-initialized value and with `seq` policy");
+    }
+    {
+        std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+        std::vector<int> dest(v.size());
+        std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+        oneapi::dpl::replace_copy_if(oneapi::dpl::execution::unseq, v.begin(), v.end(), dest.begin(), [](auto x) { return x == 3; }, {});
+        EXPECT_TRUE(dest == expected, "wrong effect from calling oneapi::dpl::replace_copy_if with empty list-initialized value and with `unseq` policy");
+    }
+
+    {
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{3},{3},{1},{8},{2},{3},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> dest_custom(v_custom.size());
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{1},{1},{5},{1},{1},{1},{8},{2},{1},{1}};
+            oneapi::dpl::replace_copy_if(oneapi::dpl::execution::par, v_custom.begin(), v_custom.end(), dest_custom.begin(), [](auto x) { return x == TestUtils::DefaultInitializedToOne{3}; }, {});
+            EXPECT_TRUE(dest_custom == expected_custom, "wrong effect from calling oneapi::dpl::replace_copy_if with empty list-initialized value and with `par` policy");
+        }
+        {
+            std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{3},{3},{1},{8},{2},{3},{1}};
+            std::vector<TestUtils::DefaultInitializedToOne> dest_custom(v_custom.size());
+            std::vector<TestUtils::DefaultInitializedToOne> expected_custom{{1},{1},{5},{1},{1},{1},{8},{2},{1},{1}};
+            oneapi::dpl::replace_copy_if(oneapi::dpl::execution::par_unseq, v_custom.begin(), v_custom.end(), dest_custom.begin(), [](auto x) { return x == TestUtils::DefaultInitializedToOne{3}; }, {});
+            EXPECT_TRUE(dest_custom == expected_custom, "wrong effect from calling oneapi::dpl::replace_copy_if with empty list-initialized value and with `par_unseq` policy");
+        }
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+    std::vector<int> dest(v.size());
+    std::vector<int> expected{0,6,0,4,0,7,8,0,0,4};
+    sycl::buffer<int> buf(v);
+    sycl::buffer<int> dest_buf(dest);
+    oneapi::dpl::replace_copy_if(oneapi::dpl::execution::dpcpp_default, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), oneapi::dpl::begin(dest_buf), [](auto x) { return x == 3; }, {});
+    EXPECT_TRUE(v == expected, "wrong effect from calling oneapi::dpl::replace_copy_if with empty list-initialized value and with `device_policy` policy");
+#endif
+}
+
 int
 main()
 {
@@ -131,6 +219,9 @@ main()
 #ifdef _PSTL_TEST_REPLACE_COPY_IF
     test_algo_basic_double<std::int32_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
 #endif
+
+    test_empty_list_initialization_for_replace_copy();
+    test_empty_list_initialization_for_replace_copy_if();
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
@@ -100,6 +100,36 @@ struct test_non_const
     }
 };
 
+void test_empty_list_initialization()
+{
+    std::vector<int> v{3,6,0,4,0,7,8,0,3,4};
+    {
+        auto val = oneapi::dpl::count(oneapi::dpl::execution::seq, v.begin(), v.end(), {});
+        EXPECT_TRUE(val == 3, "an empty list-initialized value is not found by oneapi::dpl::count with `seq` policy");
+    }
+    {
+        auto val = oneapi::dpl::count(oneapi::dpl::execution::unseq, v.begin(), v.end(), {});
+        EXPECT_TRUE(val == 3, "an empty list-initialized value is not found by oneapi::dpl::count with `unseq` policy");
+    }
+
+    {
+        std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{1},{5},{1},{3},{1},{8},{2},{0},{1}};
+        {
+            auto val = oneapi::dpl::count(oneapi::dpl::execution::par, v_custom.begin(), v_custom.end(), {});
+            EXPECT_TRUE(val == 4, "an empty list-initialized value is not found by oneapi::dpl::count with `par` policy");
+        }
+        {
+            auto val = oneapi::dpl::count(oneapi::dpl::execution::par_unseq, v_custom.begin(), v_custom.end(), {});
+            EXPECT_TRUE(val == 4, "an empty list-initialized value is not found by oneapi::dpl::count with `par_unseq` policy");
+        }
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    sycl::buffer<int> buf(v);
+    auto val = oneapi::dpl::count(oneapi::dpl::execution::dpcpp_default, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), {});
+    EXPECT_TRUE(val == 3, "an empty list-initialized value is not found by oneapi::dpl::count with `device_policy` policy");
+#endif
+}
+
 int
 main()
 {
@@ -113,6 +143,8 @@ main()
 #ifdef _PSTL_TEST_COUNT_IF
     test_algo_basic_single<std::int32_t>(run_for_rnd_fw<test_non_const>());
 #endif
+
+    test_empty_list_initialization();
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
@@ -96,6 +96,52 @@ struct test_non_const
     }
 };
 
+void test_empty_list_initialization()
+{
+    std::vector<int> v{3,6,5,4,0,0,0,0,2,4};
+    {
+        auto it = oneapi::dpl::search_n(oneapi::dpl::execution::seq, v.begin(), v.end(), 4, {});
+        EXPECT_TRUE(it == (v.begin() + 4), "an empty list-initialized value is not found by oneapi::dpl::search_n with `seq` policy");
+    }
+    {
+        auto it = oneapi::dpl::search_n(oneapi::dpl::execution::seq, v.begin(), v.end(), 4, {}, std::equal_to{});
+        EXPECT_TRUE(it == (v.begin() + 4), "an empty list-initialized value is not found by oneapi::dpl::search_n with `seq` policy with predicate");
+    }
+    {
+        auto it = oneapi::dpl::search_n(oneapi::dpl::execution::unseq, v.begin(), v.end(), 4, {});
+        EXPECT_TRUE(it == (v.begin() + 4), "an empty list-initialized value is not found by oneapi::dpl::search_n with `unseq` policy");
+    }
+    {
+        auto it = oneapi::dpl::search_n(oneapi::dpl::execution::unseq, v.begin(), v.end(), 4, {}, std::equal_to{});
+        EXPECT_TRUE(it == (v.begin() + 4), "an empty list-initialized value is not found by oneapi::dpl::search_n with `unseq` policy with predicate");
+    }
+
+    {
+        std::vector<TestUtils::DefaultInitializedToOne> v_custom{{3},{6},{5},{4},{3},{1},{1},{1},{1},{4}};
+        {
+            auto it = oneapi::dpl::search_n(oneapi::dpl::execution::par, v_custom.begin(), v_custom.end(), 4, {});
+            EXPECT_TRUE(it == (v_custom.begin() + 5), "an empty list-initialized value is not found by oneapi::dpl::search_n with `par` policy");
+        }
+        {
+            auto it = oneapi::dpl::search_n(oneapi::dpl::execution::par, v_custom.begin(), v_custom.end(), 4, {}, std::equal_to{});
+            EXPECT_TRUE(it == (v_custom.begin() + 5), "an empty list-initialized value is not found by oneapi::dpl::search_n with `par` policy with predicate");
+        }
+        {
+            auto it = oneapi::dpl::search_n(oneapi::dpl::execution::par_unseq, v_custom.begin(), v_custom.end(), 4, {});
+            EXPECT_TRUE(it == (v_custom.begin() + 5), "an empty list-initialized value is not found by oneapi::dpl::search_n with `par_unseq` policy");
+        }
+        {
+            auto it = oneapi::dpl::search_n(oneapi::dpl::execution::par_unseq, v_custom.begin(), v_custom.end(), 4, {}, std::equal_to{});
+            EXPECT_TRUE(it == (v_custom.begin() + 5), "an empty list-initialized value is not found by oneapi::dpl::search_n with `par_unseq` policy with predicate");
+        }
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    sycl::buffer<int> buf(v);
+    auto it = oneapi::dpl::search_n(oneapi::dpl::execution::dpcpp_default, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), {});
+    EXPECT_TRUE(it.get_idx() == 4, "an empty list-initialized value is not found by oneapi::dpl::search_n with `device_policy` policy");
+#endif
+}
+
 int
 main()
 {
@@ -107,6 +153,8 @@ main()
     test<bool>();
 
     test_algo_basic_single<std::int32_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
+
+    test_empty_list_initialization();
 
     return done();
 }

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1300,6 +1300,17 @@ struct NoDefaultCtorWrapper {
     }
 };
 
+struct DefaultInitializedToOne
+{
+    int value = 1;
+
+    friend bool
+    operator==(const DefaultInitializedToOne& x, const DefaultInitializedToOne& y)
+    {
+        return x.value == y.value;
+    }
+};
+
 } /* namespace TestUtils */
 
 #endif // _UTILS_H


### PR DESCRIPTION
The [link](http://wg21.link/p2248) to the proposal

Implementing Iterator-based algorithms only. Ranges-based implementation is going on separately.

There are no breaking changes. All the breaking changes in C++ standard come into `std::ranges` namespace but even they are irrelevant to oneDPL because we implement list-initialization enabling right away, so there is no template parameters swapping

There are two oversights for P2248:
- `find_last` was not included (see [this paper](http://wg21.link/p3217)). However, it's irrelevant for Iterator-based algorithms because `find_last` exists in `std::ranges:` namespace only
- `uninitialized_fill` was not included (see [this paper](http://wg21.link/p3787). However, it's not included for C++26. We are trying to achieve that but there is no guarantee. The question is do we want to implement it proactively?

Binary Search-like algorithms from P2248 (e.g., `lower_bound`, `upper_bound`, etc.) are not relevant either because our API for those does not have `T`-like template parameter.
