### PR TITLE
Fix definition with same mangled name in tests

### DIFF
--- a/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
@@ -50,7 +50,7 @@ DEFINE_TEST(test_adjacent_find)
             *(host_keys.get() + n - 1) = *(host_keys.get() + n - 2);
             host_keys.update_data();
         }
-        result = std::adjacent_find(CLONE_TEST_POLICY(exec), first, last, comp);
+        result = std::adjacent_find(CLONE_TEST_POLICY_IDX(exec, 0), first, last, comp);
         expected = max_dis > 1 ? last - 2 : last;
         wait_and_throw(exec);
 
@@ -65,14 +65,14 @@ DEFINE_TEST(test_adjacent_find)
             *(host_keys.get() + max_dis / 2) = *(host_keys.get() + max_dis / 2 - 1);
             host_keys.update_data();
         }
-        result = std::adjacent_find(CLONE_TEST_POLICY(exec), first, last, comp);
+        result = std::adjacent_find(CLONE_TEST_POLICY_IDX(exec, 0), first, last, comp);
         expected = max_dis > 1 ? it - 1 : last;
         wait_and_throw(exec);
 
         EXPECT_EQ(expected, result, "wrong effect from adjacent_find (Test #3 middle element)");
 
         // check with an adjacent element (no predicate)
-        result = std::adjacent_find(CLONE_TEST_POLICY(exec), first, last);
+        result = std::adjacent_find(CLONE_TEST_POLICY_IDX(exec, 0), first, last);
         wait_and_throw(exec);
 
         EXPECT_EQ(expected, result, "wrong effect from adjacent_find (Test #4 middle element (no predicate))");
@@ -84,7 +84,7 @@ DEFINE_TEST(test_adjacent_find)
             *(host_keys.get() + 1) = *host_keys.get();
             host_keys.update_data();
         }
-        result = std::adjacent_find(CLONE_TEST_POLICY(exec), first, last, comp);
+        result = std::adjacent_find(CLONE_TEST_POLICY_IDX(exec, 0), first, last, comp);
         expected = max_dis > 1 ? first : last;
         wait_and_throw(exec);
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -81,7 +81,7 @@ struct test_shift
         TestUtils::usm_data_transfer<alloc_type, _ValueType> dt_helper(exec, first, m);
 
         auto ptr = dt_helper.get_data();
-        using _NewKernelName = USMKernelName<Algo, _ValueType>;
+        using _NewKernelName = USMKernelName<alloc_type, Algo, _ValueType>;
         auto het_res = algo(CLONE_TEST_POLICY_NAME(exec, _NewKernelName), ptr, ptr + m, n);
         _DiffType res_idx = het_res - ptr;
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.sort/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.sort/sort.pass.cpp
@@ -31,7 +31,7 @@ int main()
 #endif
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device"}, sizes, Device<0>{},
+    test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device"}, sizes, Device<0, SortTestConfig>{},
                                     Converter<TestUtils::float32_t>{});
 
     auto sycl_half_convert = [](size_t /*index*/, size_t val) {
@@ -50,17 +50,17 @@ int main()
     };
 
     // Test radix-sort bit conversions
-    test_sort<std::uint8_t>(SortTestConfig{cfg, "uint8_t, device"}, small_sizes, Device<1>{},
+    test_sort<std::uint8_t>(SortTestConfig{cfg, "uint8_t, device"}, small_sizes, Device<1, SortTestConfig>{},
                             Converter<std::uint8_t>{});
-    test_sort<std::int16_t>(SortTestConfig{cfg, "int16_t, device"}, small_sizes, Device<2>{},
+    test_sort<std::int16_t>(SortTestConfig{cfg, "int16_t, device"}, small_sizes, Device<2, SortTestConfig>{},
                             Converter<std::int16_t>{});
-    test_sort<std::uint32_t>(SortTestConfig{cfg, "uint32_t, device"}, small_sizes, Device<3>{},
+    test_sort<std::uint32_t>(SortTestConfig{cfg, "uint32_t, device"}, small_sizes, Device<3, SortTestConfig>{},
                              Converter<std::uint32_t>{});
-    test_sort<std::int64_t>(SortTestConfig{cfg, "int64_t, device"}, small_sizes, Device<4>{},
+    test_sort<std::int64_t>(SortTestConfig{cfg, "int64_t, device"}, small_sizes, Device<4, SortTestConfig>{},
                             Converter<std::int64_t>{});
-    test_sort<TestUtils::float64_t>(SortTestConfig{cfg, "float64_t, device"}, small_sizes, Device<5>{},
+    test_sort<TestUtils::float64_t>(SortTestConfig{cfg, "float64_t, device"}, small_sizes, Device<5, SortTestConfig>{},
                                     Converter<TestUtils::float64_t>{});
-    test_sort<sycl::half>(SortTestConfig{cfg, "sycl::half, device"}, small_sizes, Device<6>{}, sycl_half_convert);
+    test_sort<sycl::half>(SortTestConfig{cfg, "sycl::half, device"}, small_sizes, Device<6, SortTestConfig>{}, sycl_half_convert);
     // TODO: add a test for a MoveConstructible only type
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.sort/sort_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.sort/sort_comp.pass.cpp
@@ -47,14 +47,14 @@ int main()
 #endif
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device, custom greater"}, sizes, Device<0>{},
+    test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device, custom greater"}, sizes, Device<0, SortTestConfig>{},
                                     Converter<TestUtils::float32_t>{}, ConstGreater{});
-    test_sort<std::uint16_t>(SortTestConfig{cfg, "uint16_t, device, non-const custom less"}, sizes, Device<1>{},
+    test_sort<std::uint16_t>(SortTestConfig{cfg, "uint16_t, device, non-const custom less"}, sizes, Device<1, SortTestConfig>{},
                              Converter<std::uint16_t>{}, NonConstLess{});
 
     // Check radix-sort with to have a higher chance to hit synchronization issues if any
     sizes.push_back(8'000'000);
-    test_sort<std::int32_t>(SortTestConfig{cfg, "int32_t, device, std::less"}, sizes, Device<2>{},
+    test_sort<std::int32_t>(SortTestConfig{cfg, "int32_t, device, std::less"}, sizes, Device<2, SortTestConfig>{},
                             Converter<std::int32_t>{}, std::less{});
 #if __SYCL_UNNAMED_LAMBDA__
     // Test potentially clashing naming for radix sort descending / ascending with minimal timing impact

--- a/test/parallel_api/algorithm/alg.sorting/alg.stable.sort/stable_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.stable.sort/stable_sort.pass.cpp
@@ -30,9 +30,9 @@ int main()
 #endif
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device"}, sizes, Device<0>{},
+    test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device"}, sizes, Device<0, SortTestConfig>{},
                                     Converter<TestUtils::float32_t>{});
-    test_sort<std::int64_t>(SortTestConfig{cfg, "int64_t, device"}, sizes, Device<1>{}, Converter<std::int64_t>{});
+    test_sort<std::int64_t>(SortTestConfig{cfg, "int64_t, device"}, sizes, Device<1, SortTestConfig>{}, Converter<std::int64_t>{});
     // TODO: add a test for stability
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.stable.sort/stable_sort_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.stable.sort/stable_sort_comp.pass.cpp
@@ -49,13 +49,13 @@ int main()
 #endif
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device, custom less comparator"}, sizes, Device<0>{},
+    test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device, custom less comparator"}, sizes, Device<0, SortTestConfig>{},
                                     Converter<TestUtils::float32_t>{}, ConstLess{});
 
     // Test merge-path sort specialization for large sizes, see __get_starting_size_limit_for_large_submitter
     std::vector<std::size_t> extended_sizes = test_sizes(8'000'000);
     test_sort<std::uint16_t>(SortTestConfig{cfg, "uint16_t, device, custom greater comparator"}, extended_sizes,
-                             Device<1>{}, Converter<std::uint16_t>{}, ConstGreater{});
+                             Device<1, SortTestConfig>{}, Converter<std::uint16_t>{}, ConstGreater{});
 #if __SYCL_UNNAMED_LAMBDA__
     // Test potentially clashing naming for radix sort descending / ascending with minimal timing impact
     test_default_name_gen(SortTestConfig{cfg, "default name generation"});

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -72,7 +72,7 @@ void test_simple_copy(size_t buffer_size)
     ::std::fill_n(host_source_begin, buffer_size, identity);
 
     test_copy<int> test(test_base_data);
-    invoke_on_all_hetero_policies<0>()(test, tr_sycl_source_begin, tr_sycl_source_end, sycl_result_begin, buffer_size, identity + 1);
+    invoke_on_all_hetero_policies<0, decltype(test)>()(test, tr_sycl_source_begin, tr_sycl_source_end, sycl_result_begin, buffer_size, identity + 1);
 }
 
 void test_ignore_copy(size_t buffer_size)
@@ -104,7 +104,7 @@ void test_ignore_copy(size_t buffer_size)
     ::std::fill_n(host_result_begin, buffer_size, ignored);
 
     test_copy<int> test(test_base_data);
-    invoke_on_all_hetero_policies<1>()(test, sycl_source_begin, sycl_source_end, tr_sycl_result_begin, buffer_size, ignored);
+    invoke_on_all_hetero_policies<1, decltype(test)>()(test, sycl_source_begin, sycl_source_end, tr_sycl_result_begin, buffer_size, ignored);
 }
 
 void test_multi_transform_copy(size_t buffer_size)
@@ -137,7 +137,7 @@ void test_multi_transform_copy(size_t buffer_size)
     ::std::fill_n(host_source_begin, buffer_size, identity);
 
     test_copy<int> test(test_base_data);
-    invoke_on_all_hetero_policies<2>()(test, tr3_sycl_source_begin, tr3_sycl_source_end, sycl_result_begin, buffer_size, identity + 3);
+    invoke_on_all_hetero_policies<2, decltype(test)>()(test, tr3_sycl_source_begin, tr3_sycl_source_end, sycl_result_begin, buffer_size, identity + 3);
 }
 
 void

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -141,14 +141,16 @@ test_with_plus(Init init, Out trash, Convert convert)
     Sequence<Out> expected(n);
     Sequence<Out> out(n, [&](std::int32_t) { return trash; });
 #ifdef _PSTL_TEST_INCLUSIVE_SCAN
-    invoke_on_all_hetero_policies<4>()(test_inclusive_scan_with_plus<In, Init, Out>(), in.begin(), in.end(),
-                                       out.begin(), out.end(), expected.begin(), expected.end(), in.size(), init,
-                                       trash);
+    test_inclusive_scan_with_plus<In, Init, Out> test_inclusive_scan_with_plus_obj;
+    invoke_on_all_hetero_policies<4, decltype(test_inclusive_scan_with_plus_obj)>()(
+        test_inclusive_scan_with_plus_obj, in.begin(), in.end(), out.begin(), out.end(), expected.begin(),
+        expected.end(), in.size(), init, trash);
 #endif
 #ifdef _PSTL_TEST_EXCLUSIVE_SCAN
-    invoke_on_all_hetero_policies<5>()(test_exclusive_scan_with_plus<In, Init, Out>(), in.begin(), in.end(),
-                                       out.begin(), out.end(), expected.begin(), expected.end(), in.size(), init,
-                                       trash);
+    test_exclusive_scan_with_plus<In, Init, Out> test_exclusive_scan_with_plus_obj;
+    invoke_on_all_hetero_policies<5, decltype(test_exclusive_scan_with_plus_obj)>()(
+        test_exclusive_scan_with_plus_obj, in.begin(), in.end(), out.begin(), out.end(), expected.begin(),
+        expected.end(), in.size(), init, trash);
 #endif
 #endif // TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
 }
@@ -296,14 +298,16 @@ test_with_multiplies()
         std::shuffle(in.begin(), in.end(), gen);
 
 #ifdef _PSTL_TEST_INCLUSIVE_SCAN
-        invoke_on_all_hetero_policies<20>()(test_inclusive_scan_with_binary_op<T>(), in.begin(), in.end(),
-                                            out.begin(), out.end(), expected.begin(), expected.end(), in.size(),
-                                            init, std::multiplies{}, trash);
+        test_inclusive_scan_with_binary_op<T> test_inclusive_scan_with_binary_op_obj;
+        invoke_on_all_hetero_policies<20, decltype(test_inclusive_scan_with_binary_op_obj)>()(
+            test_inclusive_scan_with_binary_op_obj, in.begin(), in.end(), out.begin(), out.end(), expected.begin(),
+            expected.end(), in.size(), init, std::multiplies{}, trash);
 #endif
 #ifdef _PSTL_TEST_EXCLUSIVE_SCAN
-        invoke_on_all_hetero_policies<21>()(test_exclusive_scan_with_binary_op<T>(), in.begin(), in.end(), out.begin(),
-                                            out.end(), expected.begin(), expected.end(), in.size(),
-                                            init, std::multiplies{}, trash);
+        test_exclusive_scan_with_binary_op<T> test_exclusive_scan_with_binary_op_obj;
+        invoke_on_all_hetero_policies<21, decltype(test_exclusive_scan_with_binary_op_obj)>()(
+            test_exclusive_scan_with_binary_op_obj, in.begin(), in.end(), out.begin(), out.end(), expected.begin(),
+            expected.end(), in.size(), init, std::multiplies{}, trash);
 #endif
     }
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -362,14 +362,14 @@ inline void unsupported_types_notifier(const sycl::device& device)
 
 
 // Invoke test::operator()(policy,rest...) for each possible policy.
-template <::std::size_t CallNumber = 0>
+template <std::size_t CallNumber, typename _CustomName>
 struct invoke_on_all_hetero_policies
 {
     template <typename Op, typename... Args>
     void
     operator()(Op op, Args&&... rest)
     {
-        auto my_policy = get_dpcpp_test_policy<CallNumber, Op>();
+        auto my_policy = get_dpcpp_test_policy<CallNumber, _CustomName>();
 
         auto cloned_policy0 = CLONE_TEST_POLICY_IDX(my_policy, 0);
         auto cloned_policy1 = CLONE_TEST_POLICY_IDX(my_policy, 1);
@@ -457,7 +457,7 @@ struct invoke_on_all_policies
 #if __SYCL_PSTL_OFFLOAD__
         invoke_on_all_pstl_offload_policies()(op, rest...);
 #endif
-        invoke_on_all_hetero_policies<CallNumber>()(op, ::std::forward<T>(rest)...);
+        invoke_on_all_hetero_policies<CallNumber, decltype(op)>()(op, std::forward<T>(rest)...);
 #else
         invoke_on_all_host_policies()(op, ::std::forward<T>(rest)...);
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -79,8 +79,8 @@ struct Converter
 
 using Host = TestUtils::invoke_on_all_host_policies;
 #if TEST_DPCPP_BACKEND_PRESENT
-template <std::size_t CallNumber>
-using Device = TestUtils::invoke_on_all_hetero_policies<CallNumber>;
+template <std::size_t CallNumber, typename _CustomName>
+using Device = TestUtils::invoke_on_all_hetero_policies<CallNumber, _CustomName>;
 #endif
 
 // Checks that an operator() can be without const qualifier

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -137,6 +137,11 @@ required_test_sycl_buffer()
     return alloc_type == sycl::usm::alloc::shared;
 }
 
+template <sycl::usm::alloc alloc_type, bool TestSyclBuffer, typename Test>
+struct CustomNameForHeteroPolicy
+{
+};
+
 template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
           bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 void
@@ -161,9 +166,11 @@ test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #    endif
-            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
-                                               inout1_offset_first, inout1_offset_first + n,
-                                               n);
+            auto test_obj = create_test_obj<TestValueType, TestName>(test_base_data);
+            invoke_on_all_hetero_policies<0, CustomNameForHeteroPolicy<alloc_type, TestSyclBuffer, decltype(test_obj)>>()(
+                test_obj,
+                inout1_offset_first, inout1_offset_first + n,
+                n);
         }
     }
 #endif
@@ -184,9 +191,11 @@ test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #endif
-            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName>(test_base_data),
-                                               inout1_offset_first, inout1_offset_first + n,
-                                               n);
+            auto test_obj = create_test_obj<TestValueType, TestName>(test_base_data);
+            invoke_on_all_hetero_policies<1, CustomNameForHeteroPolicy<alloc_type, TestSyclBuffer, decltype(test_obj)>>()(
+                test_obj,
+                inout1_offset_first, inout1_offset_first + n,
+                n);
         }
     }
 }
@@ -218,10 +227,12 @@ test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #    endif
-            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
-                                               inout1_offset_first, inout1_offset_first + n,
-                                               inout2_offset_first, inout2_offset_first + n,
-                                               n);
+            auto test_obj = create_test_obj<TestValueType, TestName>(test_base_data);
+            invoke_on_all_hetero_policies<0, CustomNameForHeteroPolicy<alloc_type, TestSyclBuffer, decltype(test_obj)>>()(
+                test_obj,
+                inout1_offset_first, inout1_offset_first + n,
+                inout2_offset_first, inout2_offset_first + n,
+                n);
         }
     }
 #endif
@@ -244,10 +255,12 @@ test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #endif
-            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName>(test_base_data),
-                                               inout1_offset_first, inout1_offset_first + n,
-                                               inout2_offset_first, inout2_offset_first + n,
-                                               n);
+            auto test_obj = create_test_obj<TestValueType, TestName>(test_base_data);
+            invoke_on_all_hetero_policies<1, CustomNameForHeteroPolicy<alloc_type, TestSyclBuffer, decltype(test_obj)>>()(
+                test_obj,
+                inout1_offset_first, inout1_offset_first + n,
+                inout2_offset_first, inout2_offset_first + n,
+                n);
         }
     }
 }
@@ -282,11 +295,13 @@ test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #    endif
-            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
-                                               inout1_offset_first, inout1_offset_first + n,
-                                               inout2_offset_first, inout2_offset_first + n,
-                                               inout3_offset_first, inout3_offset_first + n * mult,
-                                               n);
+            auto test_obj = create_test_obj<TestValueType, TestName>(test_base_data);
+            invoke_on_all_hetero_policies<0, CustomNameForHeteroPolicy<alloc_type, TestSyclBuffer, decltype(test_obj)>>()(
+                test_obj,
+                inout1_offset_first, inout1_offset_first + n,
+                inout2_offset_first, inout2_offset_first + n,
+                inout3_offset_first, inout3_offset_first + n * mult,
+                n);
         }
     }
 #endif
@@ -311,11 +326,13 @@ test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #endif
-            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName>(test_base_data),
-                                               inout1_offset_first, inout1_offset_first + n,
-                                               inout2_offset_first, inout2_offset_first + n,
-                                               inout3_offset_first, inout3_offset_first + n * mult,
-                                               n);
+            auto test_obj = create_test_obj<TestValueType, TestName>(test_base_data);
+            invoke_on_all_hetero_policies<1, CustomNameForHeteroPolicy<alloc_type, TestSyclBuffer, decltype(test_obj)>>()(
+                test_obj,
+                inout1_offset_first, inout1_offset_first + n,
+                inout2_offset_first, inout2_offset_first + n,
+                inout3_offset_first, inout3_offset_first + n * mult,
+                n);
         }
     }
 }
@@ -352,12 +369,14 @@ test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #    endif
-            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
-                                               inout1_offset_first, inout1_offset_first + n,
-                                               inout2_offset_first, inout2_offset_first + n,
-                                               inout3_offset_first, inout3_offset_first + n * mult,
-                                               inout4_offset_first, inout4_offset_first + n * mult,
-                                               n);
+            auto test_obj = create_test_obj<TestValueType, TestName>(test_base_data);
+            invoke_on_all_hetero_policies<0, CustomNameForHeteroPolicy<alloc_type, TestSyclBuffer, decltype(test_obj)>>()(
+                test_obj,
+                inout1_offset_first, inout1_offset_first + n,
+                inout2_offset_first, inout2_offset_first + n,
+                inout3_offset_first, inout3_offset_first + n * mult,
+                inout4_offset_first, inout4_offset_first + n * mult,
+                n);
         }
     }
 #endif
@@ -384,12 +403,14 @@ test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #endif
-            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName>(test_base_data),
-                                               inout1_offset_first, inout1_offset_first + n,
-                                               inout2_offset_first, inout2_offset_first + n,
-                                               inout3_offset_first, inout3_offset_first + n * mult,
-                                               inout4_offset_first, inout4_offset_first + n * mult,
-                                               n);
+            auto test_obj = create_test_obj<TestValueType, TestName>(test_base_data);
+            invoke_on_all_hetero_policies<1, CustomNameForHeteroPolicy<alloc_type, TestSyclBuffer, decltype(test_obj)>>()(
+                test_obj,
+                inout1_offset_first, inout1_offset_first + n,
+                inout2_offset_first, inout2_offset_first + n,
+                inout3_offset_first, inout3_offset_first + n * mult,
+                inout4_offset_first, inout4_offset_first + n * mult,
+                n);
         }
     }
 }


### PR DESCRIPTION
The PR addresses an issue with kernel name generation in SYCL tests where identical mangled names could cause conflicts. The fix ensures unique kernel names by incorporating template parameters from calling functions into the kernel naming scheme.

- Adds a `CustomNameForHeteroPolicy` template struct to encode caller context into kernel names
- Updates `invoke_on_all_hetero_policies` to accept a custom name template parameter
- Replaces inline test object creation with explicit variable declarations to enable `decltype` usage

### Details

I think I found the issue in Kernel names inside test environment.
We generates Kernel name for each test in the `struct invoke_on_all_hetero_policies::operator()` like
```C++
template <::std::size_t CallNumber = 0>
struct invoke_on_all_hetero_policies
{
    template <typename Op, typename... Args>
    void
    operator()(Op op, Args&&... rest)
    {
        auto my_policy = get_dpcpp_test_policy<CallNumber, Op>();
        /// ....
    }
};
```
So the Kernel name for each test depends only from test plus some `CallNumber`.


But It's not enough because we have different `invoke_on_all_hetero_policies::operator()` calls.
For example:
```C++
template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
void
test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
{
    // ...
            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
                                               inout1_offset_first, inout1_offset_first + n,
                                               n);
    // ...
}
```
and etc.

This mean that in each case like that Kernel name used in test should contain also template parameters of caller function.
In this case we need have to `sycl::usm::alloc alloc_type` and `bool TestSyclBuffer` in Kernel name too.

Now for this purpose I introduces the new structure:
```C++
template <sycl::usm::alloc alloc_type, bool TestSyclBuffer, typename Test>
struct CustomNameForHeteroPolicy
{
};
```

Ang the usage is:
```C++
            auto test_obj = create_test_obj<TestValueType, TestName>(test_base_data);
            invoke_on_all_hetero_policies<0, CustomNameForHeteroPolicy<alloc_type, TestSyclBuffer, decltype(test_obj)>>()(
                test_obj,
                inout1_offset_first, inout1_offset_first + n,
                n);
```