### PR TITLE
Replace `std::exclusive_scan` to `exclusive_scan_serial` call

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -20,6 +20,7 @@
 #include _PSTL_TEST_HEADER(numeric)
 
 #include "support/utils.h"
+#include "support/scan_serial_impl.h"
 
 #include <iostream>
 #include <vector>
@@ -116,7 +117,7 @@ test_diff_iterators(Policy&& exec)
     // Calculate expected result using serial exclusive_scan
     std::vector<int> result_expected(N);
     auto result_rbegin_expected = result_expected.rbegin();
-    std::exclusive_scan(
+    exclusive_scan_serial(
         input_rbegin,                       // Start of reversed input range
         input_rend,                         // End of reversed input range
         result_rbegin_expected,             // Start of reversed output range


### PR DESCRIPTION
This PR replaces the usage of `std::exclusive_scan` with `exclusive_scan_serial` in a test file to ensure consistent serial execution behavior in test calculations.

- Replaces `std::exclusive_scan` with `exclusive_scan_serial` for expected result calculation
- Adds necessary include for the serial implementation