### PR TITLE
Fix `oneapi::dpl::__internal::__compare` specializations

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -546,7 +546,7 @@ auto
 __pattern_adjacent_find_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pred __pred,
                         _Proj __proj)
 {
-    oneapi::dpl::__internal::__compare __pred_2{__pred, __proj};
+    oneapi::dpl::__internal::__compare<_Pred, _Proj> __pred_2{__pred, __proj};
 
     auto __idx =
         oneapi::dpl::__internal::__ranges::__pattern_adjacent_find(__tag, std::forward<_ExecutionPolicy>(__exec),
@@ -560,7 +560,7 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename
 bool
 __pattern_is_sorted(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
-    oneapi::dpl::__internal::__compare __pred_2{__comp, __proj};
+    oneapi::dpl::__internal::__compare<_Comp, _Proj> __pred_2{__comp, __proj};
 
     return oneapi::dpl::__internal::__ranges::__pattern_adjacent_find(__tag,
         std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__ranges::views::all_read(__r),
@@ -936,7 +936,7 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename
 std::ranges::borrowed_iterator_t<_R>
 __pattern_min_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
-    oneapi::dpl::__internal::__compare __comp_2{__comp, __proj};
+    oneapi::dpl::__internal::__compare<_Comp, _Proj> __comp_2{__comp, __proj};
 
     const auto __idx = oneapi::dpl::__internal::__ranges::__pattern_min_element(
         __tag, std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__ranges::views::all_read(__r), __comp_2);
@@ -948,7 +948,7 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename
 std::ranges::range_value_t<_R>
 __pattern_min(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
-    oneapi::dpl::__internal::__compare __comp_2{__comp, __proj};
+    oneapi::dpl::__internal::__compare<_Comp, _Proj> __comp_2{__comp, __proj};
 
     [[maybe_unused]] const auto& [__idx, __val] =
         __pattern_min_element_impl(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
@@ -1019,7 +1019,7 @@ std::pair<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t
 __pattern_minmax_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp,
                          _Proj __proj)
 {
-    oneapi::dpl::__internal::__compare __comp_2{__comp, __proj};
+    oneapi::dpl::__internal::__compare<_Comp, _Proj> __comp_2{__comp, __proj};
 
     const auto [__min_idx, __max_idx] =
         oneapi::dpl::__internal::__ranges::__pattern_minmax_element(__tag, std::forward<_ExecutionPolicy>(__exec),
@@ -1032,7 +1032,7 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename
 std::pair<std::ranges::range_value_t<_R>, std::ranges::range_value_t<_R>>
 __pattern_minmax(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
-    oneapi::dpl::__internal::__compare __comp_2{__comp, __proj};
+    oneapi::dpl::__internal::__compare<_Comp, _Proj> __comp_2{__comp, __proj};
 
     [[maybe_unused]] const auto& [__res_min, __res_max] =
         __pattern_minmax_element_impl(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),


### PR DESCRIPTION
This PR fixes compilation errors in the oneAPI DPL library by adding explicit template parameter specifications to `oneapi::dpl::__internal::__compare` instantiations. The changes ensure proper template argument deduction for the `__compare` class template.

- Adds explicit template parameters `<_Pred, _Proj>`, `<_Comp, _Proj>` to `__compare` instantiations
- Fixes template argument deduction issues that were causing compile-time errors
- Updates multiple algorithm implementations including adjacent_find, is_sorted, min_element, min, minmax_element, and minmax

### Compile error
```C++
oneapi/dpl/pstl/algorithm_ranges_impl.h:247:40: error: alias template '__compare' requires template arguments; argument deduction only allowed for class templates
  247 |     oneapi::dpl::__internal::__compare __pred_2{__pred, __proj};
      |                                        ^
```