### PR TITLE
Clarify new predicate return types to merge

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -69,9 +69,6 @@ template <typename _Tp>
 class __set_value;
 
 template <typename _Proj>
-struct __projection;
-
-template <typename _Proj>
 struct __projection_deref;
 
 template <typename _Comp, typename _Proj>
@@ -195,12 +192,6 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 template <typename _Tp>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__set_value, _Tp)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Tp>
-{
-};
-
-template <typename _Proj>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__projection, _Proj)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<_Proj>
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1008,34 +1008,31 @@ struct __brick_includes
     {
         using std::get;
 
-        oneapi::dpl::__internal::__projection<_Proj1> __proj_rng_1{__proj1};
-        oneapi::dpl::__internal::__projection<_Proj2> __proj_rng_2{__proj2};
-
         // testing __comp(*__first2, *__first1) or __comp(*(__last1 - 1), *(__last2 - 1))
-        if ((__idx == 0 && std::invoke(__comp, __proj_rng_1(__rng1[0]), __proj_rng_2(__rng2[0]))) ||
+        if ((__idx == 0 && std::invoke(__comp, std::invoke(__proj1, __rng1[0]), std::invoke(__proj2, __rng2[0]))) ||
             (__idx == __size1 - 1 &&
-             std::invoke(__comp, __proj_rng_2(__rng2[__size2 - 1]), __proj_rng_1(__rng1[__size1 - 1]))))
+             std::invoke(__comp, std::invoke(__proj2, __rng2[__size2 - 1]), std::invoke(__proj1, __rng1[__size1 - 1]))))
             return true; //__rng2 doesn't include __rng1
 
         const auto __idx_b = 0 + __idx;
         const auto __val_b = __rng1[__idx_b];
 
-        auto __res = __internal::__pstl_lower_bound(__rng2, _Size1{0}, __size2, __proj_rng_1(__val_b), __comp, __proj2);
+        auto __res = __internal::__pstl_lower_bound(__rng2, _Size1{0}, __size2, std::invoke(__proj1, __val_b), __comp, __proj2);
 
         // {a} < {b} or __val_b != __rng2[__res]
-        if (__res == __size2 || std::invoke(__comp, __proj_rng_1(__val_b), __proj_rng_2(__rng2[__res])))
+        if (__res == __size2 || std::invoke(__comp, std::invoke(__proj1, __val_b), std::invoke(__proj2, __rng2[__res])))
             return true; //__rng2 doesn't include __rng1
 
         auto __val_a = __rng2[__res];
 
         //searching number of duplication
         const auto __count_a =
-            __internal::__pstl_right_bound(__rng2, __res, __size2, __proj_rng_2(__val_a), __comp, __proj2) -
-            __internal::__pstl_left_bound(__rng2, _Size1{0}, __res, __proj_rng_2(__val_a), __comp, __proj2);
+            __internal::__pstl_right_bound(__rng2, __res, __size2, std::invoke(__proj2, __val_a), __comp, __proj2) -
+            __internal::__pstl_left_bound(__rng2, _Size1{0}, __res, std::invoke(__proj2, __val_a), __comp, __proj2);
 
         const auto __count_b =
-            __internal::__pstl_right_bound(__rng1, _Size2(__idx_b), __size1, __proj_rng_1(__val_b), __comp, __proj1) -
-            __internal::__pstl_left_bound(__rng1, _Size2{0}, _Size2(__idx_b), __proj_rng_1(__val_b), __comp, __proj1);
+            __internal::__pstl_right_bound(__rng1, _Size2(__idx_b), __size1, std::invoke(__proj1, __val_b), __comp, __proj1) -
+            __internal::__pstl_left_bound(__rng1, _Size2{0}, _Size2(__idx_b), std::invoke(__proj1, __val_b), __comp, __proj1);
 
         return __count_b > __count_a; //false means __rng2 includes __rng1
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -129,20 +129,6 @@ class __pstl_assign
 };
 
 template <typename _Proj>
-struct __projection
-{
-    //'mutable' is to relax the requirements for a user comparator or/and projection type operator() may be non-const
-    mutable _Proj __proj;
-
-    template <typename _TValue>
-    decltype(auto)
-    operator()(_TValue&& __val) const
-    {
-        return std::invoke(__proj, std::forward<_TValue>(__val));
-    }
-};
-
-template <typename _Proj>
 struct __projection_deref
 {
     //'mutable' is to relax the requirements for a user comparator or/and projection type operator() may be non-const
@@ -152,19 +138,17 @@ struct __projection_deref
     decltype(auto)
     operator()(_Iterator __it) const
     {
-        __projection<_Proj> __proj_obj{__proj};
-
         if constexpr (std::is_lvalue_reference_v<decltype(*__it)>)
         {
-            return __proj_obj(*__it);
+            return std::invoke(__proj, *__it);
         }
         else
         {
-            using __proj_result_t = decltype(__proj_obj(*__it));
+            using __proj_result_t = decltype(std::invoke(__proj, *__it));
             using __proj_result_decayed_t = std::decay_t<__proj_result_t>;
 
             // create temporary copy of the projection returning value
-            __proj_result_decayed_t __res = __proj_obj(*__it);
+            __proj_result_decayed_t __res = std::invoke(__proj, *__it);
 
             return __res;
         }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -154,14 +154,13 @@ struct __projection_deref
     {
         __projection<_Proj> __proj_obj{__proj};
 
-        using __proj_result_t = decltype(__proj_obj(*__it));
-
-        if constexpr (std::is_lvalue_reference_v<__proj_result_t>)
+        if constexpr (std::is_lvalue_reference_v<decltype(*__it)>)
         {
             return __proj_obj(*__it);
         }
         else
         {
+            using __proj_result_t = decltype(__proj_obj(*__it));
             using __proj_result_decayed_t = std::decay_t<__proj_result_t>;
 
             // create temporary copy of the projection returning value

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -147,10 +147,8 @@ struct __projection_deref
             using __proj_result_t = decltype(std::invoke(__proj, *__it));
             using __proj_result_decayed_t = std::decay_t<__proj_result_t>;
 
-            // create temporary copy of the projection returning value
-            __proj_result_decayed_t __res = std::invoke(__proj, *__it);
-
-            return __res;
+            // create temporary copy of the projection and return it as prvalue
+            return __proj_result_decayed_t{std::invoke(__proj, *__it)};
         }
     }
 };

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -148,6 +148,7 @@ struct __projection_deref
             using __proj_result_decayed_t = std::decay_t<__proj_result_t>;
 
             // create temporary copy of the projection and return it as prvalue
+            // - for that we should create and return temporary object (but not local variable)
             return __proj_result_decayed_t{std::invoke(__proj, *__it)};
         }
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -135,7 +135,7 @@ struct __projection
     mutable _Proj __proj;
 
     template <typename _TValue>
-    auto
+    decltype(auto)
     operator()(_TValue&& __val) const
     {
         return std::invoke(__proj, std::forward<_TValue>(__val));
@@ -149,10 +149,13 @@ struct __projection_deref
     mutable _Proj __proj;
 
     template <typename _Iterator>
-    auto
+    decltype(auto)
     operator()(_Iterator __it) const
     {
-        return std::invoke(__proj, *__it);
+        if constexpr (std::is_rvalue_reference_v<decltype(*__it)>)
+            return std::invoke(__proj, decltype (*__it)(*__it)); // create temporary copy of the dereferenced value
+        else
+            return std::invoke(__proj, *__it);
     }
 };
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -152,10 +152,23 @@ struct __projection_deref
     decltype(auto)
     operator()(_Iterator __it) const
     {
-        if constexpr (std::is_rvalue_reference_v<decltype(*__it)>)
-            return std::invoke(__proj, decltype (*__it)(*__it)); // create temporary copy of the dereferenced value
+        __projection<_Proj> __proj_obj{__proj};
+
+        using __proj_result_t = decltype(__proj_obj(*__it));
+
+        if constexpr (std::is_lvalue_reference_v<__proj_result_t>)
+        {
+            return __proj_obj(*__it);
+        }
         else
-            return std::invoke(__proj, *__it);
+        {
+            using __proj_result_decayed_t = std::decay_t<__proj_result_t>;
+
+            // create temporary copy of the projection returning value
+            __proj_result_decayed_t __res = __proj_obj(*__it);
+
+            return __res;
+        }
     }
 };
 


### PR DESCRIPTION
This PR refactors projection utilities by removing the `__projection` struct and updating return type specifications for better type handling. It eliminates redundant wrapper classes and improves reference handling in projection operations.

- Removed `__projection` struct and replaced its usage with direct `std::invoke` calls
- Updated `__projection_deref` to use `decltype(auto)` return type with explicit lvalue/rvalue reference handling
- Cleaned up SYCL trait specializations by removing references to the deleted `__projection` struct

Per-commit CI checks started in https://github.com/uxlfoundation/oneDPL/pull/2405/checks