### PR TITLE
[Test] Restrict no comma operator test builds

### DIFF
--- a/test/support/compile_only_checks.h
+++ b/test/support/compile_only_checks.h
@@ -246,7 +246,7 @@ void
 check_compilation_no_comma(Policy&& policy, Op&& op, Args&&... rest)
 {
     //for libc++, we disable these checks because their sort implementation is broken for deleted comma operator iter
-#if !_PSTL_LIBCPP_NO_COMMA_TESTS_BROKEN
+#if TEST_NO_COMMA_ITERATORS
     volatile bool always_false = false;
     if (always_false)
     {

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -293,11 +293,14 @@
 #    error "TEST_ONLY_HETERO_POLICIES is passed but device backend is not available"
 #endif
 
-// There are issues with stable_sort for libcpp with iterators with a deleted comma operator, disable those tests
-#if (defined(_LIBCPP_VERSION))
-#   define _PSTL_LIBCPP_NO_COMMA_TESTS_BROKEN 1
+//There are issues with stable_sort for libcpp with iterators with a deleted comma operator, disable no_comma compile
+// only tests. Also, since this adds significant amount of code compilation to the build, lets be more conservative
+// about when we try to test this. Since debug build mode and unnamed lambda support dont change the code in any way
+// which should interact with what we are testing for here, lets disable it for those cases for time / build space.
+#if !defined(_LIBCPP_VERSION) && !defined(_DEBUG) && __SYCL_UNNAMED_LAMBDA__
+#   define TEST_NO_COMMA_ITERATORS 1
 #else
-#   define _PSTL_LIBCPP_NO_COMMA_TESTS_BROKEN 0
+#   define TEST_NO_COMMA_ITERATORS 0
 #endif
 
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -297,7 +297,7 @@
 // only tests. Also, since this adds significant amount of code compilation to the build, lets be more conservative
 // about when we try to test this. Since debug build mode and unnamed lambda support dont change the code in any way
 // which should interact with what we are testing for here, lets disable it for those cases for time / build space.
-#if !defined(_LIBCPP_VERSION) && !defined(_DEBUG) && defined(__SYCL_UNNAMED_LAMBDA__)
+#if !defined(_LIBCPP_VERSION) && !PSTL_USE_DEBUG && (TEST_UNNAMED_LAMBDAS || !TEST_DPCPP_BACKEND_PRESENT)
 #   define TEST_NO_COMMA_ITERATORS 1
 #else
 #   define TEST_NO_COMMA_ITERATORS 0

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -297,7 +297,7 @@
 // only tests. Also, since this adds significant amount of code compilation to the build, lets be more conservative
 // about when we try to test this. Since debug build mode and unnamed lambda support dont change the code in any way
 // which should interact with what we are testing for here, lets disable it for those cases for time / build space.
-#if !defined(_LIBCPP_VERSION) && !defined(_DEBUG) && __SYCL_UNNAMED_LAMBDA__
+#if !defined(_LIBCPP_VERSION) && !defined(_DEBUG) && defined(__SYCL_UNNAMED_LAMBDA__)
 #   define TEST_NO_COMMA_ITERATORS 1
 #else
 #   define TEST_NO_COMMA_ITERATORS 0


### PR DESCRIPTION
No comma operator tests are causing very long build times without additional benefit for debug runs. 
We don't gain any coverage of code by running these compile only tests in DEBUG mode or in no unnamed lambda mode.
Lets turn off the no comma tests for those cases.