### PR TITLE
Remove `struct _SubscriptAdapter`

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3319,18 +3319,18 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
                 //try searching for the first element which not equal to *__b
                 if (__b != __first1)
-                    __b = __internal::__pstl_upper_bound_proj(__b, __last1, __proj1_deref(__b), __comp, __proj1);
+                    __b = __internal::__pstl_upper_bound(__b, __last1, __proj1_deref(__b), __comp, __proj1);
 
                 //try searching for the first element which not equal to *__e
                 if (__e != __last1)
-                    __e = __internal::__pstl_upper_bound_proj(__e, __last1, __proj1_deref(__e), __comp, __proj1);
+                    __e = __internal::__pstl_upper_bound(__e, __last1, __proj1_deref(__e), __comp, __proj1);
 
                 //check is [__b; __e) empty
                 if (__e - __b < 1)
                 {
                     _RandomAccessIterator2 __bb = __last2;
                     if (__b != __last1)
-                        __bb = __internal::__pstl_lower_bound_proj(__first2, __last2, __proj1_deref(__b), __comp, __proj2);
+                        __bb = __internal::__pstl_lower_bound(__first2, __last2, __proj1_deref(__b), __comp, __proj2);
 
                     const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                     return _SetRange{0, 0, __buf_pos};
@@ -3339,11 +3339,11 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 //try searching for "corresponding" subrange [__bb; __ee) in the second sequence
                 _RandomAccessIterator2 __bb = __first2;
                 if (__b != __first1)
-                    __bb = __internal::__pstl_lower_bound_proj(__first2, __last2, __proj1_deref(__b), __comp, __proj2);
+                    __bb = __internal::__pstl_lower_bound(__first2, __last2, __proj1_deref(__b), __comp, __proj2);
 
                 _RandomAccessIterator2 __ee = __last2;
                 if (__e != __last1)
-                    __ee = __internal::__pstl_lower_bound_proj(__bb, __last2, __proj1_deref(__e), __comp, __proj2);
+                    __ee = __internal::__pstl_lower_bound(__bb, __last2, __proj1_deref(__e), __comp, __proj2);
 
                 const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                 auto __buffer_b = __tmp_memory + __buf_pos;
@@ -3399,7 +3399,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
                                                  __result, __copy_range);
 
     // testing  whether the sequences are intersected
-    _RandomAccessIterator1 __left_bound_seq_1 = __internal::__pstl_lower_bound_proj(
+    _RandomAccessIterator1 __left_bound_seq_1 = __internal::__pstl_lower_bound(
         __first1, __last1, __proj2_deref(__first2), __comp, __proj1);
 
     if (__left_bound_seq_1 == __last1)
@@ -3417,7 +3417,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
     }
 
     // testing  whether the sequences are intersected
-    _RandomAccessIterator2 __left_bound_seq_2 = __internal::__pstl_lower_bound_proj(
+    _RandomAccessIterator2 __left_bound_seq_2 = __internal::__pstl_lower_bound(
         __first2, __last2, __proj1_deref(__first1), __comp, __proj2);
 
     if (__left_bound_seq_2 == __last2)

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3319,21 +3319,18 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
                 //try searching for the first element which not equal to *__b
                 if (__b != __first1)
-                    __b = __internal::__pstl_upper_bound(__internal::_SubscriptAdapter{}, __b, __last1,
-                                                         __proj1_deref(__b), __comp, __proj1);
+                    __b = __internal::__pstl_upper_bound_proj(__b, __last1, __proj1_deref(__b), __comp, __proj1);
 
                 //try searching for the first element which not equal to *__e
                 if (__e != __last1)
-                    __e = __internal::__pstl_upper_bound(__internal::_SubscriptAdapter{}, __e, __last1,
-                                                         __proj1_deref(__e), __comp, __proj1);
+                    __e = __internal::__pstl_upper_bound_proj(__e, __last1, __proj1_deref(__e), __comp, __proj1);
 
                 //check is [__b; __e) empty
                 if (__e - __b < 1)
                 {
                     _RandomAccessIterator2 __bb = __last2;
                     if (__b != __last1)
-                        __bb = __internal::__pstl_lower_bound(__internal::_SubscriptAdapter{}, __first2, __last2,
-                                                              __proj1_deref(__b), __comp, __proj2);
+                        __bb = __internal::__pstl_lower_bound_proj(__first2, __last2, __proj1_deref(__b), __comp, __proj2);
 
                     const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                     return _SetRange{0, 0, __buf_pos};
@@ -3342,13 +3339,11 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 //try searching for "corresponding" subrange [__bb; __ee) in the second sequence
                 _RandomAccessIterator2 __bb = __first2;
                 if (__b != __first1)
-                    __bb = __internal::__pstl_lower_bound(__internal::_SubscriptAdapter{}, __first2, __last2,
-                                                          __proj1_deref(__b), __comp, __proj2);
+                    __bb = __internal::__pstl_lower_bound_proj(__first2, __last2, __proj1_deref(__b), __comp, __proj2);
 
                 _RandomAccessIterator2 __ee = __last2;
                 if (__e != __last1)
-                    __ee = __internal::__pstl_lower_bound(__internal::_SubscriptAdapter{}, __bb, __last2,
-                                                          __proj1_deref(__e), __comp, __proj2);
+                    __ee = __internal::__pstl_lower_bound_proj(__bb, __last2, __proj1_deref(__e), __comp, __proj2);
 
                 const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                 auto __buffer_b = __tmp_memory + __buf_pos;
@@ -3404,8 +3399,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
                                                  __result, __copy_range);
 
     // testing  whether the sequences are intersected
-    _RandomAccessIterator1 __left_bound_seq_1 = __internal::__pstl_lower_bound(
-        __internal::_SubscriptAdapter{}, __first1, __last1, __proj2_deref(__first2), __comp, __proj1);
+    _RandomAccessIterator1 __left_bound_seq_1 = __internal::__pstl_lower_bound_proj(
+        __first1, __last1, __proj2_deref(__first2), __comp, __proj1);
 
     if (__left_bound_seq_1 == __last1)
     {
@@ -3422,8 +3417,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
     }
 
     // testing  whether the sequences are intersected
-    _RandomAccessIterator2 __left_bound_seq_2 = __internal::__pstl_lower_bound(
-        __internal::_SubscriptAdapter{}, __first2, __last2, __proj1_deref(__first1), __comp, __proj2);
+    _RandomAccessIterator2 __left_bound_seq_2 = __internal::__pstl_lower_bound_proj(
+        __first2, __last2, __proj1_deref(__first1), __comp, __proj2);
 
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -713,7 +713,7 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
         std::invoke(__comp, __proj1_deref(__last1 - 1), __proj2_deref(__last2 - 1)))
         return false;
 
-    __first1 = oneapi::dpl::__internal::__pstl_lower_bound_proj(__first1, __last1, __proj2_deref(__first2), __comp, __proj1);
+    __first1 = oneapi::dpl::__internal::__pstl_lower_bound(__first1, __last1, __proj2_deref(__first2), __comp, __proj1);
     if (__first1 == __last1)
         return false;
 
@@ -742,15 +742,15 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
                 if (__is_equal_sorted(__i, __j - 1))
                     return false;
 
-                __i = oneapi::dpl::__internal::__pstl_upper_bound_proj(__i, __last2, __proj2_deref(__i), __comp, __proj2);
+                __i = oneapi::dpl::__internal::__pstl_upper_bound(__i, __last2, __proj2_deref(__i), __comp, __proj2);
             }
 
             //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"
             if (__j < __last2 && __is_equal_sorted(__j - 1, __j))
-                __j = oneapi::dpl::__internal::__pstl_upper_bound_proj(__j, __last2, __proj2_deref(__j), __comp, __proj2);
+                __j = oneapi::dpl::__internal::__pstl_upper_bound(__j, __last2, __proj2_deref(__j), __comp, __proj2);
 
             //2. testing is __a subsequence of the second range included into the first range
-            auto __b = oneapi::dpl::__internal::__pstl_lower_bound_proj(__first1, __last1, __proj2_deref(__i), __comp, __proj1);
+            auto __b = oneapi::dpl::__internal::__pstl_lower_bound(__first1, __last1, __proj2_deref(__i), __comp, __proj1);
 
             //assert(!__comp(*(__last1 - 1), *__b));
             //assert(!__comp(*(__j - 1), *__i));
@@ -903,14 +903,14 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
         return __pattern_set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __result};
 
     // testing  whether the sequences are intersected
-    auto __left_bound_seq_1 = oneapi::dpl::__internal::__pstl_lower_bound_proj(
+    auto __left_bound_seq_1 = oneapi::dpl::__internal::__pstl_lower_bound(
         __first1, __last1, __proj2_deref(__first2), __comp, __proj1);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, the intersection is empty
     if (__left_bound_seq_1 == __last1)
         return __pattern_set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __result};
 
     // testing  whether the sequences are intersected
-    auto __left_bound_seq_2 = oneapi::dpl::__internal::__pstl_lower_bound_proj(
+    auto __left_bound_seq_2 = oneapi::dpl::__internal::__pstl_lower_bound(
         __first2, __last2, __proj1_deref(__first1), __comp, __proj2);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, the intersection is empty
     if (__left_bound_seq_2 == __last2)
@@ -1032,7 +1032,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     }
 
     // testing  whether the sequences are intersected
-    auto __left_bound_seq_1 = oneapi::dpl::__internal::__pstl_lower_bound_proj(
+    auto __left_bound_seq_1 = oneapi::dpl::__internal::__pstl_lower_bound(
         __first1, __last1, __proj2_deref(__first2), __comp, __proj1);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
@@ -1043,7 +1043,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     }
 
     // testing  whether the sequences are intersected
-    auto __left_bound_seq_2 = oneapi::dpl::__internal::__pstl_lower_bound_proj(
+    auto __left_bound_seq_2 = oneapi::dpl::__internal::__pstl_lower_bound(
         __first2, __last2, __proj1_deref(__first1), __comp, __proj2);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -713,8 +713,7 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
         std::invoke(__comp, __proj1_deref(__last1 - 1), __proj2_deref(__last2 - 1)))
         return false;
 
-    __first1 = oneapi::dpl::__internal::__pstl_lower_bound(oneapi::dpl::__internal::_SubscriptAdapter{}, __first1,
-                                                           __last1, __proj2_deref(__first2), __comp, __proj1);
+    __first1 = oneapi::dpl::__internal::__pstl_lower_bound_proj(__first1, __last1, __proj2_deref(__first2), __comp, __proj1);
     if (__first1 == __last1)
         return false;
 
@@ -743,18 +742,15 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
                 if (__is_equal_sorted(__i, __j - 1))
                     return false;
 
-                __i = oneapi::dpl::__internal::__pstl_upper_bound(oneapi::dpl::__internal::_SubscriptAdapter{}, __i,
-                                                                  __last2, __proj2_deref(__i), __comp, __proj2);
+                __i = oneapi::dpl::__internal::__pstl_upper_bound_proj(__i, __last2, __proj2_deref(__i), __comp, __proj2);
             }
 
             //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"
             if (__j < __last2 && __is_equal_sorted(__j - 1, __j))
-                __j = oneapi::dpl::__internal::__pstl_upper_bound(oneapi::dpl::__internal::_SubscriptAdapter{}, __j,
-                                                                  __last2, __proj2_deref(__j), __comp, __proj2);
+                __j = oneapi::dpl::__internal::__pstl_upper_bound_proj(__j, __last2, __proj2_deref(__j), __comp, __proj2);
 
             //2. testing is __a subsequence of the second range included into the first range
-            auto __b = oneapi::dpl::__internal::__pstl_lower_bound(
-                oneapi::dpl::__internal::_SubscriptAdapter{}, __first1, __last1, __proj2_deref(__i), __comp, __proj1);
+            auto __b = oneapi::dpl::__internal::__pstl_lower_bound_proj(__first1, __last1, __proj2_deref(__i), __comp, __proj1);
 
             //assert(!__comp(*(__last1 - 1), *__b));
             //assert(!__comp(*(__j - 1), *__i));
@@ -907,15 +903,15 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
         return __pattern_set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __result};
 
     // testing  whether the sequences are intersected
-    auto __left_bound_seq_1 = oneapi::dpl::__internal::__pstl_lower_bound(
-        oneapi::dpl::__internal::_SubscriptAdapter{}, __first1, __last1, __proj2_deref(__first2), __comp, __proj1);
+    auto __left_bound_seq_1 = oneapi::dpl::__internal::__pstl_lower_bound_proj(
+        __first1, __last1, __proj2_deref(__first2), __comp, __proj1);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, the intersection is empty
     if (__left_bound_seq_1 == __last1)
         return __pattern_set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __result};
 
     // testing  whether the sequences are intersected
-    auto __left_bound_seq_2 = oneapi::dpl::__internal::__pstl_lower_bound(
-        oneapi::dpl::__internal::_SubscriptAdapter{}, __first2, __last2, __proj1_deref(__first1), __comp, __proj2);
+    auto __left_bound_seq_2 = oneapi::dpl::__internal::__pstl_lower_bound_proj(
+        __first2, __last2, __proj1_deref(__first1), __comp, __proj2);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, the intersection is empty
     if (__left_bound_seq_2 == __last2)
         return __pattern_set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __result};
@@ -1036,8 +1032,8 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     }
 
     // testing  whether the sequences are intersected
-    auto __left_bound_seq_1 = oneapi::dpl::__internal::__pstl_lower_bound(
-        oneapi::dpl::__internal::_SubscriptAdapter{}, __first1, __last1, __proj2_deref(__first2), __comp, __proj1);
+    auto __left_bound_seq_1 = oneapi::dpl::__internal::__pstl_lower_bound_proj(
+        __first1, __last1, __proj2_deref(__first2), __comp, __proj1);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
     {
@@ -1047,8 +1043,8 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     }
 
     // testing  whether the sequences are intersected
-    auto __left_bound_seq_2 = oneapi::dpl::__internal::__pstl_lower_bound(
-        oneapi::dpl::__internal::_SubscriptAdapter{}, __first2, __last2, __proj1_deref(__first1), __comp, __proj2);
+    auto __left_bound_seq_2 = oneapi::dpl::__internal::__pstl_lower_bound_proj(
+        __first2, __last2, __proj1_deref(__first1), __comp, __proj2);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -682,8 +682,8 @@ template <typename _Acc, typename _Size1, typename _Value, typename _Compare, ty
 _Size1
 __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
-    return __pstl_lower_bound_impl(__first, __last, [&](_Size1 __it) {
-        return std::invoke(__comp, std::invoke(__proj, __acc[__it]), __value);
+    return __pstl_lower_bound_impl(__first, __last, [&](_Size1 __idx) {
+        return std::invoke(__comp, std::invoke(__proj, __acc[__idx]), __value);
     });
 }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -655,13 +655,13 @@ __dpl_signbit(const _T& __x)
     return (__x & __mask) != 0;
 }
 
-template <typename _ForwardIterator, typename _CompareOp>
-_ForwardIterator
-__pstl_lower_bound_impl(_ForwardIterator __first, _ForwardIterator __last, _CompareOp __compareOp)
+template <typename _Size1, typename _CompareOp>
+_Size1
+__pstl_lower_bound_impl(_Size1 __first, _Size1 __last, _CompareOp __compareOp)
 {
     auto __n = __last - __first;
     auto __cur = __n;
-    _ForwardIterator __it;
+    _Size1 __it;
     while (__n > 0)
     {
         __it = __first;
@@ -678,27 +678,27 @@ __pstl_lower_bound_impl(_ForwardIterator __first, _ForwardIterator __last, _Comp
     return __first;
 }
 
-template <typename _Acc, typename _ForwardIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_ForwardIterator
-__pstl_lower_bound(_Acc __acc, _ForwardIterator __first, _ForwardIterator __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_Size1
+__pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
-    return __pstl_lower_bound_impl(__first, __last, [__acc, &__value, __comp, __proj](_ForwardIterator __it) {
+    return __pstl_lower_bound_impl(__first, __last, [__acc, &__value, __comp, __proj](_Size1 __it) {
         return std::invoke(__comp, std::invoke(__proj, __acc[__it]), __value);
     });
 }
 
-template <typename _ForwardIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_ForwardIterator
-__pstl_lower_bound(_ForwardIterator __first, _ForwardIterator __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_Size1
+__pstl_lower_bound(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
-    return __pstl_lower_bound_impl(__first, __last, [&__value, __comp, __proj](_ForwardIterator __it) {
+    return __pstl_lower_bound_impl(__first, __last, [&__value, __comp, __proj](_Size1 __it) {
         return std::invoke(__comp, std::invoke(__proj, *__it), __value);
     });
 }
 
-template <typename _Acc, typename _ForwardIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_ForwardIterator
-__pstl_upper_bound(_Acc __acc, _ForwardIterator __first, _ForwardIterator __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_Size1
+__pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
@@ -706,9 +706,9 @@ __pstl_upper_bound(_Acc __acc, _ForwardIterator __first, _ForwardIterator __last
     return __pstl_lower_bound(__acc, __first, __last, __value, __negation_reordered_comp, __proj);
 }
 
-template <typename _ForwardIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_ForwardIterator
-__pstl_upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_Size1
+__pstl_upper_bound(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -655,13 +655,13 @@ __dpl_signbit(const _T& __x)
     return (__x & __mask) != 0;
 }
 
-template <typename _Size1, typename _CompareOp>
-_Size1
-__pstl_lower_bound_impl(_Size1 __first, _Size1 __last, _CompareOp __compareOp)
+template <typename _ForwardIterator, typename _CompareOp>
+_ForwardIterator
+__pstl_lower_bound_impl(_ForwardIterator __first, _ForwardIterator __last, _CompareOp __compareOp)
 {
     auto __n = __last - __first;
     auto __cur = __n;
-    _Size1 __it;
+    _ForwardIterator __it;
     while (__n > 0)
     {
         __it = __first;
@@ -678,27 +678,27 @@ __pstl_lower_bound_impl(_Size1 __first, _Size1 __last, _CompareOp __compareOp)
     return __first;
 }
 
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_Size1
-__pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+template <typename _Acc, typename _ForwardIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_ForwardIterator
+__pstl_lower_bound(_Acc __acc, _ForwardIterator __first, _ForwardIterator __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
-    return __pstl_lower_bound_impl(__first, __last, [__acc, &__value, __comp, __proj](_Size1 __it) {
+    return __pstl_lower_bound_impl(__first, __last, [__acc, &__value, __comp, __proj](_ForwardIterator __it) {
         return std::invoke(__comp, std::invoke(__proj, __acc[__it]), __value);
     });
 }
 
-template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_Size1
-__pstl_lower_bound(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+template <typename _ForwardIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_ForwardIterator
+__pstl_lower_bound(_ForwardIterator __first, _ForwardIterator __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
-    return __pstl_lower_bound_impl(__first, __last, [&__value, __comp, __proj](_Size1 __it) {
+    return __pstl_lower_bound_impl(__first, __last, [&__value, __comp, __proj](_ForwardIterator __it) {
         return std::invoke(__comp, std::invoke(__proj, __it), __value);
     });
 }
 
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_Size1
-__pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+template <typename _Acc, typename _ForwardIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_ForwardIterator
+__pstl_upper_bound(_Acc __acc, _ForwardIterator __first, _ForwardIterator __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
@@ -706,9 +706,9 @@ __pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
     return __pstl_lower_bound(__acc, __first, __last, __value, __negation_reordered_comp, __proj);
 }
 
-template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_Size1
-__pstl_upper_bound(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+template <typename _ForwardIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_ForwardIterator
+__pstl_upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -682,7 +682,7 @@ template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
 _Size1
 __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
-    return __pstl_lower_bound_impl(__first, __last, [__acc, &__value, __comp](_Size1 __it) {
+    return __pstl_lower_bound_impl(__first, __last, [&](_Size1 __it) {
         return std::invoke(__comp, __acc[__it], __value);
     });
 }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -689,7 +689,7 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
 
 template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
 _Size1
-__pstl_lower_bound_proj(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+__pstl_lower_bound(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
     return __pstl_lower_bound_impl(__first, __last, [&__value, __comp, __proj](_Size1 __it) {
         return std::invoke(__comp, std::invoke(__proj, __it), __value);
@@ -708,12 +708,12 @@ __pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
 
 template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
 _Size1
-__pstl_upper_bound_proj(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+__pstl_upper_bound(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound_proj(__first, __last, __value, __negation_reordered_comp, __proj);
+    return __pstl_lower_bound(__first, __last, __value, __negation_reordered_comp, __proj);
 }
 
 // Searching for the first element strongly greater than a passed value - right bound

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -678,6 +678,29 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
     return __first;
 }
 
+template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_Size1
+__pstl_lower_bound_proj(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+{
+    auto __n = __last - __first;
+    auto __cur = __n;
+    _Size1 __it;
+    while (__n > 0)
+    {
+        __it = __first;
+        __cur = __n / 2;
+        __it += __cur;
+        if (std::invoke(__comp, std::invoke(__proj, *__it), __value))
+        {
+            __n -= __cur + 1;
+            __first = ++__it;
+        }
+        else
+            __n = __cur;
+    }
+    return __first;
+}
+
 template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
 _Size1
 __pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
@@ -686,6 +709,16 @@ __pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
     return __pstl_lower_bound(__acc, __first, __last, __value, __negation_reordered_comp, __proj);
+}
+
+template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_Size1
+__pstl_upper_bound_proj(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+{
+    __reorder_pred<_Compare> __reordered_comp{__comp};
+    __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
+
+    return __pstl_lower_bound_proj(__first, __last, __value, __negation_reordered_comp, __proj);
 }
 
 // Searching for the first element strongly greater than a passed value - right bound

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -687,15 +687,6 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
     });
 }
 
-template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_Size1
-__pstl_lower_bound(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
-{
-    return __pstl_lower_bound_impl(__first, __last, [&__value, __comp, __proj](_Size1 __it) {
-        return std::invoke(__comp, std::invoke(__proj, *__it), __value);
-    });
-}
-
 template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
 _Size1
 __pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
@@ -706,9 +697,20 @@ __pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
     return __pstl_lower_bound(__acc, __first, __last, __value, __negation_reordered_comp);
 }
 
-template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
-_Size1
-__pstl_upper_bound(_Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+template <typename _RandomAccessIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_RandomAccessIterator
+__pstl_lower_bound(_RandomAccessIterator __first, _RandomAccessIterator __last, const _Value& __value, _Compare __comp,
+                   _Proj __proj = {})
+{
+    return __pstl_lower_bound_impl(__first, __last, [&__value, __comp, __proj](_RandomAccessIterator __it) {
+        return std::invoke(__comp, std::invoke(__proj, *__it), __value);
+    });
+}
+
+template <typename _RandomAccessIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+_RandomAccessIterator
+__pstl_upper_bound(_RandomAccessIterator __first, _RandomAccessIterator __last, const _Value& __value, _Compare __comp,
+                   _Proj __proj = {})
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -655,17 +655,6 @@ __dpl_signbit(const _T& __x)
     return (__x & __mask) != 0;
 }
 
-// Adapts __pstl_lower_bound and other related functions to use with host backends
-struct _SubscriptAdapter
-{
-    template <typename _Iterator>
-    decltype(auto)
-    operator[](_Iterator __it) const
-    {
-        return *__it;
-    }
-};
-
 template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
 _Size1
 __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -678,12 +678,12 @@ __pstl_lower_bound_impl(_Size1 __first, _Size1 __last, _CompareOp __compareOp)
     return __first;
 }
 
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
 _Size1
-__pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+__pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
-    return __pstl_lower_bound_impl(__first, __last, [__acc, &__value, __comp, __proj](_Size1 __it) {
-        return std::invoke(__comp, std::invoke(__proj, __acc[__it]), __value);
+    return __pstl_lower_bound_impl(__first, __last, [__acc, &__value, __comp](_Size1 __it) {
+        return std::invoke(__comp, __acc[__it], __value);
     });
 }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -696,14 +696,14 @@ __pstl_lower_bound(_Size1 __first, _Size1 __last, const _Value& __value, _Compar
     });
 }
 
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
 _Size1
-__pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
+__pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound(__acc, __first, __last, __value, __negation_reordered_comp, __proj);
+    return __pstl_lower_bound(__acc, __first, __last, __value, __negation_reordered_comp);
 }
 
 template <typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -702,7 +702,7 @@ _RandomAccessIterator
 __pstl_lower_bound(_RandomAccessIterator __first, _RandomAccessIterator __last, const _Value& __value, _Compare __comp,
                    _Proj __proj = {})
 {
-    return __pstl_lower_bound_impl(__first, __last, [&__value, __comp, __proj](_RandomAccessIterator __it) {
+    return __pstl_lower_bound_impl(__first, __last, [&](_RandomAccessIterator __it) {
         return std::invoke(__comp, std::invoke(__proj, *__it), __value);
     });
 }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -692,7 +692,7 @@ _ForwardIterator
 __pstl_lower_bound(_ForwardIterator __first, _ForwardIterator __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
     return __pstl_lower_bound_impl(__first, __last, [&__value, __comp, __proj](_ForwardIterator __it) {
-        return std::invoke(__comp, std::invoke(__proj, __it), __value);
+        return std::invoke(__comp, std::invoke(__proj, *__it), __value);
     });
 }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -678,23 +678,23 @@ __pstl_lower_bound_impl(_Size1 __first, _Size1 __last, _CompareOp __compareOp)
     return __first;
 }
 
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
 _Size1
-__pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
+__pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
     return __pstl_lower_bound_impl(__first, __last, [&](_Size1 __it) {
-        return std::invoke(__comp, __acc[__it], __value);
+        return std::invoke(__comp, std::invoke(__proj, __acc[__it]), __value);
     });
 }
 
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>
 _Size1
-__pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
+__pstl_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj = {})
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound(__acc, __first, __last, __value, __negation_reordered_comp);
+    return __pstl_lower_bound(__acc, __first, __last, __value, __negation_reordered_comp, __proj);
 }
 
 template <typename _RandomAccessIterator, typename _Value, typename _Compare, typename _Proj = oneapi::dpl::identity>


### PR DESCRIPTION
This PR removes the `struct _SubscriptAdapter` that was used to adapt iterator access patterns and replaces it with direct function implementations that use projection-based approaches, simplifying the codebase architecture.

- Removes the `_SubscriptAdapter` struct and its single `operator[]` method
- Introduces new direct projection-based variants of `__pstl_lower_bound` and `__pstl_upper_bound` functions
- Updates all call sites across multiple algorithm implementation files to use the new direct function variants

### CI per-commit checks
https://github.com/uxlfoundation/oneDPL/pull/2410/checks