### PR TITLE
Avoid proxy construction of borrowed_iterator_t with an init list

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -599,7 +599,7 @@ __pattern_fill(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, const _T& __valu
     const auto __last = __first + std::ranges::size(__r);
     oneapi::dpl::__internal::__pattern_fill(__tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __value);
 
-    return {__last};
+    return __last;
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _T>


### PR DESCRIPTION
There is no need to construct an initialized list and then construct `std::ranges::borrowed_iterator_t` from it.
This change is moved from #2292 as not related.