### PR TITLE
Modify pattern return types

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -524,13 +524,13 @@ __pattern_minmax_element(__serial_tag</*IsVector*/ std::false_type>, _ExecutionP
 //---------------------------------------------------------------------------------------------------------------------
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
-std::pair<std::ranges::range_value_t<_R>, std::ranges::range_value_t<_R>>
+std::ranges::minmax_result<std::ranges::range_value_t<_R>>
 __pattern_minmax(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
-    auto [__it_min, __it_max] =
+    auto __res =
         __pattern_minmax_element(__tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj);
 
-    return {*__it_min, *__it_max};
+    return {*__res.min, *__res.max};
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -494,7 +494,7 @@ __pattern_min(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Pr
 //---------------------------------------------------------------------------------------------------------------------
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
-auto
+std::ranges::minmax_element_result<std::ranges::borrowed_iterator_t<_R>>
 __pattern_minmax_element(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
@@ -503,13 +503,16 @@ __pattern_minmax_element(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp 
         return __comp(std::invoke(__proj, std::forward<decltype(__val1)>(__val1)),
                       std::invoke(__proj, std::forward<decltype(__val2)>(__val2)));
     };
-    return oneapi::dpl::__internal::__pattern_minmax_element(
+
+    auto __res = oneapi::dpl::__internal::__pattern_minmax_element(
         __tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__r),
         std::ranges::begin(__r) + std::ranges::size(__r), __comp_2);
+
+    return {__res.first, __res.second};
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
-auto
+std::ranges::minmax_element_result<std::ranges::borrowed_iterator_t<_R>>
 __pattern_minmax_element(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&&, _R&& __r, _Comp __comp,
                          _Proj __proj)
 {

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -618,11 +618,8 @@ struct __minmax_element_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        const auto& [__min, __max] =
-            oneapi::dpl::__internal::__ranges::__pattern_minmax_element(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::forward<_R>(__r), __comp, __proj);
-
-        return {__min, __max};
+        return oneapi::dpl::__internal::__ranges::__pattern_minmax_element(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj);
     }
 }; //__minmax_element_fn
 } //__internal
@@ -1734,7 +1731,7 @@ max_element(_ExecutionPolicy&& __exec, _Range&& __rng)
 template <typename _ExecutionPolicy, typename _Range, typename _Compare>
 oneapi::dpl::__internal::__enable_if_execution_policy<
     _ExecutionPolicy,
-    ::std::pair<oneapi::dpl::__internal::__difference_t<_Range>, oneapi::dpl::__internal::__difference_t<_Range>>>
+    std::ranges::minmax_element_result<std::ranges::borrowed_iterator_t<_Range>>>
 minmax_element(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -697,10 +697,8 @@ struct __minmax_fn
         assert(std::ranges::size(__r) > 0);
 
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        const auto& [__min, __max] = oneapi::dpl::__internal::__ranges::__pattern_minmax(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj);
-
-        return {__min, __max};
+        return oneapi::dpl::__internal::__ranges::__pattern_minmax(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj);
     }
 
 }; //__minmax_fn

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1028,7 +1028,7 @@ __pattern_minmax_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
-std::pair<std::ranges::range_value_t<_R>, std::ranges::range_value_t<_R>>
+std::ranges::minmax_result<std::ranges::range_value_t<_R>>
 __pattern_minmax(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
     oneapi::dpl::__internal::__compare<_Comp, _Proj> __comp_2{__comp, __proj};

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1033,14 +1033,11 @@ __pattern_minmax(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R&& __r,
 {
     oneapi::dpl::__internal::__compare<_Comp, _Proj> __comp_2{__comp, __proj};
 
-    [[maybe_unused]] const auto& [__res_min, __res_max] =
+    const auto& [__res_min, __res_max] =
         __pattern_minmax_element_impl(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
         std::forward<_R>(__r), __comp_2);
 
-    [[maybe_unused]] const auto& [__idx_min, __min] = __res_min;
-    [[maybe_unused]] const auto& [__idx_max, __max] = __res_max;
-
-    return {__min, __max};
+    return {__res_min.second, __res_max.second};
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Pred, typename _Proj1,


### PR DESCRIPTION
This PR modifies the return types of pattern functions to use standard C++20 ranges result types instead of custom `std::pair` types. The changes align the implementation with the C++20 ranges standard by using `std::ranges::minmax_element_result` and `std::ranges::minmax_result` types.

- Updates return types from `std::pair` to standardized ranges result types
- Modifies function implementations to construct and return the new result types
- Simplifies code by removing intermediate variable assignments and directly returning results