### PR TITLE
Remove redundant template parameter `class _IsVector` from `__pattern_walk1` forward declaration

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -62,7 +62,7 @@ template <class _RandomAccessIterator, class _Function>
 void __brick_walk1(_RandomAccessIterator, _RandomAccessIterator, _Function,
                    /*vector=*/::std::true_type);
 
-template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
+template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
 __pattern_walk1(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Function);
 


### PR DESCRIPTION
This PR removes a redundant template parameter from a forward declaration in the algorithm header file. The `__pattern_walk1` function's forward declaration previously included an unused `class _IsVector` template parameter that has been removed to clean up the interface.

- Removes unused `class _IsVector` template parameter from `__pattern_walk1` forward declaration