### PR TITLE
Remove all capture by references to get of tuple temp

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -627,7 +627,7 @@ struct __get_bounds_partitioned
     auto // Returns a tuple of the form (start1, end1, start2, end2)
     operator()(const _Rng& __in_rng, const _IndexT __id) const
     {
-        const auto& __rng_tmp_diag = std::get<2>(__in_rng.tuple()); // set a temp storage sequence
+        auto __rng_tmp_diag = std::get<2>(__in_rng.tuple()); // set a temp storage sequence
 
         using _SizeType = decltype(std::get<0>(__in_rng.tuple()).size());
 
@@ -656,8 +656,8 @@ struct __get_bounds_simple
     auto // Returns a tuple of the form (start1, end1, start2, end2)
     operator()(const _Rng& __in_rng, const _IndexT) const
     {
-        const auto& __rng1 = std::get<0>(__in_rng.tuple()); // first sequence
-        const auto& __rng2 = std::get<1>(__in_rng.tuple()); // second sequence
+        const auto __rng1 = std::get<0>(__in_rng.tuple()); // first sequence
+        const auto __rng2 = std::get<1>(__in_rng.tuple()); // second sequence
 
         using _SizeType = decltype(__rng1.size());
         return std::make_tuple(_SizeType{0}, __rng1.size(), _SizeType{0}, __rng2.size());
@@ -748,8 +748,8 @@ struct __gen_set_balanced_path
     {
         // First we must extract individual sequences from zip iterator because they may not have the same length,
         // dereferencing is dangerous
-        const auto& __rng1 = std::get<0>(__in_rng.tuple()); // first sequence
-        const auto& __rng2 = std::get<1>(__in_rng.tuple()); // second sequence
+        const auto __rng1 = std::get<0>(__in_rng.tuple()); // first sequence
+        const auto __rng2 = std::get<1>(__in_rng.tuple()); // second sequence
 
         auto __rng1_temp_diag = std::get<2>(__in_rng.tuple()); // set a temp storage sequence
 
@@ -790,8 +790,8 @@ struct __gen_set_balanced_path
     {
         // First we must extract individual sequences from zip iterator because they may not have the same length,
         // dereferencing is dangerous
-        const auto& __rng1 = std::get<0>(__in_rng.tuple());  // first sequence
-        const auto& __rng2 = std::get<1>(__in_rng.tuple());  // second sequence
+        const auto __rng1 = std::get<0>(__in_rng.tuple());  // first sequence
+        const auto __rng2 = std::get<1>(__in_rng.tuple());  // second sequence
         auto __rng_tmp_diag = std::get<2>(__in_rng.tuple()); // temp diag sequence
 
         _IndexT __rng1_balanced_pos = 0;
@@ -856,10 +856,10 @@ struct __gen_set_op_from_known_balanced_path
     {
         // First we must extract individual sequences from zip iterator because they may not have the same length,
         // dereferencing is dangerous
-        const auto& __rng1 = std::get<0>(__in_rng.tuple()); // first sequence
-        const auto& __rng2 = std::get<1>(__in_rng.tuple()); // second sequence
+        const auto __rng1 = std::get<0>(__in_rng.tuple()); // first sequence
+        const auto __rng2 = std::get<1>(__in_rng.tuple()); // second sequence
 
-        const auto& __rng1_temp_diag =
+        const auto __rng1_temp_diag =
             std::get<2>(__in_rng.tuple()); // set a temp storage sequence, star value in sign bit
         using _SizeType = decltype(__rng1.size());
         _SizeType __i_elem = __id * __diagonal_spacing;


### PR DESCRIPTION
We introduced a bug in #2318 which caused a reference to a temporary tuple which had left scope. 

In these cases, `zip_view::tuple()` returns a temporary copy of the tuple member field of the tuple of the views.  We then apply `std::get`, and capture its result by reference. The temporary copy only lives within the expression argument to `std::get` and the reference returned refers to data which is no longer in scope.  

When we try to use it, bad things happen.

This PR removes the capture by reference which were not helping much given that these views should be light-weight, and copies are OK.