### PR TITLE
Fix compile error in `std_ranges_reverse_copy.pass.cpp`

### DIFF
--- a/test/parallel_api/ranges/std_ranges_reverse_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_reverse_copy.pass.cpp
@@ -29,7 +29,7 @@ main()
         const auto out_size = std::ranges::size(r_out);
         const auto skipped = in_size - std::ranges::min(in_size, out_size);
 
-        // To avoid compile error in libstdc++10 which mistakenly doesn't treat drop_view(r_in) as a borrowed_range
+        // To avoid compile error in libstdc++10 which mistakenly doesn't treat drop_view(r_in, skipped) as a borrowed_range
         auto tmp_view = std::ranges::drop_view(r_in, skipped);
         auto res = std::ranges::reverse_copy(tmp_view, std::ranges::begin(r_out));
 


### PR DESCRIPTION
In this PR we fix compile error in `std_ranges_reverse_copy.pass.cpp` under `libstdc++10` :

```C++
        oneDPL/test/parallel_api/ranges/std_ranges_reverse_copy.pass.cpp:42:25: error: no viable conversion from 'std::ranges::dangling' to '__gnu_cxx::__normal_iterator<int *, std::vector<int>>'
           42 |         return ret_type{res.in, std::ranges::begin(r_in) + skipped, res.out};
              |                         ^~~~~~
```

This happens due implementation error in `libstdc++10` : 
```C++
std::ranges::borrowed_range<decltype(std::ranges::drop_view(r_in, skipped))>); // <<< static assertion here
```