### PR TITLE
Bump compiler version in _PSTL_LAMBDA_PTR_TO_MEMBER_WINDOWS_BROKEN

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -284,7 +284,7 @@
     (_MSC_VER && TEST_DPCPP_BACKEND_PRESENT && __INTEL_LLVM_COMPILER < 20250100)
 
 // Intel(R) oneAPI DPC++/C++ compiler produces 'Unexpected kernel lambda size issue' error
-#define _PSTL_LAMBDA_PTR_TO_MEMBER_WINDOWS_BROKEN (_MSC_VER && TEST_DPCPP_BACKEND_PRESENT && __INTEL_LLVM_COMPILER < 20250300)
+#define _PSTL_LAMBDA_PTR_TO_MEMBER_WINDOWS_BROKEN (_MSC_VER && TEST_DPCPP_BACKEND_PRESENT && __INTEL_LLVM_COMPILER < 20250400)
 
 // To prevent the assertion from Microsoft STL implementation about the comparison of iterators from different containers
 #define _PSTL_TEST_ITERATORS_POSSIBLY_EQUAL_BROKEN (_DEBUG && _MSC_VER)


### PR DESCRIPTION
Raising the version of the macro since the corresponding tests do not compile with the latest builds of the icx compiler on Windows.


A side note. According to the documentation the test cases are not valid:

https://github.com/uxlfoundation/oneDPL/blob/9d72f92c12f1822f50fec9c1cae39329fbddfdcc/documentation/library_guide/introduction.rst?plain=1#L112

Hence, another solution is to turn off the tests permanently on any platform. However, it will require non-trivial modifications in the tests, which should be better done after the 2022.10 release.

