### PR TITLE
Fix header inclusion memory tests for libstdc++10

### DIFF
--- a/test/general/header_inclusion_order_memory_0.pass.cpp
+++ b/test/general/header_inclusion_order_memory_0.pass.cpp
@@ -21,7 +21,6 @@
 #include "support/utils.h"
 
 #if ONEDPL_HAS_RANGE_ALGORITHMS >= 202509L
-#include <memory>    // std::make_unique_for_overwrite
 #include <ranges>    // std::ranges::subrange
 #include <algorithm> // std::ranges::count
 #endif
@@ -31,7 +30,10 @@ main()
 {
 #if ONEDPL_HAS_RANGE_ALGORITHMS >= 202509L
     constexpr int n = 10;
-    std::unique_ptr<int[]> ptr = std::make_unique_for_overwrite<int[]>(n);
+    std::allocator<int> alloc;
+    int* raw_ptr = alloc.allocate(n);
+    auto deleter = [&](int* p){ alloc.deallocate(p, n); };
+    std::unique_ptr<int, decltype(deleter)> ptr(raw_ptr, deleter);
     std::ranges::subrange subrange(ptr.get(), ptr.get() + n);
     oneapi::dpl::ranges::uninitialized_fill(oneapi::dpl::execution::seq, subrange, 42);
     EXPECT_TRUE(std::ranges::count(subrange, 42) == n, "wrong results in uninitialized_fill");

--- a/test/general/header_inclusion_order_memory_0.pass.cpp
+++ b/test/general/header_inclusion_order_memory_0.pass.cpp
@@ -21,6 +21,7 @@
 #include "support/utils.h"
 
 #if ONEDPL_HAS_RANGE_ALGORITHMS >= 202509L
+#include <memory>    // std::unique_ptr
 #include <ranges>    // std::ranges::subrange
 #include <algorithm> // std::ranges::count
 #endif

--- a/test/general/header_inclusion_order_memory_0.pass.cpp
+++ b/test/general/header_inclusion_order_memory_0.pass.cpp
@@ -30,10 +30,7 @@ main()
 {
 #if ONEDPL_HAS_RANGE_ALGORITHMS >= 202509L
     constexpr int n = 10;
-    std::allocator<int> alloc;
-    int* raw_ptr = alloc.allocate(n);
-    auto deleter = [&](int* p){ alloc.deallocate(p, n); };
-    std::unique_ptr<int, decltype(deleter)> ptr(raw_ptr, deleter);
+    std::unique_ptr<int[]> ptr(new int[n]);
     std::ranges::subrange subrange(ptr.get(), ptr.get() + n);
     oneapi::dpl::ranges::uninitialized_fill(oneapi::dpl::execution::seq, subrange, 42);
     EXPECT_TRUE(std::ranges::count(subrange, 42) == n, "wrong results in uninitialized_fill");

--- a/test/general/header_inclusion_order_memory_1.pass.cpp
+++ b/test/general/header_inclusion_order_memory_1.pass.cpp
@@ -21,7 +21,6 @@
 #include "support/utils.h"
 
 #if ONEDPL_HAS_RANGE_ALGORITHMS >= 202509L
-#include <memory>    // std::make_unique_for_overwrite
 #include <ranges>    // std::ranges::subrange
 #include <algorithm> // std::ranges::count
 #endif
@@ -31,10 +30,7 @@ main()
 {
 #if ONEDPL_HAS_RANGE_ALGORITHMS >= 202509L
     constexpr int n = 10;
-    std::allocator<int> alloc;
-    int* raw_ptr = alloc.allocate(n);
-    auto deleter = [&](int* p){ alloc.deallocate(p, n); };
-    std::unique_ptr<int, decltype(deleter)> ptr(raw_ptr, deleter);
+    std::unique_ptr<int[]> ptr(new int[n]);
     std::ranges::subrange subrange(ptr.get(), ptr.get() + n);
     oneapi::dpl::ranges::uninitialized_fill(oneapi::dpl::execution::seq, subrange, 42);
     EXPECT_TRUE(std::ranges::count(subrange, 42) == n, "wrong results in uninitialized_fill");

--- a/test/general/header_inclusion_order_memory_1.pass.cpp
+++ b/test/general/header_inclusion_order_memory_1.pass.cpp
@@ -31,7 +31,10 @@ main()
 {
 #if ONEDPL_HAS_RANGE_ALGORITHMS >= 202509L
     constexpr int n = 10;
-    std::unique_ptr<int[]> ptr = std::make_unique_for_overwrite<int[]>(n);
+    std::allocator<int> alloc;
+    int* raw_ptr = alloc.allocate(n);
+    auto deleter = [&](int* p){ alloc.deallocate(p, n); };
+    std::unique_ptr<int, decltype(deleter)> ptr(raw_ptr, deleter);
     std::ranges::subrange subrange(ptr.get(), ptr.get() + n);
     oneapi::dpl::ranges::uninitialized_fill(oneapi::dpl::execution::seq, subrange, 42);
     EXPECT_TRUE(std::ranges::count(subrange, 42) == n, "wrong results in uninitialized_fill");

--- a/test/general/header_inclusion_order_memory_1.pass.cpp
+++ b/test/general/header_inclusion_order_memory_1.pass.cpp
@@ -21,6 +21,7 @@
 #include "support/utils.h"
 
 #if ONEDPL_HAS_RANGE_ALGORITHMS >= 202509L
+#include <memory>    // std::unique_ptr
 #include <ranges>    // std::ranges::subrange
 #include <algorithm> // std::ranges::count
 #endif


### PR DESCRIPTION
`std::make_unique_for_overwrite` is available in libstdc++11 and newer.