### PR TITLE
Fix coverity issues in set parallel range algorithms #1

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -389,7 +389,8 @@ struct __gen_set_mask
 
         std::size_t __nb = __set_b.size();
 
-        const auto& __val_a_proj = std::invoke(__proj1, __set_a[__id]);
+        auto&& __val_a = __set_a[__id];
+        auto&& __val_a_proj = std::invoke(__proj1, __val_a);
 
         auto __res =
             oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a_proj, __comp, __proj2);
@@ -404,7 +405,8 @@ struct __gen_set_mask
         }
         else
         {
-            const auto& __val_b_proj = std::invoke(__proj2, __set_b[__res]);
+            auto&& __val_b = __set_b[__res];
+            auto&& __val_b_proj = std::invoke(__proj2, __val_b);
 
             //Difference operation logic: if number of duplication in __set_a on left side from __id > total number of
             //duplication in __set_b then a mask is 1

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -389,7 +389,8 @@ struct __gen_set_mask
 
         std::size_t __nb = __set_b.size();
 
-        // This local variable extends the lifetime of operator[] return in case of temporary object
+        // This reference extends the lifetime of a temporary object returned by operator[]
+        // so that it can be safely used with identity projections
         auto&& __val_a = __set_a[__id];
         auto&& __val_a_proj = std::invoke(__proj1, std::forward<decltype(__val_a)>(__val_a));
 
@@ -406,7 +407,8 @@ struct __gen_set_mask
         }
         else
         {
-            // This local variable extends the lifetime of operator[] return in case of temporary object
+            // This reference extends the lifetime of a temporary object returned by operator[]
+            // so that it can be safely used with identity projections
             auto&& __val_b = __set_b[__res];
             auto&& __val_b_proj = std::invoke(__proj2, std::forward<decltype(__val_b)>(__val_b));
 
@@ -711,7 +713,8 @@ struct __gen_set_balanced_path
             return std::make_tuple(__merge_path_rng1, __merge_path_rng2, false);
         }
 
-        // This local variable extends the lifetime of operator[] return in case of temporary object
+        // This reference extends the lifetime of a temporary object returned by operator[]
+        // so that it can be safely used with identity projections
         auto&& __ele_val = __rng1[__merge_path_rng1 - 1];
         auto&& __ele_val_proj = std::invoke(__proj1, std::forward<decltype(__ele_val)>(__ele_val));
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -389,6 +389,7 @@ struct __gen_set_mask
 
         std::size_t __nb = __set_b.size();
 
+        // This local variable extends the lifetime of operator[] return in case of temporary object
         auto&& __val_a = __set_a[__id];
         auto&& __val_a_proj = std::invoke(__proj1, std::forward<decltype(__val_a)>(__val_a));
 
@@ -405,6 +406,7 @@ struct __gen_set_mask
         }
         else
         {
+            // This local variable extends the lifetime of operator[] return in case of temporary object
             auto&& __val_b = __set_b[__res];
             auto&& __val_b_proj = std::invoke(__proj2, std::forward<decltype(__val_b)>(__val_b));
 
@@ -709,6 +711,7 @@ struct __gen_set_balanced_path
             return std::make_tuple(__merge_path_rng1, __merge_path_rng2, false);
         }
 
+        // This local variable extends the lifetime of operator[] return in case of temporary object
         auto&& __ele_val = __rng1[__merge_path_rng1 - 1];
         auto&& __ele_val_proj = std::invoke(__proj1, std::forward<decltype(__ele_val)>(__ele_val));
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -709,7 +709,8 @@ struct __gen_set_balanced_path
             return std::make_tuple(__merge_path_rng1, __merge_path_rng2, false);
         }
 
-        const auto& __ele_val_proj = std::invoke(__proj1, __rng1[__merge_path_rng1 - 1]);
+        auto&& __ele_val = __rng1[__merge_path_rng1 - 1];
+        auto&& __ele_val_proj = std::invoke(__proj1, __ele_val);
 
         if (std::invoke(__comp, __ele_val_proj, std::invoke(__proj2, __rng2[__merge_path_rng2])))
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -390,7 +390,7 @@ struct __gen_set_mask
         std::size_t __nb = __set_b.size();
 
         auto&& __val_a = __set_a[__id];
-        auto&& __val_a_proj = std::invoke(__proj1, __val_a);
+        auto&& __val_a_proj = std::invoke(__proj1, std::forward<decltype(__val_a)>(__val_a));
 
         auto __res =
             oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a_proj, __comp, __proj2);
@@ -406,7 +406,7 @@ struct __gen_set_mask
         else
         {
             auto&& __val_b = __set_b[__res];
-            auto&& __val_b_proj = std::invoke(__proj2, __val_b);
+            auto&& __val_b_proj = std::invoke(__proj2, std::forward<decltype(__val_b)>(__val_b));
 
             //Difference operation logic: if number of duplication in __set_a on left side from __id > total number of
             //duplication in __set_b then a mask is 1
@@ -710,7 +710,7 @@ struct __gen_set_balanced_path
         }
 
         auto&& __ele_val = __rng1[__merge_path_rng1 - 1];
-        auto&& __ele_val_proj = std::invoke(__proj1, __ele_val);
+        auto&& __ele_val_proj = std::invoke(__proj1, std::forward<decltype(__ele_val)>(__ele_val));
 
         if (std::invoke(__comp, __ele_val_proj, std::invoke(__proj2, __rng2[__merge_path_rng2])))
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1020,7 +1020,8 @@ struct __brick_includes
 
         const _SizeB __idx_b = __b_beg + __idx;
 
-        // This local variable extends the lifetime of operator[] return in case of temporary object
+        // This reference extends the lifetime of a temporary object returned by operator[]
+        // so that it can be safely used with identity projections
         auto&& __val_b = __rngB[__idx_b];
         auto&& __val_b_proj = std::invoke(__projB, std::forward<decltype(__val_b)>(__val_b));
 
@@ -1030,7 +1031,8 @@ struct __brick_includes
         if (__res == __a_end || std::invoke(__comp, __val_b_proj, std::invoke(__projA, __rngA[__res])))
             return true; //__rngA doesn't include __rngB
 
-        // This local variable extends the lifetime of operator[] return in case of temporary object
+        // This reference extends the lifetime of a temporary object returned by operator[]
+        // so that it can be safely used with identity projections
         auto&& __val_a = __rngA[__res];
         auto&& __val_a_proj = std::invoke(__projA, std::forward<decltype(__val_a)>(__val_a));
 
@@ -1279,7 +1281,8 @@ class __brick_set_op
         auto __idx_c = __idx;
         const _SizeA __idx_a = _SizeA(__idx);
 
-        // This local variable extends the lifetime of operator[] return in case of temporary object
+        // This reference extends the lifetime of a temporary object returned by operator[]
+        // so that it can be safely used with identity projections
         auto&& __val_a = __a[__a_beg + __idx_a];
         auto&& __val_a_proj = std::invoke(__projA, std::forward<decltype(__val_a)>(__val_a));
 
@@ -1293,7 +1296,8 @@ class __brick_set_op
         }
         else
         {
-            // This local variable extends the lifetime of operator[] return in case of temporary object
+            // This reference extends the lifetime of a temporary object returned by operator[]
+            // so that it can be safely used with identity projections
             auto&& __val_b = __b[__b_beg + __res];
             auto&& __val_b_proj = std::invoke(__projB, std::forward<decltype(__val_b)>(__val_b));
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1020,6 +1020,7 @@ struct __brick_includes
 
         const _SizeB __idx_b = __b_beg + __idx;
 
+        // This local variable extends the lifetime of operator[] return in case of temporary object
         auto&& __val_b = __rngB[__idx_b];
         auto&& __val_b_proj = std::invoke(__projB, std::forward<decltype(__val_b)>(__val_b));
 
@@ -1029,6 +1030,7 @@ struct __brick_includes
         if (__res == __a_end || std::invoke(__comp, __val_b_proj, std::invoke(__projA, __rngA[__res])))
             return true; //__rngA doesn't include __rngB
 
+        // This local variable extends the lifetime of operator[] return in case of temporary object
         auto&& __val_a = __rngA[__res];
         auto&& __val_a_proj = std::invoke(__projA, std::forward<decltype(__val_a)>(__val_a));
 
@@ -1277,6 +1279,7 @@ class __brick_set_op
         auto __idx_c = __idx;
         const _SizeA __idx_a = _SizeA(__idx);
 
+        // This local variable extends the lifetime of operator[] return in case of temporary object
         auto&& __val_a = __a[__a_beg + __idx_a];
         auto&& __val_a_proj = std::invoke(__projA, std::forward<decltype(__val_a)>(__val_a));
 
@@ -1290,6 +1293,7 @@ class __brick_set_op
         }
         else
         {
+            // This local variable extends the lifetime of operator[] return in case of temporary object
             auto&& __val_b = __b[__b_beg + __res];
             auto&& __val_b_proj = std::invoke(__projB, std::forward<decltype(__val_b)>(__val_b));
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1019,7 +1019,9 @@ struct __brick_includes
             return true; //__rngA doesn't include __rngB
 
         const _SizeB __idx_b = __b_beg + __idx;
-        const auto& __val_b_proj = std::invoke(__projB, __rngB[__idx_b]);
+
+        auto&& __val_b = __rngB[__idx_b];
+        auto&& __val_b_proj = std::invoke(__projB, __val_b);
 
         const _SizeA __res = __internal::__pstl_lower_bound(__rngA, __a_beg, __a_end, __val_b_proj, __comp, __projA);
 
@@ -1027,7 +1029,8 @@ struct __brick_includes
         if (__res == __a_end || std::invoke(__comp, __val_b_proj, std::invoke(__projA, __rngA[__res])))
             return true; //__rngA doesn't include __rngB
 
-        const auto& __val_a_proj = std::invoke(__projA, __rngA[__res]);
+        auto&& __val_a = __rngA[__res];
+        auto&& __val_a_proj = std::invoke(__projA, __val_a);
 
         //searching number of duplication
         const auto __count_a = __internal::__pstl_right_bound(__rngA, __res, __a_end, __val_a_proj, __comp, __projA) -

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1276,7 +1276,9 @@ class __brick_set_op
 
         auto __idx_c = __idx;
         const _SizeA __idx_a = _SizeA(__idx);
-        const auto& __val_a_proj = std::invoke(__projA, __a[__a_beg + __idx_a]);
+
+        auto&& __val_a = __a[__a_beg + __idx_a];
+        auto&& __val_a_proj = std::invoke(__projA, __val_a);
 
         const _SizeB __res = __internal::__pstl_lower_bound(__b, __b_beg, __nb, __val_a_proj, __comp, __projB);
 
@@ -1288,7 +1290,8 @@ class __brick_set_op
         }
         else
         {
-            const auto& __val_b_proj = std::invoke(__projB, __b[__b_beg + __res]);
+            auto&& __val_b = __b[__b_beg + __res];
+            auto&& __val_b_proj = std::invoke(__projB, __val_b);
 
             //Difference operation logic: if number of duplication in __a on left side from __idx > total number of
             //duplication in __b than a mask is 1

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1021,7 +1021,7 @@ struct __brick_includes
         const _SizeB __idx_b = __b_beg + __idx;
 
         auto&& __val_b = __rngB[__idx_b];
-        auto&& __val_b_proj = std::invoke(__projB, __val_b);
+        auto&& __val_b_proj = std::invoke(__projB, std::forward<decltype(__val_b)>(__val_b));
 
         const _SizeA __res = __internal::__pstl_lower_bound(__rngA, __a_beg, __a_end, __val_b_proj, __comp, __projA);
 
@@ -1030,7 +1030,7 @@ struct __brick_includes
             return true; //__rngA doesn't include __rngB
 
         auto&& __val_a = __rngA[__res];
-        auto&& __val_a_proj = std::invoke(__projA, __val_a);
+        auto&& __val_a_proj = std::invoke(__projA, std::forward<decltype(__val_a)>(__val_a));
 
         //searching number of duplication
         const auto __count_a = __internal::__pstl_right_bound(__rngA, __res, __a_end, __val_a_proj, __comp, __projA) -
@@ -1278,7 +1278,7 @@ class __brick_set_op
         const _SizeA __idx_a = _SizeA(__idx);
 
         auto&& __val_a = __a[__a_beg + __idx_a];
-        auto&& __val_a_proj = std::invoke(__projA, __val_a);
+        auto&& __val_a_proj = std::invoke(__projA, std::forward<decltype(__val_a)>(__val_a));
 
         const _SizeB __res = __internal::__pstl_lower_bound(__b, __b_beg, __nb, __val_a_proj, __comp, __projB);
 
@@ -1291,7 +1291,7 @@ class __brick_set_op
         else
         {
             auto&& __val_b = __b[__b_beg + __res];
-            auto&& __val_b_proj = std::invoke(__projB, __val_b);
+            auto&& __val_b_proj = std::invoke(__projB, std::forward<decltype(__val_b)>(__val_b));
 
             //Difference operation logic: if number of duplication in __a on left side from __idx > total number of
             //duplication in __b than a mask is 1


### PR DESCRIPTION
This PR fixes Coverity static analysis issues in set parallel range algorithms by addressing potential object lifetime problems. The changes replace direct projection of temporary objects with proper intermediate variable storage to ensure object lifetime extends through the projection operation.

- Introduces intermediate variables to store array element values before applying projections
- Modifies three different set operation implementations to use the safer pattern
- Addresses potential dangling reference issues that could cause undefined behavior

Alternative approach implemented in the PR https://github.com/uxlfoundation/oneDPL/pull/2459

Source issue has been introduced in the PR #2320 
