### PR TITLE
Refactoring of utility functions to evaluate projected values and compare result  in one place

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3318,12 +3318,12 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
                 //try searching for the first element which not equal to *__b
                 if (__b != __first1)
-                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b,
+                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b, // TODO __pstl_upper_bound - iterator dereferencee
                                                           std::invoke(__proj1, *__b), __comp, __proj1);
 
                 //try searching for the first element which not equal to *__e
                 if (__e != __last1)
-                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e,
+                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e, // TODO __pstl_upper_bound - iterator dereferencee
                                                           std::invoke(__proj1, *__e), __comp, __proj1);
 
                 //check is [__b; __e) empty
@@ -3331,7 +3331,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 {
                     _RandomAccessIterator2 __bb = __last2;
                     if (__b != __last1)
-                        __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+                        __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
                                                                          std::invoke(__proj1, *__b), __comp, __proj2);
 
                     const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
@@ -3341,12 +3341,12 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 //try searching for "corresponding" subrange [__bb; __ee) in the second sequence
                 _RandomAccessIterator2 __bb = __first2;
                 if (__b != __first1)
-                    __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+                    __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
                                                                      std::invoke(__proj1, *__b), __comp, __proj2);
 
                 _RandomAccessIterator2 __ee = __last2;
                 if (__e != __last1)
-                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb,
+                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, // TODO __pstl_lower_bound - iterator dereferencee
                                                                  std::invoke(__proj1, *__e), __comp, __proj2);
 
                 const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
@@ -3402,7 +3402,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 =
-        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1,
+        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
                                                   std::invoke(__proj2, *__first2), __comp, __proj1);
 
     if (__left_bound_seq_1 == __last1)
@@ -3421,7 +3421,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 =
-        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
                                                   std::invoke(__proj1, *__first1), __comp, __proj2);
 
     if (__left_bound_seq_2 == __last2)

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3318,13 +3318,11 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
                 //try searching for the first element which not equal to *__b
                 if (__b != __first1)
-                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b, // TODO __pstl_upper_bound - iterator dereference
-                                                          __b, __comp, __proj1, __proj1);
+                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b, __b, __comp, __proj1, __proj1);
 
                 //try searching for the first element which not equal to *__e
                 if (__e != __last1)
-                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e, // TODO __pstl_upper_bound - iterator dereference
-                                                          __e, __comp, __proj1, __proj1);
+                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e, __e, __comp, __proj1, __proj1);
 
                 //check is [__b; __e) empty
                 if (__e - __b < 1)
@@ -3332,8 +3330,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                     _RandomAccessIterator2 __bb = __last2;
                     if (__b != __last1)
                         __bb =
-                            __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereference
-                                                                      __b, __comp, __proj2, __proj1);
+                            __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __b, __comp, __proj2, __proj1);
 
                     const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                     return _SetRange{0, 0, __buf_pos};
@@ -3342,13 +3339,11 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 //try searching for "corresponding" subrange [__bb; __ee) in the second sequence
                 _RandomAccessIterator2 __bb = __first2;
                 if (__b != __first1)
-                    __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereference
-                                                                     __b, __comp, __proj2, __proj1);
+                    __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __b, __comp, __proj2, __proj1);
 
                 _RandomAccessIterator2 __ee = __last2;
                 if (__e != __last1)
-                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, // TODO __pstl_lower_bound - iterator dereference
-                                                                 __e, __comp, __proj2, __proj1);
+                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, __e, __comp, __proj2, __proj1);
 
                 const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                 auto __buffer_b = __tmp_memory + __buf_pos;
@@ -3403,8 +3398,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 =
-        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereference
-                                                  __first2, __comp, __proj1, __proj2);
+        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
                                                   
     if (__left_bound_seq_1 == __last1)
     {
@@ -3422,8 +3416,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 =
-        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereference
-                                                  __first1, __comp, __proj2, __proj1);
+        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp, __proj2, __proj1);
 
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3318,11 +3318,13 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
                 //try searching for the first element which not equal to *__b
                 if (__b != __first1)
-                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b, __b, __comp, __proj1, __proj1);
+                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b, __b, __comp, __proj1,
+                                                          __proj1);
 
                 //try searching for the first element which not equal to *__e
                 if (__e != __last1)
-                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e, __e, __comp, __proj1, __proj1);
+                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e, __e, __comp, __proj1,
+                                                          __proj1);
 
                 //check is [__b; __e) empty
                 if (__e - __b < 1)
@@ -3330,7 +3332,8 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                     _RandomAccessIterator2 __bb = __last2;
                     if (__b != __last1)
                         __bb =
-                            __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __b, __comp, __proj2, __proj1);
+                            __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+                                                                      __b, __comp, __proj2, __proj1);
 
                     const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                     return _SetRange{0, 0, __buf_pos};
@@ -3339,11 +3342,13 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 //try searching for "corresponding" subrange [__bb; __ee) in the second sequence
                 _RandomAccessIterator2 __bb = __first2;
                 if (__b != __first1)
-                    __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __b, __comp, __proj2, __proj1);
+                    __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+                                                                     __b, __comp, __proj2, __proj1);
 
                 _RandomAccessIterator2 __ee = __last2;
                 if (__e != __last1)
-                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, __e, __comp, __proj2, __proj1);
+                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, __e, __comp,
+                                                                 __proj2, __proj1);
 
                 const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                 auto __buffer_b = __tmp_memory + __buf_pos;
@@ -3398,8 +3403,9 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 =
-        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
-                                                  
+        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp,
+                                                  __proj1, __proj2);
+
     if (__left_bound_seq_1 == __last1)
     {
         //{1} < {2}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
@@ -3416,7 +3422,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 =
-        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp, __proj2, __proj1);
+        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp,
+                                                  __proj2, __proj1);
 
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3318,22 +3318,19 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
                 //try searching for the first element which not equal to *__b
                 if (__b != __first1)
-                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b, __b, __comp, __proj1,
-                                                          __proj1);
+                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b, __b, __comp, __proj1, __proj1);
 
                 //try searching for the first element which not equal to *__e
                 if (__e != __last1)
-                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e, __e, __comp, __proj1,
-                                                          __proj1);
+                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e, __e, __comp, __proj1, __proj1);
 
                 //check is [__b; __e) empty
                 if (__e - __b < 1)
                 {
                     _RandomAccessIterator2 __bb = __last2;
                     if (__b != __last1)
-                        __bb =
-                            __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
-                                                                      __b, __comp, __proj2, __proj1);
+                        __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+                                                                         __b, __comp, __proj2, __proj1);
 
                     const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                     return _SetRange{0, 0, __buf_pos};
@@ -3347,8 +3344,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
                 _RandomAccessIterator2 __ee = __last2;
                 if (__e != __last1)
-                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, __e, __comp,
-                                                                 __proj2, __proj1);
+                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, __e, __comp, __proj2, __proj1);
 
                 const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                 auto __buffer_b = __tmp_memory + __buf_pos;

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3318,21 +3318,22 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
                 //try searching for the first element which not equal to *__b
                 if (__b != __first1)
-                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b, // TODO __pstl_upper_bound - iterator dereferencee
-                                                          std::invoke(__proj1, *__b), __comp, __proj1);
+                    __b += __internal::__pstl_upper_bound(__b, _DifferenceType1{0}, __last1 - __b, // TODO __pstl_upper_bound - iterator dereference
+                                                          __b, __comp, __proj1, __proj1);
 
                 //try searching for the first element which not equal to *__e
                 if (__e != __last1)
-                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e, // TODO __pstl_upper_bound - iterator dereferencee
-                                                          std::invoke(__proj1, *__e), __comp, __proj1);
+                    __e += __internal::__pstl_upper_bound(__e, _DifferenceType1{0}, __last1 - __e, // TODO __pstl_upper_bound - iterator dereference
+                                                          __e, __comp, __proj1, __proj1);
 
                 //check is [__b; __e) empty
                 if (__e - __b < 1)
                 {
                     _RandomAccessIterator2 __bb = __last2;
                     if (__b != __last1)
-                        __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
-                                                                         std::invoke(__proj1, *__b), __comp, __proj2);
+                        __bb =
+                            __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereference
+                                                                      __b, __comp, __proj2, __proj1);
 
                     const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                     return _SetRange{0, 0, __buf_pos};
@@ -3341,13 +3342,13 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 //try searching for "corresponding" subrange [__bb; __ee) in the second sequence
                 _RandomAccessIterator2 __bb = __first2;
                 if (__b != __first1)
-                    __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
-                                                                     std::invoke(__proj1, *__b), __comp, __proj2);
+                    __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereference
+                                                                     __b, __comp, __proj2, __proj1);
 
                 _RandomAccessIterator2 __ee = __last2;
                 if (__e != __last1)
-                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, // TODO __pstl_lower_bound - iterator dereferencee
-                                                                 std::invoke(__proj1, *__e), __comp, __proj2);
+                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, // TODO __pstl_lower_bound - iterator dereference
+                                                                 __e, __comp, __proj2, __proj1);
 
                 const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                 auto __buffer_b = __tmp_memory + __buf_pos;
@@ -3402,9 +3403,9 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 =
-        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
-                                                  std::invoke(__proj2, *__first2), __comp, __proj1);
-
+        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereference
+                                                  __first2, __comp, __proj1, __proj2);
+                                                  
     if (__left_bound_seq_1 == __last1)
     {
         //{1} < {2}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
@@ -3421,8 +3422,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 =
-        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
-                                                  std::invoke(__proj1, *__first1), __comp, __proj2);
+        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereference
+                                                  __first1, __comp, __proj2, __proj1);
 
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3399,8 +3399,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 =
-        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp,
-                                                  __proj1, __proj2);
+        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
 
     if (__left_bound_seq_1 == __last1)
     {
@@ -3418,8 +3417,7 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 =
-        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp,
-                                                  __proj2, __proj1);
+        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp, __proj2, __proj1);
 
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3330,7 +3330,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                     _RandomAccessIterator2 __bb = __last2;
                     if (__b != __last1)
                         __bb = __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
-                                                                         __b, __comp, __proj2, __proj1);
+                                                                      __b, __comp, __proj2, __proj1);
 
                     const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                     return _SetRange{0, 0, __buf_pos};
@@ -3344,7 +3344,8 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
 
                 _RandomAccessIterator2 __ee = __last2;
                 if (__e != __last1)
-                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, __e, __comp, __proj2, __proj1);
+                    __ee = __bb + __internal::__pstl_lower_bound(__bb, _DifferenceType2{0}, __last2 - __bb, __e, __comp,
+                                                                 __proj2, __proj1);
 
                 const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
                 auto __buffer_b = __tmp_memory + __buf_pos;
@@ -3399,7 +3400,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator1 __left_bound_seq_1 =
-        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
+        __first1 + __internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp,
+                                                  __proj1, __proj2);
 
     if (__left_bound_seq_1 == __last1)
     {
@@ -3417,7 +3419,8 @@ __parallel_set_union_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __ex
 
     // testing  whether the sequences are intersected
     _RandomAccessIterator2 __left_bound_seq_2 =
-        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp, __proj2, __proj1);
+        __first2 + __internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp,
+                                                  __proj2, __proj1);
 
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -693,7 +693,7 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
         return false;
 
     __first1 += oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
-                                                            std::invoke(__proj2, *__first2), __comp, __proj1);
+                                                            __first2, __comp, __proj1, __proj2);
     if (__first1 == __last1)
         return false;
 
@@ -722,18 +722,18 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
                     return false;
 
                 __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, // TODO __pstl_upper_bound - iterator dereferencee
-                                                                   std::invoke(__proj2, *__i), __comp, __proj2);
+                                                                   __i, __comp, __proj2, __proj2);
             }
 
             //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"
             if (__j < __last2 && __is_equal_sorted(__j - 1, __j))
                 __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, // TODO __pstl_upper_bound - iterator dereferencee
-                                                                   std::invoke(__proj2, *__j), __comp, __proj2);
+                                                                   __j, __comp, __proj2, __proj2);
 
             //2. testing is __a subsequence of the second range included into the first range
             auto __b = __first1 +
                        oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
-                                                                   std::invoke(__proj2, *__i), __comp, __proj1);
+                                                                   __i, __comp, __proj1, __proj2);
 
             return !std::ranges::includes(__b, __last1, __i, __j, __comp, __proj1, __proj2);
         });
@@ -885,7 +885,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     // testing  whether the sequences are intersected
     auto __left_bound_seq_1 =
         __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
-                                                               std::invoke(__proj2, *__first2), __comp, __proj1);
+                                                               __first2, __comp, __proj1, __proj2);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, the intersection is empty
     if (__left_bound_seq_1 == __last1)
         return {__last1, __last2, __result};
@@ -893,7 +893,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     // testing  whether the sequences are intersected
     auto __left_bound_seq_2 =
         __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
-                                                               std::invoke(__proj1, *__first1), __comp, __proj2);
+                                                               __first1, __comp, __proj2, __proj1);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, the intersection is empty
     if (__left_bound_seq_2 == __last2)
         return {__last1, __last2, __result};
@@ -1021,7 +1021,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     // testing  whether the sequences are intersected
     auto __left_bound_seq_1 =
         __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
-                                                               std::invoke(__proj2, *__first2), __comp, __proj1);
+                                                               __first2, __comp, __proj1, __proj2);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
     {
@@ -1033,7 +1033,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
     // testing  whether the sequences are intersected
     auto __left_bound_seq_2 =
         __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
-                                                               std::invoke(__proj1, *__first1), __comp, __proj2);
+                                                               __first1, __comp, __proj2, __proj1);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -721,8 +721,7 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
                 if (__is_equal_sorted(__i, __j - 1))
                     return false;
 
-                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, __i, __comp,
-                                                                   __proj2, __proj2);
+                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, __i, __comp, __proj2, __proj2);
             }
 
             //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -721,12 +721,14 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
                 if (__is_equal_sorted(__i, __j - 1))
                     return false;
 
-                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, __i, __comp, __proj2, __proj2);
+                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, __i, __comp,
+                                                                   __proj2, __proj2);
             }
 
             //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"
             if (__j < __last2 && __is_equal_sorted(__j - 1, __j))
-                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, __j, __comp, __proj2, __proj2);
+                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, __j, __comp,
+                                                                   __proj2, __proj2);
 
             //2. testing is __a subsequence of the second range included into the first range
             auto __b = __first1 + oneapi::dpl::__internal::__pstl_lower_bound(

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -692,8 +692,7 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
         std::invoke(__comp, std::invoke(__proj1, *(__last1 - 1)), std::invoke(__proj2, *(__last2 - 1))))
         return false;
 
-    __first1 += oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
-                                                            __first2, __comp, __proj1, __proj2);
+    __first1 += oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
     if (__first1 == __last1)
         return false;
 
@@ -721,19 +720,16 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
                 if (__is_equal_sorted(__i, __j - 1))
                     return false;
 
-                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, // TODO __pstl_upper_bound - iterator dereferencee
-                                                                   __i, __comp, __proj2, __proj2);
+                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, __i, __comp, __proj2, __proj2);
             }
 
             //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"
             if (__j < __last2 && __is_equal_sorted(__j - 1, __j))
-                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, // TODO __pstl_upper_bound - iterator dereferencee
-                                                                   __j, __comp, __proj2, __proj2);
+                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, __j, __comp, __proj2, __proj2);
 
             //2. testing is __a subsequence of the second range included into the first range
             auto __b = __first1 +
-                       oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
-                                                                   __i, __comp, __proj1, __proj2);
+                       oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __i, __comp, __proj1, __proj2);
 
             return !std::ranges::includes(__b, __last1, __i, __j, __comp, __proj1, __proj2);
         });
@@ -884,16 +880,14 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_1 =
-        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
-                                                               __first2, __comp, __proj1, __proj2);
+        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, the intersection is empty
     if (__left_bound_seq_1 == __last1)
         return {__last1, __last2, __result};
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_2 =
-        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
-                                                               __first1, __comp, __proj2, __proj1);
+        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp, __proj2, __proj1);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, the intersection is empty
     if (__left_bound_seq_2 == __last2)
         return {__last1, __last2, __result};
@@ -1020,8 +1014,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_1 =
-        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
-                                                               __first2, __comp, __proj1, __proj2);
+        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
     {
@@ -1032,8 +1025,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_2 =
-        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
-                                                               __first1, __comp, __proj2, __proj1);
+        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp, __proj2, __proj1);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -692,7 +692,7 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
         std::invoke(__comp, std::invoke(__proj1, *(__last1 - 1)), std::invoke(__proj2, *(__last2 - 1))))
         return false;
 
-    __first1 += oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1,
+    __first1 += oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
                                                             std::invoke(__proj2, *__first2), __comp, __proj1);
     if (__first1 == __last1)
         return false;
@@ -721,18 +721,18 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
                 if (__is_equal_sorted(__i, __j - 1))
                     return false;
 
-                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i,
+                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, // TODO __pstl_upper_bound - iterator dereferencee
                                                                    std::invoke(__proj2, *__i), __comp, __proj2);
             }
 
             //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"
             if (__j < __last2 && __is_equal_sorted(__j - 1, __j))
-                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j,
+                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, // TODO __pstl_upper_bound - iterator dereferencee
                                                                    std::invoke(__proj2, *__j), __comp, __proj2);
 
             //2. testing is __a subsequence of the second range included into the first range
             auto __b = __first1 +
-                       oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1,
+                       oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
                                                                    std::invoke(__proj2, *__i), __comp, __proj1);
 
             return !std::ranges::includes(__b, __last1, __i, __j, __comp, __proj1, __proj2);
@@ -884,7 +884,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_1 =
-        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1,
+        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
                                                                std::invoke(__proj2, *__first2), __comp, __proj1);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, the intersection is empty
     if (__left_bound_seq_1 == __last1)
@@ -892,7 +892,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_2 =
-        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
                                                                std::invoke(__proj1, *__first1), __comp, __proj2);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, the intersection is empty
     if (__left_bound_seq_2 == __last2)
@@ -1020,7 +1020,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_1 =
-        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1,
+        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, // TODO __pstl_lower_bound - iterator dereferencee
                                                                std::invoke(__proj2, *__first2), __comp, __proj1);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
@@ -1032,7 +1032,7 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_2 =
-        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, // TODO __pstl_lower_bound - iterator dereferencee
                                                                std::invoke(__proj1, *__first1), __comp, __proj2);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -727,8 +727,7 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
 
             //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"
             if (__j < __last2 && __is_equal_sorted(__j - 1, __j))
-                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, __j, __comp,
-                                                                   __proj2, __proj2);
+                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, __j, __comp, __proj2, __proj2);
 
             //2. testing is __a subsequence of the second range included into the first range
             auto __b = __first1 + oneapi::dpl::__internal::__pstl_lower_bound(

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -692,7 +692,8 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
         std::invoke(__comp, std::invoke(__proj1, *(__last1 - 1)), std::invoke(__proj2, *(__last2 - 1))))
         return false;
 
-    __first1 += oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
+    __first1 += oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2,
+                                                            __comp, __proj1, __proj2);
     if (__first1 == __last1)
         return false;
 
@@ -720,16 +721,18 @@ __pattern_includes(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _
                 if (__is_equal_sorted(__i, __j - 1))
                     return false;
 
-                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, __i, __comp, __proj2, __proj2);
+                __i += oneapi::dpl::__internal::__pstl_upper_bound(__i, _DifferenceType2{0}, __last2 - __i, __i, __comp,
+                                                                   __proj2, __proj2);
             }
 
             //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"
             if (__j < __last2 && __is_equal_sorted(__j - 1, __j))
-                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, __j, __comp, __proj2, __proj2);
+                __j += oneapi::dpl::__internal::__pstl_upper_bound(__j, _DifferenceType2{0}, __last2 - __j, __j, __comp,
+                                                                   __proj2, __proj2);
 
             //2. testing is __a subsequence of the second range included into the first range
-            auto __b = __first1 +
-                       oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __i, __comp, __proj1, __proj2);
+            auto __b = __first1 + oneapi::dpl::__internal::__pstl_lower_bound(
+                                      __first1, _DifferenceType1{0}, __last1 - __first1, __i, __comp, __proj1, __proj2);
 
             return !std::ranges::includes(__b, __last1, __i, __j, __comp, __proj1, __proj2);
         });
@@ -880,14 +883,16 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_1 =
-        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
+        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1,
+                                                               __first2, __comp, __proj1, __proj2);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, the intersection is empty
     if (__left_bound_seq_1 == __last1)
         return {__last1, __last2, __result};
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_2 =
-        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp, __proj2, __proj1);
+        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+                                                               __first1, __comp, __proj2, __proj1);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, the intersection is empty
     if (__left_bound_seq_2 == __last2)
         return {__last1, __last2, __result};
@@ -1014,7 +1019,8 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_1 =
-        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1, __first2, __comp, __proj1, __proj2);
+        __first1 + oneapi::dpl::__internal::__pstl_lower_bound(__first1, _DifferenceType1{0}, __last1 - __first1,
+                                                               __first2, __comp, __proj1, __proj2);
     //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
     if (__left_bound_seq_1 == __last1)
     {
@@ -1025,7 +1031,8 @@ __pattern_set_difference(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 
     // testing  whether the sequences are intersected
     auto __left_bound_seq_2 =
-        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2, __first1, __comp, __proj2, __proj1);
+        __first2 + oneapi::dpl::__internal::__pstl_lower_bound(__first2, _DifferenceType2{0}, __last2 - __first2,
+                                                               __first1, __comp, __proj2, __proj1);
     //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
     if (__left_bound_seq_2 == __last2)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1996,9 +1996,9 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p1 */ __global_idx - __start_1 +
                 /* relative position in p3 */
-                oneapi::dpl::__internal::__pstl_lower_bound(__in_acc2, __start_2, __part_end_2, __in_acc1[__global_idx], // TODO __pstl_lower_bound - operator[]
-                                                            __comp, oneapi::dpl::identity{}) -
-                __start_2;
+                oneapi::dpl::__internal::__pstl_lower_bound(__in_acc2, __start_2, __part_end_2, // TODO __pstl_lower_bound - operator[]
+                                                            __in_acc1, __global_idx, __comp, oneapi::dpl::identity{},
+                                                            oneapi::dpl::identity{}) - __start_2;
             __out_acc[__out_shift + __shift] = __in_acc1[__global_idx];
         }
         // Handle elements from p2
@@ -2015,8 +2015,9 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p3 */ __global_idx - __start_2 +
                 /* relative position in p1 */
-                oneapi::dpl::__internal::__pstl_upper_bound(__in_acc1, __start_1, __part_end_1, __in_acc2[__global_idx], // TODO __pstl_upper_bound - operator[]
-                                                            __comp, oneapi::dpl::identity{}) -
+                oneapi::dpl::__internal::__pstl_upper_bound(
+                    __in_acc1, __start_1, __part_end_1, // TODO __pstl_upper_bound - operator[]
+                    __in_acc2, __global_idx, __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
                 __start_1;
             __out_acc[__out_shift + __shift] = __in_acc2[__global_idx];
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1996,8 +1996,8 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p1 */ __global_idx - __start_1 +
                 /* relative position in p3 */
-                oneapi::dpl::__internal::__pstl_lower_bound(__in_acc2, __start_2, __part_end_2, __in_acc1, __global_idx,
-                                                            __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
+                oneapi::dpl::__internal::__pstl_lower_bound_idx(__in_acc2, __start_2, __part_end_2, __in_acc1, __global_idx,
+                                                                __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
                 __start_2;
             __out_acc[__out_shift + __shift] = __in_acc1[__global_idx];
         }
@@ -2015,8 +2015,8 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p3 */ __global_idx - __start_2 +
                 /* relative position in p1 */
-                oneapi::dpl::__internal::__pstl_upper_bound(__in_acc1, __start_1, __part_end_1, __in_acc2, __global_idx,
-                                                            __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
+                oneapi::dpl::__internal::__pstl_upper_bound_idx(__in_acc1, __start_1, __part_end_1, __in_acc2, __global_idx,
+                                                                __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
                 __start_1;
             __out_acc[__out_shift + __shift] = __in_acc2[__global_idx];
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1996,7 +1996,7 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p1 */ __global_idx - __start_1 +
                 /* relative position in p3 */
-                oneapi::dpl::__internal::__pstl_lower_bound(__in_acc2, __start_2, __part_end_2, __in_acc1[__global_idx],
+                oneapi::dpl::__internal::__pstl_lower_bound(__in_acc2, __start_2, __part_end_2, __in_acc1[__global_idx], // TODO __pstl_lower_bound - operator[]
                                                             __comp, oneapi::dpl::identity{}) -
                 __start_2;
             __out_acc[__out_shift + __shift] = __in_acc1[__global_idx];
@@ -2015,7 +2015,7 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p3 */ __global_idx - __start_2 +
                 /* relative position in p1 */
-                oneapi::dpl::__internal::__pstl_upper_bound(__in_acc1, __start_1, __part_end_1, __in_acc2[__global_idx],
+                oneapi::dpl::__internal::__pstl_upper_bound(__in_acc1, __start_1, __part_end_1, __in_acc2[__global_idx], // TODO __pstl_upper_bound - operator[]
                                                             __comp, oneapi::dpl::identity{}) -
                 __start_1;
             __out_acc[__out_shift + __shift] = __in_acc2[__global_idx];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1996,9 +1996,9 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p1 */ __global_idx - __start_1 +
                 /* relative position in p3 */
-                oneapi::dpl::__internal::__pstl_lower_bound(__in_acc2, __start_2, __part_end_2, // TODO __pstl_lower_bound - operator[]
-                                                            __in_acc1, __global_idx, __comp, oneapi::dpl::identity{},
-                                                            oneapi::dpl::identity{}) - __start_2;
+                oneapi::dpl::__internal::__pstl_lower_bound(
+                    __in_acc2, __start_2, __part_end_2, __in_acc1, __global_idx,
+                    __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) - __start_2;
             __out_acc[__out_shift + __shift] = __in_acc1[__global_idx];
         }
         // Handle elements from p2
@@ -2016,9 +2016,8 @@ struct __partial_merge_kernel
                 /* index inside p3 */ __global_idx - __start_2 +
                 /* relative position in p1 */
                 oneapi::dpl::__internal::__pstl_upper_bound(
-                    __in_acc1, __start_1, __part_end_1, // TODO __pstl_upper_bound - operator[]
-                    __in_acc2, __global_idx, __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
-                __start_1;
+                    __in_acc1, __start_1, __part_end_1, __in_acc2, __global_idx,
+                    __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) - __start_1;
             __out_acc[__out_shift + __shift] = __in_acc2[__global_idx];
         }
         // Handle elements from p4

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1996,8 +1996,9 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p1 */ __global_idx - __start_1 +
                 /* relative position in p3 */
-                oneapi::dpl::__internal::__pstl_lower_bound_idx(__in_acc2, __start_2, __part_end_2, __in_acc1, __global_idx,
-                                                                __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
+                oneapi::dpl::__internal::__pstl_lower_bound_idx(__in_acc2, __start_2, __part_end_2, __in_acc1,
+                                                                __global_idx, __comp, oneapi::dpl::identity{},
+                                                                oneapi::dpl::identity{}) -
                 __start_2;
             __out_acc[__out_shift + __shift] = __in_acc1[__global_idx];
         }
@@ -2015,8 +2016,9 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p3 */ __global_idx - __start_2 +
                 /* relative position in p1 */
-                oneapi::dpl::__internal::__pstl_upper_bound_idx(__in_acc1, __start_1, __part_end_1, __in_acc2, __global_idx,
-                                                                __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
+                oneapi::dpl::__internal::__pstl_upper_bound_idx(__in_acc1, __start_1, __part_end_1, __in_acc2,
+                                                                __global_idx, __comp, oneapi::dpl::identity{},
+                                                                oneapi::dpl::identity{}) -
                 __start_1;
             __out_acc[__out_shift + __shift] = __in_acc2[__global_idx];
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1996,9 +1996,9 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p1 */ __global_idx - __start_1 +
                 /* relative position in p3 */
-                oneapi::dpl::__internal::__pstl_lower_bound(
-                    __in_acc2, __start_2, __part_end_2, __in_acc1, __global_idx,
-                    __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) - __start_2;
+                oneapi::dpl::__internal::__pstl_lower_bound(__in_acc2, __start_2, __part_end_2, __in_acc1, __global_idx,
+                                                            __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
+                __start_2;
             __out_acc[__out_shift + __shift] = __in_acc1[__global_idx];
         }
         // Handle elements from p2
@@ -2015,9 +2015,9 @@ struct __partial_merge_kernel
             const auto __shift =
                 /* index inside p3 */ __global_idx - __start_2 +
                 /* relative position in p1 */
-                oneapi::dpl::__internal::__pstl_upper_bound(
-                    __in_acc1, __start_1, __part_end_1, __in_acc2, __global_idx,
-                    __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) - __start_1;
+                oneapi::dpl::__internal::__pstl_upper_bound(__in_acc1, __start_1, __part_end_1, __in_acc2, __global_idx,
+                                                            __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
+                __start_1;
             __out_acc[__out_shift + __shift] = __in_acc2[__global_idx];
         }
         // Handle elements from p4

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -389,7 +389,8 @@ struct __gen_set_mask
 
         std::size_t __nb = __set_b.size();
 
-        auto __res = oneapi::dpl::__internal::__pstl_lower_bound_idx(__set_b, std::size_t{0}, __nb, __set_a, __id, __comp, __proj2, __proj1);
+        auto __res = oneapi::dpl::__internal::__pstl_lower_bound_idx(__set_b, std::size_t{0}, __nb, __set_a, __id,
+                                                                     __comp, __proj2, __proj1);
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
 
         //initialization is true in case of difference operation; false - intersection.
@@ -703,7 +704,7 @@ struct __gen_set_balanced_path
         }
 
         if (std::invoke(__comp, std::invoke(__proj1, __rng1[__merge_path_rng1 - 1]),
-                                std::invoke(__proj2, __rng2[__merge_path_rng2])))
+                        std::invoke(__proj2, __rng2[__merge_path_rng2])))
         {
             // There is no chance that the balanced path differs from the merge path here, because the previous element of
             // rng1 does not match the next element of rng2. We can just return the merge path.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -389,8 +389,7 @@ struct __gen_set_mask
 
         std::size_t __nb = __set_b.size();
 
-        auto __res = oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __set_a, __id, __comp,
-                                                                 __proj2, __proj1);
+        auto __res = oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __set_a, __id, __comp, __proj2, __proj1);
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
 
         //initialization is true in case of difference operation; false - intersection.
@@ -410,15 +409,11 @@ struct __gen_set_mask
             //duplication in __set_b then a mask is 1
 
             const std::size_t __count_a_left =
-                __id -
-                oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id, __set_a, __id, __comp,
-                                                           __proj1, __proj1) +
-                1;
+                __id - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id, __set_a, __id, __comp, __proj1, __proj1) + 1;
 
-            const std::size_t __count_b = oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __set_b,
-                                                                                      __res, __comp, __proj2, __proj2) -
-                                          oneapi::dpl::__internal::__pstl_left_bound(
-                                              __set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
+            const std::size_t __count_b = 
+                oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
+                oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -708,7 +703,7 @@ struct __gen_set_balanced_path
         }
 
         if (std::invoke(__comp, std::invoke(__proj1, __rng1[__merge_path_rng1 - 1]),
-                        std::invoke(__proj2, __rng2[__merge_path_rng2])))
+                                std::invoke(__proj2, __rng2[__merge_path_rng2])))
         {
             // There is no chance that the balanced path differs from the merge path here, because the previous element of
             // rng1 does not match the next element of rng2. We can just return the merge path.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -389,14 +389,15 @@ struct __gen_set_mask
 
         std::size_t __nb = __set_b.size();
 
-        auto __res =
-            oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __set_a, __id, __comp, __proj2, __proj1); 
+        auto __res = oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __set_a, __id, __comp,
+                                                                 __proj2, __proj1);
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
 
         //initialization is true in case of difference operation; false - intersection.
         bool bres = __is_difference;
 
-        if (__res == __nb || std::invoke(__comp, std::invoke(__proj1, __set_a[__id]), std::invoke(__proj2, __set_b[__res])))
+        if (__res == __nb ||
+            std::invoke(__comp, std::invoke(__proj1, __set_a[__id]), std::invoke(__proj2, __set_b[__res])))
         {
             // there is no __set_a[__id] in __set_b, so __set_b in the difference {__set_a}/{__set_b};
         }
@@ -409,11 +410,15 @@ struct __gen_set_mask
             //duplication in __set_b then a mask is 1
 
             const std::size_t __count_a_left =
-                __id - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id, __set_a, __id, __comp, __proj1, __proj1) + 1; 
+                __id -
+                oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id, __set_a, __id, __comp,
+                                                           __proj1, __proj1) +
+                1;
 
-            const std::size_t __count_b =
-                oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
-                oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
+            const std::size_t __count_b = oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __set_b,
+                                                                                      __res, __comp, __proj2, __proj2) -
+                                          oneapi::dpl::__internal::__pstl_left_bound(
+                                              __set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -702,7 +707,8 @@ struct __gen_set_balanced_path
             return std::make_tuple(__merge_path_rng1, __merge_path_rng2, false);
         }
 
-        if (std::invoke(__comp, std::invoke(__proj1, __rng1[__merge_path_rng1 - 1]), std::invoke(__proj2, __rng2[__merge_path_rng2])))
+        if (std::invoke(__comp, std::invoke(__proj1, __rng1[__merge_path_rng1 - 1]),
+                        std::invoke(__proj2, __rng2[__merge_path_rng2])))
         {
             // There is no chance that the balanced path differs from the merge path here, because the previous element of
             // rng1 does not match the next element of rng2. We can just return the merge path.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -395,7 +395,7 @@ struct __gen_set_mask
         auto&& __val_a_proj = std::invoke(__proj1, std::forward<decltype(__val_a)>(__val_a));
 
         auto __res =
-            oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a_proj, __comp, __proj2);
+            oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a_proj, __comp, __proj2); // TODO __pstl_lower_bound - operator[]
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
 
         //initialization is true in case of difference operation; false - intersection.
@@ -422,7 +422,7 @@ struct __gen_set_mask
                 __id - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id, __val_a_proj, __comp, __proj1) + 1;
 
             const std::size_t __count_b =
-                oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __val_b_proj, __comp, __proj2) -
+                oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __val_b_proj, __comp, __proj2) - // TODO __pstl_right_bound - operator[]
                 oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, __val_b_proj, __comp,
                                                            __proj2);
 
@@ -726,10 +726,10 @@ struct __gen_set_balanced_path
         }
 
         // find first element of repeating sequence in the first set of the previous element
-        _Index __rng1_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>(
+        _Index __rng1_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>( // TODO __biased_lower_bound - operator[]
             __rng1, __rng1_begin, __merge_path_rng1, __ele_val_proj, __comp, __proj1);
         // find first element of repeating sequence in the second set of the next element
-        _Index __rng2_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>(
+        _Index __rng2_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>( // TODO __biased_lower_bound - operator[]
             __rng2, __rng2_begin, __merge_path_rng2, __ele_val_proj, __comp, __proj2);
 
         _Index __rng1_repeats = __merge_path_rng1 - __rng1_repeat_start;
@@ -748,7 +748,7 @@ struct __gen_set_balanced_path
         // Calculate the max location to search in the second set for future repeats, limiting to the edge of the range
         _Index __fwd_search_bound = std::min(__merge_path_rng2 + __fwd_search_count, __rng2_end);
 
-        _Index __balanced_path_intersection_rng2 = oneapi::dpl::__internal::__pstl_upper_bound(
+        _Index __balanced_path_intersection_rng2 = oneapi::dpl::__internal::__pstl_upper_bound( // TODO __pstl_upper_bound - operator[]
             __rng2, __merge_path_rng2, __fwd_search_bound, __ele_val_proj, __comp, __proj2);
 
         // Calculate the number of matchable "future" repeats in the second set

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -390,8 +390,7 @@ struct __gen_set_mask
         std::size_t __nb = __set_b.size();
 
         auto __res =
-            oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, // TODO __pstl_lower_bound - operator[]
-                                                        __set_a, __id, __comp, __proj2, __proj1); 
+            oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __set_a, __id, __comp, __proj2, __proj1); 
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
 
         //initialization is true in case of difference operation; false - intersection.
@@ -410,14 +409,11 @@ struct __gen_set_mask
             //duplication in __set_b then a mask is 1
 
             const std::size_t __count_a_left =
-                __id - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id, // TODO __pstl_left_bound - operator[]
-                                                                  __set_a, __id, __comp, __proj1, __proj1) + 1; 
+                __id - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id, __set_a, __id, __comp, __proj1, __proj1) + 1; 
 
             const std::size_t __count_b =
-                oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, // TODO __pstl_right_bound - operator[]
-                                                            __set_b, __res, __comp, __proj2, __proj2) -
-                oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, // TODO __pstl_left_bound - operator[]
-                                                           __set_b, __res, __comp, __proj2, __proj2);
+                oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
+                oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -714,13 +710,11 @@ struct __gen_set_balanced_path
         }
 
         // find first element of repeating sequence in the first set of the previous element
-        _Index __rng1_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>( // TODO __biased_lower_bound - operator[]
-            __rng1, __rng1_begin, __merge_path_rng1,
-            __rng1, __merge_path_rng1 - 1, __comp, __proj1, __proj1);
+        _Index __rng1_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>(
+            __rng1, __rng1_begin, __merge_path_rng1, __rng1, __merge_path_rng1 - 1, __comp, __proj1, __proj1);
         // find first element of repeating sequence in the second set of the next element
-        _Index __rng2_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>( // TODO __biased_lower_bound - operator[]
-            __rng2, __rng2_begin, __merge_path_rng2,
-            __rng1, __merge_path_rng1 - 1, __comp, __proj2, __proj1);
+        _Index __rng2_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>(
+            __rng2, __rng2_begin, __merge_path_rng2, __rng1, __merge_path_rng1 - 1, __comp, __proj2, __proj1);
 
         _Index __rng1_repeats = __merge_path_rng1 - __rng1_repeat_start;
         _Index __rng2_repeats_bck = __merge_path_rng2 - __rng2_repeat_start;
@@ -738,9 +732,8 @@ struct __gen_set_balanced_path
         // Calculate the max location to search in the second set for future repeats, limiting to the edge of the range
         _Index __fwd_search_bound = std::min(__merge_path_rng2 + __fwd_search_count, __rng2_end);
 
-        _Index __balanced_path_intersection_rng2 = 
-            oneapi::dpl::__internal::__pstl_upper_bound(__rng2, __merge_path_rng2, __fwd_search_bound,  // TODO __pstl_upper_bound - operator[]
-                                                        __rng1, __merge_path_rng1 - 1, __comp, __proj2, __proj1);
+        _Index __balanced_path_intersection_rng2 = oneapi::dpl::__internal::__pstl_upper_bound(
+            __rng2, __merge_path_rng2, __fwd_search_bound, __rng1, __merge_path_rng1 - 1, __comp, __proj2, __proj1);
 
         // Calculate the number of matchable "future" repeats in the second set
         _Index __matchable_forward_ele_rng2 = __balanced_path_intersection_rng2 - __merge_path_rng2;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -389,7 +389,7 @@ struct __gen_set_mask
 
         std::size_t __nb = __set_b.size();
 
-        auto __res = oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __set_a, __id, __comp, __proj2, __proj1);
+        auto __res = oneapi::dpl::__internal::__pstl_lower_bound_idx(__set_b, std::size_t{0}, __nb, __set_a, __id, __comp, __proj2, __proj1);
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
 
         //initialization is true in case of difference operation; false - intersection.
@@ -409,11 +409,11 @@ struct __gen_set_mask
             //duplication in __set_b then a mask is 1
 
             const std::size_t __count_a_left =
-                __id - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id, __set_a, __id, __comp, __proj1, __proj1) + 1;
+                __id - oneapi::dpl::__internal::__pstl_left_bound_idx(__set_a, std::size_t{0}, __id, __set_a, __id, __comp, __proj1, __proj1) + 1;
 
             const std::size_t __count_b = 
-                oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
-                oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
+                oneapi::dpl::__internal::__pstl_right_bound_idx(__set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
+                oneapi::dpl::__internal::__pstl_left_bound_idx(__set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -711,10 +711,10 @@ struct __gen_set_balanced_path
         }
 
         // find first element of repeating sequence in the first set of the previous element
-        _Index __rng1_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>(
+        _Index __rng1_repeat_start = oneapi::dpl::__internal::__biased_lower_bound_idx</*__last_bias=*/true>(
             __rng1, __rng1_begin, __merge_path_rng1, __rng1, __merge_path_rng1 - 1, __comp, __proj1, __proj1);
         // find first element of repeating sequence in the second set of the next element
-        _Index __rng2_repeat_start = oneapi::dpl::__internal::__biased_lower_bound</*__last_bias=*/true>(
+        _Index __rng2_repeat_start = oneapi::dpl::__internal::__biased_lower_bound_idx</*__last_bias=*/true>(
             __rng2, __rng2_begin, __merge_path_rng2, __rng1, __merge_path_rng1 - 1, __comp, __proj2, __proj1);
 
         _Index __rng1_repeats = __merge_path_rng1 - __rng1_repeat_start;
@@ -733,7 +733,7 @@ struct __gen_set_balanced_path
         // Calculate the max location to search in the second set for future repeats, limiting to the edge of the range
         _Index __fwd_search_bound = std::min(__merge_path_rng2 + __fwd_search_count, __rng2_end);
 
-        _Index __balanced_path_intersection_rng2 = oneapi::dpl::__internal::__pstl_upper_bound(
+        _Index __balanced_path_intersection_rng2 = oneapi::dpl::__internal::__pstl_upper_bound_idx(
             __rng2, __merge_path_rng2, __fwd_search_bound, __rng1, __merge_path_rng1 - 1, __comp, __proj2, __proj1);
 
         // Calculate the number of matchable "future" repeats in the second set

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1020,8 +1020,7 @@ struct __brick_includes
 
         const _SizeB __idx_b = __b_beg + __idx;
 
-        const _SizeA __res = __internal::__pstl_lower_bound(__rngA, __a_beg, __a_end, // TODO __pstl_lower_bound - operator[]
-                                                            __rngB, __idx_b, __comp, __projA, __projB); 
+        const _SizeA __res = __internal::__pstl_lower_bound(__rngA, __a_beg, __a_end, __rngB, __idx_b, __comp, __projA, __projB); 
 
         // {a} < {b} or __rngB[__idx_b] != __rngA[__res]
         if (__res == __a_end || std::invoke(__comp, std::invoke(__projB, __rngB[__idx_b]),
@@ -1029,15 +1028,11 @@ struct __brick_includes
             return true; //__rngA doesn't include __rngB
 
         //searching number of duplication
-        const auto __count_a = __internal::__pstl_right_bound(__rngA, __res, __a_end, // TODO __pstl_right_bound - operator[]
-                                                              __rngA, __res, __comp, __projA, __projA) - 
-                               __internal::__pstl_left_bound(__rngA, __a_beg, __res, // TODO __pstl_left_bound - operator[]
-                                                             __rngA, __res, __comp, __projA, __projA); 
+        const auto __count_a = __internal::__pstl_right_bound(__rngA, __res, __a_end, __rngA, __res, __comp, __projA, __projA) - 
+                               __internal::__pstl_left_bound(__rngA, __a_beg, __res, __rngA, __res, __comp, __projA, __projA); 
 
-        const auto __count_b = __internal::__pstl_right_bound(__rngB, __idx_b, __b_end, // TODO __pstl_right_bound - operator[]
-                                                              __rngB, __idx_b, __comp, __projB, __projB) - 
-                               __internal::__pstl_left_bound(__rngB, __b_beg, __idx_b, // TODO __pstl_left_bound - operator[]
-                                                             __rngB, __idx_b, __comp, __projB, __projB); 
+        const auto __count_b = __internal::__pstl_right_bound(__rngB, __idx_b, __b_end, __rngB, __idx_b, __comp, __projB, __projB) - 
+                               __internal::__pstl_left_bound(__rngB, __b_beg, __idx_b, __rngB, __idx_b, __comp, __projB, __projB); 
 
         return __count_b > __count_a; //false means __rngA includes __rngB
     }
@@ -1277,8 +1272,7 @@ class __brick_set_op
         auto __idx_c = __idx;
         const _SizeA __idx_a = _SizeA(__idx);
 
-        const _SizeB __res = __internal::__pstl_lower_bound(__b, __b_beg, __nb, // TODO __pstl_lower_bound - operator[]
-                                                            __a, __a_beg + __idx_a, __comp, __projB, __projA); 
+        const _SizeB __res = __internal::__pstl_lower_bound(__b, __b_beg, __nb, __a, __a_beg + __idx_a, __comp, __projB, __projA); 
 
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
         bool bres = __is_difference; //initialization is true in case of difference operation; false - intersection.
@@ -1295,13 +1289,10 @@ class __brick_set_op
             //duplication in __b than a mask is 1
 
             const _SizeA __count_a_left =
-                __idx_a - __internal::__pstl_left_bound(__a, __a_beg, __idx_a, // TODO __pstl_left_bound - operator[]
-                                                        __a, __a_beg + __idx_a, __comp, __projA, __projA) + 1; 
+                __idx_a - __internal::__pstl_left_bound(__a, __a_beg, __idx_a, __a, __a_beg + __idx_a, __comp, __projA, __projA) + 1; 
 
-            const _SizeB __count_b = __internal::__pstl_right_bound(__b, __res, __nb,// TODO __pstl_right_bound - operator[]
-                                                                    __b, __b_beg + __res, __comp, __projB, __projB) - 
-                                     __internal::__pstl_left_bound(__b, __b_beg, __res, // TODO __pstl_left_bound - operator[]
-                                                                   __b, __b_beg + __res, __comp, __projB, __projB); 
+            const _SizeB __count_b = __internal::__pstl_right_bound(__b, __res, __nb, __b, __b_beg + __res, __comp, __projB, __projB) - 
+                                     __internal::__pstl_left_bound(__b, __b_beg, __res, __b, __b_beg + __res, __comp, __projB, __projB); 
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1294,9 +1294,7 @@ class __brick_set_op
             //duplication in __b than a mask is 1
 
             const _SizeA __count_a_left =
-                __idx_a -
-                __internal::__pstl_left_bound(__a, __a_beg, __idx_a, __a, __a_beg + __idx_a, __comp, __projA, __projA) +
-                1;
+                __idx_a - __internal::__pstl_left_bound(__a, __a_beg, __idx_a, __a, __a_beg + __idx_a, __comp, __projA, __projA) + 1;
 
             const _SizeB __count_b =
                 __internal::__pstl_right_bound(__b, __res, __nb, __b, __b_beg + __res, __comp, __projB, __projB) -

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1020,19 +1020,22 @@ struct __brick_includes
 
         const _SizeB __idx_b = __b_beg + __idx;
 
-        const _SizeA __res = __internal::__pstl_lower_bound(__rngA, __a_beg, __a_end, __rngB, __idx_b, __comp, __projA, __projB); 
+        const _SizeA __res =
+            __internal::__pstl_lower_bound(__rngA, __a_beg, __a_end, __rngB, __idx_b, __comp, __projA, __projB);
 
         // {a} < {b} or __rngB[__idx_b] != __rngA[__res]
-        if (__res == __a_end || std::invoke(__comp, std::invoke(__projB, __rngB[__idx_b]),
-                                                    std::invoke(__projA, __rngA[__res])))
+        if (__res == __a_end ||
+            std::invoke(__comp, std::invoke(__projB, __rngB[__idx_b]), std::invoke(__projA, __rngA[__res])))
             return true; //__rngA doesn't include __rngB
 
         //searching number of duplication
-        const auto __count_a = __internal::__pstl_right_bound(__rngA, __res, __a_end, __rngA, __res, __comp, __projA, __projA) - 
-                               __internal::__pstl_left_bound(__rngA, __a_beg, __res, __rngA, __res, __comp, __projA, __projA); 
+        const auto __count_a =
+            __internal::__pstl_right_bound(__rngA, __res, __a_end, __rngA, __res, __comp, __projA, __projA) -
+            __internal::__pstl_left_bound(__rngA, __a_beg, __res, __rngA, __res, __comp, __projA, __projA);
 
-        const auto __count_b = __internal::__pstl_right_bound(__rngB, __idx_b, __b_end, __rngB, __idx_b, __comp, __projB, __projB) - 
-                               __internal::__pstl_left_bound(__rngB, __b_beg, __idx_b, __rngB, __idx_b, __comp, __projB, __projB); 
+        const auto __count_b =
+            __internal::__pstl_right_bound(__rngB, __idx_b, __b_end, __rngB, __idx_b, __comp, __projB, __projB) -
+            __internal::__pstl_left_bound(__rngB, __b_beg, __idx_b, __rngB, __idx_b, __comp, __projB, __projB);
 
         return __count_b > __count_a; //false means __rngA includes __rngB
     }
@@ -1272,11 +1275,13 @@ class __brick_set_op
         auto __idx_c = __idx;
         const _SizeA __idx_a = _SizeA(__idx);
 
-        const _SizeB __res = __internal::__pstl_lower_bound(__b, __b_beg, __nb, __a, __a_beg + __idx_a, __comp, __projB, __projA); 
+        const _SizeB __res =
+            __internal::__pstl_lower_bound(__b, __b_beg, __nb, __a, __a_beg + __idx_a, __comp, __projB, __projA);
 
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
         bool bres = __is_difference; //initialization is true in case of difference operation; false - intersection.
-        if (__res == __nb || std::invoke(__comp, std::invoke(__projA, __a[__a_beg + __idx_a]), std::invoke(__projB, __b[__b_beg + __res])))
+        if (__res == __nb || std::invoke(__comp, std::invoke(__projA, __a[__a_beg + __idx_a]),
+                                         std::invoke(__projB, __b[__b_beg + __res])))
         {
             // there is no __a[__a_beg + __idx_a] in __b, so __b in the difference {__a}/{__b};
         }
@@ -1289,10 +1294,13 @@ class __brick_set_op
             //duplication in __b than a mask is 1
 
             const _SizeA __count_a_left =
-                __idx_a - __internal::__pstl_left_bound(__a, __a_beg, __idx_a, __a, __a_beg + __idx_a, __comp, __projA, __projA) + 1; 
+                __idx_a -
+                __internal::__pstl_left_bound(__a, __a_beg, __idx_a, __a, __a_beg + __idx_a, __comp, __projA, __projA) +
+                1;
 
-            const _SizeB __count_b = __internal::__pstl_right_bound(__b, __res, __nb, __b, __b_beg + __res, __comp, __projB, __projB) - 
-                                     __internal::__pstl_left_bound(__b, __b_beg, __res, __b, __b_beg + __res, __comp, __projB, __projB); 
+            const _SizeB __count_b =
+                __internal::__pstl_right_bound(__b, __res, __nb, __b, __b_beg + __res, __comp, __projB, __projB) -
+                __internal::__pstl_left_bound(__b, __b_beg, __res, __b, __b_beg + __res, __comp, __projB, __projB);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1021,7 +1021,7 @@ struct __brick_includes
         const _SizeB __idx_b = __b_beg + __idx;
 
         const _SizeA __res =
-            __internal::__pstl_lower_bound(__rngA, __a_beg, __a_end, __rngB, __idx_b, __comp, __projA, __projB);
+            __internal::__pstl_lower_bound_idx(__rngA, __a_beg, __a_end, __rngB, __idx_b, __comp, __projA, __projB);
 
         // {a} < {b} or __rngB[__idx_b] != __rngA[__res]
         if (__res == __a_end ||
@@ -1030,12 +1030,12 @@ struct __brick_includes
 
         //searching number of duplication
         const auto __count_a =
-            __internal::__pstl_right_bound(__rngA, __res, __a_end, __rngA, __res, __comp, __projA, __projA) -
-            __internal::__pstl_left_bound(__rngA, __a_beg, __res, __rngA, __res, __comp, __projA, __projA);
+            __internal::__pstl_right_bound_idx(__rngA, __res, __a_end, __rngA, __res, __comp, __projA, __projA) -
+            __internal::__pstl_left_bound_idx(__rngA, __a_beg, __res, __rngA, __res, __comp, __projA, __projA);
 
         const auto __count_b =
-            __internal::__pstl_right_bound(__rngB, __idx_b, __b_end, __rngB, __idx_b, __comp, __projB, __projB) -
-            __internal::__pstl_left_bound(__rngB, __b_beg, __idx_b, __rngB, __idx_b, __comp, __projB, __projB);
+            __internal::__pstl_right_bound_idx(__rngB, __idx_b, __b_end, __rngB, __idx_b, __comp, __projB, __projB) -
+            __internal::__pstl_left_bound_idx(__rngB, __b_beg, __idx_b, __rngB, __idx_b, __comp, __projB, __projB);
 
         return __count_b > __count_a; //false means __rngA includes __rngB
     }
@@ -1276,7 +1276,7 @@ class __brick_set_op
         const _SizeA __idx_a = _SizeA(__idx);
 
         const _SizeB __res =
-            __internal::__pstl_lower_bound(__b, __b_beg, __nb, __a, __a_beg + __idx_a, __comp, __projB, __projA);
+            __internal::__pstl_lower_bound_idx(__b, __b_beg, __nb, __a, __a_beg + __idx_a, __comp, __projB, __projA);
 
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
         bool bres = __is_difference; //initialization is true in case of difference operation; false - intersection.
@@ -1294,11 +1294,11 @@ class __brick_set_op
             //duplication in __b than a mask is 1
 
             const _SizeA __count_a_left =
-                __idx_a - __internal::__pstl_left_bound(__a, __a_beg, __idx_a, __a, __a_beg + __idx_a, __comp, __projA, __projA) + 1;
+                __idx_a - __internal::__pstl_left_bound_idx(__a, __a_beg, __idx_a, __a, __a_beg + __idx_a, __comp, __projA, __projA) + 1;
 
             const _SizeB __count_b =
-                __internal::__pstl_right_bound(__b, __res, __nb, __b, __b_beg + __res, __comp, __projB, __projB) -
-                __internal::__pstl_left_bound(__b, __b_beg, __res, __b, __b_beg + __res, __comp, __projB, __projB);
+                __internal::__pstl_right_bound_idx(__b, __res, __nb, __b, __b_beg + __res, __comp, __projB, __projB) -
+                __internal::__pstl_left_bound_idx(__b, __b_beg, __res, __b, __b_beg + __res, __comp, __projB, __projB);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1025,7 +1025,7 @@ struct __brick_includes
         auto&& __val_b = __rngB[__idx_b];
         auto&& __val_b_proj = std::invoke(__projB, std::forward<decltype(__val_b)>(__val_b));
 
-        const _SizeA __res = __internal::__pstl_lower_bound(__rngA, __a_beg, __a_end, __val_b_proj, __comp, __projA);
+        const _SizeA __res = __internal::__pstl_lower_bound(__rngA, __a_beg, __a_end, __val_b_proj, __comp, __projA); // TODO __pstl_lower_bound - operator[]
 
         // {a} < {b} or __val_b != __rngA[__res]
         if (__res == __a_end || std::invoke(__comp, __val_b_proj, std::invoke(__projA, __rngA[__res])))
@@ -1037,10 +1037,10 @@ struct __brick_includes
         auto&& __val_a_proj = std::invoke(__projA, std::forward<decltype(__val_a)>(__val_a));
 
         //searching number of duplication
-        const auto __count_a = __internal::__pstl_right_bound(__rngA, __res, __a_end, __val_a_proj, __comp, __projA) -
+        const auto __count_a = __internal::__pstl_right_bound(__rngA, __res, __a_end, __val_a_proj, __comp, __projA) - // TODO __pstl_right_bound - operator[]
                                __internal::__pstl_left_bound(__rngA, __a_beg, __res, __val_a_proj, __comp, __projA);
 
-        const auto __count_b = __internal::__pstl_right_bound(__rngB, __idx_b, __b_end, __val_b_proj, __comp, __projB) -
+        const auto __count_b = __internal::__pstl_right_bound(__rngB, __idx_b, __b_end, __val_b_proj, __comp, __projB) - // TODO __pstl_right_bound - operator[]
                                __internal::__pstl_left_bound(__rngB, __b_beg, __idx_b, __val_b_proj, __comp, __projB);
 
         return __count_b > __count_a; //false means __rngA includes __rngB
@@ -1286,7 +1286,7 @@ class __brick_set_op
         auto&& __val_a = __a[__a_beg + __idx_a];
         auto&& __val_a_proj = std::invoke(__projA, std::forward<decltype(__val_a)>(__val_a));
 
-        const _SizeB __res = __internal::__pstl_lower_bound(__b, __b_beg, __nb, __val_a_proj, __comp, __projB);
+        const _SizeB __res = __internal::__pstl_lower_bound(__b, __b_beg, __nb, __val_a_proj, __comp, __projB); // TODO __pstl_lower_bound - operator[]
 
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
         bool bres = __is_difference; //initialization is true in case of difference operation; false - intersection.
@@ -1310,7 +1310,7 @@ class __brick_set_op
             const _SizeA __count_a_left =
                 __idx_a - __internal::__pstl_left_bound(__a, __a_beg, __idx_a, __val_a_proj, __comp, __projA) + 1;
 
-            const _SizeB __count_b = __internal::__pstl_right_bound(__b, __res, __nb, __val_b_proj, __comp, __projB) -
+            const _SizeB __count_b = __internal::__pstl_right_bound(__b, __res, __nb, __val_b_proj, __comp, __projB) - // TODO __pstl_right_bound - operator[]
                                      __internal::__pstl_left_bound(__b, __b_beg, __res, __val_b_proj, __comp, __projB);
 
             if constexpr (__is_difference)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1281,7 +1281,7 @@ class __brick_set_op
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
         bool bres = __is_difference; //initialization is true in case of difference operation; false - intersection.
         if (__res == __nb || std::invoke(__comp, std::invoke(__projA, __a[__a_beg + __idx_a]),
-                                                 std::invoke(__projB, __b[__b_beg + __res])))
+                                         std::invoke(__projB, __b[__b_beg + __res])))
         {
             // there is no __a[__a_beg + __idx_a] in __b, so __b in the difference {__a}/{__b};
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1281,7 +1281,7 @@ class __brick_set_op
         constexpr bool __is_difference = std::is_same_v<_SetTag, oneapi::dpl::unseq_backend::_DifferenceTag>;
         bool bres = __is_difference; //initialization is true in case of difference operation; false - intersection.
         if (__res == __nb || std::invoke(__comp, std::invoke(__projA, __a[__a_beg + __idx_a]),
-                                         std::invoke(__projB, __b[__b_beg + __res])))
+                                                 std::invoke(__projB, __b[__b_beg + __res])))
         {
             // there is no __a[__a_beg + __idx_a] in __b, so __b in the difference {__a}/{__b};
         }

--- a/include/oneapi/dpl/pstl/histogram_binhash_utils.h
+++ b/include/oneapi/dpl/pstl/histogram_binhash_utils.h
@@ -90,7 +90,7 @@ __custom_boundary_get_bin_helper(_Acc __acc, ::std::int32_t __size, _T2 __value,
     std::int32_t ret = -1;
     if (__value >= __min && __value < __max)
     {
-        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, __value, std::less<_T2>{},
+        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, __value, std::less<_T2>{}, // TODO __pstl_upper_bound - value (maybe processed as pointer dereference)
                                                           oneapi::dpl::identity{}) - 1;
     }
     return ret;

--- a/include/oneapi/dpl/pstl/histogram_binhash_utils.h
+++ b/include/oneapi/dpl/pstl/histogram_binhash_utils.h
@@ -90,7 +90,8 @@ __custom_boundary_get_bin_helper(_Acc __acc, ::std::int32_t __size, _T2 __value,
     std::int32_t ret = -1;
     if (__value >= __min && __value < __max)
     {
-        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, &__value, std::less<_T2>{},
+        _T2* __value_ptr = &__value;
+        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, __value_ptr, std::less<_T2>{},
                                                           oneapi::dpl::identity{}, oneapi::dpl::identity{}) - 1;
     }
     return ret;

--- a/include/oneapi/dpl/pstl/histogram_binhash_utils.h
+++ b/include/oneapi/dpl/pstl/histogram_binhash_utils.h
@@ -92,7 +92,8 @@ __custom_boundary_get_bin_helper(_Acc __acc, ::std::int32_t __size, _T2 __value,
     {
         _T2* __value_ptr = &__value;
         ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, __value_ptr, std::less<_T2>{},
-                                                          oneapi::dpl::identity{}, oneapi::dpl::identity{}) - 1;
+                                                          oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
+              1;
     }
     return ret;
 }

--- a/include/oneapi/dpl/pstl/histogram_binhash_utils.h
+++ b/include/oneapi/dpl/pstl/histogram_binhash_utils.h
@@ -90,8 +90,8 @@ __custom_boundary_get_bin_helper(_Acc __acc, ::std::int32_t __size, _T2 __value,
     std::int32_t ret = -1;
     if (__value >= __min && __value < __max)
     {
-        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, __value, std::less<_T2>{}, // TODO __pstl_upper_bound - value (maybe processed as pointer dereference)
-                                                          oneapi::dpl::identity{}) - 1;
+        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, // TODO __pstl_upper_bound - value (maybe processed as pointer dereference)
+                                                          &__value, std::less<_T2>{}, oneapi::dpl::identity{}, oneapi::dpl::identity{}) - 1;
     }
     return ret;
 }

--- a/include/oneapi/dpl/pstl/histogram_binhash_utils.h
+++ b/include/oneapi/dpl/pstl/histogram_binhash_utils.h
@@ -90,8 +90,8 @@ __custom_boundary_get_bin_helper(_Acc __acc, ::std::int32_t __size, _T2 __value,
     std::int32_t ret = -1;
     if (__value >= __min && __value < __max)
     {
-        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, // TODO __pstl_upper_bound - value (maybe processed as pointer dereference)
-                                                          &__value, std::less<_T2>{}, oneapi::dpl::identity{}, oneapi::dpl::identity{}) - 1;
+        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, &__value, std::less<_T2>{},
+                                                          oneapi::dpl::identity{}, oneapi::dpl::identity{}) - 1;
     }
     return ret;
 }

--- a/include/oneapi/dpl/pstl/histogram_binhash_utils.h
+++ b/include/oneapi/dpl/pstl/histogram_binhash_utils.h
@@ -92,8 +92,7 @@ __custom_boundary_get_bin_helper(_Acc __acc, ::std::int32_t __size, _T2 __value,
     {
         _T2* __value_ptr = &__value;
         ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, __value_ptr, std::less<_T2>{},
-                                                          oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
-              1;
+                                                          oneapi::dpl::identity{}, oneapi::dpl::identity{}) - 1;
     }
     return ret;
 }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -668,8 +668,7 @@ __pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, 
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1,
-                              __proj2);
+    return __pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
 }
 
 template <typename _Rng1, typename _Size1, typename _Rng2It, typename _Compare, typename _Proj1, typename _Proj2>
@@ -731,8 +730,7 @@ __biased_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2
     if (__n > 0)
     {
         // End up fully at binary search
-        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp,
-                                                           __proj1, __proj2);
+        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1, __proj2);
     }
     return __first1;
 }
@@ -746,8 +744,7 @@ __biased_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __biased_lower_bound<__bias_last>(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp,
-                                             __proj1, __proj2);
+    return __biased_lower_bound<__bias_last>(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
 }
 
 template <typename _IntType, typename _Acc>

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -778,14 +778,15 @@ struct _ReverseCounter
 // Reverse searching for the first element strongly less than a passed value - left bound
 template <typename _Buffer, typename _Index, typename _Value, typename _Compare, typename _Proj>
 _Index
-__pstl_left_bound(_Buffer& __a, _Index __first, _Index __last, const _Value& __val, _Compare __comp, _Proj __proj)
+__pstl_left_bound(_Buffer& __a, _Index __first, _Index __last, _Value&& __value_proj, _Compare __comp, _Proj __proj)
 {
     auto __beg = _ReverseCounter<_Index, _Buffer>{__last - 1};
     auto __end = _ReverseCounter<_Index, _Buffer>{__first - 1};
 
     __not_pred<decltype(__comp)> __negation_comp{__comp};
 
-    return __pstl_lower_bound(__a, __beg, __end, __val, __negation_comp, __proj);
+    // We should forward __value_proj to preserve their value category
+    return __pstl_lower_bound(__a, __beg, __end, std::forward<_Value>(__value_proj), __negation_comp, __proj);
 }
 
 // Lower bound implementation based on Shar's algorithm for binary search.

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -645,10 +645,11 @@ _Size1
 __pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
                    _Proj1 __proj1, _Proj2 __proj2)
 {
-    return __pstl_lower_bound_impl(
-        __first1, __last1, [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
-            return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng1_idx]), std::invoke(__proj2, __rng2[__rng2_idx]));
-        });
+    return __pstl_lower_bound_impl(__first1, __last1,
+                                   [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
+                                       return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng1_idx]),
+                                                          std::invoke(__proj2, __rng2[__rng2_idx]));
+                                   });
 }
 
 // __rng1[__first, __last1), __iterator, __comp, __proj1, __proj2
@@ -673,7 +674,8 @@ __pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, 
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
+    return __pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1,
+                              __proj2);
 }
 
 // __rng1[__first, __last1), __rng2_it, __comp, __proj1, __proj2
@@ -738,8 +740,8 @@ __biased_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2
     if (__n > 0)
     {
         // End up fully at binary search
-        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1,
-                                                           __proj2);
+        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp,
+                                                           __proj1, __proj2);
     }
     return __first1;
 }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -638,78 +638,78 @@ __pstl_lower_bound_impl(_Size __first, _Size __last, _Comparator&& __comp)
     return __first;
 }
 
-// __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
+// __rng1[__first1, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
-__pstl_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+__pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
                    _Proj1 __proj1, _Proj2 __proj2)
 {
     return __pstl_lower_bound_impl(
-        __first, __last, [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
+        __first1, __last1, [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
             return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng2_idx]), std::invoke(__proj2, __rng2[__rng2_idx]));
         });
 }
 
-// __rng1[__first, __last), __iterator, __comp, __proj1, __proj2
+// __rng1[__first, __last1), __iterator, __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Rng2It, typename _Compare, typename _Proj1, typename _Proj2>
 _Size1
-__pstl_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2It __rng2_it, _Compare __comp, _Proj1 __proj1,
+__pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2_it, _Compare __comp, _Proj1 __proj1,
                    _Proj2 __proj2)
 {
     return __pstl_lower_bound_impl(
-        __first, __last, [__rng1, __rng2_it, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
+        __first1, __last1, [__rng1, __rng2_it, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
             return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng1_idx]), std::invoke(__proj2, *__rng2_it));
         });
 }
 
-// __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
+// __rng1[__first, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
-__pstl_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+__pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
                    _Proj1 __proj1, _Proj2 __proj2)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound(__rng1, __first, __last, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
+    return __pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
 }
 
-// __rng1[__first, __last), __iterator, __comp, __proj1, __proj2
+// __rng1[__first, __last1), __iterator, __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Iterator, typename _Compare, typename _Proj1, typename _Proj2>
 _Size1
-__pstl_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Iterator __iterator, _Compare __comp, _Proj1 __proj1,
+__pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Iterator __iterator, _Compare __comp, _Proj1 __proj1,
                    _Proj2 __proj2)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound(__rng1, __first, __last, __iterator, __negation_reordered_comp, __proj1, __proj2);
+    return __pstl_lower_bound(__rng1, __first1, __last1, __iterator, __negation_reordered_comp, __proj1, __proj2);
 }
 
-// __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
+// __rng1[__first, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
-__pstl_right_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+__pstl_right_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
                    _Proj1 __proj1, _Proj2 __proj2)
 {
-    return __pstl_upper_bound(__rng1, __first, __last, __rng2, __rng2_idx, __comp, __proj1, __proj2);
+    return __pstl_upper_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1, __proj2);
 }
 
 // Performs a "biased" binary search targets the split point close to one edge of the range.
 // When __bias_last==true, it searches first near the last element, otherwise it searches first near the first element.
 // After each iteration which fails to capture the element in the small side, it reduces the "bias", eventually
 // resulting in a standard binary search.
-// __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
+// __rng1[__first1, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare,
           typename _Proj1, typename _Proj2>
 _Size1
-__biased_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+__biased_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
                      _Proj1 __proj1, _Proj2 __proj2)
 {
-    auto __n = __last - __first;
+    auto __n = __last1 - __first1;
     std::int8_t __shift_right_div = 10; // divide by 2^10 = 1024
     _Size1 __it = 0;
     _Size1 __cur_idx = 0;
@@ -721,40 +721,40 @@ __biased_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, 
             __cur_idx = __n - __biased_step - 1;
         else
             __cur_idx = __biased_step;
-        __it = __first + __cur_idx;
+        __it = __first1 + __cur_idx;
 
         if (std::invoke(__comp, std::invoke(__proj1, __rng1[__it]), std::invoke(__proj2, __rng2[__rng2_idx])))
         {
-            __first = __it + 1;
+            __first1 = __it + 1;
         }
         else
         {
-            __last = __it;
+            __last1 = __it;
         }
-        __n = __last - __first;
+        __n = __last1 - __first1;
         // get closer and closer to binary search with more iterations
         __shift_right_div -= 3;
     }
     if (__n > 0)
     {
         // End up fully at binary search
-        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first, __last, __rng2, __rng2_idx, __comp, __proj1,
+        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1,
                                                            __proj2);
     }
     return __first;
 }
 
-// __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
+// __rng1[__first1, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare,
           typename _Proj1, typename _Proj2>
 _Size1
-__biased_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+__biased_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
                      _Proj1 __proj1, _Proj2 __proj2)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __biased_lower_bound<__bias_last>(__rng1, __first, __last, __rng2, __rng2_idx, __negation_reordered_comp,
+    return __biased_lower_bound<__bias_last>(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp,
                                              __proj1, __proj2);
 }
 
@@ -819,15 +819,15 @@ struct _ReverseCounter
 };
 
 // Reverse searching for the first element strongly less than a passed value - left bound
-// __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
+// __rng1[__first, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
-__pstl_left_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+__pstl_left_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
                   _Proj1 __proj1, _Proj2 __proj2)
 {
-    auto __beg = _ReverseCounter<_Size1, _Rng1>{__last - 1};
-    auto __end = _ReverseCounter<_Size1, _Rng1>{__first - 1};
+    auto __beg = _ReverseCounter<_Size1, _Rng1>{__last1 - 1};
+    auto __end = _ReverseCounter<_Size1, _Rng1>{__first1 - 1};
 
     __not_pred<decltype(__comp)> __negation_comp{__comp};
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -741,7 +741,7 @@ __biased_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2
         return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1,
                                                            __proj2);
     }
-    return __first;
+    return __first1;
 }
 
 // __rng1[__first1, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -676,16 +676,16 @@ __pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, 
     return __pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
 }
 
-// __rng1[__first, __last1), __iterator, __comp, __proj1, __proj2
-template <typename _Rng1, typename _Size1, typename _Iterator, typename _Compare, typename _Proj1, typename _Proj2>
+// __rng1[__first, __last1), __rng2_it, __comp, __proj1, __proj2
+template <typename _Rng1, typename _Size1, typename _Rng2It, typename _Compare, typename _Proj1, typename _Proj2>
 _Size1
-__pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Iterator __iterator, _Compare __comp, _Proj1 __proj1,
+__pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2_it, _Compare __comp, _Proj1 __proj1,
                    _Proj2 __proj2)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound(__rng1, __first1, __last1, __iterator, __negation_reordered_comp, __proj1, __proj2);
+    return __pstl_lower_bound(__rng1, __first1, __last1, __rng2_it, __negation_reordered_comp, __proj1, __proj2);
 }
 
 // __rng1[__first, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -644,7 +644,7 @@ __pstl_lower_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rn
     return __pstl_lower_bound_impl(__first1, __last1,
                                    [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
                                        return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng1_idx]),
-                                                                  std::invoke(__proj2, __rng2[__rng2_idx]));
+                                                          std::invoke(__proj2, __rng2[__rng2_idx]));
                                    });
 }
 
@@ -698,8 +698,8 @@ __pstl_right_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rn
 template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare,
           typename _Proj1, typename _Proj2>
 _Size1
-__biased_lower_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
-                         _Proj1 __proj1, _Proj2 __proj2)
+__biased_lower_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx,
+                         _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
 {
     auto __n = __last1 - __first1;
     std::int8_t __shift_right_div = 10; // divide by 2^10 = 1024
@@ -730,7 +730,8 @@ __biased_lower_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __
     if (__n > 0)
     {
         // End up fully at binary search
-        return oneapi::dpl::__internal::__pstl_lower_bound_idx(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1, __proj2);
+        return oneapi::dpl::__internal::__pstl_lower_bound_idx(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp,
+                                                               __proj1, __proj2);
     }
     return __first1;
 }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -638,7 +638,6 @@ __pstl_lower_bound_impl(_Size __first, _Size __last, _Comparator&& __comp)
     return __first;
 }
 
-// __rng1[__first1, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
@@ -652,7 +651,6 @@ __pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, 
                                    });
 }
 
-// __rng1[__first, __last1), __iterator, __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Rng2It, typename _Compare, typename _Proj1, typename _Proj2>
 _Size1
 __pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2_it, _Compare __comp, _Proj1 __proj1,
@@ -664,7 +662,6 @@ __pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2
         });
 }
 
-// __rng1[__first, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
@@ -678,7 +675,6 @@ __pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, 
                               __proj2);
 }
 
-// __rng1[__first, __last1), __rng2_it, __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Rng2It, typename _Compare, typename _Proj1, typename _Proj2>
 _Size1
 __pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2_it, _Compare __comp, _Proj1 __proj1,
@@ -690,7 +686,6 @@ __pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2
     return __pstl_lower_bound(__rng1, __first1, __last1, __rng2_it, __negation_reordered_comp, __proj1, __proj2);
 }
 
-// __rng1[__first, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
@@ -704,7 +699,6 @@ __pstl_right_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, 
 // When __bias_last==true, it searches first near the last element, otherwise it searches first near the first element.
 // After each iteration which fails to capture the element in the small side, it reduces the "bias", eventually
 // resulting in a standard binary search.
-// __rng1[__first1, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare,
           typename _Proj1, typename _Proj2>
 _Size1
@@ -746,7 +740,6 @@ __biased_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2
     return __first1;
 }
 
-// __rng1[__first1, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare,
           typename _Proj1, typename _Proj2>
 _Size1
@@ -821,7 +814,6 @@ struct _ReverseCounter
 };
 
 // Reverse searching for the first element strongly less than a passed value - left bound
-// __rng1[__first, __last1), __rng2(__rng2_idx), __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -638,13 +638,13 @@ __pstl_lower_bound_impl(_Size __first, _Size __last, _Comparator&& __comp)
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
-__pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
-                   _Proj1 __proj1, _Proj2 __proj2)
+__pstl_lower_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                       _Proj1 __proj1, _Proj2 __proj2)
 {
     return __pstl_lower_bound_impl(__first1, __last1,
                                    [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
                                        return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng1_idx]),
-                                                          std::invoke(__proj2, __rng2[__rng2_idx]));
+                                                                  std::invoke(__proj2, __rng2[__rng2_idx]));
                                    });
 }
 
@@ -662,13 +662,13 @@ __pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
-__pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
-                   _Proj1 __proj1, _Proj2 __proj2)
+__pstl_upper_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                       _Proj1 __proj1, _Proj2 __proj2)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
+    return __pstl_lower_bound_idx(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
 }
 
 template <typename _Rng1, typename _Size1, typename _Rng2It, typename _Compare, typename _Proj1, typename _Proj2>
@@ -685,10 +685,10 @@ __pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
-__pstl_right_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
-                   _Proj1 __proj1, _Proj2 __proj2)
+__pstl_right_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                       _Proj1 __proj1, _Proj2 __proj2)
 {
-    return __pstl_upper_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1, __proj2);
+    return __pstl_upper_bound_idx(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1, __proj2);
 }
 
 // Performs a "biased" binary search targets the split point close to one edge of the range.
@@ -698,8 +698,8 @@ __pstl_right_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, 
 template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare,
           typename _Proj1, typename _Proj2>
 _Size1
-__biased_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
-                     _Proj1 __proj1, _Proj2 __proj2)
+__biased_lower_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                         _Proj1 __proj1, _Proj2 __proj2)
 {
     auto __n = __last1 - __first1;
     std::int8_t __shift_right_div = 10; // divide by 2^10 = 1024
@@ -730,7 +730,7 @@ __biased_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2
     if (__n > 0)
     {
         // End up fully at binary search
-        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1, __proj2);
+        return oneapi::dpl::__internal::__pstl_lower_bound_idx(__rng1, __first1, __last1, __rng2, __rng2_idx, __comp, __proj1, __proj2);
     }
     return __first1;
 }
@@ -738,13 +738,14 @@ __biased_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2
 template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare,
           typename _Proj1, typename _Proj2>
 _Size1
-__biased_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
-                     _Proj1 __proj1, _Proj2 __proj2)
+__biased_upper_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx,
+                         _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __biased_lower_bound<__bias_last>(__rng1, __first1, __last1, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
+    return __biased_lower_bound_idx<__bias_last>(__rng1, __first1, __last1, __rng2, __rng2_idx,
+                                                 __negation_reordered_comp, __proj1, __proj2);
 }
 
 template <typename _IntType, typename _Acc>
@@ -811,15 +812,15 @@ struct _ReverseCounter
 template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
           typename _Proj2>
 _Size1
-__pstl_left_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
-                  _Proj1 __proj1, _Proj2 __proj2)
+__pstl_left_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                      _Proj1 __proj1, _Proj2 __proj2)
 {
     _ReverseCounter<_Size1, _Rng1> __beg{__last1 - 1};
     _ReverseCounter<_Size1, _Rng1> __end{__first1 - 1};
 
     __not_pred<decltype(__comp)> __negation_comp{__comp};
 
-    return __pstl_lower_bound(__rng1, __beg, __end, __rng2, __rng2_idx, __negation_comp, __proj1, __proj2);
+    return __pstl_lower_bound_idx(__rng1, __beg, __end, __rng2, __rng2_idx, __negation_comp, __proj1, __proj2);
 }
 
 // Lower bound implementation based on Shar's algorithm for binary search.

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -714,7 +714,7 @@ template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, type
 _Size1
 __pstl_right_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
 {
-    return __pstl_upper_bound(__rng1, __first, __last, __rng2, __rng2_idx, __comp, __proj1, __proj2); // TODO __pstl_upper_bound - operator[]
+    return __pstl_upper_bound(__rng1, __first, __last, __rng2, __rng2_idx, __comp, __proj1, __proj2);
 }
 
 // Searching for the first element strongly greater than a passed value - right bound
@@ -764,8 +764,7 @@ __biased_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, 
     if (__n > 0)
     {
         // End up fully at binary search
-        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first, __last, // TODO __pstl_lower_bound - operator[]
-                                                           __rng2, __rng2_idx, __comp, __proj1, __proj2);
+        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first, __last, __rng2, __rng2_idx, __comp, __proj1, __proj2);
     }
     return __first;
 }
@@ -825,7 +824,7 @@ __biased_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, 
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __biased_lower_bound<__bias_last>(__rng1, __first, __last, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2); // TODO __biased_lower_bound - operator[]
+    return __biased_lower_bound<__bias_last>(__rng1, __first, __last, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
 }
 
 template <bool __bias_last = true, typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj>
@@ -910,7 +909,7 @@ __pstl_left_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Si
 
     __not_pred<decltype(__comp)> __negation_comp{__comp};
 
-    return __pstl_lower_bound(__rng1, __beg, __end, __rng2, __rng2_idx, __negation_comp, __proj1, __proj2); // TODO __pstl_lower_bound - operator[]
+    return __pstl_lower_bound(__rng1, __beg, __end, __rng2, __rng2_idx, __negation_comp, __proj1, __proj2);
 }
 
 // Reverse searching for the first element strongly less than a passed value - left bound

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -639,12 +639,14 @@ __pstl_lower_bound(_Acc __acc, _Size __first, _Size __last, _Value&& __value_pro
 
 template <typename _Acc, typename _Size, typename _Value, typename _Compare, typename _Proj>
 _Size
-__pstl_upper_bound(_Acc __acc, _Size __first, _Size __last, const _Value& __value, _Compare __comp, _Proj __proj)
+__pstl_upper_bound(_Acc __acc, _Size __first, _Size __last, _Value&& __value_proj, _Compare __comp, _Proj __proj)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __pstl_lower_bound(__acc, __first, __last, __value, __negation_reordered_comp, __proj);
+    // We should forward __value_proj to preserve their value category
+    return __pstl_lower_bound(__acc, __first, __last, std::forward<_Value>(__value_proj), __negation_reordered_comp,
+                              __proj);
 }
 
 // Searching for the first element strongly greater than a passed value - right bound

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -613,7 +613,7 @@ __dpl_signbit(const _T& __x)
 
 template <typename _Acc, typename _Size, typename _Value, typename _Compare, typename _Proj>
 _Size
-__pstl_lower_bound(_Acc __acc, _Size __first, _Size __last, const _Value& __value, _Compare __comp, _Proj __proj)
+__pstl_lower_bound(_Acc __acc, _Size __first, _Size __last, _Value&& __value_proj, _Compare __comp, _Proj __proj)
 {
     auto __n = __last - __first;
     auto __cur = __n;
@@ -623,7 +623,10 @@ __pstl_lower_bound(_Acc __acc, _Size __first, _Size __last, const _Value& __valu
         __idx = __first;
         __cur = __n / 2;
         __idx += __cur;
-        if (std::invoke(__comp, std::invoke(__proj, __acc[__idx]), __value))
+
+        // We able to forward __value_proj multiple times because comparator shouldn't change it
+        // We should forward __value_proj to preserve their value category
+        if (std::invoke(__comp, std::invoke(__proj, __acc[__idx]), std::forward<_Value>(__value_proj)))
         {
             __n -= __cur + 1;
             __first = ++__idx;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -639,33 +639,36 @@ __pstl_lower_bound_impl(_Size __first, _Size __last, _Comparator&& __comp)
 }
 
 // __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
-template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
+          typename _Proj2>
 _Size1
-__pstl_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
+__pstl_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                   _Proj1 __proj1, _Proj2 __proj2)
 {
-    return __pstl_lower_bound_impl(__first, __last,
-                                   [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __idx) mutable {
-                                       return std::invoke(__comp, std::invoke(__proj1, __rng1[__idx]),
-                                                                  std::invoke(__proj2, __rng2[__rng2_idx]));
-                                   });
+    return __pstl_lower_bound_impl(
+        __first, __last, [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __idx) mutable {
+            return std::invoke(__comp, std::invoke(__proj1, __rng1[__idx]), std::invoke(__proj2, __rng2[__rng2_idx]));
+        });
 }
 
 // __rng1[__first, __last), __iterator, __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Rng2It, typename _Compare, typename _Proj1, typename _Proj2>
 _Size1
-__pstl_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2It __rng2_it, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
+__pstl_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2It __rng2_it, _Compare __comp, _Proj1 __proj1,
+                   _Proj2 __proj2)
 {
-    return __pstl_lower_bound_impl(__first, __last,
-                                   [__rng1, __rng2_it, __comp, __proj1, __proj2](_Size1 __idx) mutable {
-                                       return std::invoke(__comp, std::invoke(__proj1, __rng1[__idx]),
-                                                                  std::invoke(__proj2, *__rng2_it));
-                                   });
+    return __pstl_lower_bound_impl(
+        __first, __last, [__rng1, __rng2_it, __comp, __proj1, __proj2](_Size1 __idx) mutable {
+            return std::invoke(__comp, std::invoke(__proj1, __rng1[__idx]), std::invoke(__proj2, *__rng2_it));
+        });
 }
 
 // __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
-template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
+          typename _Proj2>
 _Size1
-__pstl_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
+__pstl_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                   _Proj1 __proj1, _Proj2 __proj2)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
@@ -676,7 +679,8 @@ __pstl_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _S
 // __rng1[__first, __last), __iterator, __comp, __proj1, __proj2
 template <typename _Rng1, typename _Size1, typename _Iterator, typename _Compare, typename _Proj1, typename _Proj2>
 _Size1
-__pstl_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Iterator __iterator, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
+__pstl_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Iterator __iterator, _Compare __comp, _Proj1 __proj1,
+                   _Proj2 __proj2)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
@@ -685,9 +689,11 @@ __pstl_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Iterator __iter
 }
 
 // __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
-template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
+          typename _Proj2>
 _Size1
-__pstl_right_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
+__pstl_right_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                   _Proj1 __proj1, _Proj2 __proj2)
 {
     return __pstl_upper_bound(__rng1, __first, __last, __rng2, __rng2_idx, __comp, __proj1, __proj2);
 }
@@ -697,9 +703,11 @@ __pstl_right_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _S
 // After each iteration which fails to capture the element in the small side, it reduces the "bias", eventually
 // resulting in a standard binary search.
 // __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
-template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1, typename _Proj2>
+template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare,
+          typename _Proj1, typename _Proj2>
 _Size1
-__biased_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
+__biased_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                     _Proj1 __proj1, _Proj2 __proj2)
 {
     auto __n = __last - __first;
     std::int8_t __shift_right_div = 10; // divide by 2^10 = 1024
@@ -730,20 +738,24 @@ __biased_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, 
     if (__n > 0)
     {
         // End up fully at binary search
-        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first, __last, __rng2, __rng2_idx, __comp, __proj1, __proj2);
+        return oneapi::dpl::__internal::__pstl_lower_bound(__rng1, __first, __last, __rng2, __rng2_idx, __comp, __proj1,
+                                                           __proj2);
     }
     return __first;
 }
 
 // __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
-template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1, typename _Proj2>
+template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare,
+          typename _Proj1, typename _Proj2>
 _Size1
-__biased_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
+__biased_upper_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                     _Proj1 __proj1, _Proj2 __proj2)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __biased_lower_bound<__bias_last>(__rng1, __first, __last, __rng2, __rng2_idx, __negation_reordered_comp, __proj1, __proj2);
+    return __biased_lower_bound<__bias_last>(__rng1, __first, __last, __rng2, __rng2_idx, __negation_reordered_comp,
+                                             __proj1, __proj2);
 }
 
 template <typename _IntType, typename _Acc>
@@ -808,9 +820,11 @@ struct _ReverseCounter
 
 // Reverse searching for the first element strongly less than a passed value - left bound
 // __rng1[__first, __last), __rng2(__rng2_idx), __comp, __proj1, __proj2
-template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
+          typename _Proj2>
 _Size1
-__pstl_left_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
+__pstl_left_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
+                  _Proj1 __proj1, _Proj2 __proj2)
 {
     auto __beg = _ReverseCounter<_Size1, _Rng1>{__last - 1};
     auto __end = _ReverseCounter<_Size1, _Rng1>{__first - 1};

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -646,8 +646,8 @@ __pstl_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2 __rng2, _S
                    _Proj1 __proj1, _Proj2 __proj2)
 {
     return __pstl_lower_bound_impl(
-        __first, __last, [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __idx) mutable {
-            return std::invoke(__comp, std::invoke(__proj1, __rng1[__idx]), std::invoke(__proj2, __rng2[__rng2_idx]));
+        __first, __last, [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
+            return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng2_idx]), std::invoke(__proj2, __rng2[__rng2_idx]));
         });
 }
 
@@ -658,8 +658,8 @@ __pstl_lower_bound(_Rng1 __rng1, _Size1 __first, _Size1 __last, _Rng2It __rng2_i
                    _Proj2 __proj2)
 {
     return __pstl_lower_bound_impl(
-        __first, __last, [__rng1, __rng2_it, __comp, __proj1, __proj2](_Size1 __idx) mutable {
-            return std::invoke(__comp, std::invoke(__proj1, __rng1[__idx]), std::invoke(__proj2, *__rng2_it));
+        __first, __last, [__rng1, __rng2_it, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
+            return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng1_idx]), std::invoke(__proj2, *__rng2_it));
         });
 }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -652,9 +652,10 @@ __pstl_upper_bound(_Acc __acc, _Size __first, _Size __last, _Value&& __value_pro
 // Searching for the first element strongly greater than a passed value - right bound
 template <typename _Buffer, typename _Index, typename _Value, typename _Compare, typename _Proj>
 _Index
-__pstl_right_bound(_Buffer& __a, _Index __first, _Index __last, const _Value& __val, _Compare __comp, _Proj __proj)
+__pstl_right_bound(_Buffer& __a, _Index __first, _Index __last, _Value&& __value_proj, _Compare __comp, _Proj __proj)
 {
-    return __pstl_upper_bound(__a, __first, __last, __val, __comp, __proj);
+    // We should forward __value_proj to preserve their value category
+    return __pstl_upper_bound(__a, __first, __last, std::forward<_Value>(__value_proj), __comp, __proj);
 }
 
 // Performs a "biased" binary search targets the split point close to one edge of the range.

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -828,8 +828,8 @@ _Size1
 __pstl_left_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp,
                   _Proj1 __proj1, _Proj2 __proj2)
 {
-    auto __beg = _ReverseCounter<_Size1, _Rng1>{__last1 - 1};
-    auto __end = _ReverseCounter<_Size1, _Rng1>{__first1 - 1};
+    _ReverseCounter<_Size1, _Rng1> __beg{__last1 - 1};
+    _ReverseCounter<_Size1, _Rng1> __end{__first1 - 1};
 
     __not_pred<decltype(__comp)> __negation_comp{__comp};
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -624,7 +624,7 @@ __pstl_lower_bound(_Acc __acc, _Size __first, _Size __last, _Value&& __value_pro
         __cur = __n / 2;
         __idx += __cur;
 
-        // We able to forward __value_proj multiple times because comparator shouldn't change it
+        // We are able to forward __value_proj multiple times because comparator shouldn't change it
         // We should forward __value_proj to preserve their value category
         if (std::invoke(__comp, std::invoke(__proj, __acc[__idx]), std::forward<_Value>(__value_proj)))
         {
@@ -680,7 +680,7 @@ __biased_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, _Value&& __value
             __cur_idx = __biased_step;
         __it = __first + __cur_idx;
 
-        // We able to forward __value_proj multiple times because comparator shouldn't change it
+        // We are able to forward __value_proj multiple times because comparator shouldn't change it
         // We should forward __value_proj to preserve their value category
         if (std::invoke(__comp, std::invoke(__proj, __acc[__it]), std::forward<_Value>(__value_proj)))
         {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -630,11 +630,8 @@ __pstl_lower_bound_impl(_Size __first, _Size __last, _Comparator&& __comp)
             __first = ++__idx;
         }
         else
-        {
             __n = __cur;
-        }
     }
-
     return __first;
 }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -645,7 +645,7 @@ __pstl_upper_bound(_Acc __acc, _Size __first, _Size __last, _Value&& __value_pro
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
     // We should forward __value_proj to preserve their value category
-    return __pstl_lower_bound(__acc, __first, __last, std::forward<_Value>(__value_proj), __negation_reordered_comp,
+    return __pstl_lower_bound(__acc, __first, __last, std::forward<_Value>(__value_proj), __negation_reordered_comp, // TODO __pstl_lower_bound - ?
                               __proj);
 }
 
@@ -655,7 +655,7 @@ _Index
 __pstl_right_bound(_Buffer& __a, _Index __first, _Index __last, _Value&& __value_proj, _Compare __comp, _Proj __proj)
 {
     // We should forward __value_proj to preserve their value category
-    return __pstl_upper_bound(__a, __first, __last, std::forward<_Value>(__value_proj), __comp, __proj);
+    return __pstl_upper_bound(__a, __first, __last, std::forward<_Value>(__value_proj), __comp, __proj); // TODO __pstl_upper_bound - operator[]
 }
 
 // Performs a "biased" binary search targets the split point close to one edge of the range.
@@ -698,7 +698,7 @@ __biased_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, _Value&& __value
     {
         // End up fully at binary search
         // We should forward __value_proj to preserve their value category
-        return oneapi::dpl::__internal::__pstl_lower_bound(__acc, __first, __last, std::forward<_Value>(__value_proj),
+        return oneapi::dpl::__internal::__pstl_lower_bound(__acc, __first, __last, std::forward<_Value>(__value_proj), // TODO __pstl_lower_bound - ?
                                                            __comp, __proj);
     }
     return __first;
@@ -712,7 +712,7 @@ __biased_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, _Value&& __value
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
     // We should forward __value_proj to preserve their value category
-    return __biased_lower_bound<__bias_last>(__acc, __first, __last, std::forward<_Value>(__value_proj), __negation_reordered_comp, __proj);
+    return __biased_lower_bound<__bias_last>(__acc, __first, __last, std::forward<_Value>(__value_proj), __negation_reordered_comp, __proj); // TODO __biased_lower_bound - ?
 }
 
 template <typename _IntType, typename _Acc>
@@ -786,7 +786,7 @@ __pstl_left_bound(_Buffer& __a, _Index __first, _Index __last, _Value&& __value_
     __not_pred<decltype(__comp)> __negation_comp{__comp};
 
     // We should forward __value_proj to preserve their value category
-    return __pstl_lower_bound(__a, __beg, __end, std::forward<_Value>(__value_proj), __negation_comp, __proj);
+    return __pstl_lower_bound(__a, __beg, __end, std::forward<_Value>(__value_proj), __negation_comp, __proj); // TODO __pstl_lower_bound - ?
 }
 
 // Lower bound implementation based on Shar's algorithm for binary search.

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -647,7 +647,7 @@ __pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, 
 {
     return __pstl_lower_bound_impl(
         __first1, __last1, [__rng1, __rng2, __rng2_idx, __comp, __proj1, __proj2](_Size1 __rng1_idx) mutable {
-            return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng2_idx]), std::invoke(__proj2, __rng2[__rng2_idx]));
+            return std::invoke(__comp, std::invoke(__proj1, __rng1[__rng1_idx]), std::invoke(__proj2, __rng2[__rng2_idx]));
         });
 }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -706,12 +706,13 @@ __biased_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, _Value&& __value
 
 template <bool __bias_last = true, typename _Acc, typename _Size1, typename _Value, typename _Compare, typename _Proj>
 _Size1
-__biased_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp, _Proj __proj)
+__biased_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, _Value&& __value_proj, _Compare __comp, _Proj __proj)
 {
     __reorder_pred<_Compare> __reordered_comp{__comp};
     __not_pred<decltype(__reordered_comp)> __negation_reordered_comp{__reordered_comp};
 
-    return __biased_lower_bound<__bias_last>(__acc, __first, __last, __value, __negation_reordered_comp, __proj);
+    // We should forward __value_proj to preserve their value category
+    return __biased_lower_bound<__bias_last>(__acc, __first, __last, std::forward<_Value>(__value_proj), __negation_reordered_comp, __proj);
 }
 
 template <typename _IntType, typename _Acc>

--- a/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
+++ b/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
@@ -240,7 +240,7 @@ test_right_biased_lower_bound_impl(Rng __rng, std::size_t __location, std::less<
 {
     auto expected_res = std::lower_bound(__rng.begin(), __rng.begin() + __location, __rng[__location], __comp);
     auto res = oneapi::dpl::__internal::__biased_lower_bound_idx</*last_biased=*/true>(
-        __rng.begin(), std::size_t{0}, __location, __rng.begin(), __location, __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
+        __rng.begin(), std::size_t{0}, __location, __rng, __location, __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
 
     if (res != expected_res - __rng.begin())
     {

--- a/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
+++ b/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
@@ -239,7 +239,7 @@ bool
 test_right_biased_lower_bound_impl(Rng __rng, std::size_t __location, std::less<typename Rng::value_type> __comp)
 {
     auto expected_res = std::lower_bound(__rng.begin(), __rng.begin() + __location, __rng[__location], __comp);
-    auto res = oneapi::dpl::__internal::__biased_lower_bound</*last_biased=*/true>(
+    auto res = oneapi::dpl::__internal::__biased_lower_bound_idx</*last_biased=*/true>(
         __rng.begin(), std::size_t{0}, __location, __rng.begin(), __location, __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
 
     if (res != expected_res - __rng.begin())

--- a/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
+++ b/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
@@ -240,7 +240,7 @@ test_right_biased_lower_bound_impl(Rng __rng, std::size_t __location, std::less<
 {
     auto expected_res = std::lower_bound(__rng.begin(), __rng.begin() + __location, __rng[__location], __comp);
     auto res = oneapi::dpl::__internal::__biased_lower_bound</*last_biased=*/true>(
-        __rng.begin(), std::size_t{0}, __location, __rng[__location], __comp, oneapi::dpl::identity{});
+        __rng.begin(), std::size_t{0}, __location, __rng.begin(), __location, __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
 
     if (res != expected_res - __rng.begin())
     {


### PR DESCRIPTION
This PR modifies binary search utility functions to compare result of both projections in one `std::invoke` call at one place.
So we avoid any life-time extensions for the source/projected values and pass projected values into comparator preserving their value category.

## Justification

Synthetic example **with compile error** based on current state of `main` branch: https://godbolt.org/z/zE7KTKPf9, https://godbolt.org/z/7e5z685cj (https://godbolt.org/z/hj6YMv6rq, https://godbolt.org/z/f9oPGbbeM with additional `static_assert` according to comment https://github.com/uxlfoundation/oneDPL/pull/2461#discussion_r2392307799 from @akukanov)
Synthetic example **without compile errors** based on current state of this PR: https://godbolt.org/z/sbz3ehhK6 (https://godbolt.org/z/aq5GxWhej with additional `static_assert` according to comment https://github.com/uxlfoundation/oneDPL/pull/2461#discussion_r2392307799 from @akukanov)

## Details

### Two functions `__pstl_lower_bound_idx` / `__pstl_lower_bound` :
- This function should be used when we using `__rng2[__rng2_idx]` value from the second range :
```C++
template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
          typename _Proj2>
_Size1
__pstl_lower_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2);
```

- This finction should be used when the value from the second range described by iterator `__rng2_it` :
```C++
template <typename _Rng1, typename _Size1, typename _Rng2It, typename _Compare, typename _Proj1, typename _Proj2>
_Size1
__pstl_lower_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2_it, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2);
```

### Two functions of `__pstl_upper_bound_idx` / `__pstl_upper_bound` :
- This function should be used when we using `__rng2[__rng2_idx]` value from the second range :
```C++
template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
          typename _Proj2>
_Size1
__pstl_upper_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2);
```

- This function should be used when the value from the second range described by iterator `__rng2_it` :
```C++
template <typename _Rng1, typename _Size1, typename _Iterator, typename _Compare, typename _Proj1, typename _Proj2>
_Size1
__pstl_upper_bound(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2It __rng2_it, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2);
```

### The function `__pstl_left_bound_idx` :
- This function should be used when we using `__rng2[__rng2_idx]` value from the second range :
```C++
template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1, typename _Proj2>
_Size1
__pstl_left_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2);
```

### The function `__pstl_right_bound_idx` :
- This function should be used when we using `__rng2[__rng2_idx]` value from the second range :
```C++
template <typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1,
          typename _Proj2>
_Size1
__pstl_right_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2);
```

### The function `__biased_lower_bound_idx` :
- This function should be used when we using `__rng2[__rng2_idx]` value from the second range :
```C++
template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1, typename _Proj2>
_Size1
__biased_lower_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2);
```

### The function `__biased_upper_bound_idx` :
- This overload should be used when we using `__rng2[__rng2_idx]` value from the second range :
```C++
template <bool __bias_last = true, typename _Rng1, typename _Size1, typename _Size2, typename _Rng2, typename _Compare, typename _Proj1, typename _Proj2>
_Size1
__biased_upper_bound_idx(_Rng1 __rng1, _Size1 __first1, _Size1 __last1, _Rng2 __rng2, _Size2 __rng2_idx, _Compare __comp, _Proj1 __proj1, _Proj2 __proj2);
```
