### PR TITLE
Fix <range> inclusion in range memory tests

### DIFF
--- a/test/parallel_api/ranges/std_ranges_destroy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_destroy.pass.cpp
@@ -15,13 +15,14 @@
 
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/memory>
-#include <oneapi/dpl/ranges>
 
 #include "support/test_config.h"
 #include "support/test_macros.h"
 #include "support/utils.h"
 
 #if _ENABLE_STD_RANGES_TESTING
+#include <ranges>
+
 #include "std_ranges_memory_test.h"
 #endif //_ENABLE_STD_RANGES_TESTING
 

--- a/test/parallel_api/ranges/std_ranges_uninitialized_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_uninitialized_copy.pass.cpp
@@ -15,13 +15,13 @@
 
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/memory>
-#include <oneapi/dpl/ranges>
 
 #include "support/test_config.h"
 #include "support/test_macros.h"
 #include "support/utils.h"
 
 #if _ENABLE_STD_RANGES_TESTING
+#include <ranges>
 
 #include "std_ranges_memory_test.h"
 

--- a/test/parallel_api/ranges/std_ranges_uninitialized_default_construct.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_uninitialized_default_construct.pass.cpp
@@ -15,13 +15,14 @@
 
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/memory>
-#include <oneapi/dpl/ranges>
 
 #include "support/test_config.h"
 #include "support/test_macros.h"
 #include "support/utils.h"
 
 #if _ENABLE_STD_RANGES_TESTING
+#include <ranges>
+
 #include "std_ranges_memory_test.h"
 #endif //_ENABLE_STD_RANGES_TESTING
 

--- a/test/parallel_api/ranges/std_ranges_uninitialized_fill.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_uninitialized_fill.pass.cpp
@@ -15,13 +15,14 @@
 
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/memory>
-#include <oneapi/dpl/ranges>
 
 #include "support/test_config.h"
 #include "support/test_macros.h"
 #include "support/utils.h"
 
 #if _ENABLE_STD_RANGES_TESTING
+#include <ranges>
+
 #include "std_ranges_memory_test.h"
 #endif //_ENABLE_STD_RANGES_TESTING
 

--- a/test/parallel_api/ranges/std_ranges_uninitialized_move.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_uninitialized_move.pass.cpp
@@ -15,13 +15,13 @@
 
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/memory>
-#include <oneapi/dpl/ranges>
 
 #include "support/test_config.h"
 #include "support/test_macros.h"
 #include "support/utils.h"
 
 #if _ENABLE_STD_RANGES_TESTING
+#include <ranges>
 
 #include "std_ranges_memory_test.h"
 

--- a/test/parallel_api/ranges/std_ranges_uninitialized_value_construct.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_uninitialized_value_construct.pass.cpp
@@ -15,13 +15,14 @@
 
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/memory>
-#include <oneapi/dpl/ranges>
 
 #include "support/test_config.h"
 #include "support/test_macros.h"
 #include "support/utils.h"
 
 #if _ENABLE_STD_RANGES_TESTING
+#include <ranges>
+
 #include "std_ranges_memory_test.h"
 #endif //_ENABLE_STD_RANGES_TESTING
 


### PR DESCRIPTION
The initial motivation is to avoid inclusion of <oneapi/dpl/ranges> everywhere, even with c++17. 
Second, its inclusion is not needed, and can be replaced with just <ranges>. 