### PR TITLE
Skip XPU drop_view test with libstdc++10

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -324,6 +324,6 @@
 #endif
 
 // Drop view throws exceptions in libstdc++ 10
-#define _PSTL_LIBCPP_RANGE_DROP_VIEW_BROKEN (_GLIBCXX_RELEASE == 10)
+#define _PSTL_LIBSTDCXX_XPU_DROP_VIEW_BROKEN (_GLIBCXX_RELEASE == 10)
 
 #endif // _TEST_CONFIG_H

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -323,4 +323,7 @@
 #    define _PSTL_LIBCPP_RANGE_SET_BROKEN 0
 #endif
 
+// Drop view throws exceptions in libstdc++ 10
+#define _PSTL_LIBCPP_RANGE_DROP_VIEW_BROKEN (_GLIBCXX_RELEASE == 10)
+
 #endif // _TEST_CONFIG_H

--- a/test/xpu_api/ranges/xpu_std_drop_view.pass.cpp
+++ b/test/xpu_api/ranges/xpu_std_drop_view.pass.cpp
@@ -27,7 +27,7 @@ main()
 {
     bool bProcessed = false;
 
-#if _ENABLE_STD_RANGES_TESTING && !_PSTL_LIBCPP_RANGE_DROP_VIEW_BROKEN
+#if _ENABLE_STD_RANGES_TESTING && !_PSTL_LIBSTDCXX_XPU_DROP_VIEW_BROKEN
     auto test = [](){
         auto res = std::ranges::views::iota(0, 4) | std::ranges::views::drop(2);
         return res.size() == 2 && res[0] == 2 && res[1] == 3 && *res.begin() == 2
@@ -36,7 +36,7 @@ main()
     const bool res = kernel_test<class std_drop_test>(test);
     EXPECT_TRUE(res, "Wrong result of drop_view check within a kernel");
     bProcessed = true;
-#endif //_ENABLE_STD_RANGES_TESTING && !_PSTL_LIBCPP_RANGE_DROP_VIEW_BROKEN
+#endif //_ENABLE_STD_RANGES_TESTING && !_PSTL_LIBSTDCXX_XPU_DROP_VIEW_BROKEN
 
     return TestUtils::done(bProcessed);
 }

--- a/test/xpu_api/ranges/xpu_std_drop_view.pass.cpp
+++ b/test/xpu_api/ranges/xpu_std_drop_view.pass.cpp
@@ -25,7 +25,9 @@
 int
 main()
 {
-#if _ENABLE_STD_RANGES_TESTING
+    bool bProcessed = false;
+
+#if _ENABLE_STD_RANGES_TESTING && !_PSTL_LIBCPP_RANGE_DROP_VIEW_BROKEN
     auto test = [](){
         auto res = std::ranges::views::iota(0, 4) | std::ranges::views::drop(2);
         return res.size() == 2 && res[0] == 2 && res[1] == 3 && *res.begin() == 2
@@ -33,7 +35,8 @@ main()
     };
     const bool res = kernel_test<class std_drop_test>(test);
     EXPECT_TRUE(res, "Wrong result of drop_view check within a kernel");
-#endif //_ENABLE_STD_RANGES_TESTING
+    bProcessed = true;
+#endif //_ENABLE_STD_RANGES_TESTING && !_PSTL_LIBCPP_RANGE_DROP_VIEW_BROKEN
 
-    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+    return TestUtils::done(bProcessed);
 }


### PR DESCRIPTION
Known limitations:
> * ``std::ranges::drop_view`` from libstdc++ version 10 may throw exceptions.
  This can lead to a "SYCL kernel cannot use exceptions" compilation error
  when it is used to pass data to a range-based algorithm with a device policy.

Issue:
> In file included from /tmp/oneDPL/test/xpu_api/ranges/xpu_std_drop_view.pass.cpp:18:
In file included from /tmp/oneDPL/test/support/utils.h:24:
In file included from /tmp/oneDPL/include/oneapi/dpl/execution:23:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/execution:32:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/pstl/glue_execution_defs.h:50:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/pstl/algorithm_impl.h:13:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/iterator:66:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/streambuf_iterator.h:35:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/streambuf:41:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/ios_base.h:41:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/locale_classes.h:40:
In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/string:54:
/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/range_access.h:981:6: error: SYCL kernel cannot use exceptions
  981 |             throw "attempt to decrement a non-bidirectional iterator";
