### PR TITLE
Histogram: workaround kernel compilation issues with icpx 2025.3

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -8,6 +8,17 @@ The Intel® oneAPI DPC++ Library (oneDPL) accompanies the Intel® oneAPI DPC++/C
 and provides high-productivity APIs aimed to minimize programming efforts of C++ developers
 creating efficient heterogeneous applications.
 
+New in 2022.10.0
+===============
+
+Known Issues and Limitations
+----------------------------
+New in This Release
+^^^^^^^^^^^^^^^^^^^
+- Calling ``histogram`` algorithm with a device execution policy may cause a segmentation fault in
+  Intel® oneAPI DPC++/C++ Compiler 2025.3 when building a program for CPU devices.
+  To avoid this, define ``ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION`` macro to a non-zero value.
+
 New in 2022.9.0
 ===============
 

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -16,7 +16,7 @@ Known Issues and Limitations
 New in This Release
 ^^^^^^^^^^^^^^^^^^^
 - Calling ``histogram`` algorithm with a device execution policy may cause a segmentation fault in
-  Intel® oneAPI DPC++/C++ Compiler 2025.3 when building a program for CPU devices.
+  Intel® oneAPI DPC++/C++ Compiler 2025.3 when compiling SYCL kernels for CPU devices.
   To avoid this, define ``ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION`` macro to a non-zero value.
 
 New in 2022.9.0

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -9,7 +9,7 @@ and provides high-productivity APIs aimed to minimize programming efforts of C++
 creating efficient heterogeneous applications.
 
 New in 2022.10.0
-===============
+================
 
 Known Issues and Limitations
 ----------------------------
@@ -17,7 +17,8 @@ New in This Release
 ^^^^^^^^^^^^^^^^^^^
 - Calling ``histogram`` algorithm with a device execution policy may cause a segmentation fault in
   Intel® oneAPI DPC++/C++ Compiler 2025.3 when compiling SYCL kernels for CPU devices.
-  To avoid this, define ``ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION`` macro to a non-zero value.
+  To avoid this, define ``ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION`` macro to a non-zero value
+  prior to including oneDPL header files.
 
 New in 2022.9.0
 ===============

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -504,12 +504,10 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, std::uint16_t(1024));
 
     auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
-    constexpr ::std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
 
-// DPC++ 2025.3 fails with a segfault when compiling __histogram_general_registers_local_reduction kernel
-#if !defined(__INTEL_LLVM_COMPILER) || (__INTEL_LLVM_COMPILER < 20250300 || __INTEL_LLVM_COMPILER >= 20250400)
+#if _ONEDPL_ENABLE_HISTOGRAM_REGISTER_REDUCTION
+    constexpr std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
     // if bins fit into registers, use register private accumulation
-
     if (__num_bins <= __max_work_item_private_bins)
     {
         return __future(__histogram_general_registers_local_reduction<_CustomName, __iters_per_work_item,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -495,7 +495,6 @@ __future<sycl::event>
 __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_event, _Range1&& __input,
                                    _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
-    using _private_histogram_type = ::std::uint16_t;
     using _local_histogram_type = ::std::uint32_t;
     using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
@@ -509,6 +508,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 // for CPU devices
 // defining ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION to a non-zero value bypasses this issue
 #if !ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION
+    using _private_histogram_type = ::std::uint16_t;
     constexpr std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
     // if bins fit into registers, use register private accumulation
     if (__num_bins <= __max_work_item_private_bins)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -505,7 +505,10 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 
     auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
 
-#if !_ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION
+// DPC++ 2025.3 fails with a segfault when compiling __histogram_general_registers_local_reduction kernel
+// for CPU devices
+// defining ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION to a non-zero value bypasses this issue
+#if !ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION
     constexpr std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
     // if bins fit into registers, use register private accumulation
     if (__num_bins <= __max_work_item_private_bins)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -495,7 +495,7 @@ __future<sycl::event>
 __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_event, _Range1&& __input,
                                    _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
-    using _local_histogram_type = ::std::uint32_t;
+    using _local_histogram_type = std::uint32_t;
     using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
     const auto __num_bins = __bins.size();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -505,7 +505,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 
     auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
 
-#if _ONEDPL_ENABLE_HISTOGRAM_REGISTER_REDUCTION
+#if !_ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION
     constexpr std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
     // if bins fit into registers, use register private accumulation
     if (__num_bins <= __max_work_item_private_bins)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -515,11 +515,9 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
             __q, __init_event, __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
             __binhash_manager));
     }
-    else if
-#else
-    if
+    else
 #endif
-        (__num_bins * sizeof(_local_histogram_type) +
+    if (__num_bins * sizeof(_local_histogram_type) +
 
     // if bins fit into SLM, use local atomics
                  __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type) <

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -506,7 +506,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
     constexpr ::std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
 
-// DPC++ 2025.3 fails to compile __histogram_general_registers_local_reduction kernel
+// DPC++ 2025.3 fails with a segfault when compiling __histogram_general_registers_local_reduction kernel
 #if !defined(__INTEL_LLVM_COMPILER) || (__INTEL_LLVM_COMPILER < 20250300 || __INTEL_LLVM_COMPILER >= 20250400)
     // if bins fit into registers, use register private accumulation
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -508,7 +508,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 // for CPU devices
 // defining ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION to a non-zero value bypasses this issue
 #if !ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION
-    using _private_histogram_type = ::std::uint16_t;
+    using _private_histogram_type = std::uint16_t;
     constexpr std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
     // if bins fit into registers, use register private accumulation
     if (__num_bins <= __max_work_item_private_bins)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -506,7 +506,10 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
     constexpr ::std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
 
+// DPC++ 2025.3 fails to compile __histogram_general_registers_local_reduction kernel
+#if !defined(__INTEL_LLVM_COMPILER) || (__INTEL_LLVM_COMPILER < 20250300 || __INTEL_LLVM_COMPILER >= 20250400)
     // if bins fit into registers, use register private accumulation
+
     if (__num_bins <= __max_work_item_private_bins)
     {
         return __future(__histogram_general_registers_local_reduction<_CustomName, __iters_per_work_item,
@@ -514,8 +517,13 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
             __q, __init_event, __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
             __binhash_manager));
     }
+    else if
+#else
+    if
+#endif
+        (__num_bins * sizeof(_local_histogram_type) +
+
     // if bins fit into SLM, use local atomics
-    else if (__num_bins * sizeof(_local_histogram_type) +
                  __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type) <
              __local_mem_size)
     {

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -350,12 +350,12 @@
 
 // DPC++ 2025.3 fails with a segfault when compiling __histogram_general_registers_local_reduction kernel
 // for CPU devices
-// Allow manually enabling this kernel for more performant execution on GPU devices.
+// ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION public macro can be used to bypass the issue
 #if !defined(__INTEL_LLVM_COMPILER) || (__INTEL_LLVM_COMPILER < 20250300 || __INTEL_LLVM_COMPILER >= 20250400) || \
-    defined(ONEDPL_ENABLE_HISTOGRAM_REGISTER_REDUCTION)
-#    define _ONEDPL_ENABLE_HISTOGRAM_REGISTER_REDUCTION 1
+    !defined(ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION)
+#    define _ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION 0
 #else
-#    define _ONEDPL_ENABLE_HISTOGRAM_REGISTER_REDUCTION 0
+#    define _ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION 1
 #endif
 
 #endif // _ONEDPL_CONFIG_H

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -348,4 +348,14 @@
 #    define _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT __has_builtin(__builtin_sycl_unique_stable_name)
 #endif // _ONEDPL_BACKEND_SYCL
 
+// DPC++ 2025.3 fails with a segfault when compiling __histogram_general_registers_local_reduction kernel
+// for CPU devices
+// Allow manually enabling this kernel for more performant execution on GPU devices.
+#if !defined(__INTEL_LLVM_COMPILER) || (__INTEL_LLVM_COMPILER < 20250300 || __INTEL_LLVM_COMPILER >= 20250400) || \
+    defined(ONEDPL_ENABLE_HISTOGRAM_REGISTER_REDUCTION)
+#    define _ONEDPL_ENABLE_HISTOGRAM_REGISTER_REDUCTION 1
+#else
+#    define _ONEDPL_ENABLE_HISTOGRAM_REGISTER_REDUCTION 0
+#endif
+
 #endif // _ONEDPL_CONFIG_H

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -348,14 +348,4 @@
 #    define _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT __has_builtin(__builtin_sycl_unique_stable_name)
 #endif // _ONEDPL_BACKEND_SYCL
 
-// DPC++ 2025.3 fails with a segfault when compiling __histogram_general_registers_local_reduction kernel
-// for CPU devices
-// ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION public macro can be used to bypass the issue
-#if !defined(__INTEL_LLVM_COMPILER) || (__INTEL_LLVM_COMPILER < 20250300 || __INTEL_LLVM_COMPILER >= 20250400) || \
-    !defined(ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION)
-#    define _ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION 0
-#else
-#    define _ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION 1
-#endif
-
 #endif // _ONEDPL_CONFIG_H


### PR DESCRIPTION
icpx 2025.3 (latest nightly build version) fails to compile `__histogram_general_registers_local_reduction` kernel for CPU devices.

The issue has already been reported, but a potential fix will not likely make it into the release. A quick solution is to fall back to a less optimized kernel. 

The fall back is done on demand by defining `ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION` to a non-zero value.
The plan is to mention this macro in the release notes as a workaround with no promise of having it for the future releases.
