### PR TITLE
Workaround an issue with drop_view and libstdc++10 in views test

### DIFF
--- a/test/parallel_api/ranges/std_ranges_test_views.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_test_views.pass.cpp
@@ -71,8 +71,10 @@ test_impl_hetero(Policy&& exec)
     //take view
     test_range_algo<2>{n}.test_view_hetero(CLONE_TEST_POLICY(exec), std::views::take(n/2), dpl_ranges::count_if, std::ranges::count_if, pred, proj);
 
+#if !_PSTL_LIBSTDCXX_XPU_DROP_VIEW_BROKEN
     //drop view
     test_range_algo<3>{n}.test_view_hetero(CLONE_TEST_POLICY(exec), std::views::drop(n/2), dpl_ranges::count_if, std::ranges::count_if, pred, proj);
+#endif
 
     //NOTICE: std::ranges::views::all, std::ranges::subrange, std::span are tested implicitly within the 'test_range_algo' test engine.
 }


### PR DESCRIPTION
One more case in the tests with the issue:

```c++
n file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/string:54:
/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/range_access.h:981:6: error: SYCL kernel cannot use exceptions
  981 |             throw "attempt to decrement a non-bidirectional iterator";

```