### PR TITLE
Fix range iterators usage after range perfect forwarding

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1102,7 +1102,7 @@ struct __reverse_fn
         auto __last = std::ranges::begin(__r) + std::ranges::size(__r);
 
         oneapi::dpl::__internal::__ranges::__pattern_reverse(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                             std::forward<_R>(__r));
+                                                             __r);
         return std::ranges::borrowed_iterator_t<_R>{__last};
     }
 
@@ -1171,8 +1171,8 @@ struct __is_sorted_until_fn
     {
         auto __last = std::ranges::begin(__r) + std::ranges::size(__r);
 
-        auto __it = oneapi::dpl::ranges::adjacent_find(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__reorder_pred<_Comp>(__comp), __proj);
+        auto __it = oneapi::dpl::ranges::adjacent_find(std::forward<_ExecutionPolicy>(__exec), __r,
+                                                       oneapi::dpl::__internal::__reorder_pred<_Comp>(__comp), __proj);
         return __it == __last ? __last : ++__it;
     }
 }; //__is_sorted_until_fn

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -936,7 +936,7 @@ __pattern_merge_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exe
         std::ranges::borrowed_iterator_t<_OutRange>>;
 
     return __return_t{std::ranges::begin(__r1) + __res.first, std::ranges::begin(__r2) + __res.second,
-            std::ranges::begin(__out_r) + __n_out};
+                      std::ranges::begin(__out_r) + __n_out};
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -806,8 +806,8 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     auto __beg_out = std::ranges::begin(__out_r);
 
     auto __idx = oneapi::dpl::__internal::__ranges::__pattern_unique_copy(
-        __tag, std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__ranges::views::all_read(std::forward<_R>(__r)),
-        oneapi::dpl::__ranges::views::all_write(std::forward<_OutRange>(__out_r)), __pred_2);
+        __tag, std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__ranges::views::all_read(__r),
+        oneapi::dpl::__ranges::views::all_write(__out_r), __pred_2);
 
     return {__end, __beg_out + __idx};
 }
@@ -853,7 +853,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&
     auto __beg = std::ranges::begin(__r);
     auto __end = __beg + std::ranges::size(__r);
     auto __idx = oneapi::dpl::__internal::__ranges::__pattern_unique(
-        __tag, std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__ranges::views::all(std::forward<_R>(__r)),
+        __tag, std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__ranges::views::all(__r),
         __pred_2);
 
     return std::ranges::borrowed_subrange_t<_R>(__beg + __idx, __end);
@@ -936,7 +936,7 @@ __pattern_merge_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exe
         std::ranges::borrowed_iterator_t<_OutRange>>;
 
     return __return_t{std::ranges::begin(__r1) + __res.first, std::ranges::begin(__r2) + __res.second,
-                      std::ranges::begin(__out_r) + __n_out};
+            std::ranges::begin(__out_r) + __n_out};
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1,
@@ -998,8 +998,7 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_1>(
                 std::forward<_ExecutionPolicy>(__exec)),
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, std::forward<_R2>(__r2),
-            std::forward<_OutRange>(__out_r));
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, __r2, __out_r);
 
         return {__first1, __first2 + __n2, __result + __idx};
     }
@@ -1011,15 +1010,14 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_2>(
                 std::forward<_ExecutionPolicy>(__exec)),
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, std::forward<_R1>(__r1),
-            std::forward<_OutRange>(__out_r));
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, __r1, __out_r);
 
         return {__first1 + __n1, __first2, __result + __idx};
     }
 
     const std::size_t __result_size = __par_backend_hetero::__parallel_set_op<unseq_backend::_UnionTag>(
-        _BackendTag{}, unseq_backend::_UnionTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1),
-        std::forward<_R2>(__r2), std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+        _BackendTag{}, unseq_backend::_UnionTag{}, std::forward<_ExecutionPolicy>(__exec), __r1, __r2, __out_r, __comp,
+        __proj1, __proj2);
 
     return {__first1 + __n1, __first2 + __n2, __result + __result_size};
 }
@@ -1043,8 +1041,8 @@ __pattern_set_intersection(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
         return {__first1 + __n1, __first2 + __n2, __result};
 
     const std::size_t __result_size = __par_backend_hetero::__parallel_set_op<unseq_backend::_IntersectionTag>(
-        _BackendTag{}, unseq_backend::_IntersectionTag{}, std::forward<_ExecutionPolicy>(__exec),
-        std::forward<_R1>(__r1), std::forward<_R2>(__r2), std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+        _BackendTag{}, unseq_backend::_IntersectionTag{}, std::forward<_ExecutionPolicy>(__exec), __r1, __r2, __out_r,
+        __comp, __proj1, __proj2);
 
     return {__first1 + __n1, __first2 + __n2, __result + __result_size};
 }
@@ -1075,15 +1073,14 @@ __pattern_set_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_difference_copy_case_1>(
                 std::forward<_ExecutionPolicy>(__exec)),
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, std::forward<_R1>(__r1),
-            std::forward<_OutRange>(__out_r));
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, __r1, __out_r);
 
         return {__first1 + __n1, __result + __idx};
     }
 
     const std::size_t __result_size = __par_backend_hetero::__parallel_set_op<unseq_backend::_DifferenceTag>(
-        _BackendTag{}, unseq_backend::_DifferenceTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1),
-        std::forward<_R2>(__r2), std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+        _BackendTag{}, unseq_backend::_DifferenceTag{}, std::forward<_ExecutionPolicy>(__exec), __r1,
+        std::forward<_R2>(__r2), __out_r, __comp, __proj1, __proj2);
 
     return {__first1 + __n1, __result + __result_size};
 }
@@ -1120,8 +1117,7 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_copy_case_1>(
                 std::forward<_ExecutionPolicy>(__exec)),
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, std::forward<_R2>(__r2),
-            std::forward<_OutRange>(__out_r));
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, __r2, __out_r);
 
         return {__first1, __first2 + __n2, __result + __idx};
     }
@@ -1133,15 +1129,14 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
             __tag,
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_copy_case_2>(
                 std::forward<_ExecutionPolicy>(__exec)),
-            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, std::forward<_R1>(__r1),
-            std::forward<_OutRange>(__out_r));
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>>{}, __r1, __out_r);
 
         return {__first1 + __n1, __first2, __result + __idx};
     }
 
     const std::size_t __result_size = __par_backend_hetero::__parallel_set_op<unseq_backend::_SymmetricDifferenceTag>(
-        _BackendTag{}, unseq_backend::_SymmetricDifferenceTag{}, std::forward<_ExecutionPolicy>(__exec),
-        std::forward<_R1>(__r1), std::forward<_R2>(__r2), std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+        _BackendTag{}, unseq_backend::_SymmetricDifferenceTag{}, std::forward<_ExecutionPolicy>(__exec), __r1, __r2,
+        __out_r, __comp, __proj1, __proj2);
 
     return {__first1 + __n1, __first2 + __n2, __result + __result_size};
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -852,9 +852,8 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&
 
     auto __beg = std::ranges::begin(__r);
     auto __end = __beg + std::ranges::size(__r);
-    auto __idx = oneapi::dpl::__internal::__ranges::__pattern_unique(
-        __tag, std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__ranges::views::all(__r),
-        __pred_2);
+    auto __idx = oneapi::dpl::__internal::__ranges::__pattern_unique(__tag, std::forward<_ExecutionPolicy>(__exec),
+                                                                     oneapi::dpl::__ranges::views::all(__r), __pred_2);
 
     return std::ranges::borrowed_subrange_t<_R>(__beg + __idx, __end);
 }

--- a/include/oneapi/dpl/pstl/hetero/memory_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/memory_ranges_impl_hetero.h
@@ -75,15 +75,13 @@ __pattern_uninitialized_value_construct(__hetero_tag<_BackendTag> __tag, _Execut
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
             __tag, std::forward<_ExecutionPolicy>(__exec),
-            oneapi::dpl::__internal::__brick_fill<__hetero_tag<_BackendTag>, _ValueType>{_ValueType()},
-            std::forward<_R>(__r));
+            oneapi::dpl::__internal::__brick_fill<__hetero_tag<_BackendTag>, _ValueType>{_ValueType()}, __r);
     }
     else
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
             __tag, std::forward<_ExecutionPolicy>(__exec),
-            oneapi::dpl::__internal::__op_uninitialized_value_construct<std::decay_t<_ExecutionPolicy>>{},
-            std::forward<_R>(__r));
+            oneapi::dpl::__internal::__op_uninitialized_value_construct<std::decay_t<_ExecutionPolicy>>{}, __r);
     }
 
     return __last;
@@ -222,7 +220,7 @@ __pattern_destroy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
             __tag, std::forward<_ExecutionPolicy>(__exec),
-            oneapi::dpl::__internal::__op_destroy<std::decay_t<_ExecutionPolicy>>{}, std::forward<_R>(__r));
+            oneapi::dpl::__internal::__op_destroy<std::decay_t<_ExecutionPolicy>>{}, __r);
     }
 
     return __last;


### PR DESCRIPTION
This PR fixes an issue where range iterators were being used after the range objects had been moved, which could lead to undefined behavior. It's looked not quite correct. The changes remove unnecessary `std::forward` calls when passing range parameters that need to remain valid for subsequent iterator operations.

- Remove `std::forward` calls for range parameters that are accessed after being passed to functions
- Ensure range objects remain valid when their iterators are used later in the same scope
- Apply consistent parameter passing pattern across multiple algorithm implementations
