### PR TITLE
Fix duplicate kernel name issue in __parallel_transform_reduce_impl with differing init types

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -305,7 +305,7 @@ struct __parallel_transform_reduce_impl
     {
         using _NoOpFunctor = unseq_backend::walk_n<oneapi::dpl::identity>;
         using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            __reduce_kernel, _CustomName, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
+            __reduce_kernel, _CustomName, _Tp, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
 
         auto __transform_pattern1 =
             unseq_backend::transform_reduce<_ReduceOp, _TransformOp, _Tp, _Commutative, _VecSize>{__reduce_op,

--- a/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
@@ -111,6 +111,22 @@ test_short_forms()
     }
 }
 
+void
+test_differing_init_type()
+{
+    using InitType = std::uint64_t;
+    using InputType = std::uint32_t;
+    // Test is designed to check compilation issues, so only a single test run is sufficient.
+    size_t n = 10042;
+    Sequence<InputType> in(n, [](size_t) { return 1; });
+    InitType init = 42;
+    InitType expected = init + n;
+
+    invoke_on_all_policies<0>()(test_long_reduce<InitType>(), in.begin(), in.end(), init, std::plus<>{}, expected);
+    invoke_on_all_policies<1>()(test_long_reduce<InputType>(), in.begin(), in.end(), static_cast<InputType>(init),
+                                std::plus<>{}, static_cast<InputType>(expected));
+}
+
 int
 main()
 {
@@ -127,6 +143,10 @@ main()
 
     // Short forms are just facade for long forms, so just test with a single type.
     test_short_forms();
+
+    // Test designed to capture kernel naming issues with the edge case where the init type differs from the sequence
+    // input type with the same binary operator.
+    test_differing_init_type();
 
     return done();
 }

--- a/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
@@ -117,8 +117,8 @@ test_differing_init_type()
     using InitType = std::uint64_t;
     using InputType = std::uint32_t;
     // Test is designed to check compilation issues, so only a single test run is sufficient.
-    size_t n = 10042;
-    Sequence<InputType> in(n, [](size_t) { return 1; });
+    std::size_t n = 10042;
+    Sequence<InputType> in(n, [](std::size_t) { return 1; });
     InitType init = 42;
     InitType expected = init + n;
 


### PR DESCRIPTION
When `oneapi::dpl::reduce` is called multiple times with a device policy and the only difference in the calls is the type of the initial value, different kernels are generated but we use the same kernel name. This results in a compilation error.

To fix this issue, we need to add the initial value type `_Tp` as a template argument to the call to `__kernel_name_generator` when generating the reduction kernel name.