### PR TITLE
Revert the workaround for kernel compilation issues in histogram

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -8,6 +8,18 @@ The Intel® oneAPI DPC++ Library (oneDPL) accompanies the Intel® oneAPI DPC++/C
 and provides high-productivity APIs aimed to minimize programming efforts of C++ developers
 creating efficient heterogeneous applications.
 
+New in 2022.10.0
+================
+
+Known Issues and Limitations
+----------------------------
+New in This Release
+^^^^^^^^^^^^^^^^^^^
+- Calling ``histogram`` algorithm with a device execution policy may cause a segmentation fault in
+  Intel® oneAPI DPC++/C++ Compiler 2025.3 when compiling SYCL kernels for CPU devices.
+  To avoid this, define ``ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION`` macro to a non-zero value
+  prior to including oneDPL header files.
+
 New in 2022.9.0
 ===============
 

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -8,18 +8,6 @@ The Intel® oneAPI DPC++ Library (oneDPL) accompanies the Intel® oneAPI DPC++/C
 and provides high-productivity APIs aimed to minimize programming efforts of C++ developers
 creating efficient heterogeneous applications.
 
-New in 2022.10.0
-================
-
-Known Issues and Limitations
-----------------------------
-New in This Release
-^^^^^^^^^^^^^^^^^^^
-- Calling ``histogram`` algorithm with a device execution policy may cause a segmentation fault in
-  Intel® oneAPI DPC++/C++ Compiler 2025.3 when compiling SYCL kernels for CPU devices.
-  To avoid this, define ``ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION`` macro to a non-zero value
-  prior to including oneDPL header files.
-
 New in 2022.9.0
 ===============
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -495,7 +495,8 @@ __future<sycl::event>
 __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_event, _Range1&& __input,
                                    _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
-    using _local_histogram_type = std::uint32_t;
+    using _private_histogram_type = ::std::uint16_t;
+    using _local_histogram_type = ::std::uint32_t;
     using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
     const auto __num_bins = __bins.size();
@@ -503,13 +504,8 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, std::uint16_t(1024));
 
     auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
+    constexpr ::std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
 
-// DPC++ 2025.3 fails with a segfault when compiling __histogram_general_registers_local_reduction kernel
-// for CPU devices
-// defining ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION to a non-zero value bypasses this issue
-#if !ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION
-    using _private_histogram_type = std::uint16_t;
-    constexpr std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
     // if bins fit into registers, use register private accumulation
     if (__num_bins <= __max_work_item_private_bins)
     {
@@ -518,11 +514,8 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
             __q, __init_event, __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
             __binhash_manager));
     }
-    else
-#endif
-    if (__num_bins * sizeof(_local_histogram_type) +
-
     // if bins fit into SLM, use local atomics
+    else if (__num_bins * sizeof(_local_histogram_type) +
                  __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type) <
              __local_mem_size)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -495,8 +495,8 @@ __future<sycl::event>
 __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_event, _Range1&& __input,
                                    _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
-    using _private_histogram_type = ::std::uint16_t;
-    using _local_histogram_type = ::std::uint32_t;
+    using _private_histogram_type = std::uint16_t;
+    using _local_histogram_type = std::uint32_t;
     using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
     const auto __num_bins = __bins.size();
@@ -504,7 +504,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, std::uint16_t(1024));
 
     auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
-    constexpr ::std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
+    constexpr std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
 
     // if bins fit into registers, use register private accumulation
     if (__num_bins <= __max_work_item_private_bins)


### PR DESCRIPTION
The compiler devs have already fixed the issue workarounded by #2465. The fix going to be cherry-picked into icpx 2025.3.
The documentation change is better to be done separately to target oneDPL 2022.10. 
