### PR TITLE
Release notes for 2022.10

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -29,7 +29,9 @@ New Features
   device execution policies on GPUs.
 - Improved performance of set operation algorithms when using device policies: ``set_union``, ``set_difference``,
   ``set_intersection``, ``set_symmetric_difference``.
-- Improved performance of parallel_find_or–based algorithms on Intel® Arc™ B-series GPU devices.
+- Improved performance of ``adjacent_find``, ``all_of``, ``any_of``, ``none_of``, ``equal``, ``find_end``,
+  ``find_first_of``, ``find_if``, ``find_if_not``, ``includes``, ``is_heap``, ``is_heap_until``, ``mismatch``,
+  ``search``, ``search_n``, algorithms on Intel® Arc™ B-series GPU devices.
 - Removed requirement of GPU double support to use ``set_union``, ``set_difference``, ``set_intersection``, and
   ``set_symmetric_difference`` on Windows operating systems.
 - Removed copy constructible requirements from value type for ``reduce`` and ``transform_reduce`` algorithms when used

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -29,7 +29,8 @@ New Features
   device execution policies on GPUs.
 - Improved performance of set operation algorithms when using device policies: ``set_union``, ``set_difference``,
   ``set_intersection``, ``set_symmetric_difference``. Removed default constructible requirements from value type of
-  reduce and transform_reduce when used with an execution policy. 
+  reduce and transform_reduce when used with an execution policy.
+- Improved performance of parallel_find_or–based algorithms on Intel® Arc™ B-series GPU devices.
 - Removed requirement of GPU double support to use ``set_union``, ``set_difference``, ``set_intersection``, and
   ``set_symmetric_difference`` on Windows operating systems.
 - Removed copy constructible requirements from value type for reduce and transform_reduce algorithms when used with a
@@ -46,6 +47,9 @@ Fixed Issues
   iterator.
 - Fixed a bug in ``oneapi::dpl::inclusive_scan`` and all prefix sum algorithms when using device policies with differing
   ``InputIterator`` and ``OutputIterator`` types.
+- Fixed error in return value types for oneapi::dpl::ranges::minmax_element and oneapi::dpl::ranges::mismatch algorithms.
+- Fixed compile errors in ``oneapi::dpl::set_union`` and ``oneapi::dpl::set_symmetric_difference`` for hetero execution
+  policies when the types of the second data and results data are different.
 
 Known Issues and Limitations
 ----------------------------

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -11,6 +11,11 @@ creating efficient heterogeneous applications.
 New in 2022.10.0
 ================
 
+Deprecation Notices
+-------------------
+The ``ONEDPL_USE_AOT_COMPILATION`` and ``ONEDPL_AOT_ARCH`` CMake options are deprecated and will be removed in a future
+release. Please use the relevant compiler flags to enable this feature.
+
 New Features
 ------------
 - Added parallel range algorithms in ``namespace oneapi::dpl::ranges``: ``set_intersection``, ``set_union``,
@@ -18,6 +23,10 @@ New Features
   ``uninitialized_fill``, ``uninitialized_move``, ``uninitialized_copy``, ``uninitialized_value_construct``,
   ``uninitialized_default_construct``, ``reverse``, ``reverse_copy``, ``swap_ranges``. These algorithms operate with
   C++20 random access ranges.
+- Improved performance of ``oneapi::dpl::experimental::kt::gpu::inclusive_scan`` and added support for binary operator
+  and type combinations which do not have a SYCL known identity.
+- Improved performance of ``oneapi::dpl::inclusive_scan_by_segment ``and ``oneapi::dpl::exclusive_scan_by_segment`` with
+  device execution policies on GPUs.
 
 Fixed Issues
 ------------
@@ -26,6 +35,10 @@ Fixed Issues
 - Fixed a compilation error **SYCL kernel cannot use exceptions** occurring with libstdc++ version 10 when calling
   range-based ``adjacent_find``, ``is_sorted`` and ``is_sorted_until`` algorithms using  device policies.
 - Fixed an issue with ``PSTL_USE_NONTEMPORAL_STORES`` macro having no effect.
+- Fixed a bug where ``oneapi::dpl::unique`` when called with a device execution policy returned an incorrect result
+  iterator.
+- Fixed a bug in ``oneapi::dpl::inclusive_scan`` and all prefix sum algorithms when using device policies with differing
+  ``InputIterator`` and ``OutputIterator`` types.
 
 Known Issues and Limitations
 ----------------------------

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -25,8 +25,8 @@ New Features
   C++20 random access ranges.
 - Improved performance of ``gpu::inclusive_scan`` kernel template and added support for binary operator and type
   combinations which do not have a SYCL known identity.
-- Improved performance of ``inclusive_scan_by_segment``, ``exclusive_scan_by_segment`` and set operation algorithms when
-  using device policies: ``set_union``, ``set_difference``, ``set_intersection``, ``set_symmetric_difference``.
+- Improved performance of ``inclusive_scan_by_segment``, ``exclusive_scan_by_segment``, ``set_union``,
+  ``set_difference``, ``set_intersection``, and ``set_symmetric_difference`` when using device policies.
 - Improved performance of search operations (e.g., ``find``, ``all_of``, ``equal``, ``search``, etc.), ``is_heap`` and
   ``is_heap_until`` algorithms on Intel® Arc™ B-series GPU devices.
 

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -36,7 +36,7 @@ Fixed Issues
   and ``set_symmetric_difference`` on Windows operating systems.
 - Removed default-constructible requirements from the value type for ``reduce`` and ``transform_reduce`` algorithms,
   as well as copy-constructible requirements when these algorithms are used with a native ("host") policy.
-- Fixed an issue with incorrect handling of different projections by ``ranges::merge``.
+- Fixed an issue with ``ranges::merge`` when projections of the two input ranges were not the same.
 - Fixed ``equal`` returning a ``false`` for empty input sequences; now it returns ``true``.
 - Fixed a compilation error **SYCL kernel cannot use exceptions** occurring with libstdc++ version 10 when calling
   ``adjacent_find``, ``is_sorted`` and ``is_sorted_until`` range algorithms with device policies.

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -53,13 +53,16 @@ Fixed Issues
 
 Known Issues and Limitations
 ----------------------------
+New in This Release
+^^^^^^^^^^^^^^^^^^^
+- Range-based ``copy_if``, ``unique_copy``, ``set_union``, ``set_intersection``, ``set_difference``,
+  ``set_symmetric_difference`` algorithms require the output range to have sufficient size to hold all resulting
+  elements.
+
 Existing Issues
 ^^^^^^^^^^^^^^^
 See oneDPL Guide for other `restrictions and known limitations`_.
 
-- Range-based ``copy_if``, ``unique_copy``, ``set_union``, ``set_intersection``, ``set_difference``,
-  ``set_symmetric_difference`` algorithms require the output range to have sufficient size to hold all resulting
-  elements.
 - ``histogram`` algorithm requires the output value type to be an integral type no larger than four bytes
   when used with a device policy on hardware that does not support 64-bit atomic operations.
 - For ``transform_exclusive_scan`` and ``exclusive_scan`` to run in-place (that is, with the same data

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -49,8 +49,8 @@ Fixed Issues
 - Fixed a bug in ``exclusive_scan``, ``inclusive_scan``, ``transform_exclusive_scan``, ``transform_inclusive_scan``,
   ``exlusive_scan_by_segment``, and ``inclusive_scan_by_segment`` algorithms when using device policies with differing
   ``InputIterator`` and ``OutputIterator`` value types.
-- Fixed error in return value types for oneapi::dpl::ranges::minmax_element and oneapi::dpl::ranges::mismatch algorithms.
-- Fixed compile errors in ``set_union`` and ``set_symmetric_difference`` for hetero execution policies when the types of
+- Fixed error in return value types of range-based ``minmax_element`` and ``mismatch`` algorithms.
+- Fixed compile errors in ``set_union`` and ``set_symmetric_difference`` with device execution policies when the types of
   the second data and results data are different.
 
 Known Issues and Limitations

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -32,8 +32,9 @@ New Features
 - Improved performance of parallel_find_or–based algorithms on Intel® Arc™ B-series GPU devices.
 - Removed requirement of GPU double support to use ``set_union``, ``set_difference``, ``set_intersection``, and
   ``set_symmetric_difference`` on Windows operating systems.
-- Removed copy constructible requirements from value type for reduce and transform_reduce algorithms when used with a
-  host policy, and default constructible requirements from value type for reduce and transform_reduce when used with an execution policy.
+- Removed copy constructible requirements from value type for ``reduce`` and ``transform_reduce`` algorithms when used
+  with a host policy, and default constructible requirements from value type for ``reduce`` and ``transform_reduce``
+  when used with any execution policy.
 
 Fixed Issues
 ------------

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -45,7 +45,8 @@ Fixed Issues
 - Fixed an issue with ``PSTL_USE_NONTEMPORAL_STORES`` macro having no effect.
 - Fixed a bug where ``unique`` when called with a device execution policy returned an incorrect result
   iterator.
-- Fixed a bug in ``inclusive_scan`` and all prefix sum algorithms when using device policies with differing
+- Fixed a bug in ``exclusive_scan``, ``inclusive_scan``, ``transform_exclusive_scan``, ``transform_inclusive_scan``,
+  ``exlusive_scan_by_segment``, and ``inclusive_scan_by_segment`` algorithms when using device policies with differing
   ``InputIterator`` and ``OutputIterator`` types.
 - Fixed error in return value types for oneapi::dpl::ranges::minmax_element and oneapi::dpl::ranges::mismatch algorithms.
 - Fixed compile errors in ``set_union`` and ``set_symmetric_difference`` for hetero execution policies when the types of

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -32,32 +32,30 @@ New Features
 
 Fixed Issues
 ------------
-- Removed requirement of GPU double support to use ``set_union``, ``set_difference``, ``set_intersection``, and
-  ``set_symmetric_difference`` on Windows operating systems.
+- Removed requirement of GPU double precision support to use ``set_union``, ``set_difference``, ``set_intersection``,
+  and ``set_symmetric_difference`` on Windows operating systems.
 - Removed copy constructible requirements from value type for ``reduce`` and ``transform_reduce`` algorithms when used
   with a host policy, and default constructible requirements from value type for ``reduce`` and ``transform_reduce``
   when used with any execution policy.
-- Fixed an issue with incorrect handling of different projections by range-based ``merge``.
+- Fixed an issue with incorrect handling of different projections by ``ranges::merge``.
 - Fixed ``equal`` returning a ``false`` for empty input sequences; now it returns ``true``.
 - Fixed a compilation error **SYCL kernel cannot use exceptions** occurring with libstdc++ version 10 when calling
-  range-based ``adjacent_find``, ``is_sorted`` and ``is_sorted_until`` algorithms using  device policies.
+  ``adjacent_find``, ``is_sorted`` and ``is_sorted_until`` range algorithms with device policies.
 - Fixed an issue with ``PSTL_USE_NONTEMPORAL_STORES`` macro having no effect.
-- Fixed a bug where ``unique`` when called with a device execution policy returned an incorrect result
-  iterator.
+- Fixed a bug where ``unique`` called with a device policy returned an incorrect result iterator.
 - Fixed a bug in ``exclusive_scan``, ``inclusive_scan``, ``transform_exclusive_scan``, ``transform_inclusive_scan``,
-  ``exlusive_scan_by_segment``, and ``inclusive_scan_by_segment`` algorithms when using device policies with differing
-  ``InputIterator`` and ``OutputIterator`` value types.
-- Fixed error in return value types of range-based ``minmax_element`` and ``mismatch`` algorithms.
-- Fixed compile errors in ``set_union`` and ``set_symmetric_difference`` with device execution policies when the types of
-  the second data and results data are different.
+  ``exlusive_scan_by_segment``, and ``inclusive_scan_by_segment`` algorithms when using device policies with different
+  input and output value types.
+- Fixed a bug in return value types of ``minmax_element`` and ``mismatch`` range algorithms.
+- Fixed compile errors in ``set_union`` and ``set_symmetric_difference`` when using device policies
+  with different second-input and output value types.
 
 Known Issues and Limitations
 ----------------------------
 New in This Release
 ^^^^^^^^^^^^^^^^^^^
-- Range-based ``copy_if``, ``unique_copy``, ``set_union``, ``set_intersection``, ``set_difference``,
-  ``set_symmetric_difference`` algorithms require the output range to have sufficient size to hold all resulting
-  elements.
+- ``copy_if``, ``unique_copy``, ``set_union``, ``set_intersection``, ``set_difference``, ``set_symmetric_difference``
+  range algorithms require the output range to have sufficient size to hold all resulting elements.
 
 Existing Issues
 ^^^^^^^^^^^^^^^

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -11,10 +11,50 @@ creating efficient heterogeneous applications.
 New in 2022.10.0
 ================
 
+New Features
+------------
+- Added parallel range algorithms in ``namespace oneapi::dpl::ranges``: ``set_intersection``, ``set_union``,
+  ``set_difference``, ``set_symmetric_difference``, ``includes``, ``unique``, ``unique_copy``, ``destroy``,
+  ``uninitialized_fill``, ``uninitialized_move``, ``uninitialized_copy``, ``uninitialized_value_construct``,
+  ``uninitialized_default_construct``, ``reverse``, ``reverse_copy``, ``swap_ranges``. These algorithms operate with
+  C++20 random access ranges.
+
+Fixed Issues
+------------
+- Fixed an issue with incorrect handling of different projections by range-based ``merge``.
+- Fixed ``equal`` returning a ``false`` for empty input sequences; now it returns ``true``.
+- Fixed a compilation error **SYCL kernel cannot use exceptions** occurring with libstdc++ version 10 when calling
+  range-based ``adjacent_find``, ``is_sorted`` and ``is_sorted_until`` algorithms using  device policies.
+- Fixed an issue with ``PSTL_USE_NONTEMPORAL_STORES`` macro having no effect.
+
 Known Issues and Limitations
 ----------------------------
 New in This Release
 ^^^^^^^^^^^^^^^^^^^
+- The `set_intersection`, `set_difference`, `set_symmetric_difference`, and `set_union` algorithms with a device policy
+require GPUs with double-precision support on Windows, regardless of the value type of the input sequences.
+
+Existing Issues
+^^^^^^^^^^^^^^^
+See oneDPL Guide for other `restrictions and known limitations`_.
+
+- Range-based ``copy_if``, ``unique_copy``, ``set_union``, ``set_intersection``, ``set_difference``,
+  ``set_symmetric_difference`` algorithms require the output range to have sufficient size to hold all resulting
+  elements.
+- ``histogram`` algorithm requires the output value type to be an integral type no larger than four bytes
+  when used with a device policy on hardware that does not support 64-bit atomic operations.
+- ``histogram`` may provide incorrect results with device policies in a program built with ``-O0`` option and the driver
+  version is 2448.13 or older.
+- For ``transform_exclusive_scan`` and ``exclusive_scan`` to run in-place (that is, with the same data
+  used for both input and destination) and with an execution policy of ``unseq`` or ``par_unseq``,
+  it is required that the provided input and destination iterators are equality comparable.
+  Furthermore, the equality comparison of the input and destination iterator must evaluate to true.
+  If these conditions are not met, the result of these algorithm calls is undefined.
+- Incorrect results may be produced by ``exclusive_scan``, ``inclusive_scan``, ``transform_exclusive_scan``,
+  ``transform_inclusive_scan``, ``exclusive_scan_by_segment``, ``inclusive_scan_by_segment``, ``reduce_by_segment``
+  with ``unseq`` or ``par_unseq`` policy when compiled by Intel® oneAPI DPC++/C++ Compiler 2024.1 or earlier
+  with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
+  To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
 
 New in 2022.9.0
 ===============

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -25,20 +25,18 @@ New Features
   C++20 random access ranges.
 - Improved performance of ``gpu::inclusive_scan`` kernel template and added support for binary operator and type
   combinations which do not have a SYCL known identity.
-- Improved performance of ``inclusive_scan_by_segment`` and ``exclusive_scan_by_segment`` with
-  device execution policies on GPUs.
-- Improved performance of set operation algorithms when using device policies: ``set_union``, ``set_difference``,
-  ``set_intersection``, ``set_symmetric_difference``.
+- Improved performance of ``inclusive_scan_by_segment``, ``exclusive_scan_by_segment`` and set operation algorithms when
+  using device policies: ``set_union``, ``set_difference``, ``set_intersection``, ``set_symmetric_difference``.
 - Improved performance of search operations (e.g., ``find``, ``all_of``, ``equal``, ``search``, etc.), ``is_heap`` and
   ``is_heap_until`` algorithms on Intel® Arc™ B-series GPU devices.
+
+Fixed Issues
+------------
 - Removed requirement of GPU double support to use ``set_union``, ``set_difference``, ``set_intersection``, and
   ``set_symmetric_difference`` on Windows operating systems.
 - Removed copy constructible requirements from value type for ``reduce`` and ``transform_reduce`` algorithms when used
   with a host policy, and default constructible requirements from value type for ``reduce`` and ``transform_reduce``
   when used with any execution policy.
-
-Fixed Issues
-------------
 - Fixed an issue with incorrect handling of different projections by range-based ``merge``.
 - Fixed ``equal`` returning a ``false`` for empty input sequences; now it returns ``true``.
 - Fixed a compilation error **SYCL kernel cannot use exceptions** occurring with libstdc++ version 10 when calling

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -67,8 +67,6 @@ See oneDPL Guide for other `restrictions and known limitations`_.
   elements.
 - ``histogram`` algorithm requires the output value type to be an integral type no larger than four bytes
   when used with a device policy on hardware that does not support 64-bit atomic operations.
-- ``histogram`` may provide incorrect results with device policies in a program built with ``-O0`` option and the driver
-  version is 2448.13 or older.
 - For ``transform_exclusive_scan`` and ``exclusive_scan`` to run in-place (that is, with the same data
   used for both input and destination) and with an execution policy of ``unseq`` or ``par_unseq``,
   it is required that the provided input and destination iterators are equality comparable.

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -27,6 +27,13 @@ New Features
   and type combinations which do not have a SYCL known identity.
 - Improved performance of ``oneapi::dpl::inclusive_scan_by_segment ``and ``oneapi::dpl::exclusive_scan_by_segment`` with
   device execution policies on GPUs.
+- Improved performance of set operation algorithms when using device policies: ``set_union``, ``set_difference``,
+  ``set_intersection``, ``set_symmetric_difference``. Removed default constructible requirements from value type of
+  reduce and transform_reduce when used with an execution policy. 
+- Removed requirement of GPU double support to use ``set_union``, ``set_difference``, ``set_intersection``, and
+  ``set_symmetric_difference`` on Windows operating systems.
+- Removed copy constructible requirements from value type for reduce and transform_reduce algorithms when used with a
+  host policy.
 
 Fixed Issues
 ------------

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -15,10 +15,6 @@ Known Issues and Limitations
 ----------------------------
 New in This Release
 ^^^^^^^^^^^^^^^^^^^
-- Calling ``histogram`` algorithm with a device execution policy may cause a segmentation fault in
-  Intel® oneAPI DPC++/C++ Compiler 2025.3 when compiling SYCL kernels for CPU devices.
-  To avoid this, define ``ONEDPL_DISABLE_HISTOGRAM_REGISTER_REDUCTION`` macro to a non-zero value
-  prior to including oneDPL header files.
 
 New in 2022.9.0
 ===============

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -23,8 +23,8 @@ New Features
   ``uninitialized_fill``, ``uninitialized_move``, ``uninitialized_copy``, ``uninitialized_value_construct``,
   ``uninitialized_default_construct``, ``reverse``, ``reverse_copy``, ``swap_ranges``. These algorithms operate with
   C++20 random access ranges.
-- Improved performance of ``oneapi::dpl::experimental::kt::gpu::inclusive_scan`` and added support for binary operator
-  and type combinations which do not have a SYCL known identity.
+- Improved performance of ``gpu::inclusive_scan`` kernel template and added support for binary operator and type
+  combinations which do not have a SYCL known identity.
 - Improved performance of ``inclusive_scan_by_segment`` and ``exclusive_scan_by_segment`` with
   device execution policies on GPUs.
 - Improved performance of set operation algorithms when using device policies: ``set_union``, ``set_difference``,
@@ -48,18 +48,13 @@ Fixed Issues
   iterator.
 - Fixed a bug in ``exclusive_scan``, ``inclusive_scan``, ``transform_exclusive_scan``, ``transform_inclusive_scan``,
   ``exlusive_scan_by_segment``, and ``inclusive_scan_by_segment`` algorithms when using device policies with differing
-  ``InputIterator`` and ``OutputIterator`` types.
+  ``InputIterator`` and ``OutputIterator`` value types.
 - Fixed error in return value types for oneapi::dpl::ranges::minmax_element and oneapi::dpl::ranges::mismatch algorithms.
 - Fixed compile errors in ``set_union`` and ``set_symmetric_difference`` for hetero execution policies when the types of
   the second data and results data are different.
 
 Known Issues and Limitations
 ----------------------------
-New in This Release
-^^^^^^^^^^^^^^^^^^^
-- The `set_intersection`, `set_difference`, `set_symmetric_difference`, and `set_union` algorithms with a device policy
-require GPUs with double-precision support on Windows, regardless of the value type of the input sequences.
-
 Existing Issues
 ^^^^^^^^^^^^^^^
 See oneDPL Guide for other `restrictions and known limitations`_.

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -34,9 +34,8 @@ Fixed Issues
 ------------
 - Removed requirement of GPU double precision support to use ``set_union``, ``set_difference``, ``set_intersection``,
   and ``set_symmetric_difference`` on Windows operating systems.
-- Removed copy constructible requirements from value type for ``reduce`` and ``transform_reduce`` algorithms when used
-  with a host policy, and default constructible requirements from value type for ``reduce`` and ``transform_reduce``
-  when used with any execution policy.
+- Removed default-constructible requirements from the value type for ``reduce`` and ``transform_reduce`` algorithms,
+  as well as copy-constructible requirements when these algorithms are used with a native ("host") policy.
 - Fixed an issue with incorrect handling of different projections by ``ranges::merge``.
 - Fixed ``equal`` returning a ``false`` for empty input sequences; now it returns ``true``.
 - Fixed a compilation error **SYCL kernel cannot use exceptions** occurring with libstdc++ version 10 when calling

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -43,13 +43,13 @@ Fixed Issues
 - Fixed a compilation error **SYCL kernel cannot use exceptions** occurring with libstdc++ version 10 when calling
   range-based ``adjacent_find``, ``is_sorted`` and ``is_sorted_until`` algorithms using  device policies.
 - Fixed an issue with ``PSTL_USE_NONTEMPORAL_STORES`` macro having no effect.
-- Fixed a bug where ``oneapi::dpl::unique`` when called with a device execution policy returned an incorrect result
+- Fixed a bug where ``unique`` when called with a device execution policy returned an incorrect result
   iterator.
-- Fixed a bug in ``oneapi::dpl::inclusive_scan`` and all prefix sum algorithms when using device policies with differing
+- Fixed a bug in ``inclusive_scan`` and all prefix sum algorithms when using device policies with differing
   ``InputIterator`` and ``OutputIterator`` types.
 - Fixed error in return value types for oneapi::dpl::ranges::minmax_element and oneapi::dpl::ranges::mismatch algorithms.
-- Fixed compile errors in ``oneapi::dpl::set_union`` and ``oneapi::dpl::set_symmetric_difference`` for hetero execution
-  policies when the types of the second data and results data are different.
+- Fixed compile errors in ``set_union`` and ``set_symmetric_difference`` for hetero execution policies when the types of
+  the second data and results data are different.
 
 Known Issues and Limitations
 ----------------------------

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -25,7 +25,7 @@ New Features
   C++20 random access ranges.
 - Improved performance of ``oneapi::dpl::experimental::kt::gpu::inclusive_scan`` and added support for binary operator
   and type combinations which do not have a SYCL known identity.
-- Improved performance of ``oneapi::dpl::inclusive_scan_by_segment ``and ``oneapi::dpl::exclusive_scan_by_segment`` with
+- Improved performance of ``inclusive_scan_by_segment`` and ``exclusive_scan_by_segment`` with
   device execution policies on GPUs.
 - Improved performance of set operation algorithms when using device policies: ``set_union``, ``set_difference``,
   ``set_intersection``, ``set_symmetric_difference``. Removed default constructible requirements from value type of

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -29,9 +29,8 @@ New Features
   device execution policies on GPUs.
 - Improved performance of set operation algorithms when using device policies: ``set_union``, ``set_difference``,
   ``set_intersection``, ``set_symmetric_difference``.
-- Improved performance of ``adjacent_find``, ``all_of``, ``any_of``, ``none_of``, ``equal``, ``find_end``,
-  ``find_first_of``, ``find_if``, ``find_if_not``, ``includes``, ``is_heap``, ``is_heap_until``, ``mismatch``,
-  ``search``, ``search_n``, algorithms on Intel® Arc™ B-series GPU devices.
+- Improved performance of search operations (e.g., ``find``, ``all_of``, ``equal``, ``search``, etc.), ``is_heap`` and
+  ``is_heap_until`` algorithms on Intel® Arc™ B-series GPU devices.
 - Removed requirement of GPU double support to use ``set_union``, ``set_difference``, ``set_intersection``, and
   ``set_symmetric_difference`` on Windows operating systems.
 - Removed copy constructible requirements from value type for ``reduce`` and ``transform_reduce`` algorithms when used

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -28,13 +28,12 @@ New Features
 - Improved performance of ``inclusive_scan_by_segment`` and ``exclusive_scan_by_segment`` with
   device execution policies on GPUs.
 - Improved performance of set operation algorithms when using device policies: ``set_union``, ``set_difference``,
-  ``set_intersection``, ``set_symmetric_difference``. Removed default constructible requirements from value type of
-  reduce and transform_reduce when used with an execution policy.
+  ``set_intersection``, ``set_symmetric_difference``.
 - Improved performance of parallel_find_or–based algorithms on Intel® Arc™ B-series GPU devices.
 - Removed requirement of GPU double support to use ``set_union``, ``set_difference``, ``set_intersection``, and
   ``set_symmetric_difference`` on Windows operating systems.
 - Removed copy constructible requirements from value type for reduce and transform_reduce algorithms when used with a
-  host policy.
+  host policy, and default constructible requirements from value type for reduce and transform_reduce when used with an execution policy.
 
 Fixed Issues
 ------------


### PR DESCRIPTION
The oneDPL release for the 2022.10.0 milestone covers roughly the changes from merged PRs #2207 to #2465.