### PR TITLE
Fix compile error in struct MinimalisticRange

### DIFF
--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1348,8 +1348,8 @@ struct MinimalisticRange
     ForwardIterator it_begin;
     ForwardIterator it_end;
 
-    ForwardIterator begin() const { return it_begin; };
-    ForwardIterator end()   const { return it_end;   };
+    ForwardIterator begin() const { return it_begin; }
+    ForwardIterator end()   const { return it_end;   }
 };
 
 #if _ENABLE_STD_RANGES_TESTING


### PR DESCRIPTION
This PR fixes a compile error in the `MinimalisticRange` struct by removing trailing semicolons from the `begin()` and `end()` method definitions.

- Removes unnecessary semicolons after the closing braces of inline method definitions