### PR TITLE
Fix CMake OpenMP flag checks with CL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ message(STATUS "Using parallel policies with ${ONEDPL_BACKEND} backend")
 string(TOLOWER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
 
 if (ONEDPL_ENABLE_SIMD)
-    # MSVC supports OpenMP 2.0 which is not sufficent for SIMD execution
+    # MSVC supports OpenMP 2.0 which is not sufficient for SIMD execution
     # TODO: check if -openmp:experimental can be used
     if ((NOT INTEL_LLVM_COMPILER AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         OR NOT INTEL_LLVM_COMPILER_VERSION VERSION_LESS 2021.4)


### PR DESCRIPTION
cl accepts `-openmp-simd` and produces:
> cl : Command line warning D9035 : option 'o' has been deprecated and will be removed in a future release

This option is then passed to cl with a cmake message:
> oneDPL: OpenMP SIMD is enabled by passing '-openmp-simd' to compiler

Obviously, this option is not supported there and confused with `-o`. 