### PR TITLE
CI: Revert "Add 3 retries to scorecard if necessary"

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,10 +36,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: "Scorecard Analysis (Attempt 1/3) - Retries on API errors"
-        id: scorecard_attempt_1
+      - name: "Run analysis"
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
-        continue-on-error: true
         with:
           results_file: results.sarif
           results_format: sarif
@@ -57,50 +55,6 @@ jobs:
           #   - `publish_results` will always be set to `false`, regardless
           #     of the value entered here.
           publish_results: true
-
-      - name: "Wait before retry"
-        if: steps.scorecard_attempt_1.outcome == 'failure'
-        run: |
-          echo "First attempt failed, waiting 60 seconds before retry..."
-          sleep 60
-
-      - name: "Scorecard Analysis (Attempt 2/3) - Retry after API failure"
-        id: scorecard_attempt_2
-        if: steps.scorecard_attempt_1.outcome == 'failure'
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
-        continue-on-error: true
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: "Wait before final retry"
-        if: steps.scorecard_attempt_1.outcome == 'failure' && steps.scorecard_attempt_2.outcome == 'failure'
-        run: |
-          echo "Second attempt failed, waiting 120 seconds before final retry..."
-          sleep 120
-
-      - name: "Scorecard Analysis (Final Attempt 3/3)"
-        id: scorecard_final
-        if: steps.scorecard_attempt_1.outcome == 'failure' && steps.scorecard_attempt_2.outcome == 'failure'
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: "Report status"
-        run: |
-          if [ "${{ steps.scorecard_attempt_1.outcome }}" == "success" ]; then
-            echo "Scorecard analysis completed successfully on first attempt"
-          elif [ "${{ steps.scorecard_attempt_2.outcome }}" == "success" ]; then
-            echo "Scorecard analysis completed successfully on second attempt"
-          elif [ "${{ steps.scorecard_final.outcome }}" == "success" ]; then
-            echo "Scorecard analysis completed successfully on final attempt"
-          else
-            echo "::error::All Scorecard attempts failed. Please try running the workflow again later."
-            exit 1
-          fi
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.


### PR DESCRIPTION
This reverts commit 8e48b66e89305a14a1dc83054867cb59fa603bd3.

It should fix the issue:
```
Wrote bundle to file /tmp/bundle3682798529
2025/11/12 10:46:59 error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: workflow verification failed: scorecard job must only have steps with `uses`, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
```

The reverted commit violated https://github.com/ossf/scorecard-action#workflow-restrictions by adding custom steps in a job with scorecard-action. 