### PR TITLE
Fix test `contains_host_pointers.pass`

### DIFF
--- a/test/general/implementation_details/contains_host_pointers.pass.cpp
+++ b/test/general/implementation_details/contains_host_pointers.pass.cpp
@@ -40,6 +40,20 @@ struct MinimalisticViewWithSubscription : TestUtils::MinimalisticView<RandomIt>
     }
 };
 
+template <typename RandomIt>
+RandomIt
+begin(MinimalisticViewWithSubscription<RandomIt> view)
+{
+    return view.it_begin;
+}
+
+template <typename RandomIt>
+RandomIt
+end(MinimalisticViewWithSubscription<RandomIt> view)
+{
+    return view.it_end;
+}
+
 template <typename _Rng>
 inline constexpr bool contains_host_pointer_v = oneapi::dpl::__ranges::__contains_host_pointer<_Rng>::value;
 


### PR DESCRIPTION
In this PR we fix compile errors in the test `contains_host_pointers.pass` :
```C++
cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_STANDARD=20 -DONEDPL_BACKEND=dpcpp_only -DONEDPL_DEVICE_TYPE=CPU '-DCMAKE_CXX_FLAGS=-DTEST_LONG_RUN=1 -DTEST_ONLY_HETERO_POLICIES ' -DCMAKE_BUILD_TYPE=debug -DONEDPL_USE_UNNAMED_LAMBDA=ON ..

make contains_host_pointers.pass
```

Compile errors:
```C++
test/general/implementation_details/contains_host_pointers.pass.cpp:63:25: error: no matching function for call to object of type 'const _All'
   63 |         auto all_view = std::ranges::views::all(MinimalisticRangeForIntVec(vec.begin(), vec.end()));
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:1117:2: note: candidate template ignored: constraints not satisfied [with _Range = MinimalisticRangeForIntVec]
 1117 |         operator()(_Range&& __r) const
      |         ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:1112:16: note: because 'TestUtils::MinimalisticRange<__gnu_cxx::__normal_iterator<int *, std::vector<int>>>' does not satisfy 'viewable_range'
 1112 |       template<viewable_range _Range>
      |                ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:671:12: note: because 'remove_cvref_t<TestUtils::MinimalisticRange<__gnu_cxx::__normal_iterator<int *, std::vector<int, std::allocator<int>>>>>' (aka 'TestUtils::MinimalisticRange<__gnu_cxx::__normal_iterator<int *, std::vector<int>>>') does not satisfy 'view'
  671 |       && ((view<remove_cvref_t<_Tp>> && constructible_from<remove_cvref_t<_Tp>, _Tp>)
      |            ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:626:39: note: because 'enable_view<TestUtils::MinimalisticRange<__gnu_cxx::__normal_iterator<int *, std::vector<int>>>>' evaluated to false
  626 |       = range<_Tp> && movable<_Tp> && enable_view<_Tp>;
      |                                       ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:672:38: note: and 'TestUtils::MinimalisticRange<__gnu_cxx::__normal_iterator<int *, std::vector<int>>>' does not satisfy 'borrowed_range'
  672 |           || (!view<remove_cvref_t<_Tp>> && borrowed_range<_Tp>));
      |                                             ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:587:23: note: because 'TestUtils::MinimalisticRange<__gnu_cxx::__normal_iterator<int *, std::vector<int>>>' does not satisfy '__maybe_borrowed_range'
  587 |       = range<_Tp> && __detail::__maybe_borrowed_range<_Tp>;
      |                       ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:84:4: note: because 'is_lvalue_reference_v<TestUtils::MinimalisticRange<__gnu_cxx::__normal_iterator<int *, std::vector<int>>>>' evaluated to false
   84 |         = is_lvalue_reference_v<_Tp>
      |           ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:85:7: note: and 'enable_borrowed_range<remove_cvref_t<TestUtils::MinimalisticRange<__gnu_cxx::__normal_iterator<int *, std::vector<int, std::allocator<int>>>>>>' evaluated to false
   85 |           || enable_borrowed_range<remove_cvref_t<_Tp>>;
      |              ^
test/general/implementation_details/contains_host_pointers.pass.cpp:71:25: error: no matching function for call to object of type 'const _All'
   71 |         auto all_view = std::ranges::views::all(mr_view);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:1117:2: note: candidate template ignored: constraints not satisfied [with _Range = MinimalisticViewWithSubscription<__gnu_cxx::__normal_iterator<int *, std::vector<int>>> &]
 1117 |         operator()(_Range&& __r) const
      |         ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:1112:16: note: because 'MinimalisticViewWithSubscription<__gnu_cxx::__normal_iterator<int *, std::vector<int>>> &' does not satisfy 'viewable_range'
 1112 |       template<viewable_range _Range>
      |                ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:670:30: note: because 'MinimalisticViewWithSubscription<__gnu_cxx::__normal_iterator<int *, std::vector<int>>> &' does not satisfy 'range'
  670 |     concept viewable_range = range<_Tp>
      |                              ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:580:2: note: because 'ranges::begin(__t)' would be invalid: no matching function for call to object of type 'const __cust_access::_Begin'
  580 |         ranges::begin(__t);
      |         ^
test/general/implementation_details/contains_host_pointers.pass.cpp:98:26: error: no matching function for call to object of type 'const _All'
   98 |         auto all_view1 = std::ranges::views::all(mrv);
      |                          ^~~~~~~~~~~~~~~~~~~~~~~
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:1117:2: note: candidate template ignored: constraints not satisfied [with _Range = MinimalisticViewWithSubscription<__gnu_cxx::__normal_iterator<int *, std::vector<int>>> &]
 1117 |         operator()(_Range&& __r) const
      |         ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:1112:16: note: because 'MinimalisticViewWithSubscription<__gnu_cxx::__normal_iterator<int *, std::vector<int>>> &' does not satisfy 'viewable_range'
 1112 |       template<viewable_range _Range>
      |                ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:670:30: note: because 'MinimalisticViewWithSubscription<__gnu_cxx::__normal_iterator<int *, std::vector<int>>> &' does not satisfy 'range'
  670 |     concept viewable_range = range<_Tp>
      |                              ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:580:2: note: because 'ranges::begin(__t)' would be invalid: no matching function for call to object of type 'const __cust_access::_Begin'
  580 |         ranges::begin(__t);
      |         ^
test/general/implementation_details/contains_host_pointers.pass.cpp:115:25: error: no matching function for call to object of type 'const _All'
  115 |         auto all_view = std::ranges::views::all(mrv);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:1117:2: note: candidate template ignored: constraints not satisfied [with _Range = MinimalisticViewWithSubscription<__gnu_cxx::__normal_iterator<int *, std::vector<int>>> &]
 1117 |         operator()(_Range&& __r) const
      |         ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:1112:16: note: because 'MinimalisticViewWithSubscription<__gnu_cxx::__normal_iterator<int *, std::vector<int>>> &' does not satisfy 'viewable_range'
 1112 |       template<viewable_range _Range>
      |                ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:670:30: note: because 'MinimalisticViewWithSubscription<__gnu_cxx::__normal_iterator<int *, std::vector<int>>> &' does not satisfy 'range'
  670 |     concept viewable_range = range<_Tp>
      |                              ^
gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:580:2: note: because 'ranges::begin(__t)' would be invalid: no matching function for call to object of type 'const __cust_access::_Begin'
  580 |         ranges::begin(__t);
      |         ^
```