### PR TITLE
Missed default constructor in `struct __subscription_impl_view_simple`

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -792,8 +792,7 @@ struct __subscription_impl_view_simple : std::ranges::view_interface<__subscript
 
     constexpr __subscription_impl_view_simple()
         requires std::default_initializable<_View>
-    {
-    }
+    = default;
 
     constexpr explicit __subscription_impl_view_simple(_View __view) : __base(std::move(__view)) {}
 


### PR DESCRIPTION
In this PR we fix issue which has been found during development of https://github.com/uxlfoundation/oneDPL/pull/2521

This PR adds a missing default constructor to the `__subscription_impl_view_simple` struct. The default constructor is constrained to only be available when the underlying `_View` type is default initializable, ensuring proper initialization semantics for the view wrapper.

This `struct __subscription_impl_view_simple` has been introduced in the PR https://github.com/uxlfoundation/oneDPL/pull/2493

**Key changes:**
- Added a constrained default constructor to `__subscription_impl_view_simple` that requires `_View` to be default initializable.

### Justification
- `GCC 10 required`;

```
cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_STANDARD=20 -DONEDPL_BACKEND=dpcpp_only -DONEDPL_DEVICE_TYPE=CPU '-DCMAKE_CXX_FLAGS=-DTEST_LONG_RUN=1 -DTEST_ONLY_HETERO_POLICIES ' -DCMAKE_BUILD_TYPE=debug -DONEDPL_USE_UNNAMED_LAMBDA=ON ..
```

```
make range_minimal_type_requirements.pass
```

Now we have compile error:
```C++
	Scanning dependencies of target range_minimal_type_requirements.pass
	Building CXX object test/CMakeFiles/range_minimal_type_requirements.pass.dir/parallel_api/ranges/range_minimal_type_requirements.pass.cpp.o
	In file included from /oneDPL/test/parallel_api/ranges/range_minimal_type_requirements.pass.cpp:20:
	In file included from /oneDPL/include/oneapi/dpl/algorithm:21:
	In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/algorithm:64:
	In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/ranges_algo.h:35:
	In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/ranges_algobase.h:38:
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ranges:105:16: error: static assertion failed
	  105 |         static_assert(view<_Derived>);
		  |                       ^~~~~~~~~~~~~~
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ranges:190:25: note: in instantiation of member function 'std::ranges::view_interface<oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>::_M_derived' requested here
	  190 |         { return ranges::begin(_M_derived())[__n]; }
		  |                                ^
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:771:74: note: in instantiation of function template specialization 'std::ranges::view_interface<oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>::operator[]<oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int
		  *>>>' requested here
	  771 | struct __has_subscription_op<_R, std::void_t<decltype(std::declval<_R>().operator[](0))>> : std::true_type
		  |                                                                          ^
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:775:56: note: during template argument deduction for class template partial specialization '__has_subscription_op<_R, std::void_t<decltype(std::declval<_R>().operator[](0))>>' [with _R = oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>]
	  775 | template <typename _Range, typename = std::enable_if_t<__has_subscription_op<_Range>::value>>
		  |                                                        ^
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:775:56: note: in instantiation of template class 'oneapi::dpl::__ranges::__has_subscription_op<oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>' requested here
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:777:1: note: in instantiation of default argument for '__get_subscription_view<oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>' required here
	  777 | __get_subscription_view(_Range&& __rng)
		  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	  778 | {
		  | ~
	  779 |     // If the range supports operator[], return it as is
		  |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	  780 |     return std::forward<_Range>(__rng);
		  |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	  781 | }
		  | ~
	/oneDPL/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h:619:16: note: (skipping 1 context in backtrace; use -ftemplate-backtrace-limit=0 to see all)
	  619 |                oneapi::dpl::__ranges::__get_subscription_view(std::forward<_Range>(__rng)))
		  |                ^
	/oneDPL/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h:640:47: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__ranges::__pattern_count<oneapi::dpl::__internal::__device_backend_tag, oneapi::dpl::execution::device_policy<> &,
		  oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>, oneapi::dpl::__internal::__count_fn_pred<int, std::identity>>' requested here
	  640 |     return oneapi::dpl::__internal::__ranges::__pattern_count(
		  |                                               ^
	/oneDPL/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h:435:51: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__ranges::__pattern_count<oneapi::dpl::__internal::__device_backend_tag, oneapi::dpl::execution::device_policy<> &, TestUtils::MinimalisticView<int *> &, int, std::identity>'
		  requested here
	  435 |         return oneapi::dpl::__internal::__ranges::__pattern_count(__dispatch_tag,
		  |                                                   ^
	/oneDPL/test/parallel_api/ranges/range_minimal_type_requirements.pass.cpp:69:22: note: in instantiation of function template specialization 'oneapi::dpl::ranges::__internal::__count_fn::operator()<oneapi::dpl::execution::device_policy<> &, TestUtils::MinimalisticView<int *> &, std::identity, int>' requested here
	   69 |         auto count = oneapi::dpl::ranges::count(policy, r1, 3);
		  |                      ^
	/oneDPL/test/parallel_api/ranges/range_minimal_type_requirements.pass.cpp:264:5: note: in instantiation of function template specialization 'test_count::operator()<oneapi::dpl::execution::device_policy<>>' requested here
	  264 |     Algorithm{}(TestUtils::get_dpcpp_test_policy());
		  |     ^
	/oneDPL/test/parallel_api/ranges/range_minimal_type_requirements.pass.cpp:274:5: note: in instantiation of function template specialization 'call_test_algo<test_count>' requested here
	  274 |     call_test_algo<test_count>    ();
		  |     ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ranges:105:16: note: because 'oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>' does not satisfy 'view'
	  105 |         static_assert(view<_Derived>);
		  |                       ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ranges:73:39: note: because 'oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>' does not satisfy 'default_initializable'
	   73 |       = range<_Tp> && movable<_Tp> && default_initializable<_Tp>
		  |                                       ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/concepts:143:37: note: because 'oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>' does not satisfy 'constructible_from'
	  143 |     concept default_initializable = constructible_from<_Tp>
		  |                                     ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/concepts:139:30: note: because 'is_constructible_v<oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>' evaluated to false
	  139 |       = destructible<_Tp> && is_constructible_v<_Tp, _Args...>;
		  |                              ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/concepts:139:30: error: no matching constructor for initialization of 'oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>'
	  139 |       = destructible<_Tp> && is_constructible_v<_Tp, _Args...>;
		  |                              ^
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:793:24: note: candidate constructor not viable: requires single argument '__view', but no arguments were provided
	  793 |     constexpr explicit __subscription_impl_view_simple(_View __view) : __base(std::move(__view)) {}
		  |                        ^                               ~~~~~~~~~~~~
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:786:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 0 were provided
	  786 | struct __subscription_impl_view_simple : std::ranges::view_interface<__subscription_impl_view_simple<_View>>
		  |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:786:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 0 were provided
	  786 | struct __subscription_impl_view_simple : std::ranges::view_interface<__subscription_impl_view_simple<_View>>
		  |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:786:8: note: '__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>' defined here
	In file included from /oneDPL/test/parallel_api/ranges/range_minimal_type_requirements.pass.cpp:20:
	In file included from /oneDPL/include/oneapi/dpl/algorithm:21:
	In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/algorithm:64:
	In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/ranges_algo.h:35:
	In file included from /usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/ranges_algobase.h:38:
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ranges:112:16: error: static assertion failed
	  112 |         static_assert(view<_Derived>);
		  |                       ^~~~~~~~~~~~~~
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ranges:195:25: note: in instantiation of member function 'std::ranges::view_interface<oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>::_M_derived' requested here
	  195 |         { return ranges::begin(_M_derived())[__n]; }
		  |                                ^
	/oneDPL/include/oneapi/dpl/pstl/hetero/../hetero/dpcpp/unseq_backend_sycl.h:212:13: note: in instantiation of function template specialization 'std::ranges::view_interface<oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>::operator[]<const
		  oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>' requested here
	  212 |         __f(__rngs[__idx]...);
		  |             ^
	/oneDPL/include/oneapi/dpl/pstl/hetero/../hetero/dpcpp/parallel_backend_sycl_utils.h:1183:13: note: in instantiation of function template specialization
		  'oneapi::dpl::unseq_backend::walk_n_vectors_or_scalars<oneapi::dpl::__internal::__brick_copy<oneapi::dpl::__internal::__hetero_tag<oneapi::dpl::__internal::__device_backend_tag>>>::operator()<std::integral_constant<bool, true>, oneapi::dpl::__par_backend_hetero::__pfor_params<true,
		  oneapi::dpl::unseq_backend::walk_n_vectors_or_scalars<oneapi::dpl::__internal::__brick_copy<oneapi::dpl::__internal::__hetero_tag<oneapi::dpl::__internal::__device_backend_tag>>>, oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>,
		  oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>, const oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>> &, const oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>> &, 0>' requested here
	 1183 |             __loop_body_op(std::true_type{}, __idx, __args...);
		  |             ^
	/oneDPL/include/oneapi/dpl/pstl/hetero/../hetero/dpcpp/parallel_backend_sycl_for.h:195:25: note: in instantiation of function template specialization 'oneapi::dpl::__par_backend_hetero::__strided_loop<'\x04'>::operator()<unsigned long,
		  oneapi::dpl::unseq_backend::walk_n_vectors_or_scalars<oneapi::dpl::__internal::__brick_copy<oneapi::dpl::__internal::__hetero_tag<oneapi::dpl::__internal::__device_backend_tag>>>, oneapi::dpl::__par_backend_hetero::__pfor_params<true,
		  oneapi::dpl::unseq_backend::walk_n_vectors_or_scalars<oneapi::dpl::__internal::__brick_copy<oneapi::dpl::__internal::__hetero_tag<oneapi::dpl::__internal::__device_backend_tag>>>, oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>,
		  oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>> &, const oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>> &, const oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>> &>' requested here
	  195 |                         __execute_loop(std::true_type{}, __idx, __stride, __brick, __params, __rngs...);
		  |                         ^
	/oneDPL/include/oneapi/dpl/pstl/hetero/../hetero/dpcpp/parallel_backend_sycl_for.h:256:20: note: in instantiation of function template specialization
		  'oneapi::dpl::__par_backend_hetero::__parallel_for_large_submitter<oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<>>::operator()<oneapi::dpl::unseq_backend::walk_n_vectors_or_scalars<oneapi::dpl::__internal::__brick_copy<oneapi::dpl::__internal::__hetero_tag<oneapi::dpl::__internal::__device_backend_tag>>>, unsigned long,
		  oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>, oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>' requested here
	  256 |             return __large_submitter{}(__q, __brick, __count, std::forward<_Ranges>(__rngs)...);
		  |                    ^
	/oneDPL/include/oneapi/dpl/pstl/hetero/../hetero/dpcpp/parallel_backend_sycl_for.h:271:47: note: (skipping 3 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
	  271 |     return oneapi::dpl::__par_backend_hetero::__parallel_for_impl<_CustomName>(__q_local, __brick, __count,
		  |                                               ^
	/oneDPL/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h:974:64: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__ranges::__pattern_merge<oneapi::dpl::__internal::__device_backend_tag, oneapi::dpl::execution::device_policy<> &,
		  oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>, oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>, oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>, std::ranges::less, std::identity, std::identity>' requested here
	  974 |     const std::pair __res = oneapi::dpl::__internal::__ranges::__pattern_merge(
		  |                                                                ^
	/oneDPL/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h:789:51: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__ranges::__pattern_merge_ranges<oneapi::dpl::__internal::__device_backend_tag, oneapi::dpl::execution::device_policy<> &, TestUtils::MinimalisticView<int *> &,
		  TestUtils::MinimalisticView<int *> &, TestUtils::MinimalisticView<int *> &, std::ranges::less, std::identity, std::identity>' requested here
	  789 |         return oneapi::dpl::__internal::__ranges::__pattern_merge_ranges(
		  |                                                   ^
	/oneDPL/test/parallel_api/ranges/range_minimal_type_requirements.pass.cpp:129:9: note: in instantiation of function template specialization 'oneapi::dpl::ranges::__internal::__merge_fn::operator()<oneapi::dpl::execution::device_policy<> &, TestUtils::MinimalisticView<int *> &, TestUtils::MinimalisticView<int *> &,
		  TestUtils::MinimalisticView<int *> &, std::ranges::less, std::identity, std::identity>' requested here
	  129 |         oneapi::dpl::ranges::merge(policy, r1, r2, r3);
		  |         ^
	/oneDPL/test/parallel_api/ranges/range_minimal_type_requirements.pass.cpp:264:5: note: in instantiation of function template specialization 'test_merge::operator()<oneapi::dpl::execution::device_policy<>>' requested here
	  264 |     Algorithm{}(TestUtils::get_dpcpp_test_policy());
		  |     ^
	/oneDPL/test/parallel_api/ranges/range_minimal_type_requirements.pass.cpp:275:5: note: in instantiation of function template specialization 'call_test_algo<test_merge>' requested here
	  275 |     call_test_algo<test_merge>    ();
		  |     ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ranges:112:16: note: because 'oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>' does not satisfy 'view'
	  112 |         static_assert(view<_Derived>);
		  |                       ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ranges:73:39: note: because 'oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>' does not satisfy 'default_initializable'
	   73 |       = range<_Tp> && movable<_Tp> && default_initializable<_Tp>
		  |                                       ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/concepts:143:37: note: because 'oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>' does not satisfy 'constructible_from'
	  143 |     concept default_initializable = constructible_from<_Tp>
		  |                                     ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/concepts:139:30: note: because 'is_constructible_v<oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>>' evaluated to false
	  139 |       = destructible<_Tp> && is_constructible_v<_Tp, _Args...>;
		  |                              ^
	/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/concepts:139:30: error: no matching constructor for initialization of 'oneapi::dpl::__ranges::__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>'
	  139 |       = destructible<_Tp> && is_constructible_v<_Tp, _Args...>;
		  |                              ^
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:793:24: note: candidate constructor not viable: requires single argument '__view', but no arguments were provided
	  793 |     constexpr explicit __subscription_impl_view_simple(_View __view) : __base(std::move(__view)) {}
		  |                        ^                               ~~~~~~~~~~~~
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:786:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 0 were provided
	  786 | struct __subscription_impl_view_simple : std::ranges::view_interface<__subscription_impl_view_simple<_View>>
		  |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:786:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 0 were provided
	  786 | struct __subscription_impl_view_simple : std::ranges::view_interface<__subscription_impl_view_simple<_View>>
		  |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	/oneDPL/include/oneapi/dpl/pstl/utils_ranges.h:786:8: note: '__subscription_impl_view_simple<TestUtils::MinimalisticView<int *>>' defined here
	4 errors generated.
	make[3]: *** [test/CMakeFiles/range_minimal_type_requirements.pass.dir/build.make:82: test/CMakeFiles/range_minimal_type_requirements.pass.dir/parallel_api/ranges/range_minimal_type_requirements.pass.cpp.o] Error 1
	make[2]: *** [CMakeFiles/Makefile2:22406: test/CMakeFiles/range_minimal_type_requirements.pass.dir/all] Error 2
	make[1]: *** [CMakeFiles/Makefile2:22413: test/CMakeFiles/range_minimal_type_requirements.pass.dir/rule] Error 2
	make: *** [Makefile:9619: range_minimal_type_requirements.pass] Error 2
```
