### PR TITLE
Add missed default constructors in some oneDPL internal views

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -734,6 +734,10 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<is_map_view<_M>::
     _Source __src; //Iterator (pointer) or unreachable range
     _M __map;      //permutation range
 
+    constexpr permutation_view_simple()
+        requires std::default_initializable<_Source> && std::default_initializable<_M>
+    = default;
+
     permutation_view_simple(_Source __data, _M __m) : __src(__data), __map(__m) {}
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range


### PR DESCRIPTION
This PR adds default constructors to several internal view classes in oneDPL's range utilities. The changes ensure these views can be default-initialized when their template parameters satisfy `std::default_initializable` requirements, improving compatibility with C++ standard concepts.

Key changes:
- Added constrained default constructors to view classes (`reverse_view_simple`, `take_view_simple`, `drop_view_simple`, etc.)
- Initialized member variables with default values where needed to support default construction
- Applied consistent `requires` clauses checking `std::default_initializable` on template parameters

If this PR make sense I propose to merge it into https://github.com/uxlfoundation/oneDPL/pull/2525