### PR TITLE
Fix incorrect checks of `in1` / `in2` fields in results of `std::range`-based `set` algorithms

### DIFF
--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -208,13 +208,13 @@ int out_size_with_empty_in2(int) { return 0; }
 auto data_gen2_default = [](auto i) { return i % 5 ? i : 0;};
 auto data_gen_unprocessed = [](auto) { return -1;};
 
-template <typename T, typename = void>
+template <typename T>
 static constexpr bool check_in_in_result{};
 
 template <typename I1, typename I2>
 static constexpr bool check_in_in_result<std::ranges::in_in_result<I1, I2>> = true;
 
-template <typename T, typename = void>
+template <typename T>
 static constexpr bool check_in_in_out_result{};
 
 template <typename I1, typename I2, typename O>


### PR DESCRIPTION
This PR fixes incorrect validation of `in`/`in2` fields in result types from `std::ranges` set algorithms. The original code didn't properly verify these fields for types like `in_in_result` and `in_in_out_result`, which contain multiple input iterators.

**Key Changes:**
- Added type trait helpers to detect `in_in_result` and `in_in_out_result` types
- Updated validation logic to correctly check both `in1` and `in2` fields using indexed accessors
- Enhanced `ret_in_val` function with template parameter to access specific input fields