### PR TITLE
[onedpl][ranges][test] A fix in ret_in_val function

### DIFF
--- a/test/parallel_api/ranges/std_ranges_reverse_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_reverse_copy.pass.cpp
@@ -40,7 +40,7 @@ main()
         return ret_type{res.in, std::ranges::begin(r_in) + skipped, res.out};
     };
 
-    test_range_algo<0, int, data_in_out_lim>{big_sz}(dpl_ranges::reverse_copy, reverse_copy_checker);
+    test_range_algo<0, int, data_in_in_out_lim>{big_sz}(dpl_ranges::reverse_copy, reverse_copy_checker);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_reverse_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_reverse_copy.pass.cpp
@@ -40,7 +40,7 @@ main()
         return ret_type{res.in, std::ranges::begin(r_in) + skipped, res.out};
     };
 
-    test_range_algo<0, int, data_in_in_out_lim>{big_sz}(dpl_ranges::reverse_copy, reverse_copy_checker);
+    test_range_algo<0, int, data_in_out_lim>{big_sz}(dpl_ranges::reverse_copy, reverse_copy_checker);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -529,7 +529,7 @@ private:
 
         if constexpr (!std::is_same_v<decltype(res), bool>)
         {
-            EXPECT_EQ(ret_in_val(expected_res, src_view1.begin()), ret_in_val(res, tr_in(A).begin()),
+            EXPECT_EQ(ret_in_val<1>(expected_res, src_view1.begin()), ret_in_val<1>(res, tr_in(A).begin()),
                       (std::string("wrong stop position with ") + typeid(Algo).name() +
                        typeid(decltype(tr_in(std::declval<Container&>()()))).name() + sizes).c_str());
         }

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -652,7 +652,7 @@ private:
         }
         else
 		{
-			static_assert(std::is_integral_v<Ret>);
+			static_assert(std::is_integral_v<std::remove_cvref_t<Ret>>);
             return ret;
 		}
     }

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -154,19 +154,27 @@ template<typename T>
 static constexpr
 bool check_in<T, std::void_t<decltype(std::declval<T>().in)>> = true;
 
+//template<typename, typename = void>
+//static constexpr bool check_in1{};
+
+//template<typename T>
+//static constexpr
+//bool check_in1<T, std::void_t<decltype(std::declval<T>().in1)>> = true;
+
+//template<typename, typename = void>
+//static constexpr bool check_in2{};
+
+//template<typename T>
+//static constexpr
+//bool check_in2<T, std::void_t<decltype(std::declval<T>().in2)>> = true;
+
 template<typename, typename = void>
-static constexpr bool check_in1{};
+static constexpr bool check_in2_in2{};
 
 template<typename T>
 static constexpr
-bool check_in1<T, std::void_t<decltype(std::declval<T>().in1)>> = true;
+bool check_in2_in2<T, std::void_t<decltype(std::declval<T>().in1, std::declval<T>().in2)>> = true;
 
-template<typename, typename = void>
-static constexpr bool check_in2{};
-
-template<typename T>
-static constexpr
-bool check_in2<T, std::void_t<decltype(std::declval<T>().in2)>> = true;
 
 template<typename, typename = void>
 static constexpr bool check_out{};
@@ -634,9 +642,9 @@ private:
 			static_assert(idx == 0); 
             return std::distance(begin, ret.in);
 		}
-        else if constexpr (check_in1<Ret> && idx == 1)
+        else if constexpr (check_in2_in2<Ret>/* && idx == 1*/)
             return std::distance(begin, ret.in1);
-        else if constexpr (check_in2<Ret> && idx == 2)
+        else if constexpr (check_in2_in2<Ret> && idx == 2)
             return std::distance(begin, ret.in2);
         else if constexpr (is_iterator<Ret>)
             return std::distance(begin, ret);
@@ -664,7 +672,7 @@ private:
             return std::distance(begin, ret.out);
         else if constexpr (is_iterator<Ret>)
             return std::distance(begin, ret);
-        else if constexpr (check_in2<Ret>)
+        else if constexpr (check_in2_in2<Ret>)
             return std::distance(begin, ret.in2);
         else if constexpr(is_range<Ret>)
             return std::pair{std::distance(begin, ret.begin()), std::ranges::distance(ret.begin(), ret.end())};

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -577,10 +577,10 @@ private:
         // check result types
         static_assert(std::is_same_v<decltype(res), decltype(expected_res)>, "Wrong return type");
 
-        EXPECT_EQ(ret_in_val(expected_res, src_view1.begin()), ret_in_val(res, tr_in(A).begin()),
+        EXPECT_EQ(ret_in_val<1>(expected_res, src_view1.begin()), ret_in_val<1>(res, tr_in(A).begin()),
                   (std::string("wrong first input stop position with ") + typeid(Algo).name() + sizes).c_str());
 
-        EXPECT_EQ(ret_in_val(expected_res, src_view2.begin()), ret_in_val(res, tr_in(B).begin()),
+        EXPECT_EQ(ret_in_val<2>(expected_res, src_view2.begin()), ret_in_val<2>(res, tr_in(B).begin()),
                   (std::string("wrong second input stop position with ") + typeid(Algo).name() + sizes).c_str());
 
         EXPECT_EQ(ret_out_val(expected_res, expected_view.begin()), ret_out_val(res, tr_out(C).begin()),
@@ -625,14 +625,18 @@ public:
     }
 private:
 
-    template<typename Ret, typename Begin>
+	//idx parameter means which input member of Ret should be processed: 0 - Ret::in, 1 - Ret::in1, 2 - Ret::in2.
+    template<int idx = 0, typename Ret, typename Begin>
     auto ret_in_val(Ret&& ret, Begin&& begin)
     {
         if constexpr (check_in<Ret>)
+		{
+			static_assert(idx == 0); 
             return std::distance(begin, ret.in);
-        else if constexpr (check_in1<Ret>)
+		}
+        else if constexpr (check_in1<Ret> && idx == 1)
             return std::distance(begin, ret.in1);
-        else if constexpr (check_in2<Ret>)
+        else if constexpr (check_in2<Ret> && idx == 2)
             return std::distance(begin, ret.in2);
         else if constexpr (is_iterator<Ret>)
             return std::distance(begin, ret);

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -652,7 +652,7 @@ private:
         }
         else
 		{
-			static_assert(std::is_integral_v<std::remove_cvref_t<Ret>>);
+			static_assert(std::is_integral_v<std::remove_cvref_t<Ret>> || std::is_same_v<std::remove_cvref_t<Ret>, P2>);
             return ret;
 		}
     }

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -651,7 +651,10 @@ private:
                 return std::pair{first, second};
         }
         else
+		{
+			static_assert(std::is_integral_v<Ret>);
             return ret;
+		}
     }
 
     template<typename Ret, typename Begin>


### PR DESCRIPTION
The PR introduces a fix in usage of ret_in_val function. The change adds a compile time index to determine which member of result type we need to process in1 or in2.

```
    //idx parameter means which input member of Ret should be processed: 0 - Ret::in, 1 - Ret::in1, 2 - Ret::in2.
    template<int idx = 0, typename Ret, typename Begin>
    auto ret_in_val(Ret&& ret, Begin&& begin)
```