### PR TITLE
Use std::optional to fix perf issues in device, result, and combined storage

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -799,9 +799,9 @@ struct __device_storage
         }
         else if (__usm_buf)
         {
-            auto& __qproxy = __usm_buf.get_deleter();
-            assert(__qproxy.__q.has_value());
-            __qproxy.__q->memcpy(__dst, __usm_buf.get() + __offset, __n * sizeof(_T)).wait();
+            auto& __q_proxy = __usm_buf.get_deleter();
+            assert(__q_proxy.__q.has_value());
+            __q_proxy.__q->memcpy(__dst, __usm_buf.get() + __offset, __n * sizeof(_T)).wait();
         }
         else
         {


### PR DESCRIPTION
* Large performance regressions are observed in find-or and certain scan algorithms due to usage of std::unique_ptr
* The deleter in std::unique_ptr requires default constructability and the gcc unique_ptr implementation seems to utilize this causing the construction of a new sycl::queue. This introduces large overhead in the SYCL runtime as new device resources are allocated and deallocated per oneDPL call.
* Switching to store an optional queue in `__sycl_usm_free` allows us to avoid queue default construction and only invoke the `sycl::queue` copy constructor when necessary, a lightweight operation.