### PR TITLE
Adding null check avoid dereferencing prior to init

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -210,6 +210,8 @@ class auto_tune_policy : public policy_base<auto_tune_policy<ResourceType, Resou
         {
             if (this->backend_)
                 this->backend_->lazy_report();
+            else
+                throw std::logic_error("selection called before initialization");
         }
         if (state_)
         {

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -127,6 +127,8 @@ class dynamic_load_policy
         {
             if (this->backend_)
                 this->backend_->lazy_report();
+            else
+                throw std::logic_error("selection called before initialization");
         }
         if (selector_)
         {


### PR DESCRIPTION
Static analysis of the code merged in #2508 identified two points where the backend is accessed and could potentially be NULL.  This PR adds the simple check to avoid the scenario.