### PR TITLE
Re-design the definition of `_ONEDPL_CPP20_RANGES_PRESENT` macro - fix compile error under `Clang 14.0.0`

### DIFF
--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -18,15 +18,6 @@
 // The oneAPI Specification version this implementation is compliant with
 #define ONEDPL_SPEC_VERSION 104
 
-// note that when ICC or Clang is in use, _ONEDPL_GCC_VERSION might not fully match
-// the actual GCC version on the system.
-#define _ONEDPL_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-
-#if __clang__
-// according to clang documentation, version can be vendor specific
-#    define _ONEDPL_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
-#endif
-
 // -- Check for C++ standard library feature macros --
 #if __has_include(<version>)
 #    include <version>

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -86,6 +86,15 @@
 #define _ONEDPL_STRING(x) _ONEDPL_STRING_AUX(x)
 #define _ONEDPL_STRING_CONCAT(x, y) x #y
 
+// note that when ICC or Clang is in use, _ONEDPL_GCC_VERSION might not fully match
+// the actual GCC version on the system.
+#define _ONEDPL_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+#if __clang__
+// according to clang documentation, version can be vendor specific
+#    define _ONEDPL_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+#endif
+
 // Enable SIMD for compilers that support OpenMP 4.0
 #if (_OPENMP >= 201307) || __INTEL_LLVM_COMPILER || (__INTEL_COMPILER >= 1600) ||                                      \
     (!defined(__INTEL_LLVM_COMPILER) && !defined(__INTEL_COMPILER) && _ONEDPL_GCC_VERSION >= 40900)


### PR DESCRIPTION
In this PR we fix compile error under `CLang 14.0.0`

This error was introduced in the PR https://github.com/uxlfoundation/oneDPL/pull/2529 in the fix for comment https://github.com/uxlfoundation/oneDPL/pull/2529/changes#r2569418335

So the correct check should include `__clang_major__` check to to avoid `CLang` compiler versions less than `16`
 
<details>
<summary>Compile error:</summary>
/usr/bin/clang++ -DTEST_LONG_RUN=1 -O0 -g CMakeFiles/header_inclusion_order_numeric_0.pass.dir/general/header_inclusion_order_numeric_0.pass.cpp.o -o header_inclusion_order_numeric_0.pass  /localdisk/tools/inteloneapi_tbb/tbb/latest/lib/intel64/gcc4.8/libtbb_debug.so.12 
In file included from /test/general/header_inclusion_order_memory_0.pass.cpp:18:
In file included from /include/oneapi/dpl/execution:23:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/execution:32:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/pstl/glue_execution_defs.h:50:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/pstl/algorithm_impl.h:13:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/iterator:61:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_iterator_base_types.h:71:
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:979:13: error: no matching function for call to '__begin'
		= decltype(ranges::__cust_access::__begin(std::declval<_Tp&>()));
				   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:590:5: note: in instantiation of template type alias '__range_iter_t' requested here
	using iterator_t = std::__detail::__range_iter_t<_Tp>;
	^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_util.h:98:43: note: in instantiation of template type alias 'iterator_t' requested here
	  data() requires contiguous_iterator<iterator_t<_Derived>>
										  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_util.h:203:29: note: in instantiation of template class 'std::ranges::view_interface<std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized>>' requested here
	class subrange : public view_interface<subrange<_It, _Sent, _Kind>>
							^
/test/general/header_inclusion_order_memory_0.pass.cpp:35:27: note: in instantiation of template class 'std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized>' requested here
	std::ranges::subrange subrange(ptr.get(), ptr.get() + n);
						  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:963:7: note: candidate template ignored: constraints not satisfied [with _Tp = std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized>]
	  __begin(_Tp& __t)
	  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:961:16: note: because 'is_array_v<std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized> >' evaluated to false
	  requires is_array_v<_Tp> || __member_begin<_Tp&> || __adl_begin<_Tp&>
			   ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:961:35: note: and 'std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized> &' does not satisfy '__member_begin'
	  requires is_array_v<_Tp> || __member_begin<_Tp&> || __adl_begin<_Tp&>
								  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:944:23: note: because '__decay_copy(__t.begin())' would be invalid: no member named 'begin' in 'std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized>'
		  { __decay_copy(__t.begin()) } -> input_or_output_iterator;
							 ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:961:59: note: and 'std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized> &' does not satisfy '__adl_begin'
	  requires is_array_v<_Tp> || __member_begin<_Tp&> || __adl_begin<_Tp&>
														  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:955:19: note: because '__decay_copy(begin(__t))' would be invalid: call to deleted function 'begin'
		  { __decay_copy(begin(__t)) } -> input_or_output_iterator;
						 ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:979:13: error: no matching function for call to '__begin'
		= decltype(ranges::__cust_access::__begin(std::declval<_Tp&>()));
				   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_base.h:590:5: note: in instantiation of template type alias '__range_iter_t' requested here
	using iterator_t = std::__detail::__range_iter_t<_Tp>;
	^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_util.h:104:25: note: in instantiation of template type alias 'iterator_t' requested here
		&& contiguous_iterator<iterator_t<const _Derived>>
							   ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/ranges_util.h:203:29: note: in instantiation of template class 'std::ranges::view_interface<std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized>>' requested here
	class subrange : public view_interface<subrange<_It, _Sent, _Kind>>
							^
/test/general/header_inclusion_order_memory_0.pass.cpp:35:27: note: in instantiation of template class 'std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized>' requested here
	std::ranges::subrange subrange(ptr.get(), ptr.get() + n);
						  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:963:7: note: candidate template ignored: constraints not satisfied [with _Tp = const std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized>]
	  __begin(_Tp& __t)
	  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:961:16: note: because 'is_array_v<const std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized> >' evaluated to false
	  requires is_array_v<_Tp> || __member_begin<_Tp&> || __adl_begin<_Tp&>
			   ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:961:35: note: and 'const std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized> &' does not satisfy '__member_begin'
	  requires is_array_v<_Tp> || __member_begin<_Tp&> || __adl_begin<_Tp&>
								  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:944:23: note: because '__decay_copy(__t.begin())' would be invalid: no member named 'begin' in 'std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized>'
		  { __decay_copy(__t.begin()) } -> input_or_output_iterator;
							 ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:961:59: note: and 'const std::ranges::subrange<int *, int *, std::ranges::subrange_kind::sized> &' does not satisfy '__adl_begin'
	  requires is_array_v<_Tp> || __member_begin<_Tp&> || __adl_begin<_Tp&>
														  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:955:19: note: because '__decay_copy(begin(__t))' would be invalid: call to deleted function 'begin'
		  { __decay_copy(begin(__t)) } -> input_or_output_iterator;
						 ^
</details>

Before the PR https://github.com/uxlfoundation/oneDPL/pull/2529, the the `_ONEDPL_CPP20_RANGES_PRESENT ` macro was implemented as
```C++
// Clang 15 and older do not support range adaptors, see https://bugs.llvm.org/show_bug.cgi?id=44833
#    define _ONEDPL_CPP20_RANGES_PRESENT ((__cpp_lib_ranges >= 201911L) && !(__clang__ && __clang_major__ < 16))
```