### PR TITLE
cherry-pick #2560 to 2022.11.0 release branch

### DIFF
--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -32,8 +32,7 @@
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
 // Ranges library is available if the standard library provides it and concepts are supported
 // Clang 15 and older do not support range adaptors, see https://bugs.llvm.org/show_bug.cgi?id=44833
-#    define _ONEDPL_CPP20_RANGES_PRESENT                                                                               \
-        ((__cpp_lib_ranges >= 201911L) && !(_LIBCPP_VERSION && _LIBCPP_VERSION < 16000))
+#    define _ONEDPL_CPP20_RANGES_PRESENT ((__cpp_lib_ranges >= 201911L) && !(__clang__ && __clang_major__ < 16))
 #else
 #    define _ONEDPL_CPP20_RANGES_PRESENT 0
 #endif


### PR DESCRIPTION
Re-design the definition of `_ONEDPL_CPP20_RANGES_PRESENT` macro - fix compile error under `Clang 14.0.0` (#2560)

Disable ranges support based on the version of clang instead of libc++