### PR TITLE
Tune chunk size for parallel_for in OpenMP backend

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1548,7 +1548,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                                       __result + __m, [__result, __first](_Tp* __i, _Tp* __j) {
                                           __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                               __i, __j, __first + (__i - __result), _IsVector{});
-                                      });
+                                      }, __par_backend::__grain_selector_for_small_workload{});
         return __first + __m;
     });
 }
@@ -1754,7 +1754,7 @@ __pattern_reverse(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
             [__first, __last](_RandomAccessIterator __inner_first, _RandomAccessIterator __inner_last) {
                 __internal::__brick_reverse(__inner_first, __inner_last, __last - (__inner_first - __first),
                                             _IsVector{});
-            });
+            }, __par_backend::__grain_selector_for_small_workload{});
     });
 }
 
@@ -1811,7 +1811,7 @@ __pattern_reverse_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ra
             [__first, __len, __d_first](_RandomAccessIterator1 __inner_first, _RandomAccessIterator1 __inner_last) {
                 __internal::__brick_reverse_copy(__inner_first, __inner_last,
                                                  __d_first + (__len - (__inner_last - __first)), _IsVector{});
-            });
+            }, __par_backend::__grain_selector_for_small_workload{});
         return __d_first + __len;
     });
 }
@@ -1897,19 +1897,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                                           [__middle, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_uninitialized_move(
                                                   __b, __e, __result + (__b - __middle), _IsVector{});
-                                          });
+                                          }, __par_backend::__grain_selector_for_small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
                                           [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_move<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __b + (__last - __middle), _IsVector{});
-                                          });
+                                          }, __par_backend::__grain_selector_for_small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + (__n - __m), [__first, __result](_Tp* __b, _Tp* __e) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __first + (__b - __result), _IsVector{});
-                                          });
+                                          }, __par_backend::__grain_selector_for_small_workload{});
 
             return __first + (__last - __middle);
         });
@@ -1923,19 +1923,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                                           [__first, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_uninitialized_move(
                                                   __b, __e, __result + (__b - __first), _IsVector{});
-                                          });
+                                          }, __par_backend::__grain_selector_for_small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
                                           [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_move<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __first + (__b - __middle), _IsVector{});
-                                          });
+                                          }, __par_backend::__grain_selector_for_small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + __m, [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
-                                          });
+                                          }, __par_backend::__grain_selector_for_small_workload{});
 
             return __first + (__last - __middle);
         });
@@ -2006,7 +2006,7 @@ __pattern_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
                         __copy(__middle, __e, __result, _IsVector{});
                     }
                 }
-            });
+            }, __par_backend::__grain_selector_for_small_workload{});
         return __result + (__last - __first);
     });
 }
@@ -2229,7 +2229,7 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
                     [__val1, __val2, __size1](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, (__val2.__pivot - __size1) + (__i - __val1.__pivot),
                                                         _IsVector{});
-                    });
+                    }, __par_backend::__grain_selector_for_small_workload{});
                 return {__new_begin, __val2.__pivot - __size1, __val2.__end};
             }
             // else we should swap the first part of false part of left range and true part of right range
@@ -2239,7 +2239,7 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
                     __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size2,
                     [__val1, __val2](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, __val2.__begin + (__i - __val1.__pivot), _IsVector{});
-                    });
+                    }, __par_backend::__grain_selector_for_small_workload{});
                 return {__new_begin, __val1.__pivot + __size2, __val2.__end};
             }
         };
@@ -2613,12 +2613,12 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                                           [__r, __d_first](_T1* __i, _T1* __j) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
-                                          });
+                                          }, __par_backend::__grain_selector_for_small_workload{});
 
             if constexpr (!::std::is_trivially_destructible_v<_T1>)
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
                                               __r + __n1,
-                                              [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); });
+                                              [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); }, __par_backend::__grain_selector_for_small_workload{});
 
             return __d_first + __n2;
         }
@@ -2802,7 +2802,7 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
                                       [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
                                           __internal::__brick_fill<__parallel_tag<_IsVector>, _Tp>{__value}(
                                               __begin, __end, _IsVector{});
-                                      });
+                                      }, __par_backend::__grain_selector_for_small_workload{});
         return __last;
     });
 }
@@ -2886,7 +2886,7 @@ __pattern_generate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Random
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                       [__g](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
                                           __internal::__brick_generate(__begin, __end, __g, _IsVector{});
-                                      });
+                                      }, __par_backend::__grain_selector_for_small_workload{});
         return __last;
     });
 }
@@ -3123,7 +3123,7 @@ ___merge_path_out_lim(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _It1
                     __it_res_2 = __res2;
                 }
             },
-            __merge_path_cut_off); //grainsize
+            __par_backend::__grain_selector_for_large_workload{}); //grainsize
     });
 
     return {__it_res_1, __it_res_2};
@@ -3218,7 +3218,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
                                       [__r, __first](_Tp* __i, _Tp* __j) {
                                           __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                               __i, __j, __first + (__i - __r), _IsVector{});
-                                      });
+                                      }, __par_backend::__grain_selector_for_small_workload{});
     });
 }
 
@@ -4434,7 +4434,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                                           [__first, __n](_DiffType __i, _DiffType __j) {
                                               __brick_move<__parallel_tag<_IsVector>>{}(
                                                   __first + __i, __first + __j, __first + __i - __n, _IsVector{});
-                                          });
+                                          }, __par_backend::__grain_selector_for_small_workload{});
         }
         else //2. n < size/2; there is not enough memory to parallel copying; doing parallel copying by n elements
         {
@@ -4446,7 +4446,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                                               [__first, __n](_DiffType __i, _DiffType __j) {
                                                   __brick_move<__parallel_tag<_IsVector>>{}(
                                                       __first + __i, __first + __j, __first + __i - __n, _IsVector{});
-                                              });
+                                              }, __par_backend::__grain_selector_for_small_workload{});
             }
         }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1548,7 +1548,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                                       __result + __m, [__result, __first](_Tp* __i, _Tp* __j) {
                                           __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                               __i, __j, __first + (__i - __result), _IsVector{});
-                                      }, __par_backend::__grain_selector_for_small_workload{});
+                                      }, __par_backend::__grain_selector_small_workload{});
         return __first + __m;
     });
 }
@@ -1754,7 +1754,7 @@ __pattern_reverse(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
             [__first, __last](_RandomAccessIterator __inner_first, _RandomAccessIterator __inner_last) {
                 __internal::__brick_reverse(__inner_first, __inner_last, __last - (__inner_first - __first),
                                             _IsVector{});
-            }, __par_backend::__grain_selector_for_small_workload{});
+            }, __par_backend::__grain_selector_small_workload{});
     });
 }
 
@@ -1811,7 +1811,7 @@ __pattern_reverse_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ra
             [__first, __len, __d_first](_RandomAccessIterator1 __inner_first, _RandomAccessIterator1 __inner_last) {
                 __internal::__brick_reverse_copy(__inner_first, __inner_last,
                                                  __d_first + (__len - (__inner_last - __first)), _IsVector{});
-            }, __par_backend::__grain_selector_for_small_workload{});
+            }, __par_backend::__grain_selector_small_workload{});
         return __d_first + __len;
     });
 }
@@ -1897,19 +1897,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                                           [__middle, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_uninitialized_move(
                                                   __b, __e, __result + (__b - __middle), _IsVector{});
-                                          }, __par_backend::__grain_selector_for_small_workload{});
+                                          }, __par_backend::__grain_selector_small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
                                           [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_move<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __b + (__last - __middle), _IsVector{});
-                                          }, __par_backend::__grain_selector_for_small_workload{});
+                                          }, __par_backend::__grain_selector_small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + (__n - __m), [__first, __result](_Tp* __b, _Tp* __e) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __first + (__b - __result), _IsVector{});
-                                          }, __par_backend::__grain_selector_for_small_workload{});
+                                          }, __par_backend::__grain_selector_small_workload{});
 
             return __first + (__last - __middle);
         });
@@ -1923,19 +1923,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                                           [__first, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_uninitialized_move(
                                                   __b, __e, __result + (__b - __first), _IsVector{});
-                                          }, __par_backend::__grain_selector_for_small_workload{});
+                                          }, __par_backend::__grain_selector_small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
                                           [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_move<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __first + (__b - __middle), _IsVector{});
-                                          }, __par_backend::__grain_selector_for_small_workload{});
+                                          }, __par_backend::__grain_selector_small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + __m, [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
-                                          }, __par_backend::__grain_selector_for_small_workload{});
+                                          }, __par_backend::__grain_selector_small_workload{});
 
             return __first + (__last - __middle);
         });
@@ -2006,7 +2006,7 @@ __pattern_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
                         __copy(__middle, __e, __result, _IsVector{});
                     }
                 }
-            }, __par_backend::__grain_selector_for_small_workload{});
+            }, __par_backend::__grain_selector_small_workload{});
         return __result + (__last - __first);
     });
 }
@@ -2229,7 +2229,7 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
                     [__val1, __val2, __size1](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, (__val2.__pivot - __size1) + (__i - __val1.__pivot),
                                                         _IsVector{});
-                    }, __par_backend::__grain_selector_for_small_workload{});
+                    }, __par_backend::__grain_selector_small_workload{});
                 return {__new_begin, __val2.__pivot - __size1, __val2.__end};
             }
             // else we should swap the first part of false part of left range and true part of right range
@@ -2239,7 +2239,7 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
                     __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size2,
                     [__val1, __val2](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, __val2.__begin + (__i - __val1.__pivot), _IsVector{});
-                    }, __par_backend::__grain_selector_for_small_workload{});
+                    }, __par_backend::__grain_selector_small_workload{});
                 return {__new_begin, __val1.__pivot + __size2, __val2.__end};
             }
         };
@@ -2613,12 +2613,12 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                                           [__r, __d_first](_T1* __i, _T1* __j) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
-                                          }, __par_backend::__grain_selector_for_small_workload{});
+                                          }, __par_backend::__grain_selector_small_workload{});
 
             if constexpr (!::std::is_trivially_destructible_v<_T1>)
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
                                               __r + __n1,
-                                              [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); }, __par_backend::__grain_selector_for_small_workload{});
+                                              [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); }, __par_backend::__grain_selector_small_workload{});
 
             return __d_first + __n2;
         }
@@ -2802,7 +2802,7 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
                                       [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
                                           __internal::__brick_fill<__parallel_tag<_IsVector>, _Tp>{__value}(
                                               __begin, __end, _IsVector{});
-                                      }, __par_backend::__grain_selector_for_small_workload{});
+                                      }, __par_backend::__grain_selector_small_workload{});
         return __last;
     });
 }
@@ -2886,7 +2886,7 @@ __pattern_generate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Random
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                       [__g](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
                                           __internal::__brick_generate(__begin, __end, __g, _IsVector{});
-                                      }, __par_backend::__grain_selector_for_small_workload{});
+                                      }, __par_backend::__grain_selector_small_workload{});
         return __last;
     });
 }
@@ -3123,7 +3123,7 @@ ___merge_path_out_lim(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _It1
                     __it_res_2 = __res2;
                 }
             },
-            __par_backend::__grain_selector_for_large_workload{}); //grainsize
+            __par_backend::__grain_selector_large_workload{}); //grainsize
     });
 
     return {__it_res_1, __it_res_2};
@@ -3218,7 +3218,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
                                       [__r, __first](_Tp* __i, _Tp* __j) {
                                           __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                               __i, __j, __first + (__i - __r), _IsVector{});
-                                      }, __par_backend::__grain_selector_for_small_workload{});
+                                      }, __par_backend::__grain_selector_small_workload{});
     });
 }
 
@@ -4434,7 +4434,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                                           [__first, __n](_DiffType __i, _DiffType __j) {
                                               __brick_move<__parallel_tag<_IsVector>>{}(
                                                   __first + __i, __first + __j, __first + __i - __n, _IsVector{});
-                                          }, __par_backend::__grain_selector_for_small_workload{});
+                                          }, __par_backend::__grain_selector_small_workload{});
         }
         else //2. n < size/2; there is not enough memory to parallel copying; doing parallel copying by n elements
         {
@@ -4446,7 +4446,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                                               [__first, __n](_DiffType __i, _DiffType __j) {
                                                   __brick_move<__parallel_tag<_IsVector>>{}(
                                                       __first + __i, __first + __j, __first + __i - __n, _IsVector{});
-                                              }, __par_backend::__grain_selector_for_small_workload{});
+                                              }, __par_backend::__grain_selector_small_workload{});
             }
         }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1548,7 +1548,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                                       __result + __m, [__result, __first](_Tp* __i, _Tp* __j) {
                                           __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                               __i, __j, __first + (__i - __result), _IsVector{});
-                                      }, __par_backend::__grain_selector_small_workload{});
+                                      }, __par_backend::__small_workload{});
         return __first + __m;
     });
 }
@@ -1754,7 +1754,7 @@ __pattern_reverse(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
             [__first, __last](_RandomAccessIterator __inner_first, _RandomAccessIterator __inner_last) {
                 __internal::__brick_reverse(__inner_first, __inner_last, __last - (__inner_first - __first),
                                             _IsVector{});
-            }, __par_backend::__grain_selector_small_workload{});
+            }, __par_backend::__small_workload{});
     });
 }
 
@@ -1811,7 +1811,7 @@ __pattern_reverse_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ra
             [__first, __len, __d_first](_RandomAccessIterator1 __inner_first, _RandomAccessIterator1 __inner_last) {
                 __internal::__brick_reverse_copy(__inner_first, __inner_last,
                                                  __d_first + (__len - (__inner_last - __first)), _IsVector{});
-            }, __par_backend::__grain_selector_small_workload{});
+            }, __par_backend::__small_workload{});
         return __d_first + __len;
     });
 }
@@ -1897,19 +1897,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                                           [__middle, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_uninitialized_move(
                                                   __b, __e, __result + (__b - __middle), _IsVector{});
-                                          }, __par_backend::__grain_selector_small_workload{});
+                                          }, __par_backend::__small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
                                           [__last, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_move<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __b + (__last - __middle), _IsVector{});
-                                          }, __par_backend::__grain_selector_small_workload{});
+                                          }, __par_backend::__small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + (__n - __m), [__first, __result](_Tp* __b, _Tp* __e) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __first + (__b - __result), _IsVector{});
-                                          }, __par_backend::__grain_selector_small_workload{});
+                                          }, __par_backend::__small_workload{});
 
             return __first + (__last - __middle);
         });
@@ -1923,19 +1923,19 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
                                           [__first, __result](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_uninitialized_move(
                                                   __b, __e, __result + (__b - __first), _IsVector{});
-                                          }, __par_backend::__grain_selector_small_workload{});
+                                          }, __par_backend::__small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
                                           [__first, __middle](_RandomAccessIterator __b, _RandomAccessIterator __e) {
                                               __internal::__brick_move<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __first + (__b - __middle), _IsVector{});
-                                          }, __par_backend::__grain_selector_small_workload{});
+                                          }, __par_backend::__small_workload{});
 
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __result,
                                           __result + __m, [__n, __m, __first, __result](_Tp* __b, _Tp* __e) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __b, __e, __first + ((__n - __m) + (__b - __result)), _IsVector{});
-                                          }, __par_backend::__grain_selector_small_workload{});
+                                          }, __par_backend::__small_workload{});
 
             return __first + (__last - __middle);
         });
@@ -2006,7 +2006,7 @@ __pattern_rotate_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
                         __copy(__middle, __e, __result, _IsVector{});
                     }
                 }
-            }, __par_backend::__grain_selector_small_workload{});
+            }, __par_backend::__small_workload{});
         return __result + (__last - __first);
     });
 }
@@ -2229,7 +2229,7 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
                     [__val1, __val2, __size1](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, (__val2.__pivot - __size1) + (__i - __val1.__pivot),
                                                         _IsVector{});
-                    }, __par_backend::__grain_selector_small_workload{});
+                    }, __par_backend::__small_workload{});
                 return {__new_begin, __val2.__pivot - __size1, __val2.__end};
             }
             // else we should swap the first part of false part of left range and true part of right range
@@ -2239,7 +2239,7 @@ __pattern_partition(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rando
                     __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size2,
                     [__val1, __val2](_RandomAccessIterator __i, _RandomAccessIterator __j) {
                         __internal::__brick_swap_ranges(__i, __j, __val2.__begin + (__i - __val1.__pivot), _IsVector{});
-                    }, __par_backend::__grain_selector_small_workload{});
+                    }, __par_backend::__small_workload{});
                 return {__new_begin, __val1.__pivot + __size2, __val2.__end};
             }
         };
@@ -2613,12 +2613,12 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                                           [__r, __d_first](_T1* __i, _T1* __j) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
-                                          }, __par_backend::__grain_selector_small_workload{});
+                                          }, __par_backend::__small_workload{});
 
             if constexpr (!::std::is_trivially_destructible_v<_T1>)
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
                                               __r + __n1,
-                                              [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); }, __par_backend::__grain_selector_small_workload{});
+                                              [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); }, __par_backend::__small_workload{});
 
             return __d_first + __n2;
         }
@@ -2802,7 +2802,7 @@ __pattern_fill(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAcce
                                       [&__value](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
                                           __internal::__brick_fill<__parallel_tag<_IsVector>, _Tp>{__value}(
                                               __begin, __end, _IsVector{});
-                                      }, __par_backend::__grain_selector_small_workload{});
+                                      }, __par_backend::__small_workload{});
         return __last;
     });
 }
@@ -2886,7 +2886,7 @@ __pattern_generate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Random
         __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                       [__g](_RandomAccessIterator __begin, _RandomAccessIterator __end) {
                                           __internal::__brick_generate(__begin, __end, __g, _IsVector{});
-                                      }, __par_backend::__grain_selector_small_workload{});
+                                      }, __par_backend::__small_workload{});
         return __last;
     });
 }
@@ -3123,7 +3123,7 @@ ___merge_path_out_lim(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _It1
                     __it_res_2 = __res2;
                 }
             },
-            __par_backend::__grain_selector_large_workload{}); //grainsize
+            __par_backend::__large_workload{}); //grainsize
     });
 
     return {__it_res_1, __it_res_2};
@@ -3218,7 +3218,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
                                       [__r, __first](_Tp* __i, _Tp* __j) {
                                           __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                               __i, __j, __first + (__i - __r), _IsVector{});
-                                      }, __par_backend::__grain_selector_small_workload{});
+                                      }, __par_backend::__small_workload{});
     });
 }
 
@@ -4434,7 +4434,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                                           [__first, __n](_DiffType __i, _DiffType __j) {
                                               __brick_move<__parallel_tag<_IsVector>>{}(
                                                   __first + __i, __first + __j, __first + __i - __n, _IsVector{});
-                                          }, __par_backend::__grain_selector_small_workload{});
+                                          }, __par_backend::__small_workload{});
         }
         else //2. n < size/2; there is not enough memory to parallel copying; doing parallel copying by n elements
         {
@@ -4446,7 +4446,7 @@ __pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Rand
                                               [__first, __n](_DiffType __i, _DiffType __j) {
                                                   __brick_move<__parallel_tag<_IsVector>>{}(
                                                       __first + __i, __first + __j, __first + __i - __n, _IsVector{});
-                                              }, __par_backend::__grain_selector_small_workload{});
+                                              }, __par_backend::__small_workload{});
             }
         }
 

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -409,7 +409,7 @@ __pattern_adjacent_difference(__parallel_tag<_IsVector>, _ExecutionPolicy&& __ex
                     __b, __e, __b + 1, __d_b + 1,
                     [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) { __z = __op(__y, __x); },
                     _IsVector{});
-            }, __par_backend::__grain_selector_for_small_workload{});
+            }, __par_backend::__grain_selector_small_workload{});
         return __d_first + (__last - __first);
     });
 }

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -409,7 +409,7 @@ __pattern_adjacent_difference(__parallel_tag<_IsVector>, _ExecutionPolicy&& __ex
                     __b, __e, __b + 1, __d_b + 1,
                     [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) { __z = __op(__y, __x); },
                     _IsVector{});
-            });
+            }, __par_backend::__grain_selector_for_small_workload{});
         return __d_first + (__last - __first);
     });
 }

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -409,7 +409,7 @@ __pattern_adjacent_difference(__parallel_tag<_IsVector>, _ExecutionPolicy&& __ex
                     __b, __e, __b + 1, __d_b + 1,
                     [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) { __z = __op(__y, __x); },
                     _IsVector{});
-            }, __par_backend::__grain_selector_small_workload{});
+            }, __par_backend::__small_workload{});
         return __d_first + (__last - __first);
     });
 }

--- a/include/oneapi/dpl/pstl/omp/parallel_for.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for.h
@@ -48,7 +48,7 @@ struct __grain_selector_any_workload
     }
 };
 
-struct __grain_selector_for_small_workload
+struct __grain_selector_small_workload
 {
     inline std::size_t operator()(std::size_t __size, int __num_threads) const
     {
@@ -69,7 +69,7 @@ struct __grain_selector_for_small_workload
     }
 };
 
-struct __grain_selector_for_large_workload
+struct __grain_selector_large_workload
 {
     inline std::size_t operator()(std::size_t __size, int __num_threads) const
     {

--- a/include/oneapi/dpl/pstl/omp/parallel_for.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for.h
@@ -27,69 +27,6 @@ namespace dpl
 namespace __omp_backend
 {
 
-struct __grain_selector_any_workload
-{
-    inline std::size_t operator()(std::size_t __size, int __num_threads) const
-    {
-        // Multiple is selected to allow vectorization inside a chunk with AVX-512 or narrower vector instructions
-        // Min/Max are found empirically
-        constexpr std::size_t __min_chunk = 256;
-        constexpr std::size_t __max_chunk = 16384;
-        constexpr std::size_t __multiple_chunk = 64;
-
-        // Aim for 3 tasks per thread for better load balancing
-        std::size_t __grainsize = __size / (__num_threads * 3);
-        if (__grainsize < __min_chunk)
-            __grainsize = __min_chunk;
-        else if (__grainsize > __max_chunk)
-            __grainsize = __max_chunk;
-        // Round up to avoid too avoid small uneven chunk at the end
-        return ((__grainsize + __multiple_chunk - 1) / __multiple_chunk) * __multiple_chunk;
-    }
-};
-
-struct __grain_selector_small_workload
-{
-    inline std::size_t operator()(std::size_t __size, int __num_threads) const
-    {
-        // Multiple is selected to allow vectorization inside a chunk with AVX-512 or narrower vector instructions
-        // Min/Max are found empirically
-        constexpr std::size_t __min_chunk = 2048;
-        constexpr std::size_t __max_chunk = 16384;
-        constexpr std::size_t __multiple_chunk = 64;
-
-        // Aim for 3 tasks per thread for better load balancing
-        std::size_t __grainsize = __size / (__num_threads * 3);
-        if (__grainsize < __min_chunk)
-            __grainsize = __min_chunk;
-        else if (__grainsize > __max_chunk)
-            __grainsize = __max_chunk;
-        // Round up to avoid too avoid small uneven chunk at the end
-        return ((__grainsize + __multiple_chunk - 1) / __multiple_chunk) * __multiple_chunk;
-    }
-};
-
-struct __grain_selector_large_workload
-{
-    inline std::size_t operator()(std::size_t __size, int __num_threads) const
-    {
-        // Multiple is selected to allow vectorization inside a chunk with AVX-512 or narrower vector instructions
-        // Min/Max are found empirically
-        constexpr std::size_t __min_chunk = 64;
-        constexpr std::size_t __max_chunk = 1024;
-        constexpr std::size_t __multiple_chunk = 64;
-
-        // Aim for 3 tasks per thread for better load balancing
-        std::size_t __grainsize = __size / (__num_threads * 3);
-        if (__grainsize < __min_chunk)
-            __grainsize = __min_chunk;
-        else if (__grainsize > __max_chunk)
-            __grainsize = __max_chunk;
-        // Round up to avoid too avoid small uneven chunk at the end
-        return ((__grainsize + __multiple_chunk - 1) / __multiple_chunk) * __multiple_chunk;
-    }
-};
-
 template <class _Index, class _Fp, class _GrainSelector>
 void
 __parallel_for_body(_Index __first, _Index __last, _Fp __f, _GrainSelector __grain_selector)

--- a/include/oneapi/dpl/pstl/omp/parallel_for.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_for.h
@@ -27,14 +27,13 @@ namespace dpl
 namespace __omp_backend
 {
 
-template <class _Index, class _Fp, class _GrainSelector>
+template <class _Index, class _Fp, class _ChunkPartitioningPolicy>
 void
-__parallel_for_body(_Index __first, _Index __last, _Fp __f, _GrainSelector __grain_selector)
+__parallel_for_body(_Index __first, _Index __last, _Fp __f, _ChunkPartitioningPolicy __partitioning_policy)
 {
-    std::size_t __grainsize = __grain_selector(__last - __first, omp_get_num_threads());
-
     // initial partition of the iteration space into chunks
-    auto __policy = oneapi::dpl::__omp_backend::__chunk_partitioner(__first, __last, __grainsize);
+    auto __policy = oneapi::dpl::__omp_backend::__chunk_partitioner(__first, __last, omp_get_num_threads(),
+                                                                    __partitioning_policy);
 
     // To avoid over-subscription we use taskloop for the nested parallelism
     _ONEDPL_PRAGMA(omp taskloop untied mergeable)
@@ -49,16 +48,16 @@ __parallel_for_body(_Index __first, _Index __last, _Fp __f, _GrainSelector __gra
 // Evaluation of brick f[i,j) for each subrange [i,j) of [first, last)
 //------------------------------------------------------------------------
 
-template <class _ExecutionPolicy, class _Index, class _Fp, class _GrainSelector = __grain_selector_any_workload>
+template <class _ExecutionPolicy, class _Index, class _Fp, class _ChunkPartitioningPolicy = __any_workload>
 void
 __parallel_for(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f,
-               _GrainSelector __grain_selector = _GrainSelector())
+               _ChunkPartitioningPolicy __partitioning_policy = _ChunkPartitioningPolicy())
 {
     if (omp_in_parallel())
     {
         // we don't create a nested parallel region in an existing parallel
         // region: just create tasks
-        oneapi::dpl::__omp_backend::__parallel_for_body(__first, __last, __f, __grain_selector);
+        oneapi::dpl::__omp_backend::__parallel_for_body(__first, __last, __f, __partitioning_policy);
     }
     else
     {
@@ -67,7 +66,7 @@ __parallel_for(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _
         _ONEDPL_PRAGMA(omp parallel)
         _ONEDPL_PRAGMA(omp single nowait)
         {
-            oneapi::dpl::__omp_backend::__parallel_for_body(__first, __last, __f, __grain_selector);
+            oneapi::dpl::__omp_backend::__parallel_for_body(__first, __last, __f, __partitioning_policy);
         }
     }
 }

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -53,36 +53,6 @@ using __buffer = oneapi::dpl::__utils::__buffer_impl<_Tp, std::allocator>;
 // Preliminary size of each chunk: requires further discussion
 constexpr std::size_t __default_chunk_size = 2048;
 
-// Multiple is selected to allow vectorization inside a chunk with AVX-512 or narrower vector instructions
-template <std::size_t _MinChunkSize, std::size_t _MaxChunkSize, std::size_t _MultipleChunkSize = 64>
-struct __grain_selector
-{
-    std::size_t operator()(std::size_t __size, int __num_threads) const
-    {
-        // Aim for 3 tasks per thread for better load balancing
-        std::size_t __grainsize = __size / (__num_threads * 3);
-        if (__grainsize < _MinChunkSize)
-            __grainsize = _MinChunkSize;
-        // No upper bound if _MaxChunkSize is 0
-        else if (__grainsize > _MaxChunkSize && _MaxChunkSize != 0)
-            __grainsize = _MaxChunkSize;
-        // Round up to avoid unbalanced load due to an extra chunk
-        return ((__grainsize + _MultipleChunkSize - 1) / _MultipleChunkSize) * _MultipleChunkSize;
-    }
-};
-
-struct __grain_selector_any_workload: public __grain_selector<256, 0>
-{
-};
-
-struct __grain_selector_small_workload: public __grain_selector<2048, 0>
-{
-};
-
-struct __grain_selector_large_workload: public __grain_selector<64, 1024>
-{
-};
-
 // Convenience function to determine when we should run serial.
 template <typename _Iterator, std::enable_if_t<!std::is_integral_v<_Iterator>, bool> = true>
 constexpr auto
@@ -109,49 +79,63 @@ struct __chunk_metrics
     std::size_t __first_chunk_size;
 };
 
-// The iteration space partitioner according to __requested_chunk_size
-template <class _RandomAccessIterator, class _Size = std::size_t>
+template <std::size_t _MinChunkSize>
+struct __chunk_partitioning_policy
+{
+    static constexpr std::size_t __min_chunk_size = _MinChunkSize;
+};
+struct __any_workload: public __chunk_partitioning_policy<256> {};
+struct __small_workload: public __chunk_partitioning_policy<2048> {};
+struct __large_workload: public __chunk_partitioning_policy<64> {};
+
+template <class _RandomAccessIterator, class _ChunkPartitioningPolicy, class _Size = std::size_t>
 auto
 __chunk_partitioner(_RandomAccessIterator __first, _RandomAccessIterator __last,
-                    _Size __requested_chunk_size = __default_chunk_size) -> __chunk_metrics
+                    const int __num_threads, _ChunkPartitioningPolicy __partitioning_policy) -> __chunk_metrics
 {
-    /*
-     * This algorithm improves distribution of elements in chunks by avoiding
-     * small tail chunks. The leftover elements that do not fit neatly into
-     * the chunk size are redistributed to early chunks. This improves
-     * utilization of the processor's prefetch and reduces the number of
-     * tasks needed by 1.
-     */
-
-    const _Size __n = __last - __first;
-    _Size __n_chunks = 0;
-    _Size __chunk_size = 0;
-    _Size __first_chunk_size = 0;
-    if (__n < __requested_chunk_size)
+    constexpr _Size __min_chunk_size = __partitioning_policy.__min_chunk_size;
+    _Size __n_chunks = 1;
+    _Size __n = __last - __first;
+    if (__n <= __min_chunk_size)
     {
-        __chunk_size = __n;
-        __first_chunk_size = __n;
-        __n_chunks = 1;
-        return __chunk_metrics{__n_chunks, __chunk_size, __first_chunk_size};
+        return __chunk_metrics{__n_chunks, __n, __n};
     }
 
-    __n_chunks = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __requested_chunk_size);
-    __chunk_size = __n / __n_chunks;
-    __first_chunk_size = __chunk_size;
-    const _Size __n_leftover_items = __n - (__n_chunks * __chunk_size);
+    // Aim for 3 tasks per thread for better load balancing
+    constexpr _Size __target_tasks_per_thread = 3;
+    _Size __target_task_count = __num_threads * __target_tasks_per_thread;
+    _Size __chunk_size = __n / __target_task_count;
 
-    if (__n_leftover_items == 0)
+    // Enough work - create the target number of tasks per thread
+    if (__chunk_size >= __min_chunk_size)
     {
+        __n_chunks = __target_task_count;
+        _Size __first_chunk_size = __n - (__chunk_size * (__n_chunks - 1));
         return __chunk_metrics{__n_chunks, __chunk_size, __first_chunk_size};
     }
-
-    const _Size __n_extra_items_per_chunk = __n_leftover_items / __n_chunks;
-    const _Size __n_final_leftover_items = __n_leftover_items - (__n_extra_items_per_chunk * __n_chunks);
-
-    __chunk_size += __n_extra_items_per_chunk;
-    __first_chunk_size = __chunk_size + __n_final_leftover_items;
-
-    return __chunk_metrics{__n_chunks, __chunk_size, __first_chunk_size};
+    // Enough work to occupy each thread with at least one task -
+    // make sure the number of tasks is multiple of the number of threads
+    else if (__chunk_size * __target_tasks_per_thread >= __min_chunk_size)
+    {
+        __n_chunks = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __min_chunk_size);
+        __n_chunks = (__n_chunks / __num_threads) * __num_threads;
+        __chunk_size = __n / __n_chunks;
+        _Size __first_chunk_size = __n - (__chunk_size * (__n_chunks - 1));
+        return __chunk_metrics{__n_chunks, __chunk_size, __first_chunk_size};
+    }
+    // Not enough work even for one task per thread
+    else
+    {
+        __chunk_size = __min_chunk_size;
+        __n_chunks = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __chunk_size);
+        __chunk_size = __n / __n_chunks;
+        const _Size __n_leftover_items = __n - (__n_chunks * __chunk_size);
+        const _Size __n_extra_items_per_chunk = __n_leftover_items / __n_chunks;
+        const _Size __n_final_leftover_items = __n_leftover_items - (__n_extra_items_per_chunk * __n_chunks);
+        __chunk_size += __n_extra_items_per_chunk;
+        const _Size __first_chunk_size = __chunk_size + __n_final_leftover_items;
+        return __chunk_metrics{__n_chunks, __chunk_size, __first_chunk_size};
+    }
 }
 
 template <typename _Iterator, typename _Index, typename _Func>

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -86,7 +86,7 @@ __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)
 
 struct __grain_selector_any_workload
 {
-    inline std::size_t
+    constexpr std::size_t
     operator()(std::size_t __size, std::size_t __num_threads) const
     {
         return 1;

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -84,10 +84,21 @@ __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)
 {
 }
 
-template <class _ExecutionPolicy, class _Index, class _Fp>
+struct __grain_selector_any_workload
+{
+    inline std::size_t
+    operator()(std::size_t __size, std::size_t __num_threads) const
+    {
+        return 1;
+    }
+};
+struct __grain_selector_small_workload: public __grain_selector_any_workload {};
+struct __grain_selector_large_workload: public __grain_selector_any_workload {};
+
+template <class _ExecutionPolicy, class _Index, class _Fp, class _GrainSelector = __grain_selector_any_workload>
 void
 __parallel_for(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last,
-               _Fp __f, std::size_t /*__grainsize*/ = 1)
+               _Fp __f, _GrainSelector = _GrainSelector())
 {
     __f(__first, __last);
 }

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -84,21 +84,19 @@ __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)
 {
 }
 
-struct __grain_selector_any_workload
+template <std::size_t _MinChunkSize>
+struct __chunk_partitioning_policy
 {
-    constexpr std::size_t
-    operator()(std::size_t __size, std::size_t __num_threads) const
-    {
-        return 1;
-    }
+    static constexpr std::size_t __min_chunk_size = _MinChunkSize;
 };
-struct __grain_selector_small_workload: public __grain_selector_any_workload {};
-struct __grain_selector_large_workload: public __grain_selector_any_workload {};
+struct __any_workload: public __chunk_partitioning_policy<1> {};
+struct __small_workload: public __chunk_partitioning_policy<1> {};
+struct __large_workload: public __chunk_partitioning_policy<1> {};
 
-template <class _ExecutionPolicy, class _Index, class _Fp, class _GrainSelector = __grain_selector_any_workload>
+template <class _ExecutionPolicy, class _Index, class _Fp, class _ChunkPartitioningPolicy = __any_workload>
 void
 __parallel_for(oneapi::dpl::__internal::__serial_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last,
-               _Fp __f, _GrainSelector = _GrainSelector())
+               _Fp __f, _ChunkPartitioningPolicy = _ChunkPartitioningPolicy())
 {
     __f(__first, __last);
 }

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -90,20 +90,19 @@ class __parallel_for_body
     _RealBody _M_body;
 };
 
-struct __grain_selector_for_any_workload
+struct __grain_selector_any_workload
 {
     constexpr std::size_t operator()() const
     {
         return 1; // matches the default grainsize value of tbb::blocked_range according to the specification
     }
 };
-
-struct __grain_selector_for_small_workload: public __grain_selector_for_any_workload {};
-struct __grain_selector_for_large_workload: public __grain_selector_for_any_workload {};
+struct __grain_selector_small_workload: public __grain_selector_any_workload {};
+struct __grain_selector_large_workload: public __grain_selector_any_workload {};
 
 //! Evaluation of brick f[i,j) for each subrange [i,j) of [first,last)
 // wrapper over tbb::parallel_for
-template <class _ExecutionPolicy, class _Index, class _Fp, class _GrainSelector = __grain_selector_for_any_workload>
+template <class _ExecutionPolicy, class _Index, class _Fp, class _GrainSelector = __grain_selector_any_workload>
 void
 __parallel_for(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f,
                _GrainSelector __grain_selector = _GrainSelector())

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -92,9 +92,11 @@ class __parallel_for_body
 
 struct __grain_selector_any_workload
 {
-    constexpr std::size_t operator()() const
+    constexpr std::size_t
+    operator()() const
     {
-        return 1; // matches the default grainsize value of tbb::blocked_range according to the specification
+        // matches the default grainsize value of tbb::blocked_range according to the specification
+        return 1;
     }
 };
 struct __grain_selector_small_workload: public __grain_selector_any_workload {};

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -90,14 +90,25 @@ class __parallel_for_body
     _RealBody _M_body;
 };
 
+struct __grain_selector_for_any_workload
+{
+    constexpr std::size_t operator()() const
+    {
+        return 1; // matches the default grainsize value of tbb::blocked_range according to the specification
+    }
+};
+
+struct __grain_selector_for_small_workload: public __grain_selector_for_any_workload {};
+struct __grain_selector_for_large_workload: public __grain_selector_for_any_workload {};
+
 //! Evaluation of brick f[i,j) for each subrange [i,j) of [first,last)
 // wrapper over tbb::parallel_for
-template <class _ExecutionPolicy, class _Index, class _Fp>
+template <class _ExecutionPolicy, class _Index, class _Fp, class _GrainSelector = __grain_selector_for_any_workload>
 void
 __parallel_for(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f,
-               std::size_t __grainsize = 1 /*matches the default grainsize value of tbb::blocked_range according to
-               the specification*/)
+               _GrainSelector __grain_selector = _GrainSelector())
 {
+    constexpr std::size_t __grainsize = __grain_selector();
     tbb::this_task_arena::isolate([=]() {
         tbb::parallel_for(tbb::blocked_range<_Index>(__first, __last, __grainsize),
                           __parallel_for_body<_Index, _Fp>(__f));

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -90,26 +90,23 @@ class __parallel_for_body
     _RealBody _M_body;
 };
 
-struct __grain_selector_any_workload
+template <std::size_t _MinChunkSize>
+struct __chunk_partitioning_policy
 {
-    constexpr std::size_t
-    operator()() const
-    {
-        // matches the default grainsize value of tbb::blocked_range according to the specification
-        return 1;
-    }
+    static constexpr std::size_t __min_chunk_size = _MinChunkSize;
 };
-struct __grain_selector_small_workload: public __grain_selector_any_workload {};
-struct __grain_selector_large_workload: public __grain_selector_any_workload {};
+struct __any_workload: public __chunk_partitioning_policy<1> {};
+struct __small_workload: public __chunk_partitioning_policy<1> {};
+struct __large_workload: public __chunk_partitioning_policy<1> {};
 
 //! Evaluation of brick f[i,j) for each subrange [i,j) of [first,last)
 // wrapper over tbb::parallel_for
-template <class _ExecutionPolicy, class _Index, class _Fp, class _GrainSelector = __grain_selector_any_workload>
+template <class _ExecutionPolicy, class _Index, class _Fp, class _ChunkPartitioningPolicy = __any_workload>
 void
 __parallel_for(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f,
-               _GrainSelector __grain_selector = _GrainSelector())
+               _ChunkPartitioningPolicy __partitioning_policy = _ChunkPartitioningPolicy())
 {
-    constexpr std::size_t __grainsize = __grain_selector();
+    constexpr std::size_t __grainsize = __partitioning_policy.__min_chunk_size;
     tbb::this_task_arena::isolate([=]() {
         tbb::parallel_for(tbb::blocked_range<_Index>(__first, __last, __grainsize),
                           __parallel_for_body<_Index, _Fp>(__f));

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -67,7 +67,7 @@ __parallel_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __f
                                               }
                                           }
                                       }
-                                  });
+                                  }, __par_backend::__grain_selector_for_small_workload{});
     return __extremum != __initial_dist ? __first + __extremum : __last;
 }
 
@@ -89,7 +89,7 @@ __parallel_or(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __fir
                                           __found.store(true, ::std::memory_order_relaxed);
                                           __par_backend::__cancel_execution(__backend_tag{});
                                       }
-                                  });
+                                  }, __par_backend::__grain_selector_for_small_workload{});
     return __found;
 }
 

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -67,7 +67,7 @@ __parallel_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __f
                                               }
                                           }
                                       }
-                                  }, __par_backend::__grain_selector_for_small_workload{});
+                                  }, __par_backend::__grain_selector_small_workload{});
     return __extremum != __initial_dist ? __first + __extremum : __last;
 }
 
@@ -89,7 +89,7 @@ __parallel_or(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __fir
                                           __found.store(true, ::std::memory_order_relaxed);
                                           __par_backend::__cancel_execution(__backend_tag{});
                                       }
-                                  }, __par_backend::__grain_selector_for_small_workload{});
+                                  }, __par_backend::__grain_selector_small_workload{});
     return __found;
 }
 

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -67,7 +67,7 @@ __parallel_find(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __f
                                               }
                                           }
                                       }
-                                  }, __par_backend::__grain_selector_small_workload{});
+                                  }, __par_backend::__small_workload{});
     return __extremum != __initial_dist ? __first + __extremum : __last;
 }
 
@@ -89,7 +89,7 @@ __parallel_or(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Index __fir
                                           __found.store(true, ::std::memory_order_relaxed);
                                           __par_backend::__cancel_execution(__backend_tag{});
                                       }
-                                  }, __par_backend::__grain_selector_small_workload{});
+                                  }, __par_backend::__small_workload{});
     return __found;
 }
 


### PR DESCRIPTION
WIP.
Algorithms other than for_each/transform usually have more or less trivial functors. That means different selectors should be used depending on an algorithm.