### PR TITLE
Reducing number of kernels for one wg radix sort

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -784,7 +784,7 @@ __future<sycl::event>
 __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range&& __in_rng,
                       _Proj __proj)
 {
-    const ::std::size_t __n = oneapi::dpl::__ranges::__size(__in_rng);
+    const std::size_t __n = oneapi::dpl::__ranges::__size(__in_rng);
     assert(__n > 1);
 
     // types
@@ -792,7 +792,7 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
     using _KeyT = oneapi::dpl::__internal::__key_t<_Proj, _Range>;
 
     // radix bits represent number of processed bits in each value during one iteration
-    constexpr ::std::uint32_t __radix_bits = 4;
+    constexpr std::uint32_t __radix_bits = 4;
 
     sycl::event __event;
 
@@ -800,8 +800,7 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
 
     // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
     // This value exceeds the current practical limit for GPUs, but may need to be re-evaluated in the future.
-    const std::uint16_t __max_wg_size =
-        static_cast<std::uint16_t>(oneapi::dpl::__internal::__max_work_group_size(__q_local, (std::size_t)4096));
+    const std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__q_local, (std::size_t)4096);
     const auto __subgroup_sizes = __q_local.get_device().template get_info<sycl::info::device::sub_group_sizes>();
     const bool __dev_has_sg16 = std::find(__subgroup_sizes.begin(), __subgroup_sizes.end(),
                                           static_cast<std::size_t>(16)) != __subgroup_sizes.end();
@@ -829,22 +828,22 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
             __q_local, std::forward<_Range>(__in_rng), __proj, __max_wg_size);
     else
     {
-        constexpr ::std::uint32_t __radix_iters = __get_buckets_in_type<_KeyT>(__radix_bits);
-        const ::std::uint32_t __radix_states = 1 << __radix_bits;
+        constexpr std::uint32_t __radix_iters = __get_buckets_in_type<_KeyT>(__radix_bits);
+        const std::uint32_t __radix_states = 1 << __radix_bits;
 
 #if _ONEDPL_RADIX_WORKLOAD_TUNING
         const auto __wg_sz_k = __n >= (1 << 15)/*32K*/ && __n < (1 << 19)/*512K*/ ? 8 : __n <= (1 << 21)/*2M*/ ? 4 : 1;
-        const ::std::size_t __wg_size = __max_wg_size / __wg_sz_k;
+        const std::size_t __wg_size = __max_wg_size / __wg_sz_k;
 #else
-        ::std::size_t __wg_size = __max_wg_size;
+        std::size_t __wg_size = __max_wg_size;
 #endif
-        const ::std::size_t __segments = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wg_size);
+        const std::size_t __segments = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wg_size);
 
         // Additional __radix_states elements are used for getting local offsets from count values + no_op flag;
         // 'No operation' flag specifies whether to skip re-order phase if the all keys are the same (lie in one bin)
-        const ::std::size_t __tmp_buf_size = __segments * __radix_states + __radix_states + 1 /*no_op flag*/;
+        const std::size_t __tmp_buf_size = __segments * __radix_states + __radix_states + 1 /*no_op flag*/;
         // memory for storing count and offset values
-        sycl::buffer<::std::uint32_t, 1> __tmp_buf{sycl::range<1>(__tmp_buf_size)};
+        sycl::buffer<std::uint32_t, 1> __tmp_buf{sycl::range<1>(__tmp_buf_size)};
 
         // memory for storing values sorted for an iteration
         oneapi::dpl::__par_backend_hetero::__buffer<_ValueT> __out_buffer_holder{__n};
@@ -854,7 +853,7 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
         // iterations per each bucket
         assert("Number of iterations must be even" && __radix_iters % 2 == 0);
         // TODO: radix for bool can be made using 1 iteration (x2 speedup against current implementation)
-        for (::std::uint32_t __radix_iter = 0; __radix_iter < __radix_iters; ++__radix_iter)
+        for (std::uint32_t __radix_iter = 0; __radix_iter < __radix_iters; ++__radix_iter)
         {
             // TODO: convert to ordered type once at the first iteration and convert back at the last one
             if (__radix_iter % 2 == 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -36,13 +36,13 @@ struct __subgroup_radix_sort
 {
     template <typename _RangeIn, typename _Proj>
     sycl::event
-    operator()(sycl::queue& __q, _RangeIn&& __src, _Proj __proj, std::uint16_t __max_wg_size)
+    operator()(sycl::queue& __q, _RangeIn&& __src, _Proj __proj, std::size_t __max_wg_size)
     {
-        using __block_size_t = std::integral_constant<::std::uint16_t, __block_size>;
-        using __radix_t = std::integral_constant<::std::uint32_t, __radix>;
-        using __call_0_t = std::integral_constant<::std::uint16_t, 0>;
-        using __call_1_t = std::integral_constant<::std::uint16_t, 1>;
-        using __call_2_t = std::integral_constant<::std::uint16_t, 2>;
+        using __block_size_t = std::integral_constant<std::uint16_t, __block_size>;
+        using __radix_t = std::integral_constant<std::uint32_t, __radix>;
+        using __call_0_t = std::integral_constant<std::uint16_t, 0>;
+        using __call_1_t = std::integral_constant<std::uint16_t, 1>;
+        using __call_2_t = std::integral_constant<std::uint16_t, 2>;
         using __is_asc_t = std::integral_constant<bool, __is_asc>;
 
         using _SortKernelLoc = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
@@ -57,9 +57,10 @@ struct __subgroup_radix_sort
         // Calculate work group size based on input size and block size
         // Round up to ensure we have enough work items to cover all elements
         assert(__src.size() <= std::numeric_limits<std::uint16_t>::max());
+        assert(__max_wg_size <= std::numeric_limits<std::uint16_t>::max());
         const std::uint16_t __n = __src.size();
         std::uint16_t __wg_size = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __block_size);
-        __wg_size = std::min(__wg_size, __max_wg_size);
+        __wg_size = std::min(__wg_size, static_cast<std::uint16_t>(__max_wg_size));
 
         //check SLM size
         const auto __SLM_available = __check_slm_size<_KeyT>(__q, __n, __wg_size);


### PR DESCRIPTION
### Reduce the number of kernels from 9 -> 4 
- Changed work-group size from compile-time constant to runtime parameter based on input size and available hardware resources
- Consolidated some small cases without significant loss of performance (could go a bit further if we want)
