### PR TITLE
Remove libsycl version check to insert local fence in ESIMD sort chained scan

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -640,7 +640,6 @@ struct __radix_sort_onesweep_kernel
                         _GlobOffsetT, __bin_width, __dpl_esimd::__ens::lsc_data_size::default_size,
                         __dpl_esimd::__ens::cache_hint::uncached, __dpl_esimd::__ens::cache_hint::cached>(
                         __p_prev_group_hist + __local_tid * __bin_width);
-                    // This fence is added to prevent a hang that occurs otherwise.
 #if _ONEDPL_ESIMD_LSC_FENCE_PRESENT
                     __dpl_esimd::__ns::fence<__dpl_esimd::__ns::memory_kind::local>();
 #else


### PR DESCRIPTION
There is an existing TODO to evaluate a local barrier in the chained scan implementation. The barrier is still required and AFAIK it has not been investigated. Let's increase the libsycl version as it is still required to avoid a hang.