### PR TITLE
Add release notes about the changes from PR #2560 

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -11,6 +11,11 @@ creating efficient heterogeneous applications.
 New in the next release
 =======================
 
+Fixed Issues
+------------
+- Fixed validation of minimal requirements for range-based algorithms. They require clang 16 and newer
+  instead of the corresponding libc++ versions.
+
 New in 2022.11.0
 =======================
 


### PR DESCRIPTION
cherry-picking the update to release notes for the 2022.11.1 patch release.