### PR TITLE
OpenMP: Fix chunk partitioning when n is multiple of the requested chunk 

### DIFF
--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -110,14 +110,8 @@ __chunk_partitioner(_RandomAccessIterator __first, _RandomAccessIterator __last,
     __first_chunk_size = __chunk_size;
     const _Size __n_leftover_items = __n - (__n_chunks * __chunk_size);
 
-    if (__n_leftover_items == __chunk_size)
+    if (__n_leftover_items == 0)
     {
-        __n_chunks += 1;
-        return __chunk_metrics{__n_chunks, __chunk_size, __first_chunk_size};
-    }
-    else if (__n_leftover_items == 0)
-    {
-        __first_chunk_size = __chunk_size;
         return __chunk_metrics{__n_chunks, __chunk_size, __first_chunk_size};
     }
 


### PR DESCRIPTION
Imagine that `__n` is `4096` and `__requested_chunk_size` is `2048`, then `__n_chunks` would have been `3` before the fix. It should be `2` to partition the sequence according to the requested chunk size.

It's not an issue right now. However, I'm exploring an option of having a fixed number of tasks per thread, where one additional chunk severely imbalances the load.