### PR TITLE
Make n_uniform std::size_t to allow comparison to max_wg_size

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -528,7 +528,7 @@ struct __parallel_copy_if_single_group_functor<__internal::__optional_kernel_nam
             std::tie(__lsize, __n_uniform) = __local_memory_needed(__n);
             auto __lacc = __dpl_sycl::__local_accessor<_ValueType>(sycl::range<1>(__lsize), __hdl);
             auto __res_acc = __get_accessor(sycl::write_only, __result, __hdl, __dpl_sycl::__no_init{});
-            std::uint16_t __wg_size = static_cast<std::uint16_t>(std::min<std::uint16_t>(__n_uniform, __max_wg_size));
+            std::uint16_t __wg_size = static_cast<std::uint16_t>(std::min<std::size_t>(__n_uniform, __max_wg_size));
 
             __hdl.parallel_for<_ScanKernelName...>(sycl::nd_range<1>(__wg_size, __wg_size),
                 [=](sycl::nd_item<1> __self_item) {


### PR DESCRIPTION
In the implementation of `copy_if` the maximum workgroup size is stored as a std::size_t (i.e., unsigned long).  When `copy_if` is called on integer data the `std::make_unsigned_t` in the declaration of `__n_uniform` will result in a variable of `unsigned int`. The implementation of `std::min` does not allow the types of the arguements passed to vary.  The following small test case will fail to compile with error "error: no matching function for call to 'min'" on https://github.com/uxlfoundation/oneDPL/blob/4fd963854b2c2008e34ad4a6b0ada60d525994cc/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h#L531

```
#include <oneapi/dpl/execution>
#include <oneapi/dpl/algorithm>
#include <oneapi/dpl/iterator>
#include <oneapi/dpl/functional>

int main() {
    oneapi::dpl::copy_if(oneapi::dpl::execution::dpcpp_default,
                         oneapi::dpl::counting_iterator(0),
                         oneapi::dpl::counting_iterator(9),
                         oneapi::dpl::discard_iterator(), oneapi::dpl::identity());
    return 0;
}
```

This PR changes the declaration of `__n_uniform` to be explicitly `std::size_t` so its type is the same as `__max_wg_size`