### PR TITLE
Add assertion to max wg size

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -923,7 +923,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     std::array<_Size, 2> __ret = {__n_out, __n};
     sycl::queue __q_local = __exec.queue();
 
-    constexpr std::uint16_t __max_elem_per_item = 2;
+    constexpr std::size_t __max_elem_per_item = 2;
     std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__q_local);
 
     // Note: earlier the data size for the single group kernel was capped by 2048


### PR DESCRIPTION
A little more protection against a future bug.  We were relying upon implementation details from a separate function to guarantee safety.  This moves the type assumptions to where they can be understood.

Follow up to #2578