### PR TITLE
Improvements to set_intersection logic

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3637,8 +3637,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _DifferenceType = std::common_type_t<_DifferenceType1, _DifferenceType2>;
 
-    _DifferenceType __n1 = __last1 - __first1;
-    _DifferenceType __n2 = __last2 - __first2;
+    _DifferenceType1 __n1 = __last1 - __first1;
+    _DifferenceType2 __n2 = __last2 - __first2;
 
     // intersection is empty
     if (__n1 == 0 || __n2 == 0)
@@ -3661,8 +3661,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     // Strategy B: Trim range2 (elements < *__first1), keep range1 full
     // Choose the strategy that trims more elements (eliminates more non-overlapping work).
 
-    const _DifferenceType __trimmed_from_range1 = __left_bound_seq_1 - __first1;
-    const _DifferenceType __trimmed_from_range2 = __left_bound_seq_2 - __first2;
+    const _DifferenceType1 __trimmed_from_range1 = __left_bound_seq_1 - __first1;
+    const _DifferenceType2 __trimmed_from_range2 = __left_bound_seq_2 - __first2;
 
     _RandomAccessIterator1 __begin1 = __first1;
     _RandomAccessIterator2 __begin2 = __first2;

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3678,7 +3678,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
         __n2 = __last2 - __begin2;
     }
 
-    const std::size_t __total_work = __n1 + __n2;
+    const _DifferenceType __total_work = __n1 + __n2;
     if (__total_work > __set_algo_cut_off)
     {
         return __internal::__except_handler([&]() {
@@ -3706,8 +3706,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                     [](_RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2,
                        _RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1, _T* __result,
                        _Compare __comp, oneapi::dpl::identity, oneapi::dpl::identity) {
-                        // Lambda params: __first1 = chunk of range2, __first2 = chunk of range1
-                        // Swap to pass logical range1 first for semantic correctness (copy from first range)
+                        // Lambda params: __lmda_first1 = iter of range2, __lmda_first2 = iter of range1
+                        // Swap to pass logical range1 first for semantic correctness (must copy from first range)
                         return oneapi::dpl::__utils::__set_intersection_construct(
                             __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
                             oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp,

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3637,8 +3637,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _DifferenceType = std::common_type_t<_DifferenceType1, _DifferenceType2>;
 
-    const auto __n1 = __last1 - __first1;
-    const auto __n2 = __last2 - __first2;
+    std::size_t __n1 = __last1 - __first1;
+    std::size_t __n2 = __last2 - __first2;
 
     // intersection is empty
     if (__n1 == 0 || __n2 == 0)
@@ -3656,48 +3656,72 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     if (__left_bound_seq_2 == __last2)
         return __result;
 
-    const auto __m1 = __last1 - __left_bound_seq_1 + __n2;
-    if (__m1 > __set_algo_cut_off)
+    // Two trimming strategies are available (mutually exclusive):
+    // Strategy A: Trim range1 (elements < *__first2), keep range2 full
+    // Strategy B: Trim range2 (elements < *__first1), keep range1 full
+    // Choose the strategy that trims more elements (eliminates more non-overlapping work).
+
+    const std::size_t __trimmed_from_range1 = __left_bound_seq_1 - __first1;
+    const std::size_t __trimmed_from_range2 = __left_bound_seq_2 - __first2;
+
+    _RandomAccessIterator1 __begin1 = __first1;
+    _RandomAccessIterator2 __begin2 = __first2;
+
+    if (__trimmed_from_range1 >= __trimmed_from_range2)
     {
-        //we know proper offset due to [first1; left_bound_seq_1) < [first2; last2)
+        __begin1 = __left_bound_seq_1;
+        __n1 = __last1 - __begin1;
+    }
+    else
+    {
+        __begin2 = __left_bound_seq_2;
+        __n2 = __last2 - __begin2;
+    }
+
+    const std::size_t __total_work = __n1 + __n2;
+    if (__total_work > __set_algo_cut_off)
+    {
         return __internal::__except_handler([&]() {
-            return __internal::__parallel_set_op(
-                __tag, std::forward<_ExecutionPolicy>(__exec), __left_bound_seq_1, __last1, __first2, __last2, __result,
-                [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
-                [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
-                   _RandomAccessIterator2 __last2, _T* __result, _Compare __comp, oneapi::dpl::identity,
-                   oneapi::dpl::identity) {
-                    return oneapi::dpl::__utils::__set_intersection_construct(
-                        __first1, __last1, __first2, __last2, __result,
-                        oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp,
-                        oneapi::dpl::identity{}, oneapi::dpl::identity{});
-                },
-                __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
+            // Decide which range to partition based on size
+            if (__n1 >= __n2)
+            {
+                // Partition the larger trimmed_range1, search into full_range2
+                return __internal::__parallel_set_op(
+                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin1, __last1, __begin2, __last2,
+                    __result, [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
+                    [](_RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1,
+                        _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result,
+                        _Compare __comp, oneapi::dpl::identity, oneapi::dpl::identity) {
+                        // Lambda params match __parallel_set_op order: trimmed_range1, full_range2
+                        return oneapi::dpl::__utils::__set_intersection_construct(
+                            __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
+                            oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp,
+                            oneapi::dpl::identity{}, oneapi::dpl::identity{});
+                    },
+                    __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
+            }
+            else
+            {
+                // Partition the larger full_range2, search into trimmed_range1
+                return __internal::__parallel_set_op(
+                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin2, __last2, __begin1, __last1,
+                    __result, [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
+                    [](_RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2,
+                        _RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1, _T* __result,
+                        _Compare __comp, oneapi::dpl::identity, oneapi::dpl::identity) {
+                        // Lambda params: __first1 = chunk of full_range2, __first2 = chunk of trimmed_range1
+                        // Swap to pass logical range1 first
+                        return oneapi::dpl::__utils::__set_intersection_construct(
+                            __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
+                            oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp,
+                            oneapi::dpl::identity{}, oneapi::dpl::identity{});
+                    },
+                    __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
+            }
         });
     }
 
-    const auto __m2 = __last2 - __left_bound_seq_2 + __n1;
-    if (__m2 > __set_algo_cut_off)
-    {
-        //we know proper offset due to [first2; left_bound_seq_2) < [first1; last1)
-        return __internal::__except_handler([&]() {
-            __result = __internal::__parallel_set_op(
-                __tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __left_bound_seq_2, __last2, __result,
-                [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
-                [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
-                   _RandomAccessIterator2 __last2, _T* __result, _Compare __comp, oneapi::dpl::identity,
-                   oneapi::dpl::identity) {
-                    return oneapi::dpl::__utils::__set_intersection_construct(
-                        __first1, __last1, __first2, __last2, __result,
-                        oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp,
-                        oneapi::dpl::identity{}, oneapi::dpl::identity{});
-                },
-                __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
-            return __result;
-        });
-    }
-
-    // [left_bound_seq_1; last1) and [left_bound_seq_2; last2) - use serial algorithm
+    // Work too small for parallelization - use serial algorithm
     return std::set_intersection(__left_bound_seq_1, __last1, __left_bound_seq_2, __last2, __result, __comp);
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3686,11 +3686,11 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
             if (__n1 >= __n2)
             {
                 return __internal::__parallel_set_op(
-                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin1, __last1, __begin2, __last2,
-                    __result, [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
+                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin1, __last1, __begin2, __last2, __result,
+                    [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
                     [](_RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1,
-                        _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result,
-                        _Compare __comp, oneapi::dpl::identity, oneapi::dpl::identity) {
+                       _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result,
+                       _Compare __comp, oneapi::dpl::identity, oneapi::dpl::identity) {
                         return oneapi::dpl::__utils::__set_intersection_construct(
                             __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
                             oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp,
@@ -3701,11 +3701,11 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
             else
             {
                 return __internal::__parallel_set_op(
-                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin2, __last2, __begin1, __last1,
-                    __result, [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
+                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin2, __last2, __begin1, __last1, __result,
+                    [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
                     [](_RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2,
-                        _RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1, _T* __result,
-                        _Compare __comp, oneapi::dpl::identity, oneapi::dpl::identity) {
+                       _RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1, _T* __result,
+                       _Compare __comp, oneapi::dpl::identity, oneapi::dpl::identity) {
                         // Lambda params: __first1 = chunk of range2, __first2 = chunk of range1
                         // Swap to pass logical range1 first for semantic correctness (copy from first range)
                         return oneapi::dpl::__utils::__set_intersection_construct(

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3303,10 +3303,10 @@ inline constexpr auto __set_algo_cut_off = 1000;
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _OutputIterator, class _SizeFunction, class _SetOP, class _Compare, class _Proj1, class _Proj2>
 _OutputIterator
-__parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
-                  _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
-                  _OutputIterator __result, _SizeFunction __size_func, _SetOP __set_op, _Compare __comp, _Proj1 __proj1,
-                  _Proj2 __proj2)
+__parallel_set_op_impl(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+                       _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
+                       _OutputIterator __result, _SizeFunction __size_func, _SetOP __set_op, _Compare __comp,
+                       _Proj1 __proj1, _Proj2 __proj2)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
@@ -3397,6 +3397,38 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
             });
         return __result + __m;
     });
+}
+
+// Thin wrapper over __parallel_set_op_impl that always partitions the larger range.
+// When range2 is larger, it swaps ranges and wraps __set_op / __size_func / projections
+// so that the leaf operation still sees the caller's original range order. This is
+// important to satisfy semantic requirements to use elements from the first sequence in
+// the output when elements are equivalent.
+template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
+          class _OutputIterator, class _SizeFunction, class _SetOP, class _Compare, class _Proj1, class _Proj2>
+_OutputIterator
+__parallel_set_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1,
+                  _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2,
+                  _OutputIterator __result, _SizeFunction __size_func, _SetOP __set_op, _Compare __comp, _Proj1 __proj1,
+                  _Proj2 __proj2)
+{
+    const auto __n1 = __last1 - __first1;
+    const auto __n2 = __last2 - __first2;
+
+    if (__n1 >= __n2)
+    {
+        return __parallel_set_op_impl(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+                                      __last2, __result, __size_func, __set_op, __comp, __proj1, __proj2);
+    }
+    // Partition the larger range2, wrapping callbacks to preserve
+    // the caller's original range order for the leaf operation.
+    return __parallel_set_op_impl(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first2, __last2, __first1, __last1, __result,
+        [&__size_func](auto __n, auto __m) { return __size_func(__m, __n); },
+        [&__set_op](auto __f2, auto __l2, auto __f1, auto __l1, auto* __res, auto __comp, auto __p2, auto __p1) {
+            return __set_op(__f1, __l1, __f2, __l2, __res, __comp, __p1, __p2);
+        },
+        __comp, __proj2, __proj1);
 }
 
 //a shared parallel pattern for '__pattern_set_union' and '__pattern_set_symmetric_difference'
@@ -3681,41 +3713,18 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     const _DifferenceType __total_work = __n1 + __n2;
     if (__total_work > __set_algo_cut_off)
     {
-        return __internal::__except_handler([&]() {
-            // Decide which range to partition based on size
-            if (__n1 >= __n2)
-            {
-                return __internal::__parallel_set_op(
-                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin1, __last1, __begin2, __last2, __result,
-                    [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
-                    [](_RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1,
-                       _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result,
-                       _Compare __comp, oneapi::dpl::identity, oneapi::dpl::identity) {
-                        return oneapi::dpl::__utils::__set_intersection_construct(
-                            __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
-                            oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp,
-                            oneapi::dpl::identity{}, oneapi::dpl::identity{});
-                    },
-                    __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
-            }
-            else
-            {
-                return __internal::__parallel_set_op(
-                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin2, __last2, __begin1, __last1, __result,
-                    [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
-                    [](_RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2,
-                       _RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1, _T* __result,
-                       _Compare __comp, oneapi::dpl::identity, oneapi::dpl::identity) {
-                        // Lambda params: __lmda_first1 = iter of range2, __lmda_first2 = iter of range1
-                        // Swap to pass logical range1 first for semantic correctness (must copy from first range)
-                        return oneapi::dpl::__utils::__set_intersection_construct(
-                            __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
-                            oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp,
-                            oneapi::dpl::identity{}, oneapi::dpl::identity{});
-                    },
-                    __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
-            }
-        });
+        return __internal::__parallel_set_op(
+            __tag, std::forward<_ExecutionPolicy>(__exec), __begin1, __last1, __begin2, __last2, __result,
+            [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
+            [](_RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1,
+               _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result, _Compare __comp,
+               oneapi::dpl::identity, oneapi::dpl::identity) {
+                return oneapi::dpl::__utils::__set_intersection_construct(
+                    __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
+                    oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp,
+                    oneapi::dpl::identity{}, oneapi::dpl::identity{});
+            },
+            __comp, oneapi::dpl::identity{}, oneapi::dpl::identity{});
     }
 
     // Work too small for parallelization - use serial algorithm

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3676,45 +3676,52 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     if (__n1 == 0 || __n2 == 0)
         return __result;
 
-    // testing  whether the sequences are intersected
-    _RandomAccessIterator1 __left_bound_seq_1 = std::lower_bound(__first1, __last1, *__first2, __comp);
-    //{1} < {2}: seq 2 is wholly greater than seq 1, so, the intersection is empty
-    if (__left_bound_seq_1 == __last1)
-        return __result;
-
-    // testing  whether the sequences are intersected
-    _RandomAccessIterator2 __left_bound_seq_2 = std::lower_bound(__first2, __last2, *__first1, __comp);
-    //{2} < {1}: seq 1 is wholly greater than seq 2, so, the intersection is empty
-    if (__left_bound_seq_2 == __last2)
-        return __result;
-
-    // Two trimming strategies are available (mutually exclusive):
-    // Strategy A: Trim range1 (elements < *__first2), keep range2 full
-    // Strategy B: Trim range2 (elements < *__first1), keep range1 full
-    // Choose the strategy that trims more elements (eliminates more non-overlapping work).
-
-    const _DifferenceType1 __trimmed_from_range1 = __left_bound_seq_1 - __first1;
-    const _DifferenceType2 __trimmed_from_range2 = __left_bound_seq_2 - __first2;
-
+    // Trim non-overlapping portions from both ends.
     _RandomAccessIterator1 __begin1 = __first1;
+    _RandomAccessIterator1 __end1 = __last1;
     _RandomAccessIterator2 __begin2 = __first2;
+    _RandomAccessIterator2 __end2 = __last2;
 
-    if (__trimmed_from_range1 >= __trimmed_from_range2)
+    // Trim the beginning of whichever range starts earlier
+    if (__comp(*__first2, *__first1))
     {
-        __begin1 = __left_bound_seq_1;
-        __n1 = __last1 - __begin1;
+        // range 2 starts before range 1; trim beginning of range 2 to *__first1
+        __begin2 = std::lower_bound(__first2, __last2, *__first1, __comp);
+        if (__begin2 == __last2)
+            return __result;
     }
-    else
+    else if (__comp(*__first1, *__first2))
     {
-        __begin2 = __left_bound_seq_2;
-        __n2 = __last2 - __begin2;
+        // range 1 starts before range 2; trim beginning of range 1 to *__first2
+        __begin1 = std::lower_bound(__first1, __last1, *__first2, __comp);
+        if (__begin1 == __last1)
+            return __result;
     }
+
+    // Trim the end of whichever range ends later
+    if (__comp(*(__end1 - 1), *(__end2 - 1)))
+    {
+        // range 1 ends before range 2; trim end of range 2 to *(__end1 - 1)
+        __end2 = std::upper_bound(__begin2, __end2, *(__end1 - 1), __comp);
+    }
+    else if (__comp(*(__end2 - 1), *(__end1 - 1)))
+    {
+        // range 2 ends before range 1; trim end of range 1 to *(__end2 - 1)
+        __end1 = std::upper_bound(__begin1, __end1, *(__end2 - 1), __comp);
+    }
+
+    // End trimming may have eliminated all overlap
+    if (__begin1 == __end1 || __begin2 == __end2)
+        return __result;
+
+    __n1 = __end1 - __begin1;
+    __n2 = __end2 - __begin2;
 
     const _DifferenceType __total_work = __n1 + __n2;
     if (__total_work > __set_algo_cut_off)
     {
         return __internal::__parallel_set_op(
-            __tag, std::forward<_ExecutionPolicy>(__exec), __begin1, __last1, __begin2, __last2, __result,
+            __tag, std::forward<_ExecutionPolicy>(__exec), __begin1, __end1, __begin2, __end2, __result,
             [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
             [](_RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1,
                _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result, _Compare __comp,
@@ -3728,7 +3735,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     }
 
     // Work too small for parallelization - use serial algorithm
-    return std::set_intersection(__left_bound_seq_1, __last1, __left_bound_seq_2, __last2, __result, __comp);
+    return std::set_intersection(__begin1, __end1, __begin2, __end2, __result, __comp);
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3412,10 +3412,7 @@ __parallel_set_op(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _R
                   _OutputIterator __result, _SizeFunction __size_func, _SetOP __set_op, _Compare __comp, _Proj1 __proj1,
                   _Proj2 __proj2)
 {
-    const auto __n1 = __last1 - __first1;
-    const auto __n2 = __last2 - __first2;
-
-    if (__n1 >= __n2)
+    if (__last1 - __first1 >= __last2 - __first2)
     {
         return __parallel_set_op_impl(__tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
                                       __last2, __result, __size_func, __set_op, __comp, __proj1, __proj2);
@@ -3714,10 +3711,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     if (__begin1 == __end1 || __begin2 == __end2)
         return __result;
 
-    __n1 = __end1 - __begin1;
-    __n2 = __end2 - __begin2;
-
-    const _DifferenceType __total_work = __n1 + __n2;
+    const _DifferenceType __total_work = (__end1 - __begin1) + (__end2 - __begin2);
     if (__total_work > __set_algo_cut_off)
     {
         return __internal::__parallel_set_op(

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -903,8 +903,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _DifferenceType = std::common_type_t<_DifferenceType1, _DifferenceType2>;
 
-    std::size_t __n1 = std::ranges::size(__r1);
-    std::size_t __n2 = std::ranges::size(__r2);
+    _DifferenceType __n1 = std::ranges::size(__r1);
+    _DifferenceType __n2 = std::ranges::size(__r2);
 
     auto __first1 = std::ranges::begin(__r1);
     auto __last1 = __first1 + __n1;
@@ -937,8 +937,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     // Strategy B: Trim range2 (elements < *__first1), keep range1 full
     // Choose the strategy that trims more elements (eliminates more non-overlapping work).
 
-    const std::size_t __trimmed_from_range1 = __left_bound_seq_1 - __first1;
-    const std::size_t __trimmed_from_range2 = __left_bound_seq_2 - __first2;
+    _DifferenceType1 __trimmed_from_range1 = __left_bound_seq_1 - __first1;
+    _DifferenceType2 __trimmed_from_range2 = __left_bound_seq_2 - __first2;
 
     _RandomAccessIterator1 __begin1 = __first1;
     _RandomAccessIterator2 __begin2 = __first2;
@@ -954,7 +954,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
         __n2 = __last2 - __begin2;
     }
 
-    const std::size_t __total_work = __n1 + __n2;
+    const _DifferenceType __total_work = __n1 + __n2;
     if (__total_work > oneapi::dpl::__internal::__set_algo_cut_off)
     {
         return __internal::__except_handler([&]() {
@@ -967,8 +967,6 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                     [](_RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1,
                        _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result,
                        _Comp __comp, _Proj2 __proj2, _Proj1 __proj1) {
-                        // Lambda params: __lmda_first2 = chunk of range2, __lmda_first1 = chunk of range1
-                        // Swap to pass logical range1 first
                         return oneapi::dpl::__utils::__set_intersection_construct(
                             __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
                             oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1,
@@ -987,7 +985,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                        _RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1, _T* __result,
                        _Comp __comp, _Proj2 __proj2, _Proj1 __proj1) {
                         // Lambda params: __lmda_first2 = chunk of range2, __lmda_first1 = chunk of range1
-                        // Swap to pass logical range1 first
+                        // Swap to pass logical range1 first for semantic correctness (copy from first set)
                         return oneapi::dpl::__utils::__set_intersection_construct(
                             __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
                             oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1,

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -903,8 +903,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _DifferenceType = std::common_type_t<_DifferenceType1, _DifferenceType2>;
 
-    _DifferenceType __n1 = std::ranges::size(__r1);
-    _DifferenceType __n2 = std::ranges::size(__r2);
+    _DifferenceType1 __n1 = std::ranges::size(__r1);
+    _DifferenceType2 __n2 = std::ranges::size(__r2);
 
     auto __first1 = std::ranges::begin(__r1);
     auto __last1 = __first1 + __n1;

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -903,8 +903,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _DifferenceType = std::common_type_t<_DifferenceType1, _DifferenceType2>;
 
-    _DifferenceType1 __n1 = std::ranges::size(__r1);
-    _DifferenceType2 __n2 = std::ranges::size(__r2);
+    _DifferenceType __n1 = std::ranges::size(__r1);
+    _DifferenceType __n2 = std::ranges::size(__r2);
 
     auto __first1 = std::ranges::begin(__r1);
     auto __last1 = __first1 + __n1;
@@ -966,13 +966,13 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                     [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
                     [](_RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1,
                        _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result,
-                       _Comp __comp, _Proj2 __proj2, _Proj1 __proj1) {
+                       _Comp __comp, _Proj1 __proj1, _Proj2 __proj2) {
                         return oneapi::dpl::__utils::__set_intersection_construct(
                             __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
                             oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1,
                             __proj2);
                     },
-                    __comp, __proj2, __proj1);
+                    __comp, __proj1, __proj2);
                 return __set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __out_last};
             }
             else

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -903,8 +903,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _DifferenceType = std::common_type_t<_DifferenceType1, _DifferenceType2>;
 
-    const auto __n1 = std::ranges::size(__r1);
-    const auto __n2 = std::ranges::size(__r2);
+    std::size_t __n1 = std::ranges::size(__r1);
+    std::size_t __n2 = std::ranges::size(__r2);
 
     auto __first1 = std::ranges::begin(__r1);
     auto __last1 = __first1 + __n1;
@@ -932,45 +932,61 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     if (__left_bound_seq_2 == __last2)
         return {__last1, __last2, __result};
 
-    const auto __m1 = __last1 - __left_bound_seq_1 + __n2;
-    if (__m1 > oneapi::dpl::__internal::__set_algo_cut_off)
+    // Two trimming strategies are available (mutually exclusive):
+    // Strategy A: Trim range1 (elements < *__first2), keep range2 full
+    // Strategy B: Trim range2 (elements < *__first1), keep range1 full
+    // Choose the strategy that trims more elements (eliminates more non-overlapping work).
+
+    const std::size_t __trimmed_from_range1 = __left_bound_seq_1 - __first1;
+    const std::size_t __trimmed_from_range2 = __left_bound_seq_2 - __first2;
+
+    _RandomAccessIterator1 __begin1 = __first1;
+    _RandomAccessIterator2 __begin2 = __first2;
+
+    if (__trimmed_from_range1 >= __trimmed_from_range2)
     {
-        //we know proper offset due to [first1; left_bound_seq_1) < [first2; last2)
+        __begin1 = __left_bound_seq_1;
+        __n1 = __last1 - __begin1;
+    }
+    else
+    {
+        __begin2 = __left_bound_seq_2;
+        __n2 = __last2 - __begin2;
+    }
+
+    const std::size_t __total_work = __n1 + __n2;
+    if (__total_work > oneapi::dpl::__internal::__set_algo_cut_off)
+    {
         return __internal::__except_handler([&]() {
-            auto __out_last = __internal::__parallel_set_op(
-                __tag, std::forward<_ExecutionPolicy>(__exec), __left_bound_seq_1, __last1, __first2, __last2, __result,
-                [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
-                [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
-                   _RandomAccessIterator2 __last2, _T* __result, _Comp __comp, _Proj1 __proj1, _Proj2 __proj2) {
-                    return oneapi::dpl::__utils::__set_intersection_construct(
-                        __first1, __last1, __first2, __last2, __result,
-                        oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1, __proj2);
-                },
-                __comp, __proj1, __proj2);
-            return __set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __out_last};
+            // Decide which range to partition based on size
+            if (__n1 >= __n2)
+            {
+                // Partition the larger trimmed_range1, search into full_range2
+                return __set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __out_last};
+            }
+            else
+            {
+                // Partition the larger full_range2, search into trimmed_range1
+                auto __out_last = __internal::__parallel_set_op(
+                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin2, __last2, __begin1, __last1, __result,
+                    [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
+                    [](_RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2,
+                       _RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1, _T* __result,
+                       _Comp __comp, _Proj2 __proj2, _Proj1 __proj1) {
+                        // Lambda params: __lmda_first2 = chunk of range2, __lmda_first1 = chunk of range1
+                        // Swap to pass logical range1 first
+                        return oneapi::dpl::__utils::__set_intersection_construct(
+                            __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
+                            oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1,
+                            __proj2);
+                    },
+                    __comp, __proj2, __proj1);
+                return __set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __out_last};
+            }
         });
     }
 
-    const auto __m2 = __last2 - __left_bound_seq_2 + __n1;
-    if (__m2 > oneapi::dpl::__internal::__set_algo_cut_off)
-    {
-        //we know proper offset due to [first2; left_bound_seq_2) < [first1; last1)
-        return __internal::__except_handler([&]() {
-            auto __out_last = __internal::__parallel_set_op(
-                __tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __left_bound_seq_2, __last2, __result,
-                [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
-                [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
-                   _RandomAccessIterator2 __last2, _T* __result, _Comp __comp, _Proj1 __proj1, _Proj2 __proj2) {
-                    return oneapi::dpl::__utils::__set_intersection_construct(
-                        __first1, __last1, __first2, __last2, __result,
-                        oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1, __proj2);
-                },
-                __comp, __proj1, __proj2);
-            return __set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __out_last};
-        });
-    }
-
-    // [left_bound_seq_1; last1) and [left_bound_seq_2; last2) - use serial algorithm
+    // Work too small for parallelization - use serial algorithm
     return std::ranges::set_intersection(__left_bound_seq_1, __last1, __left_bound_seq_2, __last2,
                                          std::ranges::begin(__out_r), __comp, __proj1, __proj2);
 }
@@ -983,7 +999,6 @@ template <typename _R1, typename _OutRange>
 using __set_difference_return_t = std::ranges::set_difference_result<std::ranges::borrowed_iterator_t<_R1>,
                                                                      std::ranges::borrowed_iterator_t<_OutRange>>;
 
-template <typename _R1, typename _R2, typename _OutRange, typename _Comp, typename _Proj1, typename _Proj2>
 __set_difference_return_t<_R1, _OutRange>
 __brick_set_difference(_R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp, _Proj1 __proj1, _Proj2 __proj2,
                        /*__is_vector=*/std::false_type) noexcept

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -984,8 +984,8 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                     [](_RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2,
                        _RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1, _T* __result,
                        _Comp __comp, _Proj2 __proj2, _Proj1 __proj1) {
-                        // Lambda params: __lmda_first2 = chunk of range2, __lmda_first1 = chunk of range1
-                        // Swap to pass logical range1 first for semantic correctness (copy from first set)
+                        // Lambda params: __lmda_first2 = iter of range2, __lmda_first1 = iter of range1
+                        // Swap to pass logical range1 first for semantic correctness (must copy from first set)
                         return oneapi::dpl::__utils::__set_intersection_construct(
                             __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
                             oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1,

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -957,44 +957,18 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
     const _DifferenceType __total_work = __n1 + __n2;
     if (__total_work > oneapi::dpl::__internal::__set_algo_cut_off)
     {
-        return __internal::__except_handler([&]() {
-            // Decide which range to partition based on size
-            if (__n1 >= __n2)
-            {
-                auto __out_last = __internal::__parallel_set_op(
-                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin1, __last1, __begin2, __last2, __result,
-                    [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
-                    [](_RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1,
-                       _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result,
-                       _Comp __comp, _Proj1 __proj1, _Proj2 __proj2) {
-                        return oneapi::dpl::__utils::__set_intersection_construct(
-                            __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
-                            oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1,
-                            __proj2);
-                    },
-                    __comp, __proj1, __proj2);
-                return __set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __out_last};
-            }
-            else
-            {
-                // Partition the larger full_range2, search into trimmed_range1
-                auto __out_last = __internal::__parallel_set_op(
-                    __tag, std::forward<_ExecutionPolicy>(__exec), __begin2, __last2, __begin1, __last1, __result,
-                    [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
-                    [](_RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2,
-                       _RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1, _T* __result,
-                       _Comp __comp, _Proj2 __proj2, _Proj1 __proj1) {
-                        // Lambda params: __lmda_first2 = iter of range2, __lmda_first1 = iter of range1
-                        // Swap to pass logical range1 first for semantic correctness (must copy from first set)
-                        return oneapi::dpl::__utils::__set_intersection_construct(
-                            __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
-                            oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1,
-                            __proj2);
-                    },
-                    __comp, __proj2, __proj1);
-                return __set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __out_last};
-            }
-        });
+        auto __out_last = __internal::__parallel_set_op(
+            __tag, std::forward<_ExecutionPolicy>(__exec), __begin1, __last1, __begin2, __last2, __result,
+            [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
+            [](_RandomAccessIterator1 __lmda_first1, _RandomAccessIterator1 __lmda_last1,
+               _RandomAccessIterator2 __lmda_first2, _RandomAccessIterator2 __lmda_last2, _T* __result, _Comp __comp,
+               _Proj1 __proj1, _Proj2 __proj2) {
+                return oneapi::dpl::__utils::__set_intersection_construct(
+                    __lmda_first1, __lmda_last1, __lmda_first2, __lmda_last2, __result,
+                    oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{}, __comp, __proj1, __proj2);
+            },
+            __comp, __proj1, __proj2);
+        return __set_intersection_return_t<_R1, _R2, _OutRange>{__last1, __last2, __out_last};
     }
 
     // Work too small for parallelization - use serial algorithm


### PR DESCRIPTION
Improves the `set_intersection` parallel algorithm logic to be more efficient and correct when selecting which input range to partition.

Now we select the trimming strategy which minimizes the total data and always parallelize along the larger dimension.  
This logic was oddly configured previously.

