### PR TITLE
Fix a missing header issue (libc++21, c++23)

### DIFF
--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <exception>
 
 #if _ONEDPL_BACKEND_SYCL
 #    include "hetero/dpcpp/sycl_defs.h"


### PR DESCRIPTION
The issue affects libc++ coming with clang++21. It happens in c++23 mode (17 and 20 are not affected).

The issue:

```
/oneDPL/include/oneapi/dpl/pstl/utils.h:80:16: error: no member named 'terminate' in namespace 'std'
   80 |         ::std::terminate(); // Good bye according to the standard [algorithms.parallel.exceptions]
      |                ^~~~~~~~~
```

It happens in:

```c++
template <typename _Fp>
auto
__except_handler(_Fp __f) -> decltype(__f())
{
    try
    {
        return __f();
    }
    catch (const ::std::bad_alloc&)
    {
        throw; // re-throw bad_alloc according to the standard [algorithms.parallel.exceptions]
    }
    catch (...)
    {
        ::std::terminate(); // Good bye according to the standard [algorithms.parallel.exceptions]
    }
}
```