### PR TITLE
Add `enable_testing()` call into `test\CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,6 @@ target_include_directories(oneDPL
 # Setup tests
 ###############################################################################
 if (NOT _onedpl_is_subproject)
-    enable_testing()
     add_subdirectory(test)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,8 @@
 ##===----------------------------------------------------------------------===##
 add_subdirectory(kt)
 
+enable_testing()
+
 # rng_tests
 set (ranlux_24_48_test.pass_timeout_debug "900") # 15min
 set (ranlux_24_48_test.pass_timeout_release "720") # 12min

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,9 +11,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 #
 ##===----------------------------------------------------------------------===##
-add_subdirectory(kt)
-
 enable_testing()
+
+add_subdirectory(kt)
 
 # rng_tests
 set (ranlux_24_48_test.pass_timeout_debug "900") # 15min


### PR DESCRIPTION
This PR adds a call to `enable_testing()` in the `test/CMakeLists.txt` file to properly enable CTest functionality for tests defined in subdirectories.

For additional details please read:
- https://cmake.org/cmake/help/latest/command/enable_testing.html
- https://cmake.org/cmake/help/latest/guide/tutorial/Testing%20and%20CTest.html