### PR TITLE
Update latest Intel LLVM compile version in tests

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -34,7 +34,7 @@
 // When such an issue is fixed, we must replace the usage of these "Latest" macros with the appropriate version number
 // before updating to the newest version in this section.
 
-#define _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER 20260000
+#define _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER 20260112
 
 #define _PSTL_TEST_LATEST_MSVC_STL_VERSION 145
 


### PR DESCRIPTION
In this PR we updates latest Intel LLVM compile version in tests:
```C++
#define _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER 20260112
```
