### PR TITLE
Mitigate intermittent failures to get public key

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -154,14 +154,24 @@ jobs:
         if: (matrix.backend == 'tbb' || matrix.backend == 'dpcpp' || matrix.cxx_compiler == 'icpx' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icx-cl' || matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'dpcpp-cl')
         run: |
           # https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2024-0/apt.html
+          success=false
           for i in 1 2 3 4 5; do
             if wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
             | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null; then
+              success=true
               break
             fi
-            echo "Attempt $i failed, retrying in 10s..."
-            sleep 10
+            if [ "$i" -lt 5 ]; then
+              echo "Attempt $i failed, retrying in 10s..."
+              sleep 10
+            else
+              echo "Attempt $i failed; no more retries left."
+            fi
           done
+          if [ "$success" = false ]; then
+            echo "Failed to download Intel GPG key after 5 attempts"
+            exit 1
+          fi
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt-get update -y
       - name: Install Intel® oneAPI Threading Building Blocks


### PR DESCRIPTION
Add retry logic to the Intel APT repository GPG key download in CI. We've been seeing intermittent DNS resolution failures when fetching the key from apt.repos.intel.com, which causes the entire CI run to fail. The download is now attempted up to 5 times with 10-second delays between retries.  