### PR TITLE
Workaround for exclusive_scan_over_group

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -506,7 +506,7 @@ __copy_kernel_for_radix_sort(sycl::nd_item<1> __self_item, const std::size_t __s
 }
 template <typename _ValueType>
 _ValueType
-__radix_sort_exclusive_scan(sycl::sub_group __sub_group, _ValueType __val, std::plus<_ValueType>, 
+__radix_sort_exclusive_scan(sycl::sub_group __sub_group, _ValueType __val,
                             [[maybe_unused]] std::uint32_t __sg_local_id, [[maybe_unused]] std::uint32_t __sg_size)
 {
     // With icpx version 2024.2, exclusive_scan_over_group encounters some crashes which
@@ -522,7 +522,7 @@ __radix_sort_exclusive_scan(sycl::sub_group __sub_group, _ValueType __val, std::
     }
     return __inclusive - __val;
 #else
-    return __dpl_sycl::__exclusive_scan_over_group(__sub_group, __val, std::plus<_ValueType>());
+    return __dpl_sycl::__exclusive_scan_over_group(__sub_group, __val, __dpl_sycl::__plus<_ValueType>());
 #endif
 }
 
@@ -557,9 +557,7 @@ __radix_sort_reorder_impl(_InputRange& __input, _OutputRange& __output, _OffsetR
         const bool __is_last_in_sg = (__sg_local_id == __sg_size - 1);
         for (std::uint32_t __b = 0; __b < __radix_states; ++__b)
         {
-            __wi_prefix[__b] = __radix_sort_exclusive_scan(__sub_group, __local_counts[__b],
-                                                           __dpl_sycl::__plus<std::uint16_t>(), __sg_local_id,
-                                                           __sg_size);
+            __wi_prefix[__b] = __radix_sort_exclusive_scan(__sub_group, __local_counts[__b], __sg_local_id, __sg_size);
             if (__is_last_in_sg)
                 __slm_counts[__sg_id * __radix_states + __b] = __wi_prefix[__b] + __local_counts[__b];
         }
@@ -583,8 +581,7 @@ __radix_sort_reorder_impl(_InputRange& __input, _OutputRange& __output, _OffsetR
                 (__sg_idx < __num_subgroups) ? __slm_counts[__sg_idx * __radix_states + __radix_state] : 0;
 
             // Exclusive scan within chunk
-            std::uint16_t __local_prefix = __radix_sort_exclusive_scan(__sub_group, __val, std::plus<std::uint16_t>(),
-                                                                       __sg_local_id, __sg_size);
+            std::uint16_t __local_prefix = __radix_sort_exclusive_scan(__sub_group, __val, __sg_local_id, __sg_size);
 
             // Add running sum from previous chunks
             std::uint16_t __prefix = __running_sum + __local_prefix;


### PR DESCRIPTION
I detected some crashes in icpx 2024.2 which are specific to the use of subgroup `__exclusive_scan_over_group` in the new reorder kernel.  I'm not sure the full scope of the issue with `__exclusive_scan_over_group`, but it only appears in icpx 2024.2 for CPU openCL targets.  

I think the best course of action is to work around this locally as shown here, but limit the workaround to where we know the problem to be (rather than impact all uses of exclusive scan over group).  This also lets our implementation know the subgroup size, subgroup id, and know that we are using `plus<_ValType>`.

This PR is targeted to the already approved multi-workgroup improvements #2566, to evaluate the workaround in isolation.

 
