### PR TITLE
Fix the default template argument for the new value type in replace[_if]

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -15,6 +15,8 @@ Fixed Issues
 ------------
 - Fixed validation of minimal requirements for range-based algorithms. They require clang 16 and newer
   instead of the corresponding libc++ versions.
+- Fixed the default template argument for the new value type in `ranges::replace` and `ranges::replace_if`
+  to not use projections.
 
 New in 2022.11.0
 =======================

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1033,8 +1033,8 @@ namespace __internal
 {
 struct __replace_if_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              typename _Proj = std::identity, typename _T = std::ranges::range_value_t<_R>,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              typename _T = std::ranges::range_value_t<_R>,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
              && std::ranges::sized_range<_R> && std::indirectly_writable<std::ranges::iterator_t<_R>, const _T&>
@@ -1067,7 +1067,8 @@ struct __replace_fn
                                                std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T1*>
 
     std::ranges::borrowed_iterator_t<_R>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T1& __old_value, const _T2& __new_value, _Proj __proj = {}) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T1& __old_value, const _T2& __new_value,
+               _Proj __proj = {}) const
     {
         return oneapi::dpl::ranges::replace_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),


### PR DESCRIPTION
While we aligned the oneDPL specification with the changes for `ranges::replace[_if]` done in C++26 (see https://github.com/uxlfoundation/oneAPI-spec/pull/658), for all that time we have not fixed the implementation.