### PR TITLE
Fix floating point zip_view test issues

### DIFF
--- a/test/parallel_api/ranges/range.zip/iterator/zip_view.deref.pass.cpp
+++ b/test/parallel_api/ranges/range.zip/iterator/zip_view.deref.pass.cpp
@@ -66,9 +66,9 @@ void test() {
 #endif
 
     x = 5;
-    y = 0.1;
+    y = 0.5;
     assert(a[0] == 5);
-    assert(b[0] == 0.1);
+    assert(b[0] == 0.5); // exact comparison is safe: 0.5 is exactly representable in all FP precisions
   }
 
   {

--- a/test/parallel_api/ranges/range.zip/iterator/zip_view.iter_swap.pass.cpp
+++ b/test/parallel_api/ranges/range.zip/iterator/zip_view.iter_swap.pass.cpp
@@ -40,7 +40,8 @@ struct ThrowingMove {
 void test() {
   {
     std::array a1{1, 2, 3, 4};
-    std::array a2{0.1, 0.2, 0.3};
+    // Use dyadic rationals to avoid x87 excess-precision issues with exact FP comparisons on 32-bit
+    std::array a2{0.5, 0.25, 0.125};
     dpl_ranges::zip_view v(a1, a2);
     auto iter1 = v.begin();
     auto iter2 = ++v.begin();
@@ -49,8 +50,8 @@ void test() {
 
     assert(a1[0] == 2);
     assert(a1[1] == 1);
-    assert(a2[0] == 0.2);
-    assert(a2[1] == 0.1);
+    assert(a2[0] == 0.25);
+    assert(a2[1] == 0.5);
 
     auto [x1, y1] = *iter1;
     assert(&x1 == &a1[0]);


### PR DESCRIPTION
It seems like on g++ 32bit arch, we see failures in a couple places due to floating point equality checks and precision issues.  
This PR fixes that by adjusting these to exactly representable floating point numbers.

Ive confirmed in the CI that this fixes the issue.
