### PR TITLE
Improve implementations of  `__set_difference_construct()` and `__set_symmetric_difference_construct()`

### DIFF
--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -230,19 +230,19 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
 
     // __proj2_val < __proj1_val
     auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        ::new (std::addressof(*__out_it)) _Tp(*__it2);
+        new (std::addressof(*__out_it)) _Tp(*__it2);
         return {__it1, ++__it2, ++__out_it};
     };
 
     // __proj1_val < __proj2_val
     auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        ::new (std::addressof(*__out_it)) _Tp(*__it1);
+        new (std::addressof(*__out_it)) _Tp(*__it1);
         return {++__it1, __it2, ++__out_it};
     };
 
     // __proj1_val == __proj2_val
     auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        ::new (std::addressof(*__out_it)) _Tp(*__it1);
+        new (std::addressof(*__out_it)) _Tp(*__it1);
         return {++__it1, ++__it2, ++__out_it};
     };
 
@@ -318,7 +318,7 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 
     // __proj1_val < __proj2_val
     auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        ::new (std::addressof(*__out_it)) _Tp(*__it1);
+        new (std::addressof(*__out_it)) _Tp(*__it1);
         return {++__it1, __it2, ++__out_it};
     };
 
@@ -359,13 +359,13 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 
     // __proj1_val < __proj2_val
     auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        ::new (std::addressof(*__out_it)) _Tp(*__it1);
+        new (std::addressof(*__out_it)) _Tp(*__it1);
         return {++__it1, __it2, ++__out_it};
     };
 
     // __proj2_val < __proj1_val
     auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        ::new (std::addressof(*__out_it)) _Tp(*__it2);
+        new (std::addressof(*__out_it)) _Tp(*__it2);
         return {__it1, ++__it2, ++__out_it};
     };
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -227,14 +227,14 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it2);
         ++__it2;
         ++__out_it;
     };
 
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
         ++__it1;
         ++__out_it;
@@ -251,11 +251,12 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
     // 1. Main set_union operation
     while (__first1 != __last1 && __first2 != __last2)
     {
-        std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2))
-            ? __op_val1_lt_val2(__first1, __first2, __result)
-            : (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1))
-                   ? __op_val2_lt_val1(__first1, __first2, __result)
-                   : __op_val1_eq_val2(__first1, __first2, __result));
+        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
+        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+
+        __val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                       : (__val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                                         : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     // 2. Copying the residual elements if one of the input sequences is exhausted
@@ -273,12 +274,12 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
                              _Proj1 __proj1, _Proj2 __proj2)
 {
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator&) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ++__it1;
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator&) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ++__it2;
     };
 
@@ -293,11 +294,12 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
     // 1. Main set_intersection operation
     while (__first1 != __last1 && __first2 != __last2)
     {
-        std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2))
-            ? __op_val1_lt_val2(__first1, __first2, __result)
-            : (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1))
-                   ? __op_val2_lt_val1(__first1, __first2, __result)
-                   : __op_val1_eq_val2(__first1, __first2, __result));
+        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
+        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+
+        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                    : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                        : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     return __result;
@@ -313,19 +315,19 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
         ++__it1;
         ++__out_it;
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator&) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ++__it2;
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator&) {
+    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ++__it1;
         ++__it2;
     };
@@ -354,21 +356,21 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
         ++__it1;
         ++__out_it;
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it2);
         ++__it2;
         ++__out_it;
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator&) {
+    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ++__it1;
         ++__it2;
     };
@@ -376,11 +378,12 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
     // 1. Main set_symmetric_difference operation
     while (__first1 != __last1 && __first2 != __last2)
     {
-        std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2))
-            ? __op_val1_lt_val2(__first1, __first2, __result)
-            : (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1))
-                   ? __op_val2_lt_val1(__first1, __first2, __result)
-                   : __op_val1_eq_val2(__first1, __first2, __result));
+        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
+        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+
+        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                        : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                            : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     // 2. Copying the residual elements if one of the input sequences is exhausted

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -314,25 +314,36 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    for (; __first1 != __last1;)
-    {
-        if (__first2 == __last2)
-            return __cc_range(__first1, __last1, __result);
+    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
 
-        if (std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
-        {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
-            ++__result;
-            ++__first1;
-        }
-        else
-        {
-            if (!std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
-                ++__first1;
-            ++__first2;
-        }
+    // __proj1_val < __proj2_val
+    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        new (std::addressof(*__out_it)) _Tp(*__it1);
+        return {++__it1, __it2, ++__out_it};
+    };
+
+    // __proj2_val < __proj1_val
+    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {__it1, ++__it2, __out_it};
+    };
+
+    // __proj1_val == __proj2_val
+    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {++__it1, ++__it2, __out_it};
+    };
+
+    // 1. Main set_difference operation
+    while (__first1 != __last1 && __first2 != __last2)
+    {
+        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
+        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+        
+        std::tie(__first1, __first2, __result) = __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                                               : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                             : __op_val1_eq_val2(__first1, __first2, __result));
     }
-    return __result;
+
+    return __cc_range(__first1, __last1, __result);
 }
 
 template <typename _ForwardIterator1, typename _ForwardIterator2, typename _OutputIterator,

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -355,29 +355,41 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    for (; __first1 != __last1;)
-    {
-        if (__first2 == __last2)
-            return __cc_range(__first1, __last1, __result);
+    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
 
-        if (std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
-        {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
-            ++__result;
-            ++__first1;
-        }
-        else
-        {
-            if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
-            {
-                ::new (::std::addressof(*__result)) _Tp(*__first2);
-                ++__result;
-            }
-            else
-                ++__first1;
-            ++__first2;
-        }
+    // __proj1_val < __proj2_val
+    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        new (std::addressof(*__out_it)) _Tp(*__it1);
+        return {++__it1, __it2, ++__out_it};
+    };
+
+    // __proj2_val < __proj1_val
+    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        new (std::addressof(*__out_it)) _Tp(*__it2);
+        return {__it1, ++__it2, ++__out_it};
+    };
+
+    // __proj1_val == __proj2_val
+    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {++__it1, ++__it2, __out_it};
+    };
+
+    // 1. Main set_symmetric_difference operation
+    while (__first1 != __last1 && __first2 != __last2)
+    {
+        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
+        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+
+        std::tie(__first1, __first2, __result) =
+            __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                           : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                             : __op_val1_eq_val2(__first1, __first2, __result));
     }
+
+    // 2. Copying the residual elements if one of the input sequences is exhausted
+    if (__first2 == __last2)
+        return __cc_range(__first1, __last1, __result);
+
     return __cc_range(__first2, __last2, __result);
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -226,23 +226,25 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    for (; __first1 != __last1; ++__result)
+    while (__first1 != __last1 && __first2 != __last2)
     {
-        if (__first2 == __last2)
-            return __cc_range(__first1, __last1, __result);
         if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first2);
+            ::new (::std::addressof(*__result++)) _Tp(*__first2);
             ++__first2;
         }
         else
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            ::new (::std::addressof(*__result++)) _Tp(*__first1);
             if (!std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
                 ++__first2;
             ++__first1;
         }
     }
+
+    if (__first2 == __last2)
+        return __cc_range(__first1, __last1, __result);
+
     return __cc_range(__first2, __last2, __result);
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -230,19 +230,19 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
 
     // __proj2_val < __proj1_val
     auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it2);
+        ::new (std::addressof(*__out_it)) _Tp(*__it2);
         return {__it1, ++__it2, ++__out_it};
     };
 
     // __proj1_val < __proj2_val
     auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it1);
+        ::new (std::addressof(*__out_it)) _Tp(*__it1);
         return {++__it1, __it2, ++__out_it};
     };
 
     // __proj1_val == __proj2_val
     auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it1);
+        ::new (std::addressof(*__out_it)) _Tp(*__it1);
         return {++__it1, ++__it2, ++__out_it};
     };
 
@@ -318,7 +318,7 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 
     // __proj1_val < __proj2_val
     auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it1);
+        ::new (std::addressof(*__out_it)) _Tp(*__it1);
         return {++__it1, __it2, ++__out_it};
     };
 
@@ -359,13 +359,13 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 
     // __proj1_val < __proj2_val
     auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it1);
+        ::new (std::addressof(*__out_it)) _Tp(*__it1);
         return {++__it1, __it2, ++__out_it};
     };
 
     // __proj2_val < __proj1_val
     auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it2);
+        ::new (std::addressof(*__out_it)) _Tp(*__it2);
         return {__it1, ++__it2, ++__out_it};
     };
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -282,25 +282,36 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    for (; __first1 != __last1;)
-    {
-        if (__first2 == __last2)
-            return __cc_range(__first1, __last1, __result);
+    // __proj1_val < __proj2_val
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator& __out_it) {
+        ::new (std::addressof(*__out_it)) _Tp(*__it1);
+        ++__it1;
+        ++__out_it;
+    };
 
-        if (std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
-        {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
-            ++__result;
-            ++__first1;
-        }
-        else
-        {
-            if (!std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
-                ++__first1;
-            ++__first2;
-        }
+    // __proj2_val < __proj1_val
+    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator&) {
+        ++__it2;
+    };
+
+    // __proj1_val == __proj2_val
+    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator&) {
+        ++__it1;
+        ++__it2;
+    };
+
+    // 1. Main set_difference operation
+    while (__first1 != __last1 && __first2 != __last2)
+    {
+        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
+        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+        
+        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                       : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                         : __op_val1_eq_val2(__first1, __first2, __result));
     }
-    return __result;
+
+    return __cc_range(__first1, __last1, __result);
 }
 
 template <typename _ForwardIterator1, typename _ForwardIterator2, typename _OutputIterator,

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -226,24 +226,26 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
-
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it2);
-        return {__it1, ++__it2, ++__out_it};
+        ++__it2;
+        ++__out_it;
     };
 
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
-        return {++__it1, __it2, ++__out_it};
+        ++__it1;
+        ++__out_it;
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
-        return {++__it1, ++__it2, ++__out_it};
+        ++__it1;
+        ++__it2;
+        ++__out_it;
     };
 
     // 1. Main set_union operation
@@ -252,10 +254,9 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
         const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
         const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
 
-        std::tie(__first1, __first2, __result) = __val2_lt_val1
-                                               ? __op_val2_lt_val1(__first1, __first2, __result)
-                                               : (__val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                                                                 : __op_val1_eq_val2(__first1, __first2, __result));
+        __val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                       : (__val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                                         : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     // 2. Copying the residual elements if one of the input sequences is exhausted
@@ -272,22 +273,22 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
                              _ForwardIterator2 __last2, _OutputIterator __result, _CopyFunc _copy, _Compare __comp,
                              _Proj1 __proj1, _Proj2 __proj2)
 {
-    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
-
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {++__it1, __it2, __out_it};
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+        ++__it1;
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {__it1, ++__it2, __out_it};
+    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+        ++__it2;
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [_copy](_ForwardIterator1 __it1, _ForwardIterator2 __it2,  _OutputIterator __out_it) -> _OperationRes {
+    auto __op_val1_eq_val2 = [_copy](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         _copy(*__it1, *__out_it);
-        return {++__it1, ++__it2, ++__out_it};
+        ++__it1;
+        ++__it2;
+        ++__out_it;
     };
 
     // 1. Main set_intersection operation
@@ -296,10 +297,9 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
         const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
         const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
 
-        std::tie(__first1, __first2, __result) =
-            __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                           : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                             : __op_val1_eq_val2(__first1, __first2, __result));
+        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                    : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                        : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     return __result;
@@ -314,22 +314,22 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
-
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
-        return {++__it1, __it2, ++__out_it};
+        ++__it1;
+        ++__out_it;
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {__it1, ++__it2, __out_it};
+    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+        ++__it2;
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {++__it1, ++__it2, __out_it};
+    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+        ++__it1;
+        ++__it2;
     };
 
     // 1. Main set_difference operation
@@ -338,9 +338,9 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
         const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
         const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
         
-        std::tie(__first1, __first2, __result) = __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                                               : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                             : __op_val1_eq_val2(__first1, __first2, __result));
+        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                       : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                         : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     return __cc_range(__first1, __last1, __result);
@@ -355,23 +355,24 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
-
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
-        return {++__it1, __it2, ++__out_it};
+        ++__it1;
+        ++__out_it;
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it2);
-        return {__it1, ++__it2, ++__out_it};
+        ++__it2;
+        ++__out_it;
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {++__it1, ++__it2, __out_it};
+    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+        ++__it1;
+        ++__it2;
     };
 
     // 1. Main set_symmetric_difference operation
@@ -380,10 +381,9 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
         const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
         const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
 
-        std::tie(__first1, __first2, __result) =
-            __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                           : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                             : __op_val1_eq_val2(__first1, __first2, __result));
+        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                        : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                            : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     // 2. Copying the residual elements if one of the input sequences is exhausted

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -226,23 +226,42 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    for (; __first1 != __last1; ++__result)
+    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
+
+    // __proj2_val < __proj1_val
+    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        new (std::addressof(*__out_it)) _Tp(*__it2);
+        return {__it1, ++__it2, ++__out_it};
+    };
+
+    // __proj1_val < __proj2_val
+    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        new (std::addressof(*__out_it)) _Tp(*__it1);
+        return {++__it1, __it2, ++__out_it};
+    };
+
+    // __proj1_val == __proj2_val
+    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        new (std::addressof(*__out_it)) _Tp(*__it1);
+        return {++__it1, ++__it2, ++__out_it};
+    };
+
+    // 1. Main set_union operation
+    while (__first1 != __last1 && __first2 != __last2)
     {
-        if (__first2 == __last2)
-            return __cc_range(__first1, __last1, __result);
-        if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
-        {
-            ::new (::std::addressof(*__result)) _Tp(*__first2);
-            ++__first2;
-        }
-        else
-        {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
-            if (!std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
-                ++__first2;
-            ++__first1;
-        }
+        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
+        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+
+        std::tie(__first1, __first2, __result) = __val2_lt_val1
+                                               ? __op_val2_lt_val1(__first1, __first2, __result)
+                                               : (__val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                                                                 : __op_val1_eq_val2(__first1, __first2, __result));
     }
+
+    // 2. Copying the residual elements if one of the input sequences is exhausted
+    if (__first1 != __last1)
+        return __cc_range(__first1, __last1, __result);
+
     return __cc_range(__first2, __last2, __result);
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -288,9 +288,7 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator&) {
-        ++__it2;
-    };
+    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator&) { ++__it2; };
 
     // __proj1_val == __proj2_val
     auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator&) {
@@ -301,9 +299,11 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
     // 1. Main set_difference operation
     while (__first1 != __last1 && __first2 != __last2)
     {
-        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
-        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
-        
+        const bool __val1_lt_val2 =
+            std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
+        const bool __val2_lt_val1 =
+            !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+
         __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
                        : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
                                          : __op_val1_eq_val2(__first1, __first2, __result));

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -355,41 +355,29 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
-
-    // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it1);
-        return {++__it1, __it2, ++__out_it};
-    };
-
-    // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it2);
-        return {__it1, ++__it2, ++__out_it};
-    };
-
-    // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {++__it1, ++__it2, __out_it};
-    };
-
-    // 1. Main set_symmetric_difference operation
-    while (__first1 != __last1 && __first2 != __last2)
+    for (; __first1 != __last1;)
     {
-        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
-        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+        if (__first2 == __last2)
+            return __cc_range(__first1, __last1, __result);
 
-        std::tie(__first1, __first2, __result) =
-            __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                           : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                             : __op_val1_eq_val2(__first1, __first2, __result));
+        if (std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
+        {
+            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            ++__result;
+            ++__first1;
+        }
+        else
+        {
+            if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
+            {
+                ::new (::std::addressof(*__result)) _Tp(*__first2);
+                ++__result;
+            }
+            else
+                ++__first1;
+            ++__first2;
+        }
     }
-
-    // 2. Copying the residual elements if one of the input sequences is exhausted
-    if (__first2 == __last2)
-        return __cc_range(__first1, __last1, __result);
-
     return __cc_range(__first2, __last2, __result);
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -226,25 +226,23 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    while (__first1 != __last1 && __first2 != __last2)
+    for (; __first1 != __last1; ++__result)
     {
+        if (__first2 == __last2)
+            return __cc_range(__first1, __last1, __result);
         if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
         {
-            ::new (::std::addressof(*__result++)) _Tp(*__first2);
+            ::new (::std::addressof(*__result)) _Tp(*__first2);
             ++__first2;
         }
         else
         {
-            ::new (::std::addressof(*__result++)) _Tp(*__first1);
+            ::new (::std::addressof(*__result)) _Tp(*__first1);
             if (!std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
                 ++__first2;
             ++__first1;
         }
     }
-
-    if (__first2 == __last2)
-        return __cc_range(__first1, __last1, __result);
-
     return __cc_range(__first2, __last2, __result);
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -282,7 +282,7 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 
     // __proj1_val < __proj2_val
     auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator& __out_it) {
-        ::new (std::addressof(*__out_it)) _Tp(*__it1);
+        ::new (::std::addressof(*__out_it)) _Tp(*__it1);
         ++__it1;
         ++__out_it;
     };

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -226,42 +226,23 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
-
-    // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it2);
-        return {__it1, ++__it2, ++__out_it};
-    };
-
-    // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it1);
-        return {++__it1, __it2, ++__out_it};
-    };
-
-    // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it1);
-        return {++__it1, ++__it2, ++__out_it};
-    };
-
-    // 1. Main set_union operation
-    while (__first1 != __last1 && __first2 != __last2)
+    for (; __first1 != __last1; ++__result)
     {
-        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
-        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
-
-        std::tie(__first1, __first2, __result) = __val2_lt_val1
-                                               ? __op_val2_lt_val1(__first1, __first2, __result)
-                                               : (__val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                                                                 : __op_val1_eq_val2(__first1, __first2, __result));
+        if (__first2 == __last2)
+            return __cc_range(__first1, __last1, __result);
+        if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
+        {
+            ::new (::std::addressof(*__result)) _Tp(*__first2);
+            ++__first2;
+        }
+        else
+        {
+            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            if (!std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
+                ++__first2;
+            ++__first1;
+        }
     }
-
-    // 2. Copying the residual elements if one of the input sequences is exhausted
-    if (__first1 != __last1)
-        return __cc_range(__first1, __last1, __result);
-
     return __cc_range(__first2, __last2, __result);
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -314,36 +314,25 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
-
-    // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        new (std::addressof(*__out_it)) _Tp(*__it1);
-        return {++__it1, __it2, ++__out_it};
-    };
-
-    // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {__it1, ++__it2, __out_it};
-    };
-
-    // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {++__it1, ++__it2, __out_it};
-    };
-
-    // 1. Main set_difference operation
-    while (__first1 != __last1 && __first2 != __last2)
+    for (; __first1 != __last1;)
     {
-        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
-        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
-        
-        std::tie(__first1, __first2, __result) = __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                                               : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                             : __op_val1_eq_val2(__first1, __first2, __result));
-    }
+        if (__first2 == __last2)
+            return __cc_range(__first1, __last1, __result);
 
-    return __cc_range(__first1, __last1, __result);
+        if (std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
+        {
+            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            ++__result;
+            ++__first1;
+        }
+        else
+        {
+            if (!std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
+                ++__first1;
+            ++__first2;
+        }
+    }
+    return __result;
 }
 
 template <typename _ForwardIterator1, typename _ForwardIterator2, typename _OutputIterator,

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -226,26 +226,24 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
+    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
+
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
         ::new (std::addressof(*__out_it)) _Tp(*__it2);
-        ++__it2;
-        ++__out_it;
+        return {__it1, ++__it2, ++__out_it};
     };
 
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
-        ++__it1;
-        ++__out_it;
+        return {++__it1, __it2, ++__out_it};
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
-        ++__it1;
-        ++__it2;
-        ++__out_it;
+        return {++__it1, ++__it2, ++__out_it};
     };
 
     // 1. Main set_union operation
@@ -254,9 +252,10 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
         const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
         const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
 
-        __val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                       : (__val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                                         : __op_val1_eq_val2(__first1, __first2, __result));
+        std::tie(__first1, __first2, __result) = __val2_lt_val1
+                                               ? __op_val2_lt_val1(__first1, __first2, __result)
+                                               : (__val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                                                                 : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     // 2. Copying the residual elements if one of the input sequences is exhausted
@@ -273,22 +272,22 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
                              _ForwardIterator2 __last2, _OutputIterator __result, _CopyFunc _copy, _Compare __comp,
                              _Proj1 __proj1, _Proj2 __proj2)
 {
+    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
+
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
-        ++__it1;
+    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {++__it1, __it2, __out_it};
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
-        ++__it2;
+    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {__it1, ++__it2, __out_it};
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [_copy](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_eq_val2 = [_copy](_ForwardIterator1 __it1, _ForwardIterator2 __it2,  _OutputIterator __out_it) -> _OperationRes {
         _copy(*__it1, *__out_it);
-        ++__it1;
-        ++__it2;
-        ++__out_it;
+        return {++__it1, ++__it2, ++__out_it};
     };
 
     // 1. Main set_intersection operation
@@ -297,9 +296,10 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
         const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
         const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
 
-        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                    : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                        : __op_val1_eq_val2(__first1, __first2, __result));
+        std::tie(__first1, __first2, __result) =
+            __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                           : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                             : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     return __result;
@@ -314,22 +314,22 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
+    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
+
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
-        ++__it1;
-        ++__out_it;
+        return {++__it1, __it2, ++__out_it};
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
-        ++__it2;
+    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {__it1, ++__it2, __out_it};
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
-        ++__it1;
-        ++__it2;
+    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {++__it1, ++__it2, __out_it};
     };
 
     // 1. Main set_difference operation
@@ -338,9 +338,9 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
         const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
         const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
         
-        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                       : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                         : __op_val1_eq_val2(__first1, __first2, __result));
+        std::tie(__first1, __first2, __result) = __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                                               : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                             : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     return __cc_range(__first1, __last1, __result);
@@ -355,24 +355,23 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
+    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
+
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
-        ++__it1;
-        ++__out_it;
+        return {++__it1, __it2, ++__out_it};
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
         ::new (std::addressof(*__out_it)) _Tp(*__it2);
-        ++__it2;
-        ++__out_it;
+        return {__it1, ++__it2, ++__out_it};
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
-        ++__it1;
-        ++__it2;
+    auto __op_val1_eq_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {++__it1, ++__it2, __out_it};
     };
 
     // 1. Main set_symmetric_difference operation
@@ -381,9 +380,10 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
         const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
         const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
 
-        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                        : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                            : __op_val1_eq_val2(__first1, __first2, __result));
+        std::tie(__first1, __first2, __result) =
+            __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                           : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                             : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     // 2. Copying the residual elements if one of the input sequences is exhausted

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -272,36 +272,21 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
                              _ForwardIterator2 __last2, _OutputIterator __result, _CopyFunc _copy, _Compare __comp,
                              _Proj1 __proj1, _Proj2 __proj2)
 {
-    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
-
-    // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {++__it1, __it2, __out_it};
-    };
-
-    // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
-        return {__it1, ++__it2, __out_it};
-    };
-
-    // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [_copy](_ForwardIterator1 __it1, _ForwardIterator2 __it2,  _OutputIterator __out_it) -> _OperationRes {
-        _copy(*__it1, *__out_it);
-        return {++__it1, ++__it2, ++__out_it};
-    };
-
-    // 1. Main set_intersection operation
     while (__first1 != __last1 && __first2 != __last2)
     {
-        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
-        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
+        if (std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
+            ++__first1;
+        else if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
+            ++__first2;
+        else
+        {
+            _copy(*__first1, *__result);
 
-        std::tie(__first1, __first2, __result) =
-            __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                           : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                             : __op_val1_eq_val2(__first1, __first2, __result));
+            ++__first1;
+            ++__first2;
+            ++__result;
+        }
     }
-
     return __result;
 }
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -227,14 +227,14 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it2);
         ++__it2;
         ++__out_it;
     };
 
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
         ++__it1;
         ++__out_it;
@@ -251,12 +251,11 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
     // 1. Main set_union operation
     while (__first1 != __last1 && __first2 != __last2)
     {
-        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
-        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
-
-        __val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                       : (__val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                                         : __op_val1_eq_val2(__first1, __first2, __result));
+        std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2))
+            ? __op_val1_lt_val2(__first1, __first2, __result)
+            : (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1))
+                   ? __op_val2_lt_val1(__first1, __first2, __result)
+                   : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     // 2. Copying the residual elements if one of the input sequences is exhausted
@@ -274,12 +273,12 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
                              _Proj1 __proj1, _Proj2 __proj2)
 {
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator&) {
         ++__it1;
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator&) {
         ++__it2;
     };
 
@@ -294,12 +293,11 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
     // 1. Main set_intersection operation
     while (__first1 != __last1 && __first2 != __last2)
     {
-        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
-        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
-
-        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                    : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                        : __op_val1_eq_val2(__first1, __first2, __result));
+        std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2))
+            ? __op_val1_lt_val2(__first1, __first2, __result)
+            : (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1))
+                   ? __op_val2_lt_val1(__first1, __first2, __result)
+                   : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     return __result;
@@ -315,19 +313,19 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
         ++__it1;
         ++__out_it;
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator&) {
         ++__it2;
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator&) {
         ++__it1;
         ++__it2;
     };
@@ -356,21 +354,21 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
     // __proj1_val < __proj2_val
-    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_lt_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2&, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it1);
         ++__it1;
         ++__out_it;
     };
 
     // __proj2_val < __proj1_val
-    auto __op_val2_lt_val1 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val2_lt_val1 = [](_ForwardIterator1&, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
         ::new (std::addressof(*__out_it)) _Tp(*__it2);
         ++__it2;
         ++__out_it;
     };
 
     // __proj1_val == __proj2_val
-    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator& __out_it) {
+    auto __op_val1_eq_val2 = [](_ForwardIterator1& __it1, _ForwardIterator2& __it2, _OutputIterator&) {
         ++__it1;
         ++__it2;
     };
@@ -378,12 +376,11 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
     // 1. Main set_symmetric_difference operation
     while (__first1 != __last1 && __first2 != __last2)
     {
-        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
-        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
-
-        __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
-                        : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
-                                            : __op_val1_eq_val2(__first1, __first2, __result));
+        std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2))
+            ? __op_val1_lt_val2(__first1, __first2, __result)
+            : (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1))
+                   ? __op_val2_lt_val1(__first1, __first2, __result)
+                   : __op_val1_eq_val2(__first1, __first2, __result));
     }
 
     // 2. Copying the residual elements if one of the input sequences is exhausted

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -323,11 +323,8 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
-    for (; __first1 != __last1;)
+    while (__first1 != __last1 && __first2 != __last2)
     {
-        if (__first2 == __last2)
-            return __cc_range(__first1, __last1, __result);
-
         if (std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
         {
             ::new (::std::addressof(*__result)) _Tp(*__first1);
@@ -346,7 +343,11 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
             ++__first2;
         }
     }
-    return __cc_range(__first2, __last2, __result);
+
+    if (__first1 == __last1)
+        return __cc_range(__first2, __last2, __result);
+
+    return __cc_range(__first1, __last1, __result);
 }
 
 template <template <typename, typename...> typename _Concrete, typename _ValueType, typename... _Args>

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -272,21 +272,36 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
                              _ForwardIterator2 __last2, _OutputIterator __result, _CopyFunc _copy, _Compare __comp,
                              _Proj1 __proj1, _Proj2 __proj2)
 {
+    using _OperationRes = std::tuple<_ForwardIterator1, _ForwardIterator2, _OutputIterator>;
+
+    // __proj1_val < __proj2_val
+    auto __op_val1_lt_val2 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {++__it1, __it2, __out_it};
+    };
+
+    // __proj2_val < __proj1_val
+    auto __op_val2_lt_val1 = [](_ForwardIterator1 __it1, _ForwardIterator2 __it2, _OutputIterator __out_it) -> _OperationRes {
+        return {__it1, ++__it2, __out_it};
+    };
+
+    // __proj1_val == __proj2_val
+    auto __op_val1_eq_val2 = [_copy](_ForwardIterator1 __it1, _ForwardIterator2 __it2,  _OutputIterator __out_it) -> _OperationRes {
+        _copy(*__it1, *__out_it);
+        return {++__it1, ++__it2, ++__out_it};
+    };
+
+    // 1. Main set_intersection operation
     while (__first1 != __last1 && __first2 != __last2)
     {
-        if (std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2)))
-            ++__first1;
-        else if (std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1)))
-            ++__first2;
-        else
-        {
-            _copy(*__first1, *__result);
+        const bool __val1_lt_val2 = std::invoke(__comp, std::invoke(__proj1, *__first1), std::invoke(__proj2, *__first2));
+        const bool __val2_lt_val1 = !__val1_lt_val2 && std::invoke(__comp, std::invoke(__proj2, *__first2), std::invoke(__proj1, *__first1));
 
-            ++__first1;
-            ++__first2;
-            ++__result;
-        }
+        std::tie(__first1, __first2, __result) =
+            __val1_lt_val2 ? __op_val1_lt_val2(__first1, __first2, __result)
+                           : (__val2_lt_val1 ? __op_val2_lt_val1(__first1, __first2, __result)
+                                             : __op_val1_eq_val2(__first1, __first2, __result));
     }
+
     return __result;
 }
 


### PR DESCRIPTION
Refactors the set-operation construction helpers in the PSTL parallel backend utilities to streamline control flow and ensure remaining ranges are copied after the main comparison loop.

**Changes:**
- Refactored `__set_difference_construct()` to use a `while` loop over both ranges and copy any remaining `[first1,last1)` tail afterward.
- Refactored `__set_symmetric_difference_construct()` to use a `while` loop over both ranges and then copy the remaining tail from whichever range is not exhausted.

These changes gave us some performance profit.