### PR TITLE
Add ranges::{starts,ends}_with

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -24,6 +24,15 @@ namespace oneapi
 {
 namespace dpl
 {
+#if _ONEDPL_CPP20_RANGES_PRESENT
+// forward declarations of function objects allow to simplify implementation code
+namespace ranges::__internal
+{
+    struct __starts_with_fn;
+    struct __ends_with_fn;
+}
+#endif
+
 namespace experimental
 {
 namespace ranges

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -28,9 +28,9 @@ namespace dpl
 // forward declarations of function objects allow to simplify implementation code
 namespace ranges::__internal
 {
-    struct __starts_with_fn;
-    struct __ends_with_fn;
-}
+struct __starts_with_fn;
+struct __ends_with_fn;
+} // namespace ranges::__internal
 #endif
 
 namespace experimental

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1266,9 +1266,16 @@ struct __ends_with_fn
         using _DistanceType = std::ranges::range_difference_t<_R1>;
         _DistanceType __n1 = std::ranges::distance(__r1);
         _DistanceType __n2 = std::ranges::distance(__r2);
-        return !(__n1 < __n2) && oneapi::dpl::ranges::equal(std::forward<_ExecutionPolicy>(__exec),
-                                                            std::views::all(__r1) | std::views::drop(__n1 - __n2),
-                                                            std::forward<_R2>(__r2), __pred, __proj1, __proj2);
+        if (__n1 < __n2)
+            return false;
+
+#if _ONEDPL_CPP20_RANGES_ADVANCE_SYCL_INCOMPATIBLE
+        oneapi::dpl::__ranges::drop_view_simple __r1_dropped {std::views::all(__r1), __n1 - __n2};
+#else
+        auto __r1_dropped = std::views::all(__r1) | std::views::drop(__n1 - __n2);
+#endif
+        return oneapi::dpl::ranges::equal(std::forward<_ExecutionPolicy>(__exec), std::move(__r1_dropped),
+                                          std::forward<_R2>(__r2), __pred, __proj1, __proj2);
     }
 }; // __ends_with_fn
 } // __internal

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1263,9 +1263,9 @@ struct __ends_with_fn
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
     {
-        using _Size = std::common_type_t<decltype(std::ranges::size(__r1)), decltype(std::ranges::size(__r2))>;
-        _Size __n1 = std::ranges::size(__r1);
-        _Size __n2 = std::ranges::size(__r2);
+        using _DistanceType = std::ranges::range_difference_t<_R1>;
+        _DistanceType __n1 = std::ranges::distance(__r1);
+        _DistanceType __n2 = std::ranges::distance(__r2);
         return !(__n1 < __n2) && oneapi::dpl::ranges::equal(std::forward<_ExecutionPolicy>(__exec),
                                                             std::views::all(__r1) | std::views::drop(__n1 - __n2),
                                                             std::forward<_R2>(__r2), __pred, __proj1, __proj2);

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1229,8 +1229,7 @@ struct __mismatch_fn
 
 inline constexpr __internal::__mismatch_fn mismatch;
 
-// [alg.starts.with] [alg.ends.with]
-
+// [alg.starts.with]
 struct __internal::__starts_with_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
@@ -1247,8 +1246,11 @@ struct __internal::__starts_with_fn
         return std::ranges::end(__r2) == oneapi::dpl::ranges::mismatch(std::forward<_ExecutionPolicy>(__exec), __r1,
                                                                        __r2, __pred, __proj1, __proj2).in2;
     }
-}; // __starts_with_fn
+};
 
+inline constexpr __internal::__starts_with_fn starts_with;
+
+// [alg.ends.with]
 struct __internal::__ends_with_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
@@ -1275,9 +1277,8 @@ struct __internal::__ends_with_fn
         return oneapi::dpl::ranges::equal(std::forward<_ExecutionPolicy>(__exec), std::move(__r1_dropped),
                                           std::forward<_R2>(__r2), __pred, __proj1, __proj2);
     }
-}; // __ends_with_fn
+};
 
-inline constexpr __internal::__starts_with_fn starts_with;
 inline constexpr __internal::__ends_with_fn ends_with;
 
 // [alg.remove_if]

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1231,9 +1231,7 @@ inline constexpr __internal::__mismatch_fn mismatch;
 
 // [alg.starts.with] [alg.ends.with]
 
-namespace __internal
-{
-struct __starts_with_fn
+struct __internal::__starts_with_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
               typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
@@ -1251,7 +1249,7 @@ struct __starts_with_fn
     }
 }; // __starts_with_fn
 
-struct __ends_with_fn
+struct __internal::__ends_with_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
               typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
@@ -1278,7 +1276,6 @@ struct __ends_with_fn
                                           std::forward<_R2>(__r2), __pred, __proj1, __proj2);
     }
 }; // __ends_with_fn
-} // __internal
 
 inline constexpr __internal::__starts_with_fn starts_with;
 inline constexpr __internal::__ends_with_fn ends_with;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1266,16 +1266,15 @@ struct __ends_with_fn
         using _Size = std::common_type_t<decltype(std::ranges::size(__r1)), decltype(std::ranges::size(__r2))>;
         _Size __n1 = std::ranges::size(__r1);
         _Size __n2 = std::ranges::size(__r2);
-        return !(__n1 < __n2) && oneapi::dpl::ranges::equal(
-            std::forward<_ExecutionPolicy>(__exec), std::views::all(__r1) | std::views::drop(__n1 - __n2),
-            std::forward<_R2>(__r2),__pred, __proj1, __proj2);
+        return !(__n1 < __n2) && oneapi::dpl::ranges::equal(std::forward<_ExecutionPolicy>(__exec),
+                                                            std::views::all(__r1) | std::views::drop(__n1 - __n2),
+                                                            std::forward<_R2>(__r2), __pred, __proj1, __proj2);
     }
 }; // __ends_with_fn
 } // __internal
 
 inline constexpr __internal::__starts_with_fn starts_with;
 inline constexpr __internal::__ends_with_fn ends_with;
-
 
 // [alg.remove_if]
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1060,16 +1060,14 @@ struct __internal::__ends_with_fn
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
     {
-        using _DistanceType = std::ranges::range_difference_t<_R1>;
-        _DistanceType __n1 = std::ranges::distance(__r1);
-        _DistanceType __n2 = std::ranges::distance(__r2);
-        if (__n1 < __n2)
+        auto __size_diff = std::ranges::distance(__r1) - std::ranges::distance(__r2);
+        if (__size_diff < 0)
             return false;
 
 #if _ONEDPL_CPP20_RANGES_ADVANCE_SYCL_INCOMPATIBLE
-        oneapi::dpl::__ranges::drop_view_simple __r1_dropped {std::views::all(__r1), __n1 - __n2};
+        oneapi::dpl::__ranges::drop_view_simple __r1_dropped {std::views::all(__r1), __size_diff};
 #else
-        auto __r1_dropped = std::views::all(__r1) | std::views::drop(__n1 - __n2);
+        auto __r1_dropped = std::views::all(__r1) | std::views::drop(__size_diff);
 #endif
         return oneapi::dpl::ranges::equal(std::forward<_ExecutionPolicy>(__exec), std::move(__r1_dropped),
                                           std::forward<_R2>(__r2), __pred, __proj1, __proj2);

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1229,6 +1229,54 @@ struct __mismatch_fn
 
 inline constexpr __internal::__mismatch_fn mismatch;
 
+// [alg.starts.with] [alg.ends.with]
+
+namespace __internal
+{
+struct __starts_with_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
+              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
+                                            _Pred, _Proj1, _Proj2>
+    bool
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
+               _Proj2 __proj2 = {}) const
+    {
+        // To ensure no dangling iterator is returned, __r2 may not be forwarded
+        return std::ranges::end(__r2) == oneapi::dpl::ranges::mismatch(std::forward<_ExecutionPolicy>(__exec), __r1,
+                                                                       __r2, __pred, __proj1, __proj2).in2;
+    }
+}; // __starts_with_fn
+
+struct __ends_with_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
+              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
+                                            _Pred, _Proj1, _Proj2>
+    bool
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
+               _Proj2 __proj2 = {}) const
+    {
+        using _Size = std::common_type_t<decltype(std::ranges::size(__r1)), decltype(std::ranges::size(__r2))>;
+        _Size __n1 = std::ranges::size(__r1);
+        _Size __n2 = std::ranges::size(__r2);
+        return !(__n1 < __n2) && oneapi::dpl::ranges::equal(
+            std::forward<_ExecutionPolicy>(__exec), std::views::all(__r1) | std::views::drop(__n1 - __n2),
+            std::forward<_R2>(__r2),__pred, __proj1, __proj2);
+    }
+}; // __ends_with_fn
+} // __internal
+
+inline constexpr __internal::__starts_with_fn starts_with;
+inline constexpr __internal::__ends_with_fn ends_with;
+
+
 // [alg.remove_if]
 
 namespace __internal

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -307,7 +307,7 @@
 #    define _ONEDPL_CPP20_OWNING_VIEW_PRESENT (_ONEDPL___cplusplus >= 202302L)
 #endif
 
-// The implementation of std::ranges::advance in GCC 10 uses throw expressions.
+// The implementation of std::ranges::advance in libstdc++ 10 uses throw expressions.
 // That prevents its use in SYCL kernels, as well as the use of std::ranges::next, std::views::drop, etc.
 #define _ONEDPL_CPP20_RANGES_ADVANCE_SYCL_INCOMPATIBLE (_ONEDPL_BACKEND_SYCL && _GLIBCXX_RELEASE == 10)
 

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -307,6 +307,10 @@
 #    define _ONEDPL_CPP20_OWNING_VIEW_PRESENT (_ONEDPL___cplusplus >= 202302L)
 #endif
 
+// The implementation of std::ranges::advance in GCC 10 uses throw expressions.
+// That prevents its use in SYCL kernels, as well as the use of std::ranges::next, std::views::drop, etc.
+#define _ONEDPL_CPP20_RANGES_ADVANCE_SYCL_INCOMPATIBLE (_ONEDPL_BACKEND_SYCL && _GLIBCXX_RELEASE == 10)
+
 // When C++20 concepts are available, we must use std::tuple as a proxy reference to satisfy iterator concepts, which
 // requires the changes to std::tuple in P2321R2 and the tuple-like basic_common_reference specialization in P2165R4.
 #define _ONEDPL_CAN_USE_STD_TUPLE_PROXY_ITERATOR                                                                       \

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -537,6 +537,16 @@ struct drop_view_simple
         assert(__n >= 0 && __n <= oneapi::dpl::__ranges::__size(__r));
     }
 
+    auto begin() const
+    {
+        return __begin(__r) + __n;
+    }
+
+    auto end() const
+    {
+        return __end(__r);
+    }
+
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__r[__i])
@@ -837,5 +847,10 @@ __get_subscription_view(_View&& __view)
 } // namespace __ranges
 } // namespace dpl
 } // namespace oneapi
+
+#if _ONEDPL_CPP20_RANGES_PRESENT
+template <typename _R, typename _Size>
+constexpr bool std::ranges::enable_view<oneapi::dpl::__ranges::drop_view_simple<_R, _Size>> = true;
+#endif
 
 #endif // _ONEDPL_UTILS_RANGES_H

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -537,12 +537,14 @@ struct drop_view_simple
         assert(__n >= 0 && __n <= oneapi::dpl::__ranges::__size(__r));
     }
 
-    auto begin() const
+    auto
+    begin() const
     {
         return __begin(__r) + __n;
     }
 
-    auto end() const
+    auto
+    end() const
     {
         return __end(__r);
     }

--- a/test/parallel_api/ranges/std_ranges_ends_with.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_ends_with.pass.cpp
@@ -9,8 +9,6 @@
 
 #include "std_ranges_test.h"
 
-#include "std_ranges_test.h"
-
 #if _ENABLE_STD_RANGES_TESTING
     template<int call_id, typename T, typename DataGen2 = std::identity>
     using launcher = test_std_ranges::test_range_algo<call_id, T, test_std_ranges::data_in_in,

--- a/test/parallel_api/ranges/std_ranges_ends_with.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_ends_with.pass.cpp
@@ -1,0 +1,54 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 UXL Foundation Contributors
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+#include "std_ranges_test.h"
+
+#if _ENABLE_STD_RANGES_TESTING
+    template<int call_id, typename T, typename DataGen2 = std::identity>
+    using launcher = test_std_ranges::test_range_algo<call_id, T, test_std_ranges::data_in_in,
+                                                      /*DataGen1*/ std::identity, DataGen2>;
+#if __cpp_lib_ranges_starts_ends_with >= 202106L
+    auto checker = TEST_PREPARE_CALLABLE(std::ranges::ends_with);
+#else
+    struct {
+        template<std::ranges::input_range R1, std::ranges::input_range R2, typename Pred = std::ranges::equal_to,
+                 typename Proj1 = std::identity, typename Proj2 = std::identity>
+        bool operator()(R1&& r1, R2&& r2, Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {})
+        {
+            std::ranges::reverse_view r2_reverse{r2};
+            auto last = r2_reverse.end();
+            return std::ranges::mismatch(std::ranges::reverse_view(r1), r2_reverse, pred, proj1, proj2).in2 == last;
+        }
+    } checker;
+#endif
+#endif
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    using data_gen_shift_med = decltype([](auto i){ return i + medium_size/2; });
+    using data_gen_shift_big = decltype([](auto i){ return i + big_size/2; });
+
+    launcher<0, int>{big_sz}(dpl_ranges::ends_with, checker, binary_pred_const);
+    launcher<1, int>{}(dpl_ranges::ends_with, checker, binary_pred, proj);
+    launcher<2, int, decltype(proj)>{}(dpl_ranges::ends_with, checker, binary_pred, proj);
+    launcher<3, P2>{}(dpl_ranges::ends_with, checker, binary_pred_const, &P2::x, &P2::proj);
+    launcher<4, P2>{}(dpl_ranges::ends_with, checker, binary_pred, &P2::proj, &P2::x);
+    launcher<5, int, data_gen_shift_med>{}(dpl_ranges::ends_with, checker);
+    launcher<6, int, data_gen_shift_big>{big_sz}(dpl_ranges::ends_with, checker);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_starts_with.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_starts_with.pass.cpp
@@ -9,8 +9,6 @@
 
 #include "std_ranges_test.h"
 
-#include "std_ranges_test.h"
-
 #if _ENABLE_STD_RANGES_TESTING
     template<int call_id, typename T, typename DataGen2 = std::identity>
     using launcher = test_std_ranges::test_range_algo<call_id, T, test_std_ranges::data_in_in,

--- a/test/parallel_api/ranges/std_ranges_starts_with.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_starts_with.pass.cpp
@@ -1,0 +1,52 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 UXL Foundation Contributors
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+#include "std_ranges_test.h"
+
+#if _ENABLE_STD_RANGES_TESTING
+    template<int call_id, typename T, typename DataGen2 = std::identity>
+    using launcher = test_std_ranges::test_range_algo<call_id, T, test_std_ranges::data_in_in,
+                                                      /*DataGen1*/ std::identity, DataGen2>;
+#if __cpp_lib_ranges_starts_ends_with >= 202106L
+    auto checker = TEST_PREPARE_CALLABLE(std::ranges::starts_with);
+#else
+    struct {
+        template<std::ranges::input_range R1, std::ranges::input_range R2, typename Pred = std::ranges::equal_to,
+                 typename Proj1 = std::identity, typename Proj2 = std::identity>
+        bool operator()(R1&& r1, R2&& r2, Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {})
+        {
+            auto last = std::ranges::end(r2);
+            return std::ranges::mismatch(r1, r2, pred, proj1, proj2).in2 == last;
+        }
+    } checker;
+#endif
+#endif
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    auto almost_always_i = [](auto i){ return (i == medium_size/2 + 19)? 0 : i; };
+    using data_gen_needle = decltype(almost_always_i);
+
+    launcher<0, int>{big_sz}(dpl_ranges::starts_with, checker, binary_pred_const);
+    launcher<1, int>{}(dpl_ranges::starts_with, checker, binary_pred, proj);
+    launcher<2, int, decltype(proj)>{}(dpl_ranges::starts_with, checker, binary_pred, proj);
+    launcher<3, P2>{}(dpl_ranges::starts_with, checker, binary_pred_const, &P2::x, &P2::proj);
+    launcher<4, P2>{}(dpl_ranges::starts_with, checker, binary_pred, &P2::proj, &P2::x);
+    launcher<5, int, data_gen_needle>{}(dpl_ranges::starts_with, checker);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}


### PR DESCRIPTION
The implementations of `ranges::starts_/ends_with` redirect to `mismatch` and `equal` respectively, as described in the C++ standard.