### PR TITLE
[RNG] Follow-up improvements for Philox RNG engine

### DIFF
--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -33,27 +33,27 @@ namespace oneapi
 namespace dpl
 {
 
-template <typename _UIntType, std::size_t _W, std::size_t _N, std::size_t _R,
-          oneapi::dpl::internal::element_type_t<_UIntType>... _Consts>
+template <typename _UIntType, std::size_t _w, std::size_t _n, std::size_t _r,
+          oneapi::dpl::internal::element_type_t<_UIntType>... _consts>
 class philox_engine;
 
-template <typename _CharT, typename _Traits, typename _UIntTypeP, std::size_t _Wp, std::size_t _Np, std::size_t _Rp,
-          oneapi::dpl::internal::element_type_t<_UIntTypeP>... _ConstsP>
-std::basic_ostream<_CharT, _Traits>&
-operator<<(std::basic_ostream<_CharT, _Traits>&, const philox_engine<_UIntTypeP, _Wp, _Np, _Rp, _ConstsP...>&);
+template <typename __CharT, typename __Traits, typename __UIntType, std::size_t __w, std::size_t __n, std::size_t __r,
+          oneapi::dpl::internal::element_type_t<__UIntType>... __consts>
+std::basic_ostream<__CharT, __Traits>&
+operator<<(std::basic_ostream<__CharT, __Traits>&, const philox_engine<__UIntType, __w, __n, __r, __consts...>&);
 
-template <typename _UIntTypeP, std::size_t _Wp, std::size_t _Np, std::size_t _Rp,
-          oneapi::dpl::internal::element_type_t<_UIntTypeP>... _ConstsP>
+template <typename __UIntType, std::size_t __w, std::size_t __n, std::size_t __r,
+          oneapi::dpl::internal::element_type_t<__UIntType>... __consts>
 const sycl::stream&
-operator<<(const sycl::stream&, const philox_engine<_UIntTypeP, _Wp, _Np, _Rp, _ConstsP...>&);
+operator<<(const sycl::stream&, const philox_engine<__UIntType, __w, __n, __r, __consts...>&);
 
-template <typename _CharT, typename _Traits, typename _UIntTypeP, std::size_t _Wp, std::size_t _Np, std::size_t _Rp,
-          oneapi::dpl::internal::element_type_t<_UIntTypeP>... _ConstsP>
-std::basic_istream<_CharT, _Traits>&
-operator>>(std::basic_istream<_CharT, _Traits>&, philox_engine<_UIntTypeP, _Wp, _Np, _Rp, _ConstsP...>&);
+template <typename __CharT, typename __Traits, typename __UIntType, std::size_t __w, std::size_t __n, std::size_t __r,
+          oneapi::dpl::internal::element_type_t<__UIntType>... __consts>
+std::basic_istream<__CharT, __Traits>&
+operator>>(std::basic_istream<__CharT, __Traits>&, philox_engine<__UIntType, __w, __n, __r, __consts...>&);
 
-template <typename _UIntType, std::size_t _W, std::size_t _N, std::size_t _R,
-          oneapi::dpl::internal::element_type_t<_UIntType>... _Consts>
+template <typename _UIntType, std::size_t _w, std::size_t _n, std::size_t _r,
+          oneapi::dpl::internal::element_type_t<_UIntType>... _consts>
 class philox_engine
 {
   public:
@@ -63,7 +63,7 @@ class philox_engine
 
   private:
     /* The size of the consts arrays */
-    static constexpr std::size_t __array_size = _N / 2;
+    static constexpr std::size_t __array_size = _n / 2;
 
     /* Method for unpacking even and odd elements of input constants into an array */
     enum class __indices_offset : std::size_t
@@ -75,20 +75,20 @@ class philox_engine
     static constexpr auto
     __get_consts_by(std::index_sequence<_Is...>)
     {
-        constexpr std::array __input_array{_Consts...};
+        constexpr std::array __input_array{_consts...};
         return std::array<scalar_type, sizeof...(_Is)>{__input_array[_Is * 2 + static_cast<std::size_t>(_Offset)]...};
     }
 
   public:
     /* Engine characteristics */
-    static constexpr std::size_t word_size = _W;
-    static constexpr std::size_t word_count = _N;
-    static constexpr std::size_t round_count = _R;
+    static constexpr std::size_t word_size = _w;
+    static constexpr std::size_t word_count = _n;
+    static constexpr std::size_t round_count = _r;
 
-    static_assert(_N == 2 || _N == 4, "parameter n must be 2 or 4");
-    static_assert(sizeof...(_Consts) == _N, "the amount of consts must be equal to n");
-    static_assert(_R > 0, "parameter r must be more than 0");
-    static_assert(_W > 0 && _W <= std::numeric_limits<scalar_type>::digits,
+    static_assert(_n == 2 || _n == 4, "parameter n must be 2 or 4");
+    static_assert(sizeof...(_consts) == _n, "the amount of consts must be equal to n");
+    static_assert(_r > 0, "parameter r must be more than 0");
+    static_assert(_w > 0 && _w <= std::numeric_limits<scalar_type>::digits,
                   "parameter w must satisfy 0 < w < std::numeric_limits<UIntType>::digits");
     static_assert(std::numeric_limits<scalar_type>::digits <= 64,
                   "size of the scalar UIntType (in case of sycl::vec<T, N> the size of T) must be less than 64 bits");
@@ -109,7 +109,7 @@ class philox_engine
     max()
     {
         // equals to 2^w - 1
-        return __in_mask;
+        return in_mask;
     }
 
     static constexpr scalar_type default_seed = 20111115u;
@@ -123,7 +123,7 @@ class philox_engine
     void
     seed(scalar_type __seed = default_seed)
     {
-        __seed_internal(__seed & __in_mask);
+        seed_internal(__seed & in_mask);
     }
 
     /* Set the state to arbitrary position */
@@ -133,109 +133,108 @@ class philox_engine
         for (std::size_t __i = 0; __i < word_count; ++__i)
         {
             // all counters are set in reverse order
-            __state.__x[word_count - __i - 1] = __counter[__i] & __in_mask;
+            state_.X[word_count - __i - 1] = __counter[__i] & in_mask;
         }
-        __state.__idx = word_count - 1;
+        state_.idx = word_count - 1;
     }
 
     /* Generating functions */
     result_type
     operator()()
     {
-        return __generate_internal<oneapi::dpl::internal::type_traits_t<result_type>::num_elems>();
+        return generate_internal<oneapi::dpl::internal::type_traits_t<result_type>::num_elems>();
     }
 
     /* operator () overload for result portion generation */
     result_type
     operator()(unsigned int __random_nums)
     {
-        return __generate_internal<oneapi::dpl::internal::type_traits_t<result_type>::num_elems>(__random_nums);
+        return generate_internal<oneapi::dpl::internal::type_traits_t<result_type>::num_elems>(__random_nums);
     }
 
     /* Shift the counter only forward relative to its current position */
     void
     discard(unsigned long long __z)
     {
-        __discard_internal(__z);
+        discard_internal(__z);
     }
 
     /* Equality operators */
     friend bool
-    operator==(const philox_engine& __eng1, const philox_engine& __eng2)
+    operator==(const philox_engine& __x, const philox_engine& __y)
     {
-        return (std::equal(__eng1.__state.__x.begin(), __eng1.__state.__x.end(), __eng2.__state.__x.begin()) &&
-                std::equal(__eng1.__state.__k.begin(), __eng1.__state.__k.end(), __eng2.__state.__k.begin()) &&
-                std::equal(__eng1.__state.__y.begin(), __eng1.__state.__y.end(), __eng2.__state.__y.begin()) &&
-                __eng1.__state.__idx == __eng2.__state.__idx);
+        return (std::equal(__x.state_.X.begin(), __x.state_.X.end(), __y.state_.X.begin()) &&
+                std::equal(__x.state_.K.begin(), __x.state_.K.end(), __y.state_.K.begin()) &&
+                std::equal(__x.state_.Y.begin(), __x.state_.Y.end(), __y.state_.Y.begin()) &&
+                __x.state_.idx == __y.state_.idx);
     }
 
     friend bool
-    operator!=(const philox_engine& __eng1, const philox_engine& __eng2)
+    operator!=(const philox_engine& __x, const philox_engine& __y)
     {
-        return !(__eng1 == __eng2);
+        return !(__x == __y);
     }
 
     /* Inserters and extractors */
-    template <typename _CharT, typename _Traits, typename _UIntTypeP, std::size_t _Wp, std::size_t _Np, std::size_t _Rp,
-              oneapi::dpl::internal::element_type_t<_UIntTypeP>... _ConstsP>
-    friend std::basic_ostream<_CharT, _Traits>&
-    operator<<(std::basic_ostream<_CharT, _Traits>&, const philox_engine<_UIntTypeP, _Wp, _Np, _Rp, _ConstsP...>&);
+    template <typename __CharT, typename __Traits, typename __UIntType, std::size_t __w, std::size_t __n,
+              std::size_t __r, oneapi::dpl::internal::element_type_t<__UIntType>... __consts>
+    friend std::basic_ostream<__CharT, __Traits>&
+    operator<<(std::basic_ostream<__CharT, __Traits>&, const philox_engine<__UIntType, __w, __n, __r, __consts...>&);
 
-    template <typename _UIntTypeP, std::size_t _Wp, std::size_t _Np, std::size_t _Rp,
-              oneapi::dpl::internal::element_type_t<_UIntTypeP>... _ConstsP>
+    template <typename __UIntType, std::size_t __w, std::size_t __n, std::size_t __r,
+              oneapi::dpl::internal::element_type_t<__UIntType>... __consts>
     friend const sycl::stream&
-    operator<<(const sycl::stream&, const philox_engine<_UIntTypeP, _Wp, _Np, _Rp, _ConstsP...>&);
+    operator<<(const sycl::stream&, const philox_engine<__UIntType, __w, __n, __r, __consts...>&);
 
-    template <typename _CharT, typename _Traits, typename _UIntTypeP, std::size_t _Wp, std::size_t _Np, std::size_t _Rp,
-              oneapi::dpl::internal::element_type_t<_UIntTypeP>... _ConstsP>
-    friend std::basic_istream<_CharT, _Traits>&
-    operator>>(std::basic_istream<_CharT, _Traits>&, philox_engine<_UIntTypeP, _Wp, _Np, _Rp, _ConstsP...>&);
+    template <typename __CharT, typename __Traits, typename __UIntType, std::size_t __w, std::size_t __n,
+              std::size_t __r, oneapi::dpl::internal::element_type_t<__UIntType>... __consts>
+    friend std::basic_istream<__CharT, __Traits>&
+    operator>>(std::basic_istream<__CharT, __Traits>&, philox_engine<__UIntType, __w, __n, __r, __consts...>&);
 
   private:
     /* Internal generator state */
-    struct __state_type
+    struct state
     {
-        std::array<scalar_type, word_count> __x;     // counters
-        std::array<scalar_type, word_count / 2> __k; // keys
-        std::array<scalar_type, word_count> __y;     // results
-        scalar_type __idx;                           // index
-    } __state;
+        std::array<scalar_type, word_count> X;     // counters
+        std::array<scalar_type, word_count / 2> K; // keys
+        std::array<scalar_type, word_count> Y;     // results
+        scalar_type idx;                           // index
+    } state_;
 
-    /* __word_mask<_WordSize> - scalar_type with the low _WordSize bits set */
-    template <std::size_t _WordSize, typename = std::enable_if_t<_WordSize != 0>>
-    static constexpr scalar_type __word_mask = ~scalar_type(0) >>
-                                               (std::numeric_limits<scalar_type>::digits - _WordSize);
+    /* __word_mask<_W> - scalar_type with the low _W bits set */
+    template <std::size_t _W, typename = std::enable_if_t<_W != 0>>
+    static constexpr scalar_type __word_mask = ~scalar_type(0) >> (std::numeric_limits<scalar_type>::digits - _W);
 
     /* Processing mask */
-    static constexpr auto __in_mask = __word_mask<word_size>;
+    static constexpr auto in_mask = __word_mask<word_size>;
 
     void
-    __seed_internal(scalar_type __seed)
+    seed_internal(scalar_type __seed)
     {
         // set to zero counters and results
         for (std::size_t __i = 0; __i < word_count; ++__i)
         {
-            __state.__x[__i] = 0;
-            __state.__y[__i] = 0;
+            state_.X[__i] = 0;
+            state_.Y[__i] = 0;
         }
         // 0th key element is set as seed, others are 0
-        __state.__k[0] = __seed & __in_mask;
+        state_.K[0] = __seed & in_mask;
         for (std::size_t __i = 1; __i < (word_count / 2); ++__i)
         {
-            __state.__k[__i] = 0;
+            state_.K[__i] = 0;
         }
 
-        __state.__idx = word_count - 1;
+        state_.idx = word_count - 1;
     }
 
     /* Increment counter by 1 */
     void
-    __increase_counter_internal()
+    increase_counter_internal()
     {
         for (std::size_t __i = 0; __i < word_count; ++__i)
         {
-            __state.__x[__i] = (__state.__x[__i] + 1) & __in_mask;
-            if (__state.__x[__i])
+            state_.X[__i] = (state_.X[__i] + 1) & in_mask;
+            if (state_.X[__i])
             {
                 return;
             }
@@ -244,19 +243,19 @@ class philox_engine
 
     /* Increment counter by an arbitrary __z */
     void
-    __increase_counter_internal(unsigned long long __z)
+    increase_counter_internal(unsigned long long __z)
     {
         unsigned long long __carry = 0;
         unsigned long long __ctr_inc = __z;
 
         for (std::size_t __i = 0; __i < word_count; ++__i)
         {
-            scalar_type __initial_x = __state.__x[__i];
-            __state.__x[__i] = (__initial_x + __ctr_inc + __carry) & __in_mask;
+            scalar_type __initial_x = state_.X[__i];
+            state_.X[__i] = (__initial_x + __ctr_inc + __carry) & in_mask;
 
             __carry = 0;
             // check overflow of the current chunk
-            if (__state.__x[__i] < __initial_x)
+            if (state_.X[__i] < __initial_x)
             {
                 __carry = 1;
             }
@@ -270,94 +269,94 @@ class philox_engine
 
     /* Decrement counter by 1 */
     void
-    __decrease_counter_internal()
+    decrease_counter_internal()
     {
         for (std::size_t __i = 0; __i < word_count; ++__i)
         {
-            if (__state.__x[__i])
+            if (state_.X[__i])
             {
-                __state.__x[__i] = (__state.__x[__i] - 1) & __in_mask;
+                state_.X[__i] = (state_.X[__i] - 1) & in_mask;
                 return;
             }
 
             /* Borrow for zero counter chunk */
-            __state.__x[__i] = __in_mask;
+            state_.X[__i] = in_mask;
         }
     }
 
-    /* __generate_internal() specified for sycl_vec output 
+    /* generate_internal() specified for sycl_vec output
        and overload for result portion generation */
-    template <unsigned int _VecSize>
-    std::enable_if_t<(_VecSize > 0), result_type>
-    __generate_internal(unsigned int __random_nums)
+    template <unsigned int _N>
+    std::enable_if_t<(_N > 0), result_type>
+    generate_internal(unsigned int __random_nums)
     {
-        if (__random_nums >= _VecSize)
+        if (__random_nums >= _N)
             return operator()();
 
         result_type __loc_result;
         for (int __elm_count = 0; __elm_count < __random_nums; ++__elm_count)
         {
-            ++__state.__idx;
+            ++state_.idx;
 
             // check if buffer is empty
-            if (__state.__idx == word_count)
+            if (state_.idx == word_count)
             {
-                __philox_kernel();
-                __increase_counter_internal();
-                __state.__idx = 0;
+                philox_kernel();
+                increase_counter_internal();
+                state_.idx = 0;
             }
-            __loc_result[__elm_count] = __state.__y[__state.__idx];
+            __loc_result[__elm_count] = state_.Y[state_.idx];
         }
 
         return __loc_result;
     }
 
-    /* __generate_internal() specified for sycl_vec output */
-    template <unsigned int _VecSize>
-    std::enable_if_t<(_VecSize > 0), result_type>
-    __generate_internal()
+    /* generate_internal() specified for sycl_vec output */
+    template <unsigned int _N>
+    std::enable_if_t<(_N > 0), result_type>
+    generate_internal()
     {
         result_type __loc_result;
-        for (int __elm_count = 0; __elm_count < _VecSize; ++__elm_count)
+        for (int __elm_count = 0; __elm_count < _N; ++__elm_count)
         {
-            ++__state.__idx;
+            ++state_.idx;
 
             // check if buffer is empty
-            if (__state.__idx == word_count)
+            if (state_.idx == word_count)
             {
-                __philox_kernel();
-                __increase_counter_internal();
-                __state.__idx = 0;
+                philox_kernel();
+                increase_counter_internal();
+                state_.idx = 0;
             }
-            __loc_result[__elm_count] = __state.__y[__state.__idx];
+            __loc_result[__elm_count] = state_.Y[state_.idx];
         }
 
         return __loc_result;
     }
 
-    /* __generate_internal() specified for a scalar output */
-    template <unsigned int _VecSize>
-    std::enable_if_t<(_VecSize == 0), result_type>
-    __generate_internal()
+    /* generate_internal() specified for a scalar output */
+    template <unsigned int _N>
+    std::enable_if_t<(_N == 0), result_type>
+    generate_internal()
     {
-        ++__state.__idx;
-        if (__state.__idx == word_count)
+        ++state_.idx;
+        if (state_.idx == word_count)
         {
-            __philox_kernel();
-            __increase_counter_internal();
-            __state.__idx = 0;
+            philox_kernel();
+            increase_counter_internal();
+            state_.idx = 0;
         }
 
-        return __state.__y[__state.__idx];
+        return state_.Y[state_.idx];
     }
 
     void
-    __discard_internal(unsigned long long __z)
+    discard_internal(unsigned long long __z)
     {
-        std::uint32_t __available_in_buffer = word_count - 1 - __state.__idx;
+        std::uint32_t __available_in_buffer = word_count - 1 - state_.idx;
         if (__z <= __available_in_buffer)
         {
-            __state.__idx += __z;
+            state_.idx += __z;
         }
         else
         {
@@ -365,65 +364,65 @@ class philox_engine
             int __tail = __z % word_count;
             if (__tail == 0)
             {
-                __increase_counter_internal(__z / word_count);
-                __state.__idx = word_count - 1;
+                increase_counter_internal(__z / word_count);
+                state_.idx = word_count - 1;
             }
             else
             {
                 if (__z > word_count)
                 {
-                    __increase_counter_internal((__z - 1) / word_count);
+                    increase_counter_internal((__z - 1) / word_count);
                 }
-                __philox_kernel();
-                __increase_counter_internal();
-                __state.__idx = __tail - 1;
+                philox_kernel();
+                increase_counter_internal();
+                state_.idx = __tail - 1;
             }
         }
     }
 
     /* Internal generation Philox kernel */
     void
-    __philox_kernel()
+    philox_kernel()
     {
         if constexpr (word_count == 2)
         {
-            scalar_type& __v0 = __state.__y[0];
-            scalar_type& __v1 = __state.__y[1];
-            __v0 = __state.__x[0];
-            __v1 = __state.__x[1];
-            scalar_type __k0 = __state.__k[0];
+            scalar_type& __v0 = state_.Y[0];
+            scalar_type& __v1 = state_.Y[1];
+            __v0 = state_.X[0];
+            __v1 = state_.X[1];
+            scalar_type __k0 = state_.K[0];
             for (std::size_t __i = 0; __i < round_count; ++__i)
             {
-                auto [__hi0, __lo0] = __mulhilo(__v0, multipliers[0]);
+                auto [__hi0, __lo0] = mulhilo(__v0, multipliers[0]);
                 __v0 = __hi0 ^ __k0 ^ __v1;
                 __v1 = __lo0;
-                __k0 = (__k0 + round_consts[0]) & __in_mask;
+                __k0 = (__k0 + round_consts[0]) & in_mask;
             }
         }
         else if constexpr (word_count == 4)
         {
-            scalar_type& __v0 = __state.__y[2];
-            scalar_type& __v1 = __state.__y[1];
-            scalar_type& __v2 = __state.__y[0];
-            scalar_type& __v3 = __state.__y[3];
+            scalar_type& __v0 = state_.Y[2];
+            scalar_type& __v1 = state_.Y[1];
+            scalar_type& __v2 = state_.Y[0];
+            scalar_type& __v3 = state_.Y[3];
 
             // permute __x to V
-            __v2 = __state.__x[0];
-            __v1 = __state.__x[1];
-            __v0 = __state.__x[2];
-            __v3 = __state.__x[3];
-            scalar_type __k0 = __state.__k[0];
-            scalar_type __k1 = __state.__k[1];
+            __v2 = state_.X[0];
+            __v1 = state_.X[1];
+            __v0 = state_.X[2];
+            __v3 = state_.X[3];
+            scalar_type __k0 = state_.K[0];
+            scalar_type __k1 = state_.K[1];
             for (std::size_t __i = 0; __i < round_count; ++__i)
             {
-                auto [__hi0, __lo0] = __mulhilo(__v0, multipliers[0]);
-                auto [__hi1, __lo1] = __mulhilo(__v2, multipliers[1]);
+                auto [__hi0, __lo0] = mulhilo(__v0, multipliers[0]);
+                auto [__hi1, __lo1] = mulhilo(__v2, multipliers[1]);
                 __v2 = __hi0 ^ __v1 ^ __k0;
                 __v1 = __lo0;
                 __v0 = __hi1 ^ __v3 ^ __k1;
                 __v3 = __lo1;
-                __k0 = (__k0 + round_consts[0]) & __in_mask;
-                __k1 = (__k1 + round_consts[1]) & __in_mask;
+                __k0 = (__k0 + round_consts[0]) & in_mask;
+                __k1 = (__k1 + round_consts[1]) & in_mask;
             }
         }
     }
@@ -431,7 +430,7 @@ class philox_engine
     /* Returns the word_size high and word_size low
        bits of the 2*word_size-bit product of __a and __b */
     static std::pair<scalar_type, scalar_type>
-    __mulhilo(scalar_type __a, scalar_type __b)
+    mulhilo(scalar_type __a, scalar_type __b)
     {
         scalar_type __res_hi, __res_lo;
 
@@ -481,66 +480,66 @@ class philox_engine
                     : __res_hi << (std::numeric_limits<scalar_type>::digits - word_size) | (__res_lo >> word_size);
         }
 
-        return {__res_hi & __in_mask, __res_lo & __in_mask};
+        return {__res_hi & in_mask, __res_lo & in_mask};
     }
 };
 
-template <typename _CharT, typename _Traits, typename _UIntTypeP, std::size_t _Wp, std::size_t _Np, std::size_t _Rp,
-          oneapi::dpl::internal::element_type_t<_UIntTypeP>... _ConstsP>
-std::basic_ostream<_CharT, _Traits>&
-operator<<(std::basic_ostream<_CharT, _Traits>& __os,
-           const philox_engine<_UIntTypeP, _Wp, _Np, _Rp, _ConstsP...>& __engine)
+template <typename __CharT, typename __Traits, typename __UIntType, std::size_t __w, std::size_t __n, std::size_t __r,
+          oneapi::dpl::internal::element_type_t<__UIntType>... __consts>
+std::basic_ostream<__CharT, __Traits>&
+operator<<(std::basic_ostream<__CharT, __Traits>& __os,
+           const philox_engine<__UIntType, __w, __n, __r, __consts...>& __engine)
 {
-    oneapi::dpl::internal::save_stream_flags<_CharT, _Traits> __flags(__os);
+    oneapi::dpl::internal::save_stream_flags<__CharT, __Traits> __flags(__os);
 
     __os.setf(std::ios_base::dec | std::ios_base::left);
-    _CharT __sp = __os.widen(' ');
+    __CharT __sp = __os.widen(' ');
     __os.fill(__sp);
 
-    for (auto __k_elm : __engine.__state.__k)
+    for (auto __k_elm : __engine.state_.K)
     {
         __os << __k_elm << __sp;
     }
-    for (auto __x_elm : __engine.__state.__x)
+    for (auto __x_elm : __engine.state_.X)
     {
         __os << __x_elm << __sp;
     }
-    __os << __engine.__state.__idx;
+    __os << __engine.state_.idx;
 
     return __os;
 }
 
-template <typename _UIntTypeP, std::size_t _Wp, std::size_t _Np, std::size_t _Rp,
-          oneapi::dpl::internal::element_type_t<_UIntTypeP>... _ConstsP>
+template <typename __UIntType, std::size_t __w, std::size_t __n, std::size_t __r,
+          oneapi::dpl::internal::element_type_t<__UIntType>... __consts>
 const sycl::stream&
-operator<<(const sycl::stream& __os, const philox_engine<_UIntTypeP, _Wp, _Np, _Rp, _ConstsP...>& __engine)
+operator<<(const sycl::stream& __os, const philox_engine<__UIntType, __w, __n, __r, __consts...>& __engine)
 {
-    for (auto __k_elm : __engine.__state.__k)
+    for (auto __k_elm : __engine.state_.K)
     {
         __os << __k_elm << ' ';
     }
-    for (auto __x_elm : __engine.__state.__x)
+    for (auto __x_elm : __engine.state_.X)
     {
         __os << __x_elm << ' ';
     }
-    __os << __engine.__state.__idx;
+    __os << __engine.state_.idx;
 
     return __os;
 }
 
-template <typename _CharT, typename _Traits, typename _UIntTypeP, std::size_t _Wp, std::size_t _Np, std::size_t _Rp,
-          oneapi::dpl::internal::element_type_t<_UIntTypeP>... _ConstsP>
-std::basic_istream<_CharT, _Traits>&
-operator>>(std::basic_istream<_CharT, _Traits>& __is, philox_engine<_UIntTypeP, _Wp, _Np, _Rp, _ConstsP...>& __engine)
+template <typename __CharT, typename __Traits, typename __UIntType, std::size_t __w, std::size_t __n, std::size_t __r,
+          oneapi::dpl::internal::element_type_t<__UIntType>... __consts>
+std::basic_istream<__CharT, __Traits>&
+operator>>(std::basic_istream<__CharT, __Traits>& __is, philox_engine<__UIntType, __w, __n, __r, __consts...>& __engine)
 {
-    oneapi::dpl::internal::save_stream_flags<_CharT, _Traits> __flags(__is);
+    oneapi::dpl::internal::save_stream_flags<__CharT, __Traits> __flags(__is);
 
     __is.setf(std::ios_base::dec);
 
-    /* Number of elements in the state (__k, __x and __idx) */
-    constexpr std::size_t __state_size = _Np / 2 + _Np + 1;
+    /* Number of elements in the state (K, X and idx) */
+    constexpr std::size_t __state_size = __n / 2 + __n + 1;
 
-    std::array<oneapi::dpl::internal::element_type_t<_UIntTypeP>, __state_size> __tmp_inp;
+    std::array<oneapi::dpl::internal::element_type_t<__UIntType>, __state_size> __tmp_inp;
     for (std::size_t __i = 0; __i < __state_size; ++__i)
     {
         __is >> __tmp_inp[__i];
@@ -549,22 +548,22 @@ operator>>(std::basic_istream<_CharT, _Traits>& __is, philox_engine<_UIntTypeP, 
     if (!__is.fail())
     {
         int __inp_itr = 0;
-        for (std::size_t __i = 0; __i < _Np / 2; ++__i, ++__inp_itr)
+        for (std::size_t __i = 0; __i < __n / 2; ++__i, ++__inp_itr)
         {
-            __engine.__state.__k[__i] = __tmp_inp[__inp_itr];
+            __engine.state_.K[__i] = __tmp_inp[__inp_itr];
         }
-        for (std::size_t __i = 0; __i < _Np; ++__i, ++__inp_itr)
+        for (std::size_t __i = 0; __i < __n; ++__i, ++__inp_itr)
         {
-            __engine.__state.__x[__i] = __tmp_inp[__inp_itr];
+            __engine.state_.X[__i] = __tmp_inp[__inp_itr];
         }
-        __engine.__state.__idx = __tmp_inp[__inp_itr];
+        __engine.state_.idx = __tmp_inp[__inp_itr];
 
         /* Counter is incremented right after the generation of Yi - to restore the unused sequence Yi, the counter has to be decremented */
-        if (__engine.__state.__idx != _Np - 1)
+        if (__engine.state_.idx != __n - 1)
         {
-            __engine.__decrease_counter_internal();
+            __engine.decrease_counter_internal();
             /* setup Yi */
-            __engine.__philox_kernel();
+            __engine.philox_kernel();
         }
     }
 


### PR DESCRIPTION
### Description
The PR addresses some comments received after #2603 was merged.

**Done:**
- Unified `get_even_element_array()` and `get_odd_element_array()` functions in the Philox class into a single `get_consts_by()`.
- Reduced the register's pressure in the `__philox_kernel()` and `__mulhilo()` internal functions.