### PR TITLE
Avoid nanorange; add basic zip_view test std::ranges in cpp20

### DIFF
--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -30,11 +30,11 @@ main()
 {
     bool run = false;
 
-#if _ENABLE_RANGES_TESTING 
+#if _ENABLE_RANGES_TESTING
 
     using namespace oneapi::dpl::experimental::ranges;
 
-#if !TEST_STD_RANGES_VIEW_CONCEPT_REQUIRES_DEFAULT_INITIALIZABLE
+ #if !(_ONEDPL_CPP20_RANGES_PRESENT && TEST_STD_RANGES_VIEW_CONCEPT_REQUIRES_DEFAULT_INITIALIZABLE)
     run = true;
     {
         constexpr int max_n = 10;
@@ -73,7 +73,7 @@ main()
         char actual_data = std::get<0>(large_z[i]);
         EXPECT_EQ(expected_data, actual_data, "wrong effect with zip_view bracket operator");
     }
-#endif // !TEST_STD_RANGES_VIEW_CONCEPT_REQUIRES_DEFAULT_INITIALIZABLE
+ #endif // !(_ONEDPL_CPP20_RANGES_PRESENT && TEST_STD_RANGES_VIEW_CONCEPT_REQUIRES_DEFAULT_INITIALIZABLE)
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
     run = true;


### PR DESCRIPTION
The nanorange ref_view type does not satisfy std::ranges::view on pre-P2325R3 standard 
  library implementations (e.g., GCC < 11.4) because the old view concept requires       
  default_initializable. This patch guards the existing nanorange-based zip_view test    
  with TEST_STD_RANGES_VIEW_CONCEPT_REQUIRES_DEFAULT_INITIALIZABLE and adds a new test
  section using C++20 std::views::iota to verify basic zip_view functionality on all     
  platforms where _ONEDPL_CPP20_RANGES_PRESENT is available.