### PR TITLE
Match histogram precision of serial test equivalent

### DIFF
--- a/test/support/histogram_serial_impl.h
+++ b/test/support/histogram_serial_impl.h
@@ -17,17 +17,18 @@
 #define _HISTOGRAM_SERIAL_IMPL_H
 
 template <typename T1, typename T2, typename Size>
-::std::enable_if_t<!std::is_floating_point_v<T1>, ::std::uint32_t>
+std::enable_if_t<!std::is_floating_point_v<T1>, std::uint32_t>
 get_bin(T1 value, T2 min, T2 max, Size num_bins)
 {
-    return ::std::uint32_t((::std::uint64_t(value - min) * ::std::uint64_t(num_bins)) / (max - min));
+    return std::uint32_t((std::uint64_t(value - min) * std::uint64_t(num_bins)) / (max - min));
 }
 
 template <typename T1, typename T2, typename Size>
-::std::enable_if_t<std::is_floating_point_v<T1>, ::std::uint32_t>
+std::enable_if_t<std::is_floating_point_v<T1>, std::uint32_t>
 get_bin(T1 value, T2 min, T2 max, Size num_bins)
 {
-    return ::std::uint32_t((value - min) * (T1(num_bins) / (max - min)));
+    T1 __scale = T1(num_bins) / (max - min);
+    return std::uint32_t((value - min) * __scale);
 }
 
 template <typename _InputIterator1, typename _Size, typename _T, typename _OutputIterator>


### PR DESCRIPTION
Saving `__scale` to the element type, to match internal implementation and avoid differences in precision affecting tests on 32 bit architecture.  Previously, the intermediate type may be preserved in a higher precision type within the expression.  

This should fix minor correctness errors on 32 bit architectures for floating point histogram.pass. 