### PR TITLE
zip_view: expanding workaround

### DIFF
--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -346,6 +346,14 @@
 #    define _ONEDPL_STD_RANGES_ALGO_CPP_FUN 0
 #endif
 
+// Hidden friend functions defined in a sibling nested class are given access to the enclosing friend class's
+// other nested classes' private members for most compilers(CWG1699). GCC < 13 and MSVC do not grant this access.
+#if defined(_MSC_VER) || (defined(__GNUC__) && !defined(__clang__) && _ONEDPL_GCC_VERSION < 130100)
+#    define _ONEDPL_HIDDEN_FRIENDS_SIBLING_ACCESS_BROKEN 1
+#else
+#    define _ONEDPL_HIDDEN_FRIENDS_SIBLING_ACCESS_BROKEN 0
+#endif
+
 // -- Configure heterogeneous backends --
 
 #if !defined(ONEDPL_ALLOW_DEFERRED_WAITING)

--- a/include/oneapi/dpl/pstl/zip_view_impl.h
+++ b/include/oneapi/dpl/pstl/zip_view_impl.h
@@ -429,13 +429,7 @@ class zip_view : public std::ranges::view_interface<zip_view<_Views...>>
       private:
         friend class zip_view;
 
-        // Hidden friend functions defined in a sibling nested class (iterator) need access to
-        // sentinel's private __get_end(). It is debated in  CWG1699 whether this access should be
-        // granted since the hidden friend is a member-declaration of a nested class within the enclosing
-        // zip_view.
-        // However, GCC < 13 and MSVC do not extend friend permissions to hidden friends of
-        // sibling nested classes. Work around by making __get_end() public on those compilers.
-#    if defined(_MSC_VER) || (defined(__GNUC__) && !defined(__clang__) && _ONEDPL_GCC_VERSION < 130100)
+#    if _ONEDPL_HIDDEN_FRIENDS_SIBLING_ACCESS_BROKEN
       public:
 #    endif
         decltype(auto)


### PR DESCRIPTION
This is a less risky #2624 which just extends the workaround to cover the affected GCC versions, and adds a comment