### PR TITLE
Remove <bit> include in SYCL radix sort KT

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -13,7 +13,6 @@
 #include <limits>
 #include <cstdint>
 #include <type_traits>
-#include <bit>
 #include <cassert>
 
 #include "../../../pstl/hetero/dpcpp/sycl_defs.h"


### PR DESCRIPTION
We use `sycl::bit_cast`, not `std::bit_cast` (a C++20 feature) in the sycl radix sort. This include causes issues on some configuration (e.g. RHEL8) and should just be removed.

Dependent on https://github.com/uxlfoundation/oneDPL/pull/2629.