### PR TITLE
Fix ranges guard macro

### DIFF
--- a/test/parallel_api/ranges/std_ranges_zip_view.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_zip_view.pass.cpp
@@ -19,9 +19,10 @@
 #define _USE_STD_VECTOR_ALGORITHMS 0
 
 #include "std_ranges_test.h"
-#include <oneapi/dpl/ranges>
 
 #if _ENABLE_STD_RANGES_TESTING
+
+#include <oneapi/dpl/ranges>
 #include <vector>
 
 void test_zip_view_base_op()


### PR DESCRIPTION
`<oneapi/dpl/ranges>` should not be included unless we are testing ranges.  This was triggering a static assertion in some environments which were appropriately skipping this test, but still needing to adhere to the GCC > 8 version requirement imposed by `oneapi/dpl/ranges`.

