### PR TITLE
[Spec] Adjust the return type of `ranges::set_difference`

### DIFF
--- a/documentation/specification/parallel_api/parallel_range_api.rst
+++ b/documentation/specification/parallel_api/parallel_range_api.rst
@@ -932,6 +932,7 @@ Set operations
    iterators to the ends of both ``r1`` and ``r2``, even if there is enough space in ``result``.
 
    The returned values are as if they were obtained by a serial algorithm that iterates over both ranges and
+   
    - determines a relative order of two elements according to ``comp``, ``proj1``, and ``proj2``,
    - advances the iterator pointing to the element ordered before the other one,
    - advances both iterators if neither of the elements is ordered before the other, and


### PR DESCRIPTION
During the implementation of set algorithms with bounded output, it was found that `std::ranges::set_difference_result` does not include an iterator to the second range. It was unnecessary while the output sequence was required to fit all the resulting elements, but with bounded output the algorithm can stop before it reaches the end of the input sequences. Not returning the stop position in the second range is a loss of potentially useful information.

This PR addresses the issue, changing the return value type to `in_in_out_result`.

**Updated:**
The PR also describes how the semantics of the returned value for `set_intersection` deviates from the С++20 standard.

Both these changes follow the most recent modifications to the C++26 parallel range algorithms. For more details about these modifications, see https://cplusplus.github.io/LWG/lwg-active.html#4544 and https://cplusplus.github.io/LWG/lwg-active.html#4548