### PR TITLE
Fix permissions issue with clang-format feature

### DIFF
--- a/.github/workflows/clang-format-apply.yml
+++ b/.github/workflows/clang-format-apply.yml
@@ -18,6 +18,7 @@ jobs:
       )
     permissions:
       contents: write
+      pull-requests: read
       issues: write
     runs-on: ubuntu-latest
     concurrency:


### PR DESCRIPTION
Roll back permission for pull-request:write which was not necessary, and scope to just the job, not the top level scope.