### PR TITLE
Update the links according to the recent documentation changes

### DIFF
--- a/documentation/_auxiliary/common_cross_document_links.txt
+++ b/documentation/_auxiliary/common_cross_document_links.txt
@@ -2,6 +2,9 @@
 
 .. |onedpl_requirements| replace:: :ref:`oneDPL System Requirements <library-requirements>`
 
+.. |onedpl_specification| replace:: the oneDPL Specification
+.. _onedpl_specification: https://uxlfoundation.github.io/oneDPL/specification/index.html
+
 .. |dpcpp_gsg| replace:: Get Started with the Intel® oneAPI DPC++/C++ Compiler
 .. _dpcpp_gsg: https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/get-started-guide/2025-2/overview.html
 

--- a/documentation/_auxiliary/common_cross_document_links.txt
+++ b/documentation/_auxiliary/common_cross_document_links.txt
@@ -2,7 +2,7 @@
 
 .. |onedpl_requirements| replace:: :ref:`oneDPL System Requirements <library-requirements>`
 
-.. |onedpl_specification| replace:: the oneDPL Specification
+.. |onedpl_specification| replace:: oneDPL Specification
 .. _onedpl_specification: https://uxlfoundation.github.io/oneDPL/specification/index.html
 
 .. |dpcpp_gsg| replace:: Get Started with the Intel® oneAPI DPC++/C++ Compiler

--- a/documentation/get_started/onedpl_gsg.rst
+++ b/documentation/get_started/onedpl_gsg.rst
@@ -32,9 +32,8 @@ Additionally, to use |onedpl_short| and other Base Kit components on non-Intel G
 `oneAPI for NVIDIA® GPUs plugin <https://developer.codeplay.com/products/oneapi/nvidia/home/>`_ or the
 `oneAPI for AMD GPUs plugin <https://developer.codeplay.com/products/oneapi/amd/home/>`_.
 
-See the |onedpl_requirements|
-for details on the compiler support required to compile applications using |onedpl_short| on CPU using OpenMP* or Intel®
-oneAPI Threading Building Blocks (oneTBB).
+See the |onedpl_requirements| for details on the compiler support required to compile applications using |onedpl_short|
+on CPU using OpenMP* or |onetbb_long|.
 
 To use Parallel API, include the corresponding header files in your source code.
 

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -1,7 +1,8 @@
 |onedpl_long| Introduction
 #######################################
 
-The |onedpl_long| (|onedpl_short|) is implemented in accordance with |onedpl_specification|_.
+The |onedpl_long| (|onedpl_short|) is implemented in accordance with the |onedpl_specification|_.
+The current implementation supports the version 1.4-rev1 in full, as well as most of the version 1.5-provisional-rev1.
 
 To support heterogeneity, |onedpl_short| uses `SYCL <https://registry.khronos.org/SYCL/>`_.
 More information about SYCL can be found in the `SYCL Specification`_.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -3,7 +3,7 @@
 
 The |onedpl_long| (|onedpl_short|) is implemented in accordance with the |onedpl_specification|_.
 The current implementation supports the version 1.4-rev1 in full, as well as most of the functionality
-added to the version 1.5-provisional-rev1.
+added to the version 1.5-rev1.
 
 To support heterogeneity, |onedpl_short| uses `SYCL <https://registry.khronos.org/SYCL/>`_.
 More information about SYCL can be found in the `SYCL Specification`_.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -1,8 +1,7 @@
 |onedpl_long| Introduction
 #######################################
 
-The |onedpl_long| (|onedpl_short|) is implemented in accordance with the `oneDPL
-Specification <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneDPL/source/index.html>`_.
+The |onedpl_long| (|onedpl_short|) is implemented in accordance with |onedpl_specification|_.
 
 To support heterogeneity, |onedpl_short| uses `SYCL <https://registry.khronos.org/SYCL/>`_.
 More information about SYCL can be found in the `SYCL Specification`_.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -2,7 +2,8 @@
 #######################################
 
 The |onedpl_long| (|onedpl_short|) is implemented in accordance with the |onedpl_specification|_.
-The current implementation supports the version 1.4-rev1 in full, as well as most of the version 1.5-provisional-rev1.
+The current implementation supports the version 1.4-rev1 in full, as well as most of the functionality
+added to the version 1.5-provisional-rev1.
 
 To support heterogeneity, |onedpl_short| uses `SYCL <https://registry.khronos.org/SYCL/>`_.
 More information about SYCL can be found in the `SYCL Specification`_.

--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -8,7 +8,7 @@ Use these macros to get the current version of |onedpl_long| (|onedpl_short|).
 ================================= ==============================
 Macro                             Description
 ================================= ==============================
-``ONEDPL_SPEC_VERSION``           The version of |onedpl_specification|_ that the implementation is compliant with.
+``ONEDPL_SPEC_VERSION``           The version of the |onedpl_specification|_ that the implementation is compliant with.
 --------------------------------- ------------------------------
 ``ONEDPL_VERSION_MAJOR``          A decimal number for the major version of the library.
 --------------------------------- ------------------------------

--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -8,9 +8,7 @@ Use these macros to get the current version of |onedpl_long| (|onedpl_short|).
 ================================= ==============================
 Macro                             Description
 ================================= ==============================
-``ONEDPL_SPEC_VERSION``           The version of the `specification
-                                  <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneDPL/source/>`_
-                                  that the implementation is compliant with.
+``ONEDPL_SPEC_VERSION``           The version of |onedpl_specification|_ that the implementation is compliant with.
 --------------------------------- ------------------------------
 ``ONEDPL_VERSION_MAJOR``          A decimal number for the major version of the library.
 --------------------------------- ------------------------------

--- a/documentation/library_guide/parallel_api/execution_policies.rst
+++ b/documentation/library_guide/parallel_api/execution_policies.rst
@@ -1,8 +1,6 @@
 Execution Policies
 ##################
 
-According to `the oneAPI specification
-<https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneDPL/source/index.html>`_,
 |onedpl_long| (|onedpl_short|) provides execution policies semantically aligned with the C++ standard,
 referred to as *standard-aligned* or *host execution policies*, as well as *device execution policies*
 to run data parallel computations on heterogeneous systems.

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -380,7 +380,7 @@ It also automatically treats the following entities as *indirectly device access
   if their underlying iterators are *indirectly device accessible*.
 
 For more information, refer to the
-`Iterators section of oneDPL specification <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneDPL/source/parallel_api/iterators.html>`_.
+`Iterators section of oneDPL specification <https://uxlfoundation.github.io/oneDPL/specification/parallel_api/iterators.html>`_.
 
 .. _`SYCL buffer`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:buffers
 .. _`SYCL device-copyable`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -1140,11 +1140,11 @@ Known Issues and Limitations
 
 .. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types and
    ``sycl::half`` (since oneDPL 2022.6) compared with ``std::less`` or ``std::greater``, otherwise Merge sort.
-.. _`oneDPL Guide`: https://uxlfoundation.github.io/oneDPL/index.html
+.. _`oneDPL Guide`: https://uxlfoundation.github.io/oneDPL/library_guide/index.html
 .. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
-.. _`restrictions and known limitations`: https://uxlfoundation.github.io/oneDPL/introduction.html#restrictions.
-.. _`Tested Standard C++ API`: https://uxlfoundation.github.io/oneDPL/api_for_sycl_kernels/tested_standard_cpp_api.html#tested-standard-c-api-reference
-.. _`Macros`: https://uxlfoundation.github.io/oneDPL/macros.html
-.. _`2022.0 Changes`: https://uxlfoundation.github.io/oneDPL/oneDPL_2022.0_changes.html
+.. _`restrictions and known limitations`: https://uxlfoundation.github.io/oneDPL/library_guide/introduction.html#restrictions.
+.. _`Tested Standard C++ API`: https://uxlfoundation.github.io/oneDPL/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.html#tested-standard-c-api-reference
+.. _`Macros`: https://uxlfoundation.github.io/oneDPL/library_guide/macros.html
+.. _`2022.0 Changes`: https://uxlfoundation.github.io/oneDPL/library_guide/oneDPL_2022.0_changes.html
 .. _`sycl device copyable`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable
 .. _`oneAPI DPC++ Library Manual Migration Guide`: https://www.intel.com/content/www/us/en/developer/articles/guide/oneapi-dpcpp-library-manual-migration.html 


### PR DESCRIPTION
Documents the supported version of the specification.

Updates the links to the latest oneDPL specification using its expected new location. The links are external in order for them to work properly within the guide published at intel.com

Also corrects the links in release notes in accordance with the expected new location of the library guide.