### PR TITLE
Histogram performance optimization for small number of bins

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -418,7 +418,9 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     // Limit the maximum work-group size for better performance. Empirically found value.
     std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, std::uint16_t(1024));
 
-    std::size_t __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
+    // Reserve some SLM as headroom for runtime overhead.
+    const std::size_t __local_mem_size =
+        (__q.get_device().template get_info<sycl::info::device::local_mem_size>() * 4) / 5;
 
     // Upper bound on useful copies: one per sub-group lane (replicas indexed by lane id).
     // Use device's max sub-group size (the realized SIMD width for ordinary kernels on Intel
@@ -440,7 +442,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     const std::size_t __n = oneapi::dpl::__ranges::__size(__input);
 
     // try to fit within a subset of SLM to preserve occupancy (at least 2 concurrent work-groups)
-    const std::size_t __target_slm_size = __local_mem_size / 3;
+    const std::size_t __target_slm_size = __local_mem_size / 2;
 
     // If we only have less than half of a single WG, replication does not make sense as contention is not an issue.
     const bool __replicate = __n > __work_group_size * __iters_per_work_item / 2;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -430,14 +430,18 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     // Replication is only worth its clear + merge overhead when input is large enough to amortize
     // it. Below that empirically determined threshold, a single SLM copy is used.
     const std::size_t __n = __input.size();
+
+    // try to fit within a subset of SLM to preserve occupancy (at least 2 concurrent work-groups)
+    const std::size_t __target_slm_size = __local_mem_size / 3;
+
     const bool __replicate =
-        (__n > __work_group_size * __iters_per_work_item / 2) && __local_mem_size / 4 > __extra_SLM_bytes;
+        (__n > __work_group_size * __iters_per_work_item / 2) && __target_slm_size > __extra_SLM_bytes;
 
     // For replication, use as many copies as fit in a quarter of local memory (leaving room for
     // concurrent work-groups to preserve occupancy), capped by the useful-copies bound.
     std::uint32_t __num_slm_copies =
         __replicate ? std::min<std::uint32_t>(__max_useful_copies,
-                                              (__local_mem_size / 4 - __extra_SLM_bytes) / __per_copy_bytes)
+                                              (__target_slm_size - __extra_SLM_bytes) / __per_copy_bytes)
                     : 0;
 
     if (__num_slm_copies == 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -173,8 +173,7 @@ template <typename _BinType, typename _FactorType, typename _HistAccessorIn, typ
           typename _HistAccessorOut, typename _Size>
 void
 __reduce_out_histograms(const _HistAccessorIn& __in_histogram, const _OffsetT& __offset,
-                        const _HistAccessorOut& __out_histogram, _Size __num_bins, std::uint32_t __num_copies,
-                        const sycl::nd_item<1>& __self_item)
+                        const _HistAccessorOut& __out_histogram, _Size __num_bins, const sycl::nd_item<1>& __self_item)
 {
     using _BinUint_t =
         ::std::conditional_t<(sizeof(_Size) >= sizeof(::std::uint32_t)), ::std::uint64_t, ::std::uint32_t>;
@@ -183,27 +182,18 @@ __reduce_out_histograms(const _HistAccessorIn& __in_histogram, const _OffsetT& _
     _FactorType __factor = oneapi::dpl::__internal::__dpl_ceiling_div(__num_bins, __gSize);
     _FactorType __k = 0;
 
-    auto __merge_bin = [&](_BinUint_t __bin) {
-        using _InValueType = typename _HistAccessorIn::value_type;
-        _InValueType __sum = 0;
-        const _BinUint_t __base = __offset + __bin * __num_copies;
-        for (std::uint32_t __s = 0; __s < __num_copies; ++__s)
-        {
-            __sum += __in_histogram[__base + __s];
-        }
-        __dpl_sycl::__atomic_ref<_BinType, sycl::access::address_space::global_space> __global_bin(
-            __out_histogram[__bin]);
-        __global_bin += __sum;
-    };
-
     for (; __k < __factor - 1; ++__k)
     {
-        __merge_bin(__gSize * __k + __self_lidx);
+        __dpl_sycl::__atomic_ref<_BinType, sycl::access::address_space::global_space> __global_bin(
+            __out_histogram[__gSize * __k + __self_lidx]);
+        __global_bin += __in_histogram[__offset + __gSize * __k + __self_lidx];
     }
     // residual
     if (__gSize * __k + __self_lidx < __num_bins)
     {
-        __merge_bin(__gSize * __k + __self_lidx);
+        __dpl_sycl::__atomic_ref<_BinType, sycl::access::address_space::global_space> __global_bin(
+            __out_histogram[__gSize * __k + __self_lidx]);
+        __global_bin += __in_histogram[__offset + __gSize * __k + __self_lidx];
     }
 }
 
@@ -286,8 +276,20 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
 
                     __dpl_sycl::__group_barrier(__self_item);
 
-                    __reduce_out_histograms<_bin_type, std::uint16_t>(__local_histogram, 0, __bins, __num_bins,
-                                                                      __num_slm_copies, __self_item);
+                    // Merge SLM histogram copies into global output via atomic add per bin.
+                    // Iterate strided so all bins are covered when __num_bins exceeds work-group size.
+                    for (std::uint16_t __bin = __self_lidx; __bin < __num_bins; __bin += __work_group_size)
+                    {
+                        _local_histogram_type __merged = 0;
+                        const std::uint32_t __base = __bin * __num_slm_copies;
+                        for (std::uint32_t __s = 0; __s < __num_slm_copies; ++__s)
+                        {
+                            __merged += __local_histogram[__base + __s];
+                        }
+                        __dpl_sycl::__atomic_ref<_bin_type, sycl::access::address_space::global_space> __global_bin(
+                            __bins[__bin]);
+                        __global_bin += __merged;
+                    }
                 });
         });
     }
@@ -386,7 +388,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                     __dpl_sycl::__group_barrier(__self_item, __dpl_sycl::__fence_space_global);
 
                     __reduce_out_histograms<_bin_type, ::std::uint32_t>(__hacc_private, __wgroup_idx * __num_bins,
-                                                                        __bins, __num_bins, 1u, __self_item);
+                                                                        __bins, __num_bins, __self_item);
                 });
         });
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -119,7 +119,7 @@ __make_SLM_binhash(_BinHash __bin_hash, _ExtraMemAccessor __slm_mem, const sycl:
 }
 
 template <typename... _Name>
-class __histo_kernel_register_local_red;
+class __histo_kernel_repl_local_red;
 
 template <typename... _Name>
 class __histo_kernel_local_atomics;
@@ -206,11 +206,11 @@ __reduce_out_histograms(const _HistAccessorIn& __in_histogram, const _OffsetT& _
     }
 }
 
-template <::std::uint16_t __iters_per_work_item, ::std::uint8_t __bins_per_work_item, typename _KernelName>
+template <std::uint16_t __iters_per_work_item, typename _KernelName>
 struct __histogram_general_repl_local_reduction_submitter;
 
-template <::std::uint16_t __iters_per_work_item, ::std::uint8_t __bins_per_work_item, typename... _KernelName>
-struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
+template <std::uint16_t __iters_per_work_item, typename... _KernelName>
+struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                                                           __internal::__optional_kernel_name<_KernelName...>>
 {
     template <typename _Range1, typename _Range2, typename _BinHashMgr>
@@ -219,15 +219,15 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                std::uint32_t __num_slm_copies, _Range1&& __input, _Range2&& __bins,
                const _BinHashMgr& __binhash_manager)
     {
-        const ::std::size_t __n = __input.size();
+        const std::size_t __n = __input.size();
         const std::uint16_t __num_bins = __bins.size();
-        using _local_histogram_type = ::std::uint32_t;
+        using _local_histogram_type = std::uint32_t;
         using _histogram_index_type = std::int16_t;
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
         using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
-        ::std::size_t __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
-        ::std::size_t __segments =
+        std::size_t __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
+        std::size_t __segments =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
         return __q.submit([&](auto& __h) {
             __h.depends_on(__init_event);
@@ -242,9 +242,9 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                 sycl::nd_range<1>(__segments * __work_group_size, __work_group_size),
                 [=](sycl::nd_item<1> __self_item) {
                     constexpr auto _atomic_address_space = sycl::access::address_space::local_space;
-                    const ::std::size_t __self_lidx = __self_item.get_local_id(0);
-                    const ::std::size_t __wgroup_idx = __self_item.get_group(0);
-                    const ::std::size_t __seg_start = __work_group_size * __iters_per_work_item * __wgroup_idx;
+                    const std::size_t __self_lidx = __self_item.get_local_id(0);
+                    const std::size_t __wgroup_idx = __self_item.get_group(0);
+                    const std::size_t __seg_start = __work_group_size * __iters_per_work_item * __wgroup_idx;
                     auto __SLM_binhash = __make_SLM_binhash(_device_copyable_func, __extra_SLM, __self_item);
                     __dpl_sycl::__sub_group __sg = __self_item.get_sub_group();
                     const std::uint32_t __sg_id = __sg.get_group_linear_id();
@@ -259,7 +259,7 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                     if (__seg_start + __work_group_size * __iters_per_work_item < __n)
                     {
                         _ONEDPL_PRAGMA_UNROLL
-                        for (::std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
+                        for (std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
                         {
                             __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
                                 __input[__seg_start + __idx * __work_group_size + __self_lidx], __local_histogram,
@@ -269,9 +269,9 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                     else
                     {
                         _ONEDPL_PRAGMA_UNROLL
-                        for (::std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
+                        for (std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
                         {
-                            ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
+                            std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
                                 __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
@@ -300,23 +300,22 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
     }
 };
 
-template <typename _CustomName, std::uint16_t __iters_per_work_item, std::uint8_t __bins_per_work_item,
-          typename _Range1, typename _Range2, typename _BinHashMgr>
+template <typename _CustomName, std::uint16_t __iters_per_work_item, typename _Range1, typename _Range2,
+          typename _BinHashMgr>
 sycl::event
 __histogram_general_repl_local_reduction(sycl::queue& __q, const sycl::event& __init_event,
                                          std::uint16_t __work_group_size, std::uint32_t __num_slm_copies,
                                          _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
-    using _iters_per_work_item_t = ::std::integral_constant<::std::uint16_t, __iters_per_work_item>;
+    using _iters_per_work_item_t = std::integral_constant<std::uint16_t, __iters_per_work_item>;
 
     // Required to include _iters_per_work_item_t in kernel name because we compile multiple kernels and decide between
     // them at runtime.  Other compile time arguments aren't required as it is the user's responsibility to provide a
     // unique kernel name to the policy for each call when using no-unamed-lambdas
-    using _RegistersLocalReducName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __histo_kernel_register_local_red<_iters_per_work_item_t, _CustomName>>;
+    using _ReplLocalReducName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+        __histo_kernel_repl_local_red<_iters_per_work_item_t, _CustomName>>;
 
-    return __histogram_general_repl_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
-                                                              _RegistersLocalReducName>()(
+    return __histogram_general_repl_local_reduction_submitter<__iters_per_work_item, _ReplLocalReducName>()(
         __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
         std::forward<_Range2>(__bins), __binhash_manager);
 }
@@ -510,7 +509,6 @@ __future<sycl::event>
 __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_event, _Range1&& __input,
                                    _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
-    using _private_histogram_type = std::uint16_t;
     using _local_histogram_type = std::uint32_t;
     using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
@@ -519,13 +517,13 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, std::uint16_t(1024));
 
     auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
-    constexpr std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
 
     // Compute number of SLM histogram copies: one per assumed sub-group, based on device's minimum
     // sub-group size (floored to 16 to avoid over-allocating on devices reporting very small sizes).
     const auto __min_sg_size = oneapi::dpl::__internal::__min_sub_group_size(__q);
     const auto __assumed_sg_size = std::max(std::size_t(16), __min_sg_size);
-    const std::uint32_t __num_slm_copies = __work_group_size / __assumed_sg_size;
+    const std::uint32_t __num_slm_copies =
+        std::max(2u, __work_group_size / static_cast<std::uint16_t>(__assumed_sg_size));
     const std::size_t __slm_replicated_size =
         __num_slm_copies * __num_bins * sizeof(_local_histogram_type) +
         __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type);
@@ -534,10 +532,9 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     // leaving room for concurrent work-groups to preserve occupancy.
     if (__slm_replicated_size <= static_cast<std::size_t>(__local_mem_size) / 4)
     {
-        return __future(
-            __histogram_general_repl_local_reduction<_CustomName, __iters_per_work_item, __max_work_item_private_bins>(
-                __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
-                std::forward<_Range2>(__bins), __binhash_manager));
+        return __future(__histogram_general_repl_local_reduction<_CustomName, __iters_per_work_item>(
+            __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
+            std::forward<_Range2>(__bins), __binhash_manager));
     }
     // if bins fit into SLM, use local atomics
     else if (__num_bins * sizeof(_local_histogram_type) +

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -225,7 +225,7 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
             auto _device_copyable_func = __binhash_manager.prepare_device_binhash(__h);
             oneapi::dpl::__ranges::__require_access(__h, __input, __bins);
             // SLM histogram copies to reduce atomic contention. Number of copies is based
-            // on device sub-group size, with sub-groups mapped to copies via modulo.
+            // on device sub-group size, with sub-group lanes mapped to copies via modulo.
             __dpl_sycl::__local_accessor<_local_histogram_type> __local_histogram(
                 sycl::range(__num_slm_copies * __num_bins), __h);
             __dpl_sycl::__local_accessor<_extra_memory_type> __extra_SLM(sycl::range(__extra_SLM_elements), __h);
@@ -445,10 +445,12 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     // try to fit within a subset of SLM to preserve occupancy (at least 2 concurrent work-groups)
     const std::size_t __target_slm_size = __local_mem_size / 3;
 
+    // If we only have less than half of a single WG, replication does not make sense as contention is not an issue.
+    // SLM comparison is to avoid underflow.
     const bool __replicate =
         (__n > __work_group_size * __iters_per_work_item / 2) && __target_slm_size > __extra_SLM_bytes;
 
-    // For replication, use as many copies as fit in a quarter of local memory (leaving room for
+    // For replication, use as many copies as fit within target memory limits (leaving room for
     // concurrent work-groups to preserve occupancy), capped by the useful-copies bound.
     std::uint32_t __num_slm_copies =
         __replicate

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -283,16 +283,17 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                     __dpl_sycl::__group_barrier(__self_item);
 
                     // Merge SLM histogram copies directly to global output.
-                    // Each of the first num_bins work-items sums one bin across all copies.
-                    if (__self_lidx < __num_bins)
+                    // Iterate over bins in a strided fashion so all bins are covered,
+                    // even when __num_bins exceeds the work-group size.
+                    for (std::uint16_t __bin = __self_lidx; __bin < __num_bins; __bin += __work_group_size)
                     {
                         _local_histogram_type __merged = 0;
                         for (std::uint32_t __s = 0; __s < __num_slm_copies; ++__s)
                         {
-                            __merged += __local_histogram[__s * __num_bins + __self_lidx];
+                            __merged += __local_histogram[__s * __num_bins + __bin];
                         }
                         __dpl_sycl::__atomic_ref<_bin_type, sycl::access::address_space::global_space> __global_bin(
-                            __bins[__self_lidx]);
+                            __bins[__bin]);
                         __global_bin += __merged;
                     }
                 });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -424,11 +424,14 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     std::size_t __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
 
     // Upper bound on useful copies: one per sub-group lane (replicas indexed by lane id).
-    // Floored to 16 to avoid over-allocating on devices reporting very small sub-group sizes.
+    // Use device's max sub-group size (the realized SIMD width for ordinary kernels on Intel
+    // GPUs), capped at 32 to bound SLM and merge cost on devices reporting larger maxima. If
+    // the compiler ends up selecting a smaller SIMD width, surplus slots are simply unused;
+    // the SLM-ratio guard further limits total allocation.
     // When sub-groups are unavailable we cannot map work-items to copies.
 #if _ONEDPL_USE_SUB_GROUPS
     const std::uint32_t __max_useful_copies =
-        std::max<std::uint32_t>(std::uint32_t(16), oneapi::dpl::__internal::__min_sub_group_size(__q));
+        std::min<std::uint32_t>(std::uint32_t(32), oneapi::dpl::__internal::__max_sub_group_size(__q));
 #else
     const std::uint32_t __max_useful_copies = 1;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -512,18 +512,18 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     using _local_histogram_type = std::uint32_t;
     using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
-    const auto __num_bins = __bins.size();
+    const std::uint32_t __num_bins = __bins.size();
     // Limit the maximum work-group size for better performance. Empirically found value.
     std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, std::uint16_t(1024));
 
-    auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
+    std::size_t __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
 
     // Compute number of SLM histogram copies: one per assumed sub-group, based on device's minimum
     // sub-group size (floored to 16 to avoid over-allocating on devices reporting very small sizes).
-    const auto __min_sg_size = oneapi::dpl::__internal::__min_sub_group_size(__q);
-    const auto __assumed_sg_size = std::max(std::size_t(16), __min_sg_size);
+    const std::uint32_t __min_sg_size = oneapi::dpl::__internal::__min_sub_group_size(__q);
+    const std::uint32_t __assumed_sg_size = std::max(std::uint32_t(16), __min_sg_size);
     const std::uint32_t __num_slm_copies =
-        std::max(2u, __work_group_size / static_cast<std::uint16_t>(__assumed_sg_size));
+        std::max<std::uint32_t>(2, static_cast<std::uint32_t>(__work_group_size) / __assumed_sg_size);
     const std::size_t __slm_replicated_size =
         __num_slm_copies * __num_bins * sizeof(_local_histogram_type) +
         __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -430,7 +430,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     // When sub-groups are unavailable we cannot map work-items to copies.
 #if _ONEDPL_USE_SUB_GROUPS
     const std::uint32_t __max_useful_copies =
-        std::min<std::uint32_t>(std::uint32_t(32), oneapi::dpl::__internal::__max_sub_group_size(__q));
+        std::min<std::uint32_t>(32u, oneapi::dpl::__internal::__max_sub_group_size(__q));
 #else
     const std::uint32_t __max_useful_copies = 1;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -156,7 +156,7 @@ __accum_local_atomics_iter(const _ValueType& __x, const _HistAccessor& __wg_loca
                            _BinFunc __func)
 {
     using _histo_value_type = typename _HistAccessor::value_type;
-    std::int32_t __c = __func.get_bin(__x);
+    auto __c = __func.get_bin(__x);
     if (__c >= 0)
     {
         __dpl_sycl::__atomic_ref<_histo_value_type, _AddressSpace> __local_bin(__wg_local_histogram[__offset + __c]);
@@ -206,12 +206,12 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                const _BinHashMgr& __binhash_manager)
     {
         const std::size_t __n = __input.size();
-        const std::uint16_t __num_bins = __bins.size();
+        const std::uint16_t __num_bins = oneapi::dpl::__ranges::__size(__bins);
         using _local_histogram_type = std::uint32_t;
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
         using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
-        std::size_t __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
+        auto __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
         std::size_t __segments =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
         return __q.submit([&](auto& __h) {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -45,7 +45,7 @@ struct __custom_boundary_range_binhash
     __custom_boundary_range_binhash(_Range __boundaries_) : __boundaries(__boundaries_) {}
 
     template <typename _T2>
-    auto
+    oneapi::dpl::__internal::__bin_idx_t
     get_bin(_T2 __value) const
     {
         return oneapi::dpl::__internal::__custom_boundary_get_bin_helper(
@@ -66,7 +66,7 @@ struct __binhash_SLM_wrapper
     }
 
     template <typename _T>
-    auto
+    oneapi::dpl::__internal::__bin_idx_t
     get_bin(_T __value) const
     {
         return __bin_hash.get_bin(__value);
@@ -102,7 +102,7 @@ struct __binhash_SLM_wrapper<__custom_boundary_range_binhash<_Range>, _ExtraMemA
     }
 
     template <typename _T>
-    auto
+    oneapi::dpl::__internal::__bin_idx_t
     get_bin(_T __value) const
     {
         auto __size = __slm_mem.size();
@@ -160,7 +160,7 @@ __accum_local_atomics_iter(const _ValueType& __x, const _HistAccessor& __wg_loca
                            std::uint32_t __stride, _BinFunc __func)
 {
     using _histo_value_type = typename _HistAccessor::value_type;
-    auto __c = __func.get_bin(__x);
+    oneapi::dpl::__internal::__bin_idx_t __c = __func.get_bin(__x);
     if (__c >= 0)
     {
         __dpl_sycl::__atomic_ref<_histo_value_type, _AddressSpace> __local_bin(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -528,9 +528,12 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
         __num_slm_copies * __num_bins * sizeof(_local_histogram_type) +
         __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type);
 
-    // Use SLM-replicated path when replicated histograms fit within a quarter of local memory,
-    // leaving room for concurrent work-groups to preserve occupancy.
-    if (__slm_replicated_size <= static_cast<std::size_t>(__local_mem_size) / 4)
+    // Use SLM-replicated path when replicated histograms fit within a quarter of local memory
+    // (leaving room for concurrent work-groups to preserve occupancy) and there is enough input
+    // to amortize the extra clear + merge overhead (more segments than SLM copies).
+    const std::size_t __n = __input.size();
+    if (__slm_replicated_size <= static_cast<std::size_t>(__local_mem_size) / 4 &&
+        __n > __work_group_size * __iters_per_work_item * __num_slm_copies)
     {
         return __future(__histogram_general_repl_local_reduction<_CustomName, __iters_per_work_item>(
             __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -415,23 +415,17 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     const std::size_t __extra_SLM_bytes = __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type);
     const std::size_t __per_copy_bytes = __num_bins * sizeof(_local_histogram_type);
 
-    // Replication is only worth its clear + merge overhead when input is large enough to amortize
-    // it. Below that empirically determined threshold, a single SLM copy is used.
-    const std::size_t __n = oneapi::dpl::__ranges::__size(__input);
-
-    // try to fit within a subset of SLM to preserve occupancy (at least 2 concurrent work-groups)
-    const std::size_t __target_slm_size = __local_mem_size / 2;
-
+    // Replication is only worth its clear + merge overhead when input is large enough to amortize it.
     // If we only have less than half of a single WG, replication does not make sense as contention is not an issue.
+    const std::size_t __n = oneapi::dpl::__ranges::__size(__input);
     const bool __replicate = __n > __work_group_size * __iters_per_work_item / 2;
 
-    // For replication, use as many copies as fit within target memory limits (leaving room for
-    // concurrent work-groups to preserve occupancy), capped by the useful-copies bound. The
-    // __target_slm_size > __extra_SLM_bytes check guards against underflow in the subtraction.
-    std::uint32_t __num_slm_copies =
-        (__target_slm_size > __extra_SLM_bytes)
-            ? std::min<std::uint32_t>(__max_useful_copies, (__target_slm_size - __extra_SLM_bytes) / __per_copy_bytes)
-            : 0;
+    // Try to fit within a subset of SLM to preserve occupancy with 2 concurrent work-groups
+    const std::size_t __target_slm_size =
+        (__local_mem_size / 2 > __extra_SLM_bytes) ? __local_mem_size / 2 - __extra_SLM_bytes : 0;
+
+    // Use as many copies as fit within target memory limits, capped by the useful-copies bound.
+    std::uint32_t __num_slm_copies = std::min<std::uint32_t>(__max_useful_copies, __target_slm_size / __per_copy_bytes);
 
     if (!__replicate || __num_slm_copies == 0)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -446,20 +446,19 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     const std::size_t __target_slm_size = __local_mem_size / 3;
 
     // If we only have less than half of a single WG, replication does not make sense as contention is not an issue.
-    // SLM comparison is to avoid underflow.
-    const bool __replicate =
-        (__n > __work_group_size * __iters_per_work_item / 2) && __target_slm_size > __extra_SLM_bytes;
+    const bool __replicate = __n > __work_group_size * __iters_per_work_item / 2;
 
     // For replication, use as many copies as fit within target memory limits (leaving room for
-    // concurrent work-groups to preserve occupancy), capped by the useful-copies bound.
+    // concurrent work-groups to preserve occupancy), capped by the useful-copies bound. The
+    // __target_slm_size > __extra_SLM_bytes check guards against underflow in the subtraction.
     std::uint32_t __num_slm_copies =
-        __replicate
+        (__target_slm_size > __extra_SLM_bytes)
             ? std::min<std::uint32_t>(__max_useful_copies, (__target_slm_size - __extra_SLM_bytes) / __per_copy_bytes)
             : 0;
 
-    if (__num_slm_copies == 0)
+    if (!__replicate || __num_slm_copies == 0)
     {
-        // If we can't fit any within 1/4 of SLM, or its not worth it to replicate, try to fit at least one copy by
+        // If the target size is too small, or its not worth it to replicate, try to fit at least one copy by
         // using all available SLM, this is better than global atomics
         __num_slm_copies = (__local_mem_size >= __per_copy_bytes + __extra_SLM_bytes) ? 1 : 0;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -451,9 +451,9 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     // For replication, use as many copies as fit in a quarter of local memory (leaving room for
     // concurrent work-groups to preserve occupancy), capped by the useful-copies bound.
     std::uint32_t __num_slm_copies =
-        __replicate ? std::min<std::uint32_t>(__max_useful_copies,
-                                              (__target_slm_size - __extra_SLM_bytes) / __per_copy_bytes)
-                    : 0;
+        __replicate
+            ? std::min<std::uint32_t>(__max_useful_copies, (__target_slm_size - __extra_SLM_bytes) / __per_copy_bytes)
+            : 0;
 
     if (__num_slm_copies == 0)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -431,7 +431,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     // it. Below that empirically determined threshold, a single SLM copy is used.
     const std::size_t __n = __input.size();
     const bool __replicate =
-        __n > __work_group_size * __iters_per_work_item / 2 && __local_mem_size / 4 > __extra_SLM_bytes;
+        (__n > __work_group_size * __iters_per_work_item / 2) && __local_mem_size / 4 > __extra_SLM_bytes;
 
     // For replication, use as many copies as fit in a quarter of local memory (leaving room for
     // concurrent work-groups to preserve occupancy), capped by the useful-copies bound.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -509,7 +509,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     // sub-group size (floored to 16 to avoid over-allocating on devices reporting very small sizes).
     const std::uint32_t __assumed_sg_size =
 #if _ONEDPL_USE_SUB_GROUPS
-        std::max(std::uint32_t(16), oneapi::dpl::__internal::__min_sub_group_size(__q));
+        std::max<std::uint32_t>(std::uint32_t(16), oneapi::dpl::__internal::__min_sub_group_size(__q));
 #else
         //if we dont have access to subgroups, use a reasonable default for a fixed level of replication.
         16;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -119,9 +119,6 @@ __make_SLM_binhash(_BinHash __bin_hash, _ExtraMemAccessor __slm_mem, const sycl:
 }
 
 template <typename... _Name>
-class __histo_kernel_repl_local_red;
-
-template <typename... _Name>
 class __histo_kernel_local_atomics;
 
 template <typename... _Name>
@@ -196,11 +193,11 @@ __reduce_out_histograms(const _HistAccessorIn& __in_histogram, const _OffsetT& _
 }
 
 template <std::uint16_t __iters_per_work_item, typename _KernelName>
-struct __histogram_general_repl_local_reduction_submitter;
+struct __histogram_general_local_atomics_submitter;
 
 template <std::uint16_t __iters_per_work_item, typename... _KernelName>
-struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
-                                                          __internal::__optional_kernel_name<_KernelName...>>
+struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
+                                                   __internal::__optional_kernel_name<_KernelName...>>
 {
     template <typename _Range1, typename _Range2, typename _BinHashMgr>
     sycl::event
@@ -234,16 +231,18 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                     const std::size_t __wgroup_idx = __self_item.get_group(0);
                     const std::size_t __seg_start = __work_group_size * __iters_per_work_item * __wgroup_idx;
                     auto __SLM_binhash = __make_SLM_binhash(_device_copyable_func, __extra_SLM, __self_item);
-                    __dpl_sycl::__sub_group __sg = __self_item.get_sub_group();
-                    const std::uint32_t __sg_id = __sg.get_group_linear_id();
-                    const std::uint32_t __copy_id = __sg_id % __num_slm_copies;
-                    const std::uint32_t __sg_offset = __copy_id * __num_bins;
+                    std::uint32_t __sg_offset = 0;
+#if _ONEDPL_USE_SUB_GROUPS
+                    if (__num_slm_copies > 1)
+                    {
+                        __dpl_sycl::__sub_group __sg = __self_item.get_sub_group();
+                        const std::uint32_t __sg_id = __sg.get_group_linear_id();
+                        __sg_offset = (__sg_id % __num_slm_copies) * __num_bins;
+                    }
+#endif
 
-                    // Clear SLM histogram copies
                     __clear_wglocal_histograms(__local_histogram, 0, __num_slm_copies * __num_bins, __self_item);
 
-                    // Main accumulation loop: SLM atomics to per-copy histogram.
-                    // No private histogram array → low GRF pressure → small GRF mode → full occupancy.
                     if (__seg_start + __work_group_size * __iters_per_work_item < __n)
                     {
                         _ONEDPL_PRAGMA_UNROLL
@@ -270,9 +269,8 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
 
                     __dpl_sycl::__group_barrier(__self_item);
 
-                    // Merge SLM histogram copies directly to global output.
-                    // Iterate over bins in a strided fashion so all bins are covered,
-                    // even when __num_bins exceeds the work-group size.
+                    // Merge SLM histogram copies into global output via atomic add per bin.
+                    // Iterate strided so all bins are covered when __num_bins exceeds work-group size.
                     for (std::uint16_t __bin = __self_lidx; __bin < __num_bins; __bin += __work_group_size)
                     {
                         _local_histogram_type __merged = 0;
@@ -292,99 +290,9 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
 template <typename _CustomName, std::uint16_t __iters_per_work_item, typename _Range1, typename _Range2,
           typename _BinHashMgr>
 sycl::event
-__histogram_general_repl_local_reduction(sycl::queue& __q, const sycl::event& __init_event,
-                                         std::uint16_t __work_group_size, std::uint32_t __num_slm_copies,
-                                         _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
-{
-    using _iters_per_work_item_t = std::integral_constant<std::uint16_t, __iters_per_work_item>;
-
-    // Required to include _iters_per_work_item_t in kernel name because we compile multiple kernels and decide between
-    // them at runtime.  Other compile time arguments aren't required as it is the user's responsibility to provide a
-    // unique kernel name to the policy for each call when using no-unamed-lambdas
-    using _ReplLocalReducName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __histo_kernel_repl_local_red<_iters_per_work_item_t, _CustomName>>;
-
-    return __histogram_general_repl_local_reduction_submitter<__iters_per_work_item, _ReplLocalReducName>()(
-        __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
-        std::forward<_Range2>(__bins), __binhash_manager);
-}
-
-template <std::uint16_t __iters_per_work_item, typename _KernelName>
-struct __histogram_general_local_atomics_submitter;
-
-template <std::uint16_t __iters_per_work_item, typename... _KernelName>
-struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
-                                                   __internal::__optional_kernel_name<_KernelName...>>
-{
-    template <typename _Range1, typename _Range2, typename _BinHashMgr>
-    sycl::event
-    operator()(sycl::queue& __q, const sycl::event& __init_event, std::uint16_t __work_group_size, _Range1&& __input,
-               _Range2&& __bins, const _BinHashMgr& __binhash_manager)
-    {
-        using _local_histogram_type = std::uint32_t;
-        using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
-        using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
-
-        std::size_t __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
-        const std::size_t __n = __input.size();
-        const std::size_t __num_bins = __bins.size();
-        std::size_t __segments =
-            oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
-        return __q.submit([&](auto& __h) {
-            __h.depends_on(__init_event);
-            auto _device_copyable_func = __binhash_manager.prepare_device_binhash(__h);
-            oneapi::dpl::__ranges::__require_access(__h, __input, __bins);
-            // minimum type size for atomics
-            __dpl_sycl::__local_accessor<_local_histogram_type> __local_histogram(sycl::range(__num_bins), __h);
-            __dpl_sycl::__local_accessor<_extra_memory_type> __extra_SLM(sycl::range(__extra_SLM_elements), __h);
-            __h.template parallel_for<_KernelName...>(
-                sycl::nd_range<1>(__segments * __work_group_size, __work_group_size),
-                [=](sycl::nd_item<1> __self_item) {
-                    constexpr auto _atomic_address_space = sycl::access::address_space::local_space;
-                    const std::size_t __self_lidx = __self_item.get_local_id(0);
-                    const std::uint32_t __wgroup_idx = __self_item.get_group(0);
-                    const std::size_t __seg_start = __work_group_size * __wgroup_idx * __iters_per_work_item;
-                    auto __SLM_binhash = __make_SLM_binhash(_device_copyable_func, __extra_SLM, __self_item);
-
-                    __clear_wglocal_histograms(__local_histogram, 0, __num_bins, __self_item);
-
-                    if (__seg_start + __work_group_size * __iters_per_work_item < __n)
-                    {
-                        _ONEDPL_PRAGMA_UNROLL
-                        for (std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
-                        {
-                            std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
-                            __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __local_histogram, 0,
-                                                                              __SLM_binhash);
-                        }
-                    }
-                    else
-                    {
-                        _ONEDPL_PRAGMA_UNROLL
-                        for (std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
-                        {
-                            std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
-                            if (__val_idx < __n)
-                            {
-                                __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __local_histogram,
-                                                                                  0, __SLM_binhash);
-                            }
-                        }
-                    }
-                    __dpl_sycl::__group_barrier(__self_item);
-
-                    __reduce_out_histograms<_bin_type, std::uint16_t>(__local_histogram, 0, __bins, __num_bins,
-                                                                      __self_item);
-                });
-        });
-    }
-};
-
-template <typename _CustomName, std::uint16_t __iters_per_work_item, typename _Range1, typename _Range2,
-          typename _BinHashMgr>
-sycl::event
 __histogram_general_local_atomics(sycl::queue& __q, const sycl::event& __init_event, std::uint16_t __work_group_size,
-                                  _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
+                                  std::uint32_t __num_slm_copies, _Range1&& __input, _Range2&& __bins,
+                                  const _BinHashMgr& __binhash_manager)
 {
     using _iters_per_work_item_t = ::std::integral_constant<::std::uint16_t, __iters_per_work_item>;
 
@@ -395,8 +303,8 @@ __histogram_general_local_atomics(sycl::queue& __q, const sycl::event& __init_ev
         __histo_kernel_local_atomics<_iters_per_work_item_t, _CustomName>>;
 
     return __histogram_general_local_atomics_submitter<__iters_per_work_item, _local_atomics_name>()(
-        __q, __init_event, __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
-        __binhash_manager);
+        __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
+        std::forward<_Range2>(__bins), __binhash_manager);
 }
 
 template <typename _KernelName>
@@ -505,40 +413,45 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 
     std::size_t __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
 
-    // Compute number of SLM histogram copies: one per assumed sub-group, based on device's minimum
-    // sub-group size (floored to 16 to avoid over-allocating on devices reporting very small sizes).
-    const std::uint32_t __assumed_sg_size =
+    // Upper bound on useful copies: one per assumed sub-group, based on device's minimum
+    // sub-group size (floored to 16 to avoid over-allocating on devices reporting very small
+    // sizes). When sub-groups are unavailable we cannot map work-items to copies.
 #if _ONEDPL_USE_SUB_GROUPS
+    const std::uint32_t __assumed_sg_size =
         std::max<std::uint32_t>(std::uint32_t(16), oneapi::dpl::__internal::__min_sub_group_size(__q));
-#else
-        //if we dont have access to subgroups, use a reasonable default for a fixed level of replication.
-        16;
-#endif
-    const std::uint32_t __num_slm_copies =
+    const std::uint32_t __max_useful_copies =
         std::max<std::uint32_t>(2, static_cast<std::uint32_t>(__work_group_size) / __assumed_sg_size);
-    const std::size_t __slm_replicated_size =
-        __num_slm_copies * __num_bins * sizeof(_local_histogram_type) +
-        __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type);
+#else
+    const std::uint32_t __max_useful_copies = 1;
+#endif
+    const std::size_t __extra_SLM_bytes = __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type);
+    const std::size_t __per_copy_bytes = __num_bins * sizeof(_local_histogram_type);
 
-    // Use SLM-replicated path when replicated histograms fit within a quarter of local memory
-    // (leaving room for concurrent work-groups to preserve occupancy) and there is enough input
-    // to amortize the extra clear + merge overhead.
+    // Replication is only worth its clear + merge overhead when input is large enough to amortize
+    // it. Below that threshold, a single SLM copy is used.
     const std::size_t __n = __input.size();
-    if (__slm_replicated_size <= static_cast<std::size_t>(__local_mem_size) / 4 &&
-        __n > __work_group_size * __iters_per_work_item / 2)
+    const bool __replicate =
+        __n > __work_group_size * __iters_per_work_item / 2 && __local_mem_size / 4 > __extra_SLM_bytes;
+
+    // For replication, use as many copies as fit in a quarter of local memory (leaving room for
+    // concurrent work-groups to preserve occupancy), capped by the useful-copies bound.
+    std::size_t __num_slm_copies =
+        __replicate ? std::min<std::uint32_t>(__max_useful_copies,
+                                              (__local_mem_size / 4 - __extra_SLM_bytes) / __per_copy_bytes)
+                    : 0;
+
+    if (__num_slm_copies == 0)
     {
-        return __future(__histogram_general_repl_local_reduction<_CustomName, __iters_per_work_item>(
-            __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
-            std::forward<_Range2>(__bins), __binhash_manager));
+        // If we can't fit any within 1/4 of SLM, or its not worth it to replicate, try to fit at least one copy by
+        // using all available SLM, this is better than global atomics
+        __num_slm_copies = static_cast<std::size_t>(__local_mem_size) - __extra_SLM_bytes >= __per_copy_bytes ? 1 : 0;
     }
-    // if bins fit into SLM, use local atomics
-    else if (__num_bins * sizeof(_local_histogram_type) +
-                 __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type) <
-             __local_mem_size)
+
+    if (__num_slm_copies > 0)
     {
         return __future(__histogram_general_local_atomics<_CustomName, __iters_per_work_item>(
-            __q, __init_event, __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
-            __binhash_manager));
+            __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
+            std::forward<_Range2>(__bins), __binhash_manager));
     }
     else // otherwise, use global atomics (private copies per workgroup)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -520,8 +520,13 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 
     // Compute number of SLM histogram copies: one per assumed sub-group, based on device's minimum
     // sub-group size (floored to 16 to avoid over-allocating on devices reporting very small sizes).
-    const std::uint32_t __min_sg_size = oneapi::dpl::__internal::__min_sub_group_size(__q);
-    const std::uint32_t __assumed_sg_size = std::max(std::uint32_t(16), __min_sg_size);
+    const std::uint32_t __assumed_sg_size =
+#if _ONEDPL_USE_SUB_GROUPS
+        std::max(std::uint32_t(16), oneapi::dpl::__internal::__min_sub_group_size(__q));
+#else
+        //if we dont have access to subgroups, use a reasonable default for a fixed level of replication.
+        16;
+#endif
     const std::uint32_t __num_slm_copies =
         std::max<std::uint32_t>(2, static_cast<std::uint32_t>(__work_group_size) / __assumed_sg_size);
     const std::size_t __slm_replicated_size =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -152,25 +152,14 @@ __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _Offset
     __dpl_sycl::__group_barrier(__self_item, __fence_space);
 }
 
-template <typename _BinIdxType, typename _ValueType, typename _HistReg, typename _BinFunc>
-void
-__accum_local_register_iter(const _ValueType& __x, _HistReg* __histogram, _BinFunc __func)
-{
-    _BinIdxType c = __func.get_bin(__x);
-    if (c >= 0)
-    {
-        ++__histogram[c];
-    }
-}
-
-template <typename _BinIdxType, sycl::access::address_space _AddressSpace, typename _ValueType, typename _HistAccessor,
+template <sycl::access::address_space _AddressSpace, typename _ValueType, typename _HistAccessor,
           typename _OffsetT, typename _BinFunc>
 void
 __accum_local_atomics_iter(const _ValueType& __x, const _HistAccessor& __wg_local_histogram, const _OffsetT& __offset,
                            _BinFunc __func)
 {
     using _histo_value_type = typename _HistAccessor::value_type;
-    _BinIdxType __c = __func.get_bin(__x);
+    std::int32_t __c = __func.get_bin(__x);
     if (__c >= 0)
     {
         __dpl_sycl::__atomic_ref<_histo_value_type, _AddressSpace> __local_bin(__wg_local_histogram[__offset + __c]);
@@ -222,7 +211,6 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
         const std::size_t __n = __input.size();
         const std::uint16_t __num_bins = __bins.size();
         using _local_histogram_type = std::uint32_t;
-        using _histogram_index_type = std::int16_t;
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
         using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
@@ -261,7 +249,7 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                         _ONEDPL_PRAGMA_UNROLL
                         for (std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
                         {
-                            __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
+                            __accum_local_atomics_iter<_atomic_address_space>(
                                 __input[__seg_start + __idx * __work_group_size + __self_lidx], __local_histogram,
                                 __sg_offset, __SLM_binhash);
                         }
@@ -274,7 +262,7 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                             std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
-                                __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
+                                __accum_local_atomics_iter<_atomic_address_space>(
                                     __input[__val_idx], __local_histogram, __sg_offset, __SLM_binhash);
                             }
                         }
@@ -321,10 +309,10 @@ __histogram_general_repl_local_reduction(sycl::queue& __q, const sycl::event& __
         std::forward<_Range2>(__bins), __binhash_manager);
 }
 
-template <::std::uint16_t __iters_per_work_item, typename _KernelName>
+template <std::uint16_t __iters_per_work_item, typename _KernelName>
 struct __histogram_general_local_atomics_submitter;
 
-template <::std::uint16_t __iters_per_work_item, typename... _KernelName>
+template <std::uint16_t __iters_per_work_item, typename... _KernelName>
 struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                                                    __internal::__optional_kernel_name<_KernelName...>>
 {
@@ -333,15 +321,14 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
     operator()(sycl::queue& __q, const sycl::event& __init_event, std::uint16_t __work_group_size, _Range1&& __input,
                _Range2&& __bins, const _BinHashMgr& __binhash_manager)
     {
-        using _local_histogram_type = ::std::uint32_t;
+        using _local_histogram_type = std::uint32_t;
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
-        using _histogram_index_type = ::std::int16_t;
         using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
-        ::std::size_t __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
-        const ::std::size_t __n = __input.size();
-        const ::std::size_t __num_bins = __bins.size();
-        ::std::size_t __segments =
+        std::size_t __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
+        const std::size_t __n = __input.size();
+        const std::size_t __num_bins = __bins.size();
+        std::size_t __segments =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
         return __q.submit([&](auto& __h) {
             __h.depends_on(__init_event);
@@ -354,9 +341,9 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                 sycl::nd_range<1>(__segments * __work_group_size, __work_group_size),
                 [=](sycl::nd_item<1> __self_item) {
                     constexpr auto _atomic_address_space = sycl::access::address_space::local_space;
-                    const ::std::size_t __self_lidx = __self_item.get_local_id(0);
-                    const ::std::uint32_t __wgroup_idx = __self_item.get_group(0);
-                    const ::std::size_t __seg_start = __work_group_size * __wgroup_idx * __iters_per_work_item;
+                    const std::size_t __self_lidx = __self_item.get_local_id(0);
+                    const std::uint32_t __wgroup_idx = __self_item.get_group(0);
+                    const std::size_t __seg_start = __work_group_size * __wgroup_idx * __iters_per_work_item;
                     auto __SLM_binhash = __make_SLM_binhash(_device_copyable_func, __extra_SLM, __self_item);
 
                     __clear_wglocal_histograms(__local_histogram, 0, __num_bins, __self_item);
@@ -364,29 +351,29 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                     if (__seg_start + __work_group_size * __iters_per_work_item < __n)
                     {
                         _ONEDPL_PRAGMA_UNROLL
-                        for (::std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
+                        for (std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
                         {
-                            ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
-                            __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
+                            std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
+                            __accum_local_atomics_iter<_atomic_address_space>(
                                 __input[__val_idx], __local_histogram, 0, __SLM_binhash);
                         }
                     }
                     else
                     {
                         _ONEDPL_PRAGMA_UNROLL
-                        for (::std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
+                        for (std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
                         {
-                            ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
+                            std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
-                                __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
+                                __accum_local_atomics_iter<_atomic_address_space>(
                                     __input[__val_idx], __local_histogram, 0, __SLM_binhash);
                             }
                         }
                     }
                     __dpl_sycl::__group_barrier(__self_item);
 
-                    __reduce_out_histograms<_bin_type, ::std::uint16_t>(__local_histogram, 0, __bins, __num_bins,
+                    __reduce_out_histograms<_bin_type, std::uint16_t>(__local_histogram, 0, __bins, __num_bins,
                                                                         __self_item);
                 });
         });
@@ -427,7 +414,6 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
         const ::std::size_t __n = __input.size();
         const ::std::size_t __num_bins = __bins.size();
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
-        using _histogram_index_type = ::std::int32_t;
 
         const std::uint64_t __global_mem_size = __q.get_device().get_info<sycl::info::device::global_mem_size>();
         const std::uint64_t __max_groups =
@@ -464,7 +450,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                         for (::std::size_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
                         {
                             ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
-                            __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
+                            __accum_local_atomics_iter<_atomic_address_space>(
                                 __input[__val_idx], __hacc_private, __wgroup_idx * __num_bins, _device_copyable_func);
                         }
                     }
@@ -475,7 +461,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                             ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
-                                __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
+                                __accum_local_atomics_iter<_atomic_address_space>(
                                     __input[__val_idx], __hacc_private, __wgroup_idx * __num_bins,
                                     _device_copyable_func);
                             }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -207,36 +207,37 @@ __reduce_out_histograms(const _HistAccessorIn& __in_histogram, const _OffsetT& _
 }
 
 template <::std::uint16_t __iters_per_work_item, ::std::uint8_t __bins_per_work_item, typename _KernelName>
-struct __histogram_general_registers_local_reduction_submitter;
+struct __histogram_general_repl_local_reduction_submitter;
 
 template <::std::uint16_t __iters_per_work_item, ::std::uint8_t __bins_per_work_item, typename... _KernelName>
-struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
-                                                               __internal::__optional_kernel_name<_KernelName...>>
+struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
+                                                           __internal::__optional_kernel_name<_KernelName...>>
 {
     template <typename _Range1, typename _Range2, typename _BinHashMgr>
     sycl::event
-    operator()(sycl::queue& __q, const sycl::event& __init_event, std::uint16_t __work_group_size, _Range1&& __input,
-               _Range2&& __bins, const _BinHashMgr& __binhash_manager)
+    operator()(sycl::queue& __q, const sycl::event& __init_event, std::uint16_t __work_group_size,
+               std::uint32_t __num_slm_copies, _Range1&& __input, _Range2&& __bins,
+               const _BinHashMgr& __binhash_manager)
     {
         const ::std::size_t __n = __input.size();
-        const ::std::uint8_t __num_bins = __bins.size();
+        const std::uint16_t __num_bins = __bins.size();
         using _local_histogram_type = ::std::uint32_t;
-        using _histogram_index_type = ::std::int8_t;
+        using _histogram_index_type = std::int16_t;
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
         using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
         ::std::size_t __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
-        const std::uint32_t __max_num_sub_groups = __work_group_size / 4; // minimum SG size is 4
         ::std::size_t __segments =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
         return __q.submit([&](auto& __h) {
             __h.depends_on(__init_event);
             auto _device_copyable_func = __binhash_manager.prepare_device_binhash(__h);
             oneapi::dpl::__ranges::__require_access(__h, __input, __bins);
-            // Per-sub-group SLM histogram copies to reduce atomic contention while avoiding
-            // private histogram registers that force large GRF mode and halve occupancy.
+            // SLM histogram copies to reduce atomic contention while avoiding private histogram
+            // registers that force large GRF mode and halve occupancy. Number of copies is based
+            // on device sub-group size, with sub-groups mapped to copies via modulo.
             __dpl_sycl::__local_accessor<_local_histogram_type> __local_histogram(
-                sycl::range(__max_num_sub_groups * __num_bins), __h);
+                sycl::range(__num_slm_copies * __num_bins), __h);
             __dpl_sycl::__local_accessor<_extra_memory_type> __extra_SLM(sycl::range(__extra_SLM_elements), __h);
             __h.template parallel_for<_KernelName...>(
                 sycl::nd_range<1>(__segments * __work_group_size, __work_group_size),
@@ -248,15 +249,14 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
                     auto __SLM_binhash = __make_SLM_binhash(_device_copyable_func, __extra_SLM, __self_item);
                     __dpl_sycl::__sub_group __sg = __self_item.get_sub_group();
                     const std::uint32_t __sg_id = __sg.get_group_linear_id();
-                    const std::uint32_t __num_sub_groups = __sg.get_group_linear_range();
-                    const std::uint32_t __sg_offset = __sg_id * __num_bins;
+                    const std::uint32_t __copy_id = __sg_id % __num_slm_copies;
+                    const std::uint32_t __sg_offset = __copy_id * __num_bins;
 
-                    // Clear per-sub-group SLM histogram copies
-                    __clear_wglocal_histograms(__local_histogram, 0, __max_num_sub_groups * __num_bins, __self_item);
+                    // Clear SLM histogram copies
+                    __clear_wglocal_histograms(__local_histogram, 0, __num_slm_copies * __num_bins, __self_item);
 
-                    // Main accumulation loop: SLM atomics to per-sub-group copy.
+                    // Main accumulation loop: SLM atomics to per-copy histogram.
                     // No private histogram array → low GRF pressure → small GRF mode → full occupancy.
-                    // Contention: only ~sg_size work-items per SLM copy (~32 atomics/bin vs 1024).
                     if (__seg_start + __work_group_size * __iters_per_work_item < __n)
                     {
                         _ONEDPL_PRAGMA_UNROLL
@@ -283,12 +283,12 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
 
                     __dpl_sycl::__group_barrier(__self_item);
 
-                    // Merge per-sub-group histograms directly to global output.
-                    // Each of the first num_bins work-items sums one bin across all sub-group copies.
+                    // Merge SLM histogram copies directly to global output.
+                    // Each of the first num_bins work-items sums one bin across all copies.
                     if (__self_lidx < __num_bins)
                     {
                         _local_histogram_type __merged = 0;
-                        for (std::uint32_t __s = 0; __s < __num_sub_groups; ++__s)
+                        for (std::uint32_t __s = 0; __s < __num_slm_copies; ++__s)
                         {
                             __merged += __local_histogram[__s * __num_bins + __self_lidx];
                         }
@@ -304,9 +304,9 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
 template <typename _CustomName, std::uint16_t __iters_per_work_item, std::uint8_t __bins_per_work_item,
           typename _Range1, typename _Range2, typename _BinHashMgr>
 sycl::event
-__histogram_general_registers_local_reduction(sycl::queue& __q, const sycl::event& __init_event,
-                                              std::uint16_t __work_group_size, _Range1&& __input, _Range2&& __bins,
-                                              const _BinHashMgr& __binhash_manager)
+__histogram_general_repl_local_reduction(sycl::queue& __q, const sycl::event& __init_event,
+                                              std::uint16_t __work_group_size, std::uint32_t __num_slm_copies,
+                                              _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
     using _iters_per_work_item_t = ::std::integral_constant<::std::uint16_t, __iters_per_work_item>;
 
@@ -316,10 +316,10 @@ __histogram_general_registers_local_reduction(sycl::queue& __q, const sycl::even
     using _RegistersLocalReducName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
         __histo_kernel_register_local_red<_iters_per_work_item_t, _CustomName>>;
 
-    return __histogram_general_registers_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
+    return __histogram_general_repl_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
                                                                    _RegistersLocalReducName>()(
-        __q, __init_event, __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
-        __binhash_manager);
+        __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
+        std::forward<_Range2>(__bins), __binhash_manager);
 }
 
 template <::std::uint16_t __iters_per_work_item, typename _KernelName>
@@ -522,13 +522,23 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     auto __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
     constexpr std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);
 
-    // if bins fit into registers, use register private accumulation
-    if (__num_bins <= __max_work_item_private_bins)
+    // Compute number of SLM histogram copies: one per assumed sub-group, based on device's minimum
+    // sub-group size (floored to 16 to avoid over-allocating on devices reporting very small sizes).
+    const auto __min_sg_size = oneapi::dpl::__internal::__min_sub_group_size(__q);
+    const auto __assumed_sg_size = std::max(std::size_t(16), __min_sg_size);
+    const std::uint32_t __num_slm_copies = __work_group_size / __assumed_sg_size;
+    const std::size_t __slm_replicated_size =
+        __num_slm_copies * __num_bins * sizeof(_local_histogram_type) +
+        __binhash_manager.get_required_SLM_elements() * sizeof(_extra_memory_type);
+
+    // Use SLM-replicated path when replicated histograms fit within a quarter of local memory,
+    // leaving room for concurrent work-groups to preserve occupancy.
+    if (__slm_replicated_size <= static_cast<std::size_t>(__local_mem_size) / 4)
     {
-        return __future(__histogram_general_registers_local_reduction<_CustomName, __iters_per_work_item,
+        return __future(__histogram_general_repl_local_reduction<_CustomName, __iters_per_work_item,
                                                                       __max_work_item_private_bins>(
-            __q, __init_event, __work_group_size, std::forward<_Range1>(__input), std::forward<_Range2>(__bins),
-            __binhash_manager));
+            __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
+            std::forward<_Range2>(__bins), __binhash_manager));
     }
     // if bins fit into SLM, use local atomics
     else if (__num_bins * sizeof(_local_histogram_type) +

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -420,7 +420,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     const std::uint32_t __assumed_sg_size =
         std::max<std::uint32_t>(std::uint32_t(16), oneapi::dpl::__internal::__min_sub_group_size(__q));
     const std::uint32_t __max_useful_copies =
-        std::max<std::uint32_t>(2, static_cast<std::uint32_t>(__work_group_size) / __assumed_sg_size);
+        oneapi::dpl::__internal::__dpl_ceiling_div(static_cast<std::uint32_t>(__work_group_size), __assumed_sg_size);
 #else
     const std::uint32_t __max_useful_copies = 1;
 #endif
@@ -428,14 +428,14 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     const std::size_t __per_copy_bytes = __num_bins * sizeof(_local_histogram_type);
 
     // Replication is only worth its clear + merge overhead when input is large enough to amortize
-    // it. Below that threshold, a single SLM copy is used.
+    // it. Below that empirically determined threshold, a single SLM copy is used.
     const std::size_t __n = __input.size();
     const bool __replicate =
         __n > __work_group_size * __iters_per_work_item / 2 && __local_mem_size / 4 > __extra_SLM_bytes;
 
     // For replication, use as many copies as fit in a quarter of local memory (leaving room for
     // concurrent work-groups to preserve occupancy), capped by the useful-copies bound.
-    std::size_t __num_slm_copies =
+    std::uint32_t __num_slm_copies =
         __replicate ? std::min<std::uint32_t>(__max_useful_copies,
                                               (__local_mem_size / 4 - __extra_SLM_bytes) / __per_copy_bytes)
                     : 0;
@@ -444,7 +444,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     {
         // If we can't fit any within 1/4 of SLM, or its not worth it to replicate, try to fit at least one copy by
         // using all available SLM, this is better than global atomics
-        __num_slm_copies = static_cast<std::size_t>(__local_mem_size) >= __per_copy_bytes + __extra_SLM_bytes ? 1 : 0;
+        __num_slm_copies = (__local_mem_size >= __per_copy_bytes + __extra_SLM_bytes) ? 1 : 0;
     }
 
     if (__num_slm_copies > 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -149,17 +149,23 @@ __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _Offset
     __dpl_sycl::__group_barrier(__self_item, __fence_space);
 }
 
+// Atomically increment the bin for __x in a histogram with generalized addressing:
+//   address = __c * __stride + __offset
+// where __c is the bin index. Stride=1 with offset=base gives the contiguous per-WG
+// layout used by the global-atomics path; stride=num_copies with offset=copy_slot gives
+// the blocked-by-bin replicated layout used by the SLM path.
 template <sycl::access::address_space _AddressSpace, typename _ValueType, typename _HistAccessor, typename _OffsetT,
-          typename _BinFunc>
+          typename _StrideT, typename _BinFunc>
 void
 __accum_local_atomics_iter(const _ValueType& __x, const _HistAccessor& __wg_local_histogram, const _OffsetT& __offset,
-                           _BinFunc __func)
+                           const _StrideT& __stride, _BinFunc __func)
 {
     using _histo_value_type = typename _HistAccessor::value_type;
     auto __c = __func.get_bin(__x);
     if (__c >= 0)
     {
-        __dpl_sycl::__atomic_ref<_histo_value_type, _AddressSpace> __local_bin(__wg_local_histogram[__offset + __c]);
+        __dpl_sycl::__atomic_ref<_histo_value_type, _AddressSpace> __local_bin(
+            __wg_local_histogram[__c * __stride + __offset]);
         ++__local_bin;
     }
 }
@@ -231,13 +237,17 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                     const std::size_t __wgroup_idx = __self_item.get_group(0);
                     const std::size_t __seg_start = __work_group_size * __iters_per_work_item * __wgroup_idx;
                     auto __SLM_binhash = __make_SLM_binhash(_device_copyable_func, __extra_SLM, __self_item);
-                    std::uint32_t __sg_offset = 0;
+                    // Blocked SLM layout: replicas of bin B occupy [B*num_copies, (B+1)*num_copies).
+                    // Each work-item picks a copy slot indexed by its sub-group lane id, so within
+                    // a sub-group every lane writes to a distinct slot of the same bin, eliminating
+                    // intra-sub-group collisions. Cross-sub-group accesses to the same slot are
+                    // time-interleaved by HW thread scheduling.
+                    std::uint32_t __copy_slot = 0;
 #if _ONEDPL_USE_SUB_GROUPS
                     if (__num_slm_copies > 1)
                     {
-                        __dpl_sycl::__sub_group __sg = __self_item.get_sub_group();
-                        const std::uint32_t __lane_id = __sg.get_local_linear_id();
-                        __sg_offset = (__lane_id % __num_slm_copies) * __num_bins;
+                        const std::uint32_t __lane_id = __self_item.get_sub_group().get_local_linear_id();
+                        __copy_slot = __lane_id % __num_slm_copies;
                     }
 #endif
 
@@ -250,7 +260,7 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                         {
                             __accum_local_atomics_iter<_atomic_address_space>(
                                 __input[__seg_start + __idx * __work_group_size + __self_lidx], __local_histogram,
-                                __sg_offset, __SLM_binhash);
+                                __copy_slot, __num_slm_copies, __SLM_binhash);
                         }
                     }
                     else
@@ -262,21 +272,24 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                             if (__val_idx < __n)
                             {
                                 __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __local_histogram,
-                                                                                  __sg_offset, __SLM_binhash);
+                                                                                  __copy_slot, __num_slm_copies,
+                                                                                  __SLM_binhash);
                             }
                         }
                     }
 
                     __dpl_sycl::__group_barrier(__self_item);
 
-                    // Merge SLM histogram copies into global output via atomic add per bin.
-                    // Iterate strided so all bins are covered when __num_bins exceeds work-group size.
+                    // Merge per-bin replica slots (contiguous in SLM under blocked layout) into
+                    // global output via atomic add. Iterate strided so all bins are covered when
+                    // __num_bins exceeds work-group size.
                     for (std::uint16_t __bin = __self_lidx; __bin < __num_bins; __bin += __work_group_size)
                     {
                         _local_histogram_type __merged = 0;
+                        const std::uint32_t __base = __bin * __num_slm_copies;
                         for (std::uint32_t __s = 0; __s < __num_slm_copies; ++__s)
                         {
-                            __merged += __local_histogram[__s * __num_bins + __bin];
+                            __merged += __local_histogram[__base + __s];
                         }
                         __dpl_sycl::__atomic_ref<_bin_type, sycl::access::address_space::global_space> __global_bin(
                             __bins[__bin]);
@@ -358,8 +371,9 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                         for (::std::size_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
                         {
                             ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
-                            __accum_local_atomics_iter<_atomic_address_space>(
-                                __input[__val_idx], __hacc_private, __wgroup_idx * __num_bins, _device_copyable_func);
+                            __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __hacc_private,
+                                                                              __wgroup_idx * __num_bins,
+                                                                              std::uint32_t{1}, _device_copyable_func);
                         }
                     }
                     else
@@ -369,9 +383,9 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                             ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
-                                __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __hacc_private,
-                                                                                  __wgroup_idx * __num_bins,
-                                                                                  _device_copyable_func);
+                                __accum_local_atomics_iter<_atomic_address_space>(
+                                    __input[__val_idx], __hacc_private, __wgroup_idx * __num_bins, std::uint32_t{1},
+                                    _device_copyable_func);
                             }
                         }
                     }
@@ -413,14 +427,12 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 
     std::size_t __local_mem_size = __q.get_device().template get_info<sycl::info::device::local_mem_size>();
 
-    // Upper bound on useful copies: one per assumed sub-group, based on device's minimum
-    // sub-group size (floored to 16 to avoid over-allocating on devices reporting very small
-    // sizes). When sub-groups are unavailable we cannot map work-items to copies.
+    // Upper bound on useful copies: one per sub-group lane (replicas indexed by lane id).
+    // Floored to 16 to avoid over-allocating on devices reporting very small sub-group sizes.
+    // When sub-groups are unavailable we cannot map work-items to copies.
 #if _ONEDPL_USE_SUB_GROUPS
-    const std::uint32_t __assumed_sg_size =
+    const std::uint32_t __max_useful_copies =
         std::max<std::uint32_t>(std::uint32_t(16), oneapi::dpl::__internal::__min_sub_group_size(__q));
-    // Per-lane replicas: useful copy count is bounded by the sub-group size (one copy per lane).
-    const std::uint32_t __max_useful_copies = __assumed_sg_size;
 #else
     const std::uint32_t __max_useful_copies = 1;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -236,8 +236,8 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                     if (__num_slm_copies > 1)
                     {
                         __dpl_sycl::__sub_group __sg = __self_item.get_sub_group();
-                        const std::uint32_t __sg_id = __sg.get_group_linear_id();
-                        __sg_offset = (__sg_id % __num_slm_copies) * __num_bins;
+                        const std::uint32_t __lane_id = __sg.get_local_linear_id();
+                        __sg_offset = (__lane_id % __num_slm_copies) * __num_bins;
                     }
 #endif
 
@@ -419,8 +419,8 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 #if _ONEDPL_USE_SUB_GROUPS
     const std::uint32_t __assumed_sg_size =
         std::max<std::uint32_t>(std::uint32_t(16), oneapi::dpl::__internal::__min_sub_group_size(__q));
-    const std::uint32_t __max_useful_copies =
-        oneapi::dpl::__internal::__dpl_ceiling_div(static_cast<std::uint32_t>(__work_group_size), __assumed_sg_size);
+    // Per-lane replicas: useful copy count is bounded by the sub-group size (one copy per lane).
+    const std::uint32_t __max_useful_copies = __assumed_sg_size;
 #else
     const std::uint32_t __max_useful_copies = 1;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -238,10 +238,7 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                     const std::size_t __seg_start = __work_group_size * __iters_per_work_item * __wgroup_idx;
                     auto __SLM_binhash = __make_SLM_binhash(_device_copyable_func, __extra_SLM, __self_item);
                     // Blocked SLM layout: replicas of bin B occupy [B*num_copies, (B+1)*num_copies).
-                    // Each work-item picks a copy slot indexed by its sub-group lane id, so within
-                    // a sub-group every lane writes to a distinct slot of the same bin, eliminating
-                    // intra-sub-group collisions. Cross-sub-group accesses to the same slot are
-                    // time-interleaved by HW thread scheduling.
+                    // Each work-item picks a copy slot indexed by its sub-group lane id.
                     std::uint32_t __copy_slot = 0;
 #if _ONEDPL_USE_SUB_GROUPS
                     if (__num_slm_copies > 1)
@@ -280,9 +277,8 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
 
                     __dpl_sycl::__group_barrier(__self_item);
 
-                    // Merge per-bin replica slots (contiguous in SLM under blocked layout) into
-                    // global output via atomic add. Iterate strided so all bins are covered when
-                    // __num_bins exceeds work-group size.
+                    // Merge SLM histogram copies into global output via atomic add per bin.
+                    // Iterate strided so all bins are covered when __num_bins exceeds work-group size.
                     for (std::uint16_t __bin = __self_lidx; __bin < __num_bins; __bin += __work_group_size)
                     {
                         _local_histogram_type __merged = 0;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -173,7 +173,8 @@ template <typename _BinType, typename _FactorType, typename _HistAccessorIn, typ
           typename _HistAccessorOut, typename _Size>
 void
 __reduce_out_histograms(const _HistAccessorIn& __in_histogram, const _OffsetT& __offset,
-                        const _HistAccessorOut& __out_histogram, _Size __num_bins, const sycl::nd_item<1>& __self_item)
+                        const _HistAccessorOut& __out_histogram, _Size __num_bins, std::uint32_t __num_copies,
+                        const sycl::nd_item<1>& __self_item)
 {
     using _BinUint_t =
         ::std::conditional_t<(sizeof(_Size) >= sizeof(::std::uint32_t)), ::std::uint64_t, ::std::uint32_t>;
@@ -182,18 +183,27 @@ __reduce_out_histograms(const _HistAccessorIn& __in_histogram, const _OffsetT& _
     _FactorType __factor = oneapi::dpl::__internal::__dpl_ceiling_div(__num_bins, __gSize);
     _FactorType __k = 0;
 
+    auto __merge_bin = [&](_BinUint_t __bin) {
+        using _InValueType = typename _HistAccessorIn::value_type;
+        _InValueType __sum = 0;
+        const _BinUint_t __base = __offset + __bin * __num_copies;
+        for (std::uint32_t __s = 0; __s < __num_copies; ++__s)
+        {
+            __sum += __in_histogram[__base + __s];
+        }
+        __dpl_sycl::__atomic_ref<_BinType, sycl::access::address_space::global_space> __global_bin(
+            __out_histogram[__bin]);
+        __global_bin += __sum;
+    };
+
     for (; __k < __factor - 1; ++__k)
     {
-        __dpl_sycl::__atomic_ref<_BinType, sycl::access::address_space::global_space> __global_bin(
-            __out_histogram[__gSize * __k + __self_lidx]);
-        __global_bin += __in_histogram[__offset + __gSize * __k + __self_lidx];
+        __merge_bin(__gSize * __k + __self_lidx);
     }
     // residual
     if (__gSize * __k + __self_lidx < __num_bins)
     {
-        __dpl_sycl::__atomic_ref<_BinType, sycl::access::address_space::global_space> __global_bin(
-            __out_histogram[__gSize * __k + __self_lidx]);
-        __global_bin += __in_histogram[__offset + __gSize * __k + __self_lidx];
+        __merge_bin(__gSize * __k + __self_lidx);
     }
 }
 
@@ -276,20 +286,8 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
 
                     __dpl_sycl::__group_barrier(__self_item);
 
-                    // Merge SLM histogram copies into global output via atomic add per bin.
-                    // Iterate strided so all bins are covered when __num_bins exceeds work-group size.
-                    for (std::uint16_t __bin = __self_lidx; __bin < __num_bins; __bin += __work_group_size)
-                    {
-                        _local_histogram_type __merged = 0;
-                        const std::uint32_t __base = __bin * __num_slm_copies;
-                        for (std::uint32_t __s = 0; __s < __num_slm_copies; ++__s)
-                        {
-                            __merged += __local_histogram[__base + __s];
-                        }
-                        __dpl_sycl::__atomic_ref<_bin_type, sycl::access::address_space::global_space> __global_bin(
-                            __bins[__bin]);
-                        __global_bin += __merged;
-                    }
+                    __reduce_out_histograms<_bin_type, std::uint16_t>(__local_histogram, 0, __bins, __num_bins,
+                                                                      __num_slm_copies, __self_item);
                 });
         });
     }
@@ -388,7 +386,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                     __dpl_sycl::__group_barrier(__self_item, __dpl_sycl::__fence_space_global);
 
                     __reduce_out_histograms<_bin_type, ::std::uint32_t>(__hacc_private, __wgroup_idx * __num_bins,
-                                                                        __bins, __num_bins, __self_item);
+                                                                        __bins, __num_bins, 1u, __self_item);
                 });
         });
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -299,8 +299,8 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                std::uint16_t __work_group_size, _Range1&& __input, _Range2&& __bins,
                const _BinHashMgr& __binhash_manager)
     {
-        const ::std::size_t __n = __input.size();
-        const ::std::size_t __num_bins = __bins.size();
+        const ::std::size_t __n = oneapi::dpl::__ranges::__size(__input);
+        const ::std::size_t __num_bins = oneapi::dpl::__ranges::__size(__bins);
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
 
         const std::uint64_t __global_mem_size = __q.get_device().get_info<sycl::info::device::global_mem_size>();
@@ -463,7 +463,7 @@ __parallel_histogram(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPo
 
     sycl::queue __q_local = __exec.queue();
 
-    if (__input.size() < 1048576) // 2^20
+    if (oneapi::dpl::__ranges::__size(__input) < 1048576) // 2^20
     {
         return __parallel_histogram_select_kernel<_CustomName, /*iters_per_workitem = */ 4>(
             __q_local, __init_event, std::forward<_Range1>(__input), std::forward<_Range2>(__bins), __binhash_manager);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -169,34 +169,6 @@ __accum_local_atomics_iter(const _ValueType& __x, const _HistAccessor& __wg_loca
     }
 }
 
-template <typename _BinType, typename _FactorType, typename _HistAccessorIn, typename _OffsetT,
-          typename _HistAccessorOut, typename _Size>
-void
-__reduce_out_histograms(const _HistAccessorIn& __in_histogram, const _OffsetT& __offset,
-                        const _HistAccessorOut& __out_histogram, _Size __num_bins, const sycl::nd_item<1>& __self_item)
-{
-    using _BinUint_t =
-        ::std::conditional_t<(sizeof(_Size) >= sizeof(::std::uint32_t)), ::std::uint64_t, ::std::uint32_t>;
-    _BinUint_t __gSize = __self_item.get_local_range()[0];
-    ::std::uint32_t __self_lidx = __self_item.get_local_id(0);
-    _FactorType __factor = oneapi::dpl::__internal::__dpl_ceiling_div(__num_bins, __gSize);
-    _FactorType __k = 0;
-
-    for (; __k < __factor - 1; ++__k)
-    {
-        __dpl_sycl::__atomic_ref<_BinType, sycl::access::address_space::global_space> __global_bin(
-            __out_histogram[__gSize * __k + __self_lidx]);
-        __global_bin += __in_histogram[__offset + __gSize * __k + __self_lidx];
-    }
-    // residual
-    if (__gSize * __k + __self_lidx < __num_bins)
-    {
-        __dpl_sycl::__atomic_ref<_BinType, sycl::access::address_space::global_space> __global_bin(
-            __out_histogram[__gSize * __k + __self_lidx]);
-        __global_bin += __in_histogram[__offset + __gSize * __k + __self_lidx];
-    }
-}
-
 template <std::uint16_t __iters_per_work_item, typename _KernelName>
 struct __histogram_general_local_atomics_submitter;
 
@@ -386,9 +358,13 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                     }
 
                     __dpl_sycl::__group_barrier(__self_item, __dpl_sycl::__fence_space_global);
-
-                    __reduce_out_histograms<_bin_type, ::std::uint32_t>(__hacc_private, __wgroup_idx * __num_bins,
-                                                                        __bins, __num_bins, __self_item);
+                    const std::size_t __offset = __wgroup_idx * __num_bins;
+                    for (std::size_t __bin = __self_lidx; __bin < __num_bins; __bin += __work_group_size)
+                    {
+                        __dpl_sycl::__atomic_ref<_bin_type, sycl::access::address_space::global_space> __global_bin(
+                            __bins[__bin]);
+                        __global_bin += __hacc_private[__offset + __bin];
+                    }
                 });
         });
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -211,7 +211,7 @@ struct __histogram_general_repl_local_reduction_submitter;
 
 template <::std::uint16_t __iters_per_work_item, ::std::uint8_t __bins_per_work_item, typename... _KernelName>
 struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
-                                                           __internal::__optional_kernel_name<_KernelName...>>
+                                                          __internal::__optional_kernel_name<_KernelName...>>
 {
     template <typename _Range1, typename _Range2, typename _BinHashMgr>
     sycl::event
@@ -233,8 +233,7 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
             __h.depends_on(__init_event);
             auto _device_copyable_func = __binhash_manager.prepare_device_binhash(__h);
             oneapi::dpl::__ranges::__require_access(__h, __input, __bins);
-            // SLM histogram copies to reduce atomic contention while avoiding private histogram
-            // registers that force large GRF mode and halve occupancy. Number of copies is based
+            // SLM histogram copies to reduce atomic contention. Number of copies is based
             // on device sub-group size, with sub-groups mapped to copies via modulo.
             __dpl_sycl::__local_accessor<_local_histogram_type> __local_histogram(
                 sycl::range(__num_slm_copies * __num_bins), __h);
@@ -305,8 +304,8 @@ template <typename _CustomName, std::uint16_t __iters_per_work_item, std::uint8_
           typename _Range1, typename _Range2, typename _BinHashMgr>
 sycl::event
 __histogram_general_repl_local_reduction(sycl::queue& __q, const sycl::event& __init_event,
-                                              std::uint16_t __work_group_size, std::uint32_t __num_slm_copies,
-                                              _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
+                                         std::uint16_t __work_group_size, std::uint32_t __num_slm_copies,
+                                         _Range1&& __input, _Range2&& __bins, const _BinHashMgr& __binhash_manager)
 {
     using _iters_per_work_item_t = ::std::integral_constant<::std::uint16_t, __iters_per_work_item>;
 
@@ -317,7 +316,7 @@ __histogram_general_repl_local_reduction(sycl::queue& __q, const sycl::event& __
         __histo_kernel_register_local_red<_iters_per_work_item_t, _CustomName>>;
 
     return __histogram_general_repl_local_reduction_submitter<__iters_per_work_item, __bins_per_work_item,
-                                                                   _RegistersLocalReducName>()(
+                                                              _RegistersLocalReducName>()(
         __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
         std::forward<_Range2>(__bins), __binhash_manager);
 }
@@ -535,10 +534,10 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     // leaving room for concurrent work-groups to preserve occupancy.
     if (__slm_replicated_size <= static_cast<std::size_t>(__local_mem_size) / 4)
     {
-        return __future(__histogram_general_repl_local_reduction<_CustomName, __iters_per_work_item,
-                                                                      __max_work_item_private_bins>(
-            __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
-            std::forward<_Range2>(__bins), __binhash_manager));
+        return __future(
+            __histogram_general_repl_local_reduction<_CustomName, __iters_per_work_item, __max_work_item_private_bins>(
+                __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),
+                std::forward<_Range2>(__bins), __binhash_manager));
     }
     // if bins fit into SLM, use local atomics
     else if (__num_bins * sizeof(_local_histogram_type) +

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -444,7 +444,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     {
         // If we can't fit any within 1/4 of SLM, or its not worth it to replicate, try to fit at least one copy by
         // using all available SLM, this is better than global atomics
-        __num_slm_copies = static_cast<std::size_t>(__local_mem_size) - __extra_SLM_bytes >= __per_copy_bytes ? 1 : 0;
+        __num_slm_copies = static_cast<std::size_t>(__local_mem_size) >= __per_copy_bytes + __extra_SLM_bytes ? 1 : 0;
     }
 
     if (__num_slm_copies > 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -530,10 +530,10 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 
     // Use SLM-replicated path when replicated histograms fit within a quarter of local memory
     // (leaving room for concurrent work-groups to preserve occupancy) and there is enough input
-    // to amortize the extra clear + merge overhead (more segments than SLM copies).
+    // to amortize the extra clear + merge overhead.
     const std::size_t __n = __input.size();
     if (__slm_replicated_size <= static_cast<std::size_t>(__local_mem_size) / 4 &&
-        __n > __work_group_size * __iters_per_work_item * __num_slm_copies)
+        __n > __work_group_size * __iters_per_work_item / 2)
     {
         return __future(__histogram_general_repl_local_reduction<_CustomName, __iters_per_work_item>(
             __q, __init_event, __work_group_size, __num_slm_copies, std::forward<_Range1>(__input),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -210,7 +210,7 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                std::uint32_t __num_slm_copies, _Range1&& __input, _Range2&& __bins,
                const _BinHashMgr& __binhash_manager)
     {
-        const std::size_t __n = __input.size();
+        const std::size_t __n = oneapi::dpl::__ranges::__size(__input);
         const std::uint16_t __num_bins = oneapi::dpl::__ranges::__size(__bins);
         using _local_histogram_type = std::uint32_t;
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
@@ -416,7 +416,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
     using _local_histogram_type = std::uint32_t;
     using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
-    const std::uint32_t __num_bins = __bins.size();
+    const std::uint32_t __num_bins = oneapi::dpl::__ranges::__size(__bins);
     // Limit the maximum work-group size for better performance. Empirically found value.
     std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, std::uint16_t(1024));
 
@@ -439,7 +439,7 @@ __parallel_histogram_select_kernel(sycl::queue& __q, const sycl::event& __init_e
 
     // Replication is only worth its clear + merge overhead when input is large enough to amortize
     // it. Below that empirically determined threshold, a single SLM copy is used.
-    const std::size_t __n = __input.size();
+    const std::size_t __n = oneapi::dpl::__ranges::__size(__input);
 
     // try to fit within a subset of SLM to preserve occupancy (at least 2 concurrent work-groups)
     const std::size_t __target_slm_size = __local_mem_size / 3;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -154,11 +154,10 @@ __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _Offset
 // where __c is the bin index. Stride=1 with offset=base gives the contiguous per-WG
 // layout used by the global-atomics path; stride=num_copies with offset=copy_slot gives
 // the blocked-by-bin replicated layout used by the SLM path.
-template <sycl::access::address_space _AddressSpace, typename _ValueType, typename _HistAccessor, typename _OffsetT,
-          typename _StrideT, typename _BinFunc>
+template <sycl::access::address_space _AddressSpace, typename _ValueType, typename _HistAccessor, typename _BinFunc>
 void
-__accum_local_atomics_iter(const _ValueType& __x, const _HistAccessor& __wg_local_histogram, const _OffsetT& __offset,
-                           const _StrideT& __stride, _BinFunc __func)
+__accum_local_atomics_iter(const _ValueType& __x, const _HistAccessor& __wg_local_histogram, std::size_t __offset,
+                           std::uint32_t __stride, _BinFunc __func)
 {
     using _histo_value_type = typename _HistAccessor::value_type;
     auto __c = __func.get_bin(__x);
@@ -368,8 +367,8 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                         {
                             ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __hacc_private,
-                                                                              __wgroup_idx * __num_bins,
-                                                                              std::uint32_t{1}, _device_copyable_func);
+                                                                              __wgroup_idx * __num_bins, 1u,
+                                                                              _device_copyable_func);
                         }
                     }
                     else
@@ -379,9 +378,9 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                             ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
-                                __accum_local_atomics_iter<_atomic_address_space>(
-                                    __input[__val_idx], __hacc_private, __wgroup_idx * __num_bins, std::uint32_t{1},
-                                    _device_copyable_func);
+                                __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __hacc_private,
+                                                                                  __wgroup_idx * __num_bins, 1u,
+                                                                                  _device_copyable_func);
                             }
                         }
                     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -152,8 +152,8 @@ __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _Offset
     __dpl_sycl::__group_barrier(__self_item, __fence_space);
 }
 
-template <sycl::access::address_space _AddressSpace, typename _ValueType, typename _HistAccessor,
-          typename _OffsetT, typename _BinFunc>
+template <sycl::access::address_space _AddressSpace, typename _ValueType, typename _HistAccessor, typename _OffsetT,
+          typename _BinFunc>
 void
 __accum_local_atomics_iter(const _ValueType& __x, const _HistAccessor& __wg_local_histogram, const _OffsetT& __offset,
                            _BinFunc __func)
@@ -262,8 +262,8 @@ struct __histogram_general_repl_local_reduction_submitter<__iters_per_work_item,
                             std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
-                                __accum_local_atomics_iter<_atomic_address_space>(
-                                    __input[__val_idx], __local_histogram, __sg_offset, __SLM_binhash);
+                                __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __local_histogram,
+                                                                                  __sg_offset, __SLM_binhash);
                             }
                         }
                     }
@@ -354,8 +354,8 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                         for (std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
                         {
                             std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
-                            __accum_local_atomics_iter<_atomic_address_space>(
-                                __input[__val_idx], __local_histogram, 0, __SLM_binhash);
+                            __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __local_histogram, 0,
+                                                                              __SLM_binhash);
                         }
                     }
                     else
@@ -366,15 +366,15 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                             std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
-                                __accum_local_atomics_iter<_atomic_address_space>(
-                                    __input[__val_idx], __local_histogram, 0, __SLM_binhash);
+                                __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __local_histogram,
+                                                                                  0, __SLM_binhash);
                             }
                         }
                     }
                     __dpl_sycl::__group_barrier(__self_item);
 
                     __reduce_out_histograms<_bin_type, std::uint16_t>(__local_histogram, 0, __bins, __num_bins,
-                                                                        __self_item);
+                                                                      __self_item);
                 });
         });
     }
@@ -461,9 +461,9 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                             ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
-                                __accum_local_atomics_iter<_atomic_address_space>(
-                                    __input[__val_idx], __hacc_private, __wgroup_idx * __num_bins,
-                                    _device_copyable_func);
+                                __accum_local_atomics_iter<_atomic_address_space>(__input[__val_idx], __hacc_private,
+                                                                                  __wgroup_idx * __num_bins,
+                                                                                  _device_copyable_func);
                             }
                         }
                     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -221,38 +221,50 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
         const ::std::size_t __n = __input.size();
         const ::std::uint8_t __num_bins = __bins.size();
         using _local_histogram_type = ::std::uint32_t;
-        using _private_histogram_type = ::std::uint16_t;
         using _histogram_index_type = ::std::int8_t;
         using _bin_type = oneapi::dpl::__internal::__value_t<_Range2>;
         using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
         ::std::size_t __extra_SLM_elements = __binhash_manager.get_required_SLM_elements();
+        const std::uint32_t __max_num_sub_groups = __work_group_size / 4; // minimum SG size is 4
         ::std::size_t __segments =
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
         return __q.submit([&](auto& __h) {
             __h.depends_on(__init_event);
             auto _device_copyable_func = __binhash_manager.prepare_device_binhash(__h);
             oneapi::dpl::__ranges::__require_access(__h, __input, __bins);
-            __dpl_sycl::__local_accessor<_local_histogram_type> __local_histogram(sycl::range(__num_bins), __h);
+            // Per-sub-group SLM histogram copies to reduce atomic contention while avoiding
+            // private histogram registers that force large GRF mode and halve occupancy.
+            __dpl_sycl::__local_accessor<_local_histogram_type> __local_histogram(
+                sycl::range(__max_num_sub_groups * __num_bins), __h);
             __dpl_sycl::__local_accessor<_extra_memory_type> __extra_SLM(sycl::range(__extra_SLM_elements), __h);
             __h.template parallel_for<_KernelName...>(
                 sycl::nd_range<1>(__segments * __work_group_size, __work_group_size),
                 [=](sycl::nd_item<1> __self_item) {
+                    constexpr auto _atomic_address_space = sycl::access::address_space::local_space;
                     const ::std::size_t __self_lidx = __self_item.get_local_id(0);
                     const ::std::size_t __wgroup_idx = __self_item.get_group(0);
                     const ::std::size_t __seg_start = __work_group_size * __iters_per_work_item * __wgroup_idx;
                     auto __SLM_binhash = __make_SLM_binhash(_device_copyable_func, __extra_SLM, __self_item);
-                    __clear_wglocal_histograms(__local_histogram, 0, __num_bins, __self_item);
-                    _private_histogram_type __histogram[__bins_per_work_item] = {0};
+                    __dpl_sycl::__sub_group __sg = __self_item.get_sub_group();
+                    const std::uint32_t __sg_id = __sg.get_group_linear_id();
+                    const std::uint32_t __num_sub_groups = __sg.get_group_linear_range();
+                    const std::uint32_t __sg_offset = __sg_id * __num_bins;
 
+                    // Clear per-sub-group SLM histogram copies
+                    __clear_wglocal_histograms(__local_histogram, 0, __max_num_sub_groups * __num_bins, __self_item);
+
+                    // Main accumulation loop: SLM atomics to per-sub-group copy.
+                    // No private histogram array → low GRF pressure → small GRF mode → full occupancy.
+                    // Contention: only ~sg_size work-items per SLM copy (~32 atomics/bin vs 1024).
                     if (__seg_start + __work_group_size * __iters_per_work_item < __n)
                     {
                         _ONEDPL_PRAGMA_UNROLL
                         for (::std::uint8_t __idx = 0; __idx < __iters_per_work_item; ++__idx)
                         {
-                            __accum_local_register_iter<_histogram_index_type>(
-                                __input[__seg_start + __idx * __work_group_size + __self_lidx], __histogram,
-                                __SLM_binhash);
+                            __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
+                                __input[__seg_start + __idx * __work_group_size + __self_lidx], __local_histogram,
+                                __sg_offset, __SLM_binhash);
                         }
                     }
                     else
@@ -263,23 +275,27 @@ struct __histogram_general_registers_local_reduction_submitter<__iters_per_work_
                             ::std::size_t __val_idx = __seg_start + __idx * __work_group_size + __self_lidx;
                             if (__val_idx < __n)
                             {
-                                __accum_local_register_iter<_histogram_index_type>(__input[__val_idx], __histogram,
-                                                                                   __SLM_binhash);
+                                __accum_local_atomics_iter<_histogram_index_type, _atomic_address_space>(
+                                    __input[__val_idx], __local_histogram, __sg_offset, __SLM_binhash);
                             }
                         }
                     }
 
-                    for (_histogram_index_type __k = 0; __k < __num_bins; ++__k)
-                    {
-                        __dpl_sycl::__atomic_ref<_local_histogram_type, sycl::access::address_space::local_space>
-                            __local_bin(__local_histogram[__k]);
-                        __local_bin += __histogram[__k];
-                    }
-
                     __dpl_sycl::__group_barrier(__self_item);
 
-                    __reduce_out_histograms<_bin_type, ::std::uint8_t>(__local_histogram, 0, __bins, __num_bins,
-                                                                       __self_item);
+                    // Merge per-sub-group histograms directly to global output.
+                    // Each of the first num_bins work-items sums one bin across all sub-group copies.
+                    if (__self_lidx < __num_bins)
+                    {
+                        _local_histogram_type __merged = 0;
+                        for (std::uint32_t __s = 0; __s < __num_sub_groups; ++__s)
+                        {
+                            __merged += __local_histogram[__s * __num_bins + __self_lidx];
+                        }
+                        __dpl_sycl::__atomic_ref<_bin_type, sycl::access::address_space::global_space> __global_bin(
+                            __bins[__self_lidx]);
+                        __global_bin += __merged;
+                    }
                 });
         });
     }

--- a/include/oneapi/dpl/pstl/histogram_binhash_utils.h
+++ b/include/oneapi/dpl/pstl/histogram_binhash_utils.h
@@ -29,6 +29,9 @@ namespace dpl
 {
 namespace __internal
 {
+
+using __bin_idx_t = std::int32_t;
+
 template <typename _T1, typename = void>
 struct __evenly_divided_binhash;
 
@@ -42,14 +45,14 @@ struct __evenly_divided_binhash<_T1, ::std::enable_if_t<::std::is_floating_point
     __evenly_divided_binhash(const _T1& __min, const _T1& __max, ::std::size_t __num_bins)
         : __minimum(__min), __maximum(__max), __scale(_T1(__num_bins) / (__max - __min))
     {
-        assert(__num_bins < ::std::numeric_limits<::std::int32_t>::max());
+        assert(__num_bins < ::std::numeric_limits<__bin_idx_t>::max());
     }
 
     template <typename _T2>
-    ::std::int32_t
+    __bin_idx_t
     get_bin(_T2 __value) const
     {
-        ::std::int32_t ret = -1;
+        __bin_idx_t ret = -1;
         if ((__value >= __minimum) && (__value < __maximum))
         {
             ret = (__value - __minimum) * __scale;
@@ -63,18 +66,18 @@ struct __evenly_divided_binhash<_T1, ::std::enable_if_t<!::std::is_floating_poin
 {
     _T1 __minimum;
     _T1 __range_size;
-    ::std::int32_t __num_bins;
+    __bin_idx_t __num_bins;
     __evenly_divided_binhash(const _T1& __min, const _T1& __max, ::std::size_t __num_bins_)
         : __minimum(__min), __range_size(__max - __min), __num_bins(__num_bins_)
     {
-        assert(__num_bins < ::std::numeric_limits<::std::int32_t>::max());
+        assert(__num_bins < ::std::numeric_limits<__bin_idx_t>::max());
     }
 
     template <typename _T2>
-    ::std::int32_t
+    __bin_idx_t
     get_bin(_T2 __value) const
     {
-        ::std::int32_t ret = -1;
+        __bin_idx_t ret = -1;
         if ((__value >= __minimum) && (__value < (__minimum + __range_size)))
         {
             ret = ::std::uint64_t(__value - __minimum) * ::std::uint64_t(__num_bins) / __range_size;
@@ -84,15 +87,16 @@ struct __evenly_divided_binhash<_T1, ::std::enable_if_t<!::std::is_floating_poin
 };
 
 template <typename _Acc, typename _T2, typename _T3>
-::std::int32_t
-__custom_boundary_get_bin_helper(_Acc __acc, ::std::int32_t __size, _T2 __value, _T3 __min, _T3 __max)
+__bin_idx_t
+__custom_boundary_get_bin_helper(_Acc __acc, __bin_idx_t __size, _T2 __value, _T3 __min, _T3 __max)
 {
-    std::int32_t ret = -1;
+    __bin_idx_t ret = -1;
     if (__value >= __min && __value < __max)
     {
         _T2* __value_ptr = &__value;
-        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, std::int32_t{0}, __size, __value_ptr, std::less<_T2>{},
-                                                          oneapi::dpl::identity{}, oneapi::dpl::identity{}) - 1;
+        ret = oneapi::dpl::__internal::__pstl_upper_bound(__acc, __bin_idx_t{0}, __size, __value_ptr, std::less<_T2>{},
+                                                          oneapi::dpl::identity{}, oneapi::dpl::identity{}) -
+              1;
     }
     return ret;
 }
@@ -105,14 +109,14 @@ struct __custom_boundary_binhash
     __custom_boundary_binhash(_RandomAccessIterator __boundary_first_, _RandomAccessIterator __boundary_last_)
         : __boundary_first(__boundary_first_), __boundary_last(__boundary_last_)
     {
-        assert(std::distance(__boundary_first, __boundary_last) < std::numeric_limits<std::int32_t>::max());
+        assert(std::distance(__boundary_first, __boundary_last) < std::numeric_limits<__bin_idx_t>::max());
     }
 
     template <typename _T2>
-    auto
+    __bin_idx_t
     get_bin(_T2 __value) const
     {
-        auto __size = ::std::distance(__boundary_first, __boundary_last);
+        __bin_idx_t __size = ::std::distance(__boundary_first, __boundary_last);
         return __custom_boundary_get_bin_helper(__boundary_first, __size, __value, __boundary_first[0],
                                                 __boundary_first[__size - 1]);
     }

--- a/include/oneapi/dpl/pstl/histogram_impl.h
+++ b/include/oneapi/dpl/pstl/histogram_impl.h
@@ -41,7 +41,7 @@ __brick_histogram(_ForwardIterator __first, _ForwardIterator __last, _IdxHashFun
 {
     for (; __first != __last; ++__first)
     {
-        std::int32_t __bin = __func.get_bin(*__first);
+        oneapi::dpl::__internal::__bin_idx_t __bin = __func.get_bin(*__first);
         if (__bin >= 0)
         {
             ++__histogram_first[__bin];


### PR DESCRIPTION
The current "registers" path for small-bin histograms uses per-work-item private histogram arrays, which forces large GRF mode on Intel GPUs and halves occupancy.  This PR replaces that approach with multiple SLM histogram copies (~one per sub-group lane), using SLM atomics for accumulation and a simple cross-copy reduction to global output. The selection heuristic is also updated: instead of checking whether  bins fit in registers, it now checks whether the replicated SLM histograms fit within 1/3 of local memory to preserve occupancy from concurrent work-groups (target 2 concurrent WGs).

At the cost of some small overhead for the small `N` values, this improves the very large case significantly due to improved occupancy.

Update: I've added some cleanup of unnecessary complexity, and some ::std -> std within the functions touched.

Update 2: I've switched from per subgroup replicates to per subgroup lane replicates, and unified the replicated and singular kernel implementations.