### PR TITLE
[Reduce_then_scan refactor pt 1] Relaxing requirement of trivial copyable types

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -342,7 +342,7 @@ struct __cooperative_lookback
             if (__is_full_ballot_bits)
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
-                    __sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                    __sub_group_size, /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(
                     __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1,
                     static_cast<decltype(__tile_value)*>(nullptr));
@@ -351,7 +351,7 @@ struct __cooperative_lookback
             else
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<
-                    __sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                    __sub_group_size, /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(
                     __subgroup, __tile_value, __binary_op, __running, static_cast<decltype(__tile_value)*>(nullptr));
                 return false;

--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -342,17 +342,18 @@ struct __cooperative_lookback
             if (__is_full_ballot_bits)
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
-                    __sub_group_size, /*__is_inclusive*/ true,
-                    /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
-                                                                          __running, __lowest_item_with_full + 1);
+                    /*__is_inclusive*/ true,
+                    /*__init_present*/ decltype(__is_initialized)::value>(
+                    __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1,
+                    static_cast<decltype(__tile_value)*>(nullptr));
                 return true;
             }
             else
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<
-                    __sub_group_size, /*__is_inclusive*/ true,
-                    /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
-                                                                          __running);
+                    /*__is_inclusive*/ true,
+                    /*__init_present*/ decltype(__is_initialized)::value>(
+                    __subgroup, __tile_value, __binary_op, __running, static_cast<decltype(__tile_value)*>(nullptr));
                 return false;
             }
         };

--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -342,7 +342,7 @@ struct __cooperative_lookback
             if (__is_full_ballot_bits)
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
-                    /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                    __sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(
                     __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1,
                     static_cast<decltype(__tile_value)*>(nullptr));
@@ -351,7 +351,7 @@ struct __cooperative_lookback
             else
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<
-                    /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                    __sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(
                     __subgroup, __tile_value, __binary_op, __running, static_cast<decltype(__tile_value)*>(nullptr));
                 return false;

--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -341,19 +341,19 @@ struct __cooperative_lookback
             // recomputed the prefix using partial values
             if (__is_full_ballot_bits)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
-                    __sub_group_size, /*__is_inclusive*/ true,
-                    /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
-                                                                          __running, __lowest_item_with_full + 1,
-                                                                          nullptr);
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
+                    /*__is_inclusive*/ true,
+                    /*__init_present*/ decltype(__is_initialized)::value>(
+                    __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1,
+                    static_cast<decltype(__tile_value)*>(nullptr));
                 return true;
             }
             else
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<
                     __sub_group_size, /*__is_inclusive*/ true,
-                    /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
-                                                                          __running, nullptr);
+                    /*__init_present*/ decltype(__is_initialized)::value>(
+                    __subgroup, __tile_value, __binary_op, __running, static_cast<decltype(__tile_value)*>(nullptr));
                 return false;
             }
         };

--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -343,17 +343,17 @@ struct __cooperative_lookback
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
                     __sub_group_size, /*__is_inclusive*/ true,
-                    /*__init_present*/ decltype(__is_initialized)::value>(
-                    __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1,
-                    static_cast<decltype(__tile_value)*>(nullptr));
+                    /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
+                                                                          __running, __lowest_item_with_full + 1,
+                                                                          nullptr);
                 return true;
             }
             else
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<
                     __sub_group_size, /*__is_inclusive*/ true,
-                    /*__init_present*/ decltype(__is_initialized)::value>(
-                    __subgroup, __tile_value, __binary_op, __running, static_cast<decltype(__tile_value)*>(nullptr));
+                    /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
+                                                                          __running, nullptr);
                 return false;
             }
         };

--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -342,7 +342,7 @@ struct __cooperative_lookback
             if (__is_full_ballot_bits)
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
-                    /*__is_inclusive*/ true,
+                    /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(
                     __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1,
                     static_cast<decltype(__tile_value)*>(nullptr));
@@ -351,7 +351,7 @@ struct __cooperative_lookback
             else
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<
-                    /*__is_inclusive*/ true,
+                    /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(
                     __subgroup, __tile_value, __binary_op, __running, static_cast<decltype(__tile_value)*>(nullptr));
                 return false;

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -91,14 +91,14 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     _ScanValueType* __no_slm = nullptr;
     if (__is_full)
     {
-        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                             /*__is_inclusive*/ true,
                                                             /*__init_present*/ false>(
             __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, __no_slm);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                 /*__is_inclusive*/ true,
                                                                 /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
@@ -111,7 +111,7 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         std::uint16_t __i = 0;
         if (__limited_iters_per_item == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops=*/true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
@@ -119,18 +119,18 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         }
         else if (__limited_iters_per_item > 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                 /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, __no_slm);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                     /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
                     __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
             }
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops=*/true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -91,13 +91,13 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     _ScanValueType* __no_slm = nullptr;
     if (__is_full)
     {
-        oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                             /*__init_present*/ false>(
             __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, __no_slm);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                                 /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
         }
@@ -109,23 +109,23 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         std::uint16_t __i = 0;
         if (__limited_iters_per_item == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, __no_slm);
         }
         else if (__limited_iters_per_item > 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, __no_slm);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
                     __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
             }
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, __no_slm);

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -91,12 +91,14 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     _ScanValueType* __no_slm = nullptr;
     if (__is_full)
     {
-        oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ false>(
+        oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                                                            /*__init_present*/ false>(
             __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, __no_slm);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ true>(
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                                                                /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
         }
     }
@@ -107,21 +109,23 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         std::uint16_t __i = 0;
         if (__limited_iters_per_item == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, __no_slm);
         }
         else if (__limited_iters_per_item > 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ false>(
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                                                                /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, __no_slm);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ true>(
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                                                                    /*__init_present*/ true>(
                     __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
             }
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, __no_slm);

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -91,15 +91,13 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     constexpr _ScanValueType* __no_slm = nullptr;
     if (__is_full)
     {
-        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                            /*__is_inclusive*/ true,
+        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                             /*__init_present*/ false>(
             __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, __no_slm);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                                /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                 /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
         }
@@ -111,27 +109,23 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         std::uint16_t __i = 0;
         if (__limited_iters_per_item == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                        /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, __no_slm);
         }
         else if (__limited_iters_per_item > 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                                /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, __no_slm);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                                    /*__is_inclusive*/ true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
                     __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
             }
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                        /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, __no_slm);

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -87,17 +87,17 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     const bool __is_full = __items_in_scan == __sub_group_size * __iters_per_item;
     oneapi::dpl::__internal::__lazy_ctor_storage<_InputType> __carry;
     oneapi::dpl::__internal::__scoped_destroyer<_InputType> __destroy_when_leaving_scope{__carry};
+    using _ScanValueType = _InputType;
+    _ScanValueType* __no_slm = nullptr;
     if (__is_full)
     {
-        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
-                                                            /*__init_present*/ false>(
-            __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry);
+        oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ false>(
+            __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, __no_slm);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
-                                                                /*__init_present*/ true>(
-                __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry);
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ true>(
+                __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
         }
     }
     else
@@ -107,26 +107,24 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         std::uint16_t __i = 0;
         if (__limited_iters_per_item == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
-                __items_in_scan - __i * __sub_group_size);
+                __items_in_scan - __i * __sub_group_size, __no_slm);
         }
         else if (__limited_iters_per_item > 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
-                                                                /*__init_present*/ false>(
-                __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry);
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ false>(
+                __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, __no_slm);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
-                                                                    /*__init_present*/ true>(
-                    __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry);
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ true>(
+                    __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
             }
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
-                __items_in_scan - __i * __sub_group_size);
+                __items_in_scan - __i * __sub_group_size, __no_slm);
         }
     }
     return __carry.__v;

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -88,7 +88,7 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     oneapi::dpl::__internal::__lazy_ctor_storage<_InputType> __carry;
     oneapi::dpl::__internal::__scoped_destroyer<_InputType> __destroy_when_leaving_scope{__carry};
     using _ScanValueType = _InputType;
-    _ScanValueType* __no_slm = nullptr;
+    constexpr _ScanValueType* __no_slm = nullptr;
     if (__is_full)
     {
         oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -91,13 +91,15 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     _ScanValueType* __no_slm = nullptr;
     if (__is_full)
     {
-        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+                                                            /*__is_inclusive*/ true,
                                                             /*__init_present*/ false>(
             __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, __no_slm);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+                                                                /*__is_inclusive*/ true,
                                                                 /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
         }
@@ -109,23 +111,27 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         std::uint16_t __i = 0;
         if (__limited_iters_per_item == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops=*/true,
+                                                                        /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, __no_slm);
         }
         else if (__limited_iters_per_item > 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+                                                                /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, __no_slm);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+                                                                    /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
                     __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
             }
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops=*/true,
+                                                                        /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, __no_slm);

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -73,27 +73,29 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         _InputType* __no_slm = nullptr;
         if (__num_iters == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups, __no_slm);
             __local_acc[__idx] = __val;
         }
         else
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ false>(
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                                                                /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, __no_slm);
             __local_acc[__idx] = __val;
             __idx += __sub_group_size;
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
             {
                 __val = __local_acc[__idx];
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ true>(
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                                                                    /*__init_present*/ true>(
                     __sub_group, __val, __binary_op, __wg_carry, __no_slm);
                 __local_acc[__idx] = __val;
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,
                 __no_slm);

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -73,7 +73,8 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         _InputType* __no_slm = nullptr;
         if (__num_iters == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true,
+                                                                        /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups, __no_slm);
             __local_acc[__idx] = __val;
@@ -88,14 +89,16 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
             {
                 __val = __local_acc[__idx];
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true,
+                                                                    /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
                     __sub_group, __val, __binary_op, __wg_carry, __no_slm);
                 __local_acc[__idx] = __val;
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true,
+                                                                        /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,
                 __no_slm);

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -75,29 +75,35 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         {
             oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                         /*__is_inclusive*/ true,
-                                                                        /*__init_present*/ false>(
-                __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups, __no_slm);
+                                                                        /*__init_present*/ false>(__sub_group, __val,
+                                                                                                  __binary_op,
+                                                                                                  __wg_carry,
+                                                                                                  __active_sub_groups,
+                                                                                                  __no_slm);
             __local_acc[__idx] = __val;
         }
         else
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
-                                                                /*__init_present*/ false>(
-                __sub_group, __val, __binary_op, __wg_carry, __no_slm);
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, 
+                                                                /*__is_inclusive*/ true,
+                                                                /*__init_present*/ false>(__sub_group, __val,
+                                                                                          __binary_op, __wg_carry,
+                                                                                          __no_slm);
             __local_acc[__idx] = __val;
             __idx += __sub_group_size;
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
             {
                 __val = __local_acc[__idx];
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
-                                                                    /*__init_present*/ true>(
-                    __sub_group, __val, __binary_op, __wg_carry, __no_slm);
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, 
+                                                                    /*__is_inclusive*/ true,
+                                                                    /*__init_present*/ true>(__sub_group, __val,
+                                                                                             __binary_op, __wg_carry,
+                                                                                             __no_slm);
                 __local_acc[__idx] = __val;
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                        /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,
                 __no_slm);

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -70,34 +70,33 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         oneapi::dpl::__internal::__lazy_ctor_storage<_InputType> __wg_carry;
         std::uint8_t __idx = __sub_group.get_local_linear_id();
         _InputType __val = __local_acc[__idx];
+        _InputType* __no_slm = nullptr;
         if (__num_iters == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
-                __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups);
+                __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups, __no_slm);
             __local_acc[__idx] = __val;
         }
         else
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
-                                                                /*__init_present*/ false>(__sub_group, __val,
-                                                                                          __binary_op, __wg_carry);
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ false>(
+                __sub_group, __val, __binary_op, __wg_carry, __no_slm);
             __local_acc[__idx] = __val;
             __idx += __sub_group_size;
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
             {
                 __val = __local_acc[__idx];
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
-                                                                    /*__init_present*/ true>(__sub_group, __val,
-                                                                                             __binary_op, __wg_carry);
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__is_inclusive*/ true, /*__init_present*/ true>(
+                    __sub_group, __val, __binary_op, __wg_carry, __no_slm);
                 __local_acc[__idx] = __val;
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
-                __sub_group, __val, __binary_op, __wg_carry,
-                __active_sub_groups - (__num_iters - 1) * __sub_group_size);
+                __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,
+                __no_slm);
             __local_acc[__idx] = __val;
         }
         // Init callback, most common case is expected to be a decoupled lookback to achieve a global scan between

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -70,7 +70,7 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         oneapi::dpl::__internal::__lazy_ctor_storage<_InputType> __wg_carry;
         std::uint8_t __idx = __sub_group.get_local_linear_id();
         _InputType __val = __local_acc[__idx];
-        _InputType* __no_slm = nullptr;
+        constexpr _InputType* __no_slm = nullptr;
         if (__num_iters == 1)
         {
             oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -73,7 +73,8 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         _InputType* __no_slm = nullptr;
         if (__num_iters == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
+                                                                        /*__use_subgroup_ops=*/true,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups, __no_slm);
@@ -81,23 +82,23 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         }
         else
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true, /*__is_inclusive*/ true,
-                                                                /*__init_present*/ false>(
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+                                                                /*__is_inclusive*/ true, /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, __no_slm);
             __local_acc[__idx] = __val;
             __idx += __sub_group_size;
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
             {
                 __val = __local_acc[__idx];
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan</*__use_subgroup_ops=*/true,
-                                                                    /*__is_inclusive*/ true,
-                                                                    /*__init_present*/ true>(
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
+                                                                    /*__is_inclusive*/ true, /*__init_present*/ true>(
                     __sub_group, __val, __binary_op, __wg_carry, __no_slm);
                 __local_acc[__idx] = __val;
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial</*__use_subgroup_ops=*/true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, 
+                                                                        /*__use_subgroup_ops=*/true,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -74,7 +74,6 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         if (__num_iters == 1)
         {
             oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                        /*__use_subgroup_ops=*/true,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups, __no_slm);
@@ -82,23 +81,22 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         }
         else
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
-                                                                /*__is_inclusive*/ true, /*__init_present*/ false>(
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
+                                                                /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, __no_slm);
             __local_acc[__idx] = __val;
             __idx += __sub_group_size;
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
             {
                 __val = __local_acc[__idx];
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops=*/true,
-                                                                    /*__is_inclusive*/ true, /*__init_present*/ true>(
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
+                                                                    /*__init_present*/ true>(
                     __sub_group, __val, __binary_op, __wg_carry, __no_slm);
                 __local_acc[__idx] = __val;
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
             oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                        /*__use_subgroup_ops=*/true,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -97,7 +97,7 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, 
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                         /*__use_subgroup_ops=*/true,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -732,9 +732,9 @@ __future<sycl::event, __result_and_scratch_storage<_Size>>
 __parallel_reduce_then_scan_copy(sycl::queue& __q, _InRng&& __in_rng, _OutRng&& __out_rng, _Size,
                                  _GenMask __generate_mask, _WriteOp __write_op, _IsUniquePattern __is_unique_pattern)
 {
-    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMask>;
+    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMask, _Size>;
     using _ReduceOp = std::plus<_Size>;
-    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>;
+    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask, _Size>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     const std::size_t __n = oneapi::dpl::__ranges::__size(__in_rng);
@@ -958,9 +958,9 @@ __parallel_set_reduce_then_scan_set_a_write(_SetTag, sycl::queue& __q, _Range1&&
     using _Size = oneapi::dpl::__internal::__difference_t<_Range3>;
     using _ScanRangeTransform = oneapi::dpl::__par_backend_hetero::__extract_range_from_zip<0>;
 
-    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMaskReduce>;
+    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMaskReduce, _Size>;
     using _ReduceOp = std::plus<_Size>;
-    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMaskScan, _ScanRangeTransform>;
+    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMaskScan, _Size, _ScanRangeTransform>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     const std::size_t __n = oneapi::dpl::__ranges::__size(__rng1);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -710,14 +710,12 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
                 return __future{std::move(__event), std::move(__dummy_result_and_scratch)};
             }
         }
-
     }
 
     if (__use_reduce_then_scan)
     {
         using _GenInput =
-            oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation,
-                                                                        typename _InitType::__value_type>;
+            oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation, typename _InitType::__value_type>;
         using _ScanInputTransform = oneapi::dpl::identity;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 
@@ -743,12 +741,13 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
         auto&& [__event, __payload] = __parallel_transform_scan_base<_CustomName>(
             __q_local, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __init,
             // local scan
-            unseq_backend::__scan<_Inclusive, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner, _Unchanged, _InitType>{
-                __binary_op, _UnaryFunctor{__unary_op}, __assign_op, __assign_op, __read_op},
+            unseq_backend::__scan<_Inclusive, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner, _Unchanged,
+                                  _InitType>{__binary_op, _UnaryFunctor{__unary_op}, __assign_op, __assign_op,
+                                             __read_op},
             // scan between groups
             unseq_backend::__scan</*inclusive=*/std::true_type, _BinaryOperation, _Unchanged, _NoAssign, _Assigner,
-                                _Unchanged, unseq_backend::__no_init_value<_Type>>{__binary_op, __read_op, __ignore_op,
-                                                                                    __assign_op, __read_op},
+                                  _Unchanged, unseq_backend::__no_init_value<_Type>>{
+                __binary_op, __read_op, __ignore_op, __assign_op, __read_op},
             // global scan
             unseq_backend::__global_scan_functor<_Inclusive, _BinaryOperation, _InitType>{__binary_op, __init},
             /*apex*/ __ignore_op);
@@ -1000,7 +999,8 @@ __parallel_set_reduce_then_scan_set_a_write(_SetTag, sycl::queue& __q, _Range1&&
 
     using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMaskReduce, _Size>;
     using _ReduceOp = std::plus<_Size>;
-    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMaskScan, _Size, _ScanRangeTransform>;
+    using _GenScanInput =
+        oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMaskScan, _Size, _ScanRangeTransform>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     const std::size_t __n = oneapi::dpl::__ranges::__size(__rng1);
@@ -1035,11 +1035,11 @@ __parallel_set_write_a_b_op(_SetTag, sycl::queue& __q, _Range1&& __rng1, _Range2
     using _ReduceOp = std::plus<_Size>;
     using _BoundsProvider = oneapi::dpl::__par_backend_hetero::__get_bounds_partitioned;
 
-    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider, _Size,
-                                                                                       _Compare, _Proj1, _Proj2>;
+    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider,
+                                                                                       _Size, _Compare, _Proj1, _Proj2>;
     using _GenScanInput =
-        oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<_SetOperation, _TempData, _Size, _Compare,
-                                                                                 _Proj1, _Proj2>;
+        oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<_SetOperation, _TempData, _Size,
+                                                                                 _Compare, _Proj1, _Proj2>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
     using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_multiple_to_id<oneapi::dpl::__internal::__pstl_assign>;
 
@@ -2490,7 +2490,6 @@ __parallel_scan_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Execu
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
     assert(oneapi::dpl::__ranges::__size(__keys) > 0);
-
 
     sycl::queue __q_local = __exec.queue();
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -995,11 +995,11 @@ __parallel_set_write_a_b_op(_SetTag, sycl::queue& __q, _Range1&& __rng1, _Range2
     using _ReduceOp = std::plus<_Size>;
     using _BoundsProvider = oneapi::dpl::__par_backend_hetero::__get_bounds_partitioned;
 
-    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider,
-                                                                                       _Compare, _Proj1, _Proj2, _Size>;
+    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider, _Size,
+                                                                                       _Compare, _Proj1, _Proj2>;
     using _GenScanInput =
-        oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<_SetOperation, _TempData, _Compare,
-                                                                                 _Proj1, _Proj2, _Size>;
+        oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<_SetOperation, _TempData, _Size, _Compare,
+                                                                                 _Proj1, _Proj2>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
     using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_multiple_to_id<oneapi::dpl::__internal::__pstl_assign>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -681,7 +681,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
 
     using _Type = typename _InitType::__value_type;
 
-    bool __use_reduce_then_scan = oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local);
+    const bool __use_reduce_then_scan = oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local);
 
     // The single work-group implementation requires a fundamental type which must be trivially copyable.
     if constexpr (std::is_trivially_copyable_v<_Type>)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -708,11 +708,14 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
                 return __future{std::move(__event), std::move(__dummy_result_and_scratch)};
             }
         }
+
     }
-    //reduce_then_scan implementation
+
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
     {
         using _GenInput =
-            oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation, typename _InitType::__value_type>;
+            oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation,
+                                                                        typename _InitType::__value_type>;
         using _ScanInputTransform = oneapi::dpl::identity;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 
@@ -723,6 +726,31 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
             __q_local, __n, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __gen_transform,
             __binary_op, __gen_transform, _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
             /*_IsUniquePattern=*/std::false_type{});
+    }
+    else // use multi pass scan implementation
+    {
+        using _Assigner = unseq_backend::__scan_assigner;
+        using _NoAssign = unseq_backend::__scan_ignore;
+        using _UnaryFunctor = unseq_backend::walk_n<_UnaryOperation>;
+        using _Unchanged = unseq_backend::__unchanged;
+
+        _Assigner __assign_op;
+        _NoAssign __ignore_op;
+        _Unchanged __read_op;
+
+        auto&& [__event, __payload] = __parallel_transform_scan_base<_CustomName>(
+            __q_local, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __init,
+            // local scan
+            unseq_backend::__scan<_Inclusive, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner, _Unchanged, _InitType>{
+                __binary_op, _UnaryFunctor{__unary_op}, __assign_op, __assign_op, __read_op},
+            // scan between groups
+            unseq_backend::__scan</*inclusive=*/std::true_type, _BinaryOperation, _Unchanged, _NoAssign, _Assigner,
+                                _Unchanged, unseq_backend::__no_init_value<_Type>>{__binary_op, __read_op, __ignore_op,
+                                                                                    __assign_op, __read_op},
+            // global scan
+            unseq_backend::__global_scan_functor<_Inclusive, _BinaryOperation, _InitType>{__binary_op, __init},
+            /*apex*/ __ignore_op);
+        return __future(std::move(__event), __result_and_scratch_storage<_Type>(__move_state_from(__payload)));
     }
 }
 
@@ -808,7 +836,7 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag, _Execution
             __q_local, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n, __n_out,
             oneapi::dpl::__internal::__unique_at_index<_BinaryPredicate, true>{__pred}, _Assign{}, __max_wg_size);
     }
-    else if (__n_out >= __n)
+    else if (__n_out >= __n && oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
     // TODO: figure out how to support limited output ranges in the reduce-then-scan pattern
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
@@ -876,18 +904,28 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag, _Execut
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _Size1 = oneapi::dpl::__internal::__difference_t<_Range1>;
-    using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
-    using _WriteOp =
-        oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
 
     sycl::queue __q_local = __exec.queue();
 
     _Size1 __n = oneapi::dpl::__ranges::__size(__rng);
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
+    {
+        using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
+        using _WriteOp =
+            oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
 
-    return __parallel_reduce_then_scan_copy<_CustomName>(
-        __q_local, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n, _GenMask{__pred}, _WriteOp{},
-        /*_IsUniquePattern=*/std::false_type{});
+        return __parallel_reduce_then_scan_copy<_CustomName>(
+            __q_local, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n, _GenMask{__pred}, _WriteOp{},
+            /*_IsUniquePattern=*/std::false_type{});
+    }
+    else
+    {
+        auto&& [__event, __payload] = __parallel_scan_copy<_CustomName>(
+            __q_local, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
+            oneapi::dpl::__internal::__pred_at_index{__pred}, unseq_backend::__partition_by_mask{});
 
+        return __future(std::move(__event), __result_and_scratch_storage<_Size1>(__move_state_from(__payload)));
+    }
 }
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _Pred,
@@ -914,7 +952,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
             __q_local, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, __n_out,
             oneapi::dpl::__internal::__pred_at_index{__pred}, __assign, __max_wg_size);
     }
-    else if (__n_out >= __n)
+    else if (__n_out >= __n && oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
     // TODO: figure out how to support limited output ranges in the reduce-then-scan pattern
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
@@ -1333,19 +1371,26 @@ std::size_t
 __set_op_impl(_SetTag __set_tag, sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
               _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
 {
-    if (__check_use_write_a_alg{}(__set_tag, __rng1, __rng2))
+    //can we use reduce then scan?
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q))
     {
-        // use reduce then scan with set_a write
-        return __set_write_a_only_op<set_a_write_wrapper<_CustomName>>(
-            __set_tag, /*use_reduce_then_scan=*/std::true_type{}, __q, std::forward<_Range1>(__rng1),
-            std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp, __proj1, __proj2);
+        if (__check_use_write_a_alg{}(__set_tag, __rng1, __rng2))
+        {
+            // use reduce then scan with set_a write
+            return __set_write_a_only_op<set_a_write_wrapper<_CustomName>>(
+                __set_tag, /*use_reduce_then_scan=*/std::true_type{}, __q, std::forward<_Range1>(__rng1),
+                std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp, __proj1, __proj2);
+        }
+        return __parallel_set_write_a_b_op<reduce_then_scan_wrapper<_CustomName>>(
+                   __set_tag, __q, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                   std::forward<_Range3>(__result), __comp, __proj1, __proj2)
+            .get();
     }
     else
     {
-        return __parallel_set_write_a_b_op<reduce_then_scan_wrapper<_CustomName>>(
-                    __set_tag, __q, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                    std::forward<_Range3>(__result), __comp, __proj1, __proj2)
-            .get();
+        return __set_write_a_only_op<scan_then_propagate_wrapper<_CustomName>>(
+            __set_tag, /*use_reduce_then_scan=*/std::false_type{}, __q, std::forward<_Range1>(__rng1),
+            std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp, __proj1, __proj2);
     }
 }
 
@@ -2273,12 +2318,15 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
     using __val_type = oneapi::dpl::__internal::__value_t<_Range2>;
     // Prior to icpx 2025.0, the reduce-then-scan path performs poorly and should be avoided.
 #if !defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER >= 20250000
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan<_CustomName>(
-        __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
-        std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values), __binary_pred, __binary_op);
-    // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the
-    // past-the-end iterator pair of segmented reduction.
-    return std::get<0>(__res.get()) + 1;
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
+    {
+        auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan<_CustomName>(
+            __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
+            std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values), __binary_pred, __binary_op);
+        // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the
+        // past-the-end iterator pair of segmented reduction.
+        return std::get<0>(__res.get()) + 1;
+    }
 #endif
     return __parallel_reduce_by_segment_fallback(
         oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
@@ -2441,11 +2489,25 @@ __parallel_scan_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Execu
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
     assert(oneapi::dpl::__ranges::__size(__keys) > 0);
 
+
     sycl::queue __q_local = __exec.queue();
-    __parallel_scan_by_segment_reduce_then_scan<_CustomName, __is_inclusive>(
-        __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
-        std::forward<_Range3>(__out_values), __binary_pred, __binary_op, __init)
-        .wait();
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
+    {
+        __parallel_scan_by_segment_reduce_then_scan<_CustomName, __is_inclusive>(
+            __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
+            std::forward<_Range3>(__out_values), __binary_pred, __binary_op, __init)
+            .wait();
+        return;
+    }
+    // Implicit synchronization in this call. We need to wrap the policy as the implementation may still call
+    // reduce-then-scan and needs to avoid duplicate kernel names.
+    __parallel_scan_by_segment_fallback<_CustomName, __is_inclusive>(
+        oneapi::dpl::__internal::__device_backend_tag{},
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__scan_by_seg_fallback>(
+            std::forward<_ExecutionPolicy>(__exec)),
+        std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_values),
+        __binary_pred, __binary_op, __init,
+        oneapi::dpl::unseq_backend::__has_known_identity<_BinaryOperator, _ValueType>{});
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -681,8 +681,6 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
 
     using _Type = typename _InitType::__value_type;
 
-    bool __use_reduce_then_scan = oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local);
-
     // The single work-group implementation requires a fundamental type which must be trivially copyable.
     if constexpr (std::is_trivially_copyable_v<_Type>)
     {
@@ -711,7 +709,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
             }
         }
     }
-    if (__use_reduce_then_scan)
+    //reduce_then_scan implementation
     {
         using _GenInput =
             oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation, typename _InitType::__value_type>;
@@ -726,30 +724,6 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
             __binary_op, __gen_transform, _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
             /*_IsUniquePattern=*/std::false_type{});
     }
-
-    //else use multi pass scan implementation
-    using _Assigner = unseq_backend::__scan_assigner;
-    using _NoAssign = unseq_backend::__scan_ignore;
-    using _UnaryFunctor = unseq_backend::walk_n<_UnaryOperation>;
-    using _Unchanged = unseq_backend::__unchanged;
-
-    _Assigner __assign_op;
-    _NoAssign __ignore_op;
-    _Unchanged __read_op;
-
-    auto&& [__event, __payload] = __parallel_transform_scan_base<_CustomName>(
-        __q_local, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __init,
-        // local scan
-        unseq_backend::__scan<_Inclusive, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner, _Unchanged, _InitType>{
-            __binary_op, _UnaryFunctor{__unary_op}, __assign_op, __assign_op, __read_op},
-        // scan between groups
-        unseq_backend::__scan</*inclusive=*/std::true_type, _BinaryOperation, _Unchanged, _NoAssign, _Assigner,
-                              _Unchanged, unseq_backend::__no_init_value<_Type>>{__binary_op, __read_op, __ignore_op,
-                                                                                 __assign_op, __read_op},
-        // global scan
-        unseq_backend::__global_scan_functor<_Inclusive, _BinaryOperation, _InitType>{__binary_op, __init},
-        /*apex*/ __ignore_op);
-    return __future(std::move(__event), __result_and_scratch_storage<_Type>(__move_state_from(__payload)));
 }
 
 template <typename _CustomName, typename _InRng, typename _OutRng, typename _Size, typename _GenMask, typename _WriteOp,
@@ -834,7 +808,7 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag, _Execution
             __q_local, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n, __n_out,
             oneapi::dpl::__internal::__unique_at_index<_BinaryPredicate, true>{__pred}, _Assign{}, __max_wg_size);
     }
-    else if (__n_out >= __n && oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
+    else if (__n_out >= __n)
     // TODO: figure out how to support limited output ranges in the reduce-then-scan pattern
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
@@ -902,28 +876,18 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag, _Execut
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _Size1 = oneapi::dpl::__internal::__difference_t<_Range1>;
+    using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
+    using _WriteOp =
+        oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
 
     sycl::queue __q_local = __exec.queue();
 
     _Size1 __n = oneapi::dpl::__ranges::__size(__rng);
-    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
-    {
-        using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
-        using _WriteOp =
-            oneapi::dpl::__par_backend_hetero::__write_to_id_if_else<oneapi::dpl::__internal::__pstl_assign>;
 
-        return __parallel_reduce_then_scan_copy<_CustomName>(
-            __q_local, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n, _GenMask{__pred}, _WriteOp{},
-            /*_IsUniquePattern=*/std::false_type{});
-    }
-    else
-    {
-        auto&& [__event, __payload] = __parallel_scan_copy<_CustomName>(
-            __q_local, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
-            oneapi::dpl::__internal::__pred_at_index{__pred}, unseq_backend::__partition_by_mask{});
+    return __parallel_reduce_then_scan_copy<_CustomName>(
+        __q_local, std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n, _GenMask{__pred}, _WriteOp{},
+        /*_IsUniquePattern=*/std::false_type{});
 
-        return __future(std::move(__event), __result_and_scratch_storage<_Size1>(__move_state_from(__payload)));
-    }
 }
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _Pred,
@@ -950,7 +914,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
             __q_local, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, __n_out,
             oneapi::dpl::__internal::__pred_at_index{__pred}, __assign, __max_wg_size);
     }
-    else if (__n_out >= __n && oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
+    else if (__n_out >= __n)
     // TODO: figure out how to support limited output ranges in the reduce-then-scan pattern
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
@@ -1369,26 +1333,19 @@ std::size_t
 __set_op_impl(_SetTag __set_tag, sycl::queue& __q, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result,
               _Compare __comp, _Proj1 __proj1, _Proj2 __proj2)
 {
-    //can we use reduce then scan?
-    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q))
+    if (__check_use_write_a_alg{}(__set_tag, __rng1, __rng2))
     {
-        if (__check_use_write_a_alg{}(__set_tag, __rng1, __rng2))
-        {
-            // use reduce then scan with set_a write
-            return __set_write_a_only_op<set_a_write_wrapper<_CustomName>>(
-                __set_tag, /*use_reduce_then_scan=*/std::true_type{}, __q, std::forward<_Range1>(__rng1),
-                std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp, __proj1, __proj2);
-        }
-        return __parallel_set_write_a_b_op<reduce_then_scan_wrapper<_CustomName>>(
-                   __set_tag, __q, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                   std::forward<_Range3>(__result), __comp, __proj1, __proj2)
-            .get();
+        // use reduce then scan with set_a write
+        return __set_write_a_only_op<set_a_write_wrapper<_CustomName>>(
+            __set_tag, /*use_reduce_then_scan=*/std::true_type{}, __q, std::forward<_Range1>(__rng1),
+            std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp, __proj1, __proj2);
     }
     else
     {
-        return __set_write_a_only_op<scan_then_propagate_wrapper<_CustomName>>(
-            __set_tag, /*use_reduce_then_scan=*/std::false_type{}, __q, std::forward<_Range1>(__rng1),
-            std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp, __proj1, __proj2);
+        return __parallel_set_write_a_b_op<reduce_then_scan_wrapper<_CustomName>>(
+                    __set_tag, __q, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                    std::forward<_Range3>(__result), __comp, __proj1, __proj2)
+            .get();
     }
 }
 
@@ -2316,18 +2273,12 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
     using __val_type = oneapi::dpl::__internal::__value_t<_Range2>;
     // Prior to icpx 2025.0, the reduce-then-scan path performs poorly and should be avoided.
 #if !defined(__INTEL_LLVM_COMPILER) || __INTEL_LLVM_COMPILER >= 20250000
-    if constexpr (std::is_trivially_copyable_v<__val_type>)
-    {
-        if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
-        {
-            auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan<_CustomName>(
-                __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
-                std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values), __binary_pred, __binary_op);
-            // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the
-            // past-the-end iterator pair of segmented reduction.
-            return std::get<0>(__res.get()) + 1;
-        }
-    }
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_reduce_by_segment_reduce_then_scan<_CustomName>(
+        __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
+        std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values), __binary_pred, __binary_op);
+    // Because our init type ends up being tuple<std::size_t, ValType>, return the first component which is the write index. Add 1 to return the
+    // past-the-end iterator pair of segmented reduction.
+    return std::get<0>(__res.get()) + 1;
 #endif
     return __parallel_reduce_by_segment_fallback(
         oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
@@ -2490,27 +2441,11 @@ __parallel_scan_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Execu
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
     assert(oneapi::dpl::__ranges::__size(__keys) > 0);
 
-    if constexpr (std::is_trivially_copyable_v<_ValueType>)
-    {
-        sycl::queue __q_local = __exec.queue();
-        if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
-        {
-            __parallel_scan_by_segment_reduce_then_scan<_CustomName, __is_inclusive>(
-                __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
-                std::forward<_Range3>(__out_values), __binary_pred, __binary_op, __init)
-                .wait();
-            return;
-        }
-    }
-    // Implicit synchronization in this call. We need to wrap the policy as the implementation may still call
-    // reduce-then-scan and needs to avoid duplicate kernel names.
-    __parallel_scan_by_segment_fallback<_CustomName, __is_inclusive>(
-        oneapi::dpl::__internal::__device_backend_tag{},
-        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__scan_by_seg_fallback>(
-            std::forward<_ExecutionPolicy>(__exec)),
-        std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_values),
-        __binary_pred, __binary_op, __init,
-        oneapi::dpl::unseq_backend::__has_known_identity<_BinaryOperator, _ValueType>{});
+    sycl::queue __q_local = __exec.queue();
+    __parallel_scan_by_segment_reduce_then_scan<_CustomName, __is_inclusive>(
+        __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values),
+        std::forward<_Range3>(__out_values), __binary_pred, __binary_op, __init)
+        .wait();
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -681,6 +681,8 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
 
     using _Type = typename _InitType::__value_type;
 
+    bool __use_reduce_then_scan = oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local);
+
     // The single work-group implementation requires a fundamental type which must be trivially copyable.
     if constexpr (std::is_trivially_copyable_v<_Type>)
     {
@@ -694,7 +696,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
 
             // GPU: reduce-then-scan is efficient for moderate-sized inputs, so the single-group cutoff is low.
             // CPU: kernel launch overhead dominates, so prefer the single-group path for larger inputs.
-            std::size_t __single_group_upper_limit = __q_local.get_device().is_gpu() ? 2048 : 16384;
+            std::size_t __single_group_upper_limit = __use_reduce_then_scan ? 2048 : 16384;
             if (__group_scan_fits_in_slm<_Type>(__q_local, __n, __n_uniform, __single_group_upper_limit))
             {
                 auto __event = __parallel_transform_scan_single_group<_CustomName>(
@@ -711,7 +713,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
 
     }
 
-    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local))
+    if (__use_reduce_then_scan)
     {
         using _GenInput =
             oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -996,10 +996,10 @@ __parallel_set_write_a_b_op(_SetTag, sycl::queue& __q, _Range1&& __rng1, _Range2
     using _BoundsProvider = oneapi::dpl::__par_backend_hetero::__get_bounds_partitioned;
 
     using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider,
-                                                                                       _Compare, _Proj1, _Proj2>;
+                                                                                       _Compare, _Proj1, _Proj2, _Size>;
     using _GenScanInput =
         oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<_SetOperation, _TempData, _Compare,
-                                                                                 _Proj1, _Proj2>;
+                                                                                 _Proj1, _Proj2, _Size>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
     using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_multiple_to_id<oneapi::dpl::__internal::__pstl_assign>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -680,14 +680,12 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
     sycl::queue __q_local = __exec.queue();
 
     using _Type = typename _InitType::__value_type;
-    // Reduce-then-scan is dependent on sycl::shift_group_right which requires the underlying type to be trivially
-    // copyable. If this is not met, then we must fallback to the multi pass scan implementation. The single
-    // work-group implementation requires a fundamental type which must also be trivially copyable.
+
+    bool __use_reduce_then_scan = oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local);
+
+    // The single work-group implementation requires a fundamental type which must be trivially copyable.
     if constexpr (std::is_trivially_copyable_v<_Type>)
     {
-        bool __use_reduce_then_scan =
-            oneapi::dpl::__par_backend_hetero::__is_gpu_with_reduce_then_scan_sg_sz(__q_local);
-
         // TODO: Consider re-implementing single group scan to support types without known identities. This could also
         // allow us to use single wg scan for the last block of reduce-then-scan if it is sufficiently small.
         constexpr bool __can_use_group_scan = unseq_backend::__has_known_identity<_BinaryOperation, _Type>::value;
@@ -711,22 +709,21 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
                 return __future{std::move(__event), std::move(__dummy_result_and_scratch)};
             }
         }
-        if (__use_reduce_then_scan)
-        {
-            using _GenInput =
-                oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation,
-                                                                         typename _InitType::__value_type>;
-            using _ScanInputTransform = oneapi::dpl::identity;
-            using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
+    }
+    if (__use_reduce_then_scan)
+    {
+        using _GenInput =
+            oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation, typename _InitType::__value_type>;
+        using _ScanInputTransform = oneapi::dpl::identity;
+        using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 
-            _GenInput __gen_transform{__unary_op};
+        _GenInput __gen_transform{__unary_op};
 
-            const std::size_t __n = oneapi::dpl::__ranges::__size(__in_rng);
-            return __parallel_transform_reduce_then_scan<sizeof(typename _InitType::__value_type), _CustomName>(
-                __q_local, __n, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __gen_transform,
-                __binary_op, __gen_transform, _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
-                /*_IsUniquePattern=*/std::false_type{});
-        }
+        const std::size_t __n = oneapi::dpl::__ranges::__size(__in_rng);
+        return __parallel_transform_reduce_then_scan<sizeof(typename _InitType::__value_type), _CustomName>(
+            __q_local, __n, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __gen_transform,
+            __binary_op, __gen_transform, _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
+            /*_IsUniquePattern=*/std::false_type{});
     }
 
     //else use multi pass scan implementation

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -694,8 +694,9 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
             // Next power of 2 greater than or equal to __n
             std::size_t __n_uniform = oneapi::dpl::__internal::__dpl_bit_ceil(__n);
 
-            // Empirically found values for reduce-then-scan and multi pass scan implementation for single wg cutoff
-            std::size_t __single_group_upper_limit = __use_reduce_then_scan ? 2048 : 16384;
+            // GPU: reduce-then-scan is efficient for moderate-sized inputs, so the single-group cutoff is low.
+            // CPU: kernel launch overhead dominates, so prefer the single-group path for larger inputs.
+            std::size_t __single_group_upper_limit = __q_local.get_device().is_gpu() ? 2048 : 16384;
             if (__group_scan_fits_in_slm<_Type>(__q_local, __n, __n_uniform, __single_group_upper_limit))
             {
                 auto __event = __parallel_transform_scan_single_group<_CustomName>(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1561,7 +1561,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         using _InitValueType = typename _InitType::__value_type;
-        return __q.submit([&, this](sycl::handler& __cgh) [[ _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32) ]] {
+        return __q.submit([&, this](sycl::handler& __cgh) {
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
@@ -1570,7 +1570,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
-            __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) {
+            __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) [[ _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32) ]] {
                 __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
                 const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
 
@@ -1733,7 +1733,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             __num_remaining -= 1;
         }
         std::uint32_t __inputs_in_block = std::min(__num_remaining, std::size_t{__max_block_size});
-        return __q.submit([&, this](sycl::handler& __cgh) [[ _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32) ]] {
+        return __q.submit([&, this](sycl::handler& __cgh) {
             // We need __num_sub_groups_local + 1 temporary SLM locations to store intermediate results:
             //   __num_sub_groups_local for each sub-group partial from the reduce kernel +
             //   1 element for the accumulated block-local carry-in from previous groups in the block
@@ -1747,7 +1747,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             auto __res_acc =
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
-            __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) {
+            __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) [[ _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32) ]] {
                 __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
                 const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
                 _InitValueType* __comm_slm_ptr = __use_slm_for_comm ? &__comm_slm[0] : nullptr;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2042,21 +2042,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
     _InitType __init;
 };
 
-// Reduce-then-scan is supported on all devices. Non-GPU targets and non-trivially-copyable types
-// use SLM-based sub-group communication instead of native sub-group operations.
-inline bool
-__is_reduce_then_scan_supported(const sycl::queue&)
-{
-    return true;
-}
-
-// Kept for backward compatibility; prefer __is_reduce_then_scan_supported.
-inline bool
-__is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
-{
-    return __is_reduce_then_scan_supported(__q);
-}
-
 // General scan-like algorithm helpers
 // _GenReduceInput - a function which accepts the input range and index to generate the data needed by the main output
 //                   used in the reduction operation (to calculate the global carries)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -692,7 +692,7 @@ struct __get_bounds_simple
 // Reduce then scan building block for set balanced path which is used in the reduction kernel to calculate the
 // balanced path intersection, store it to temporary data with "star" status, then count the number of elements to write
 // to the output for the reduction operation.
-template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
+template <typename _SetOpCount, typename _BoundsProvider, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
 struct __gen_set_balanced_path
 {
     using TempData = __noop_temp_data;
@@ -882,7 +882,7 @@ struct __gen_set_balanced_path
 // Reduce then scan building block for set balanced path which is used in the scan kernel to decode the stored balanced
 // path intersection, perform the serial set operation for the diagonal, counting the number of elements and writing
 // the output to temporary data in registers to be ready for the scan and write operations to follow.
-template <typename _SetOpCount, typename _TempData, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
+template <typename _SetOpCount, typename _TempData, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
 struct __gen_set_op_from_known_balanced_path
 {
     using TempData = _TempData;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1612,7 +1612,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
-                _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
                 std::size_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
@@ -1670,7 +1670,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                                                             (__sub_group, __v, __reduce_op, __sub_group_carry,
                                                             __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
                         if (__sub_group_local_id < __active_subgroups)
-                            __tmp_ptr[__start_id + __sub_group_local_id] = __v;
+                            __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
                     else
                     {
@@ -1679,7 +1679,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         _InitValueType __v = __sub_group_partials[__reduction_scan_id];
                         __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
                             __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
-                        __tmp_ptr[__start_id + __reduction_scan_id] = __v;
+                        __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         __reduction_scan_id += __sub_group_size;
 
                         for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
@@ -1687,7 +1687,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                             __v = __sub_group_partials[__reduction_scan_id];
                             __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                                 __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
-                            __tmp_ptr[__start_id + __reduction_scan_id] = __v;
+                            __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
                         }
                         // If we are past the input range, then the previous value of v is passed to the sub-group scan.
@@ -1701,7 +1701,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                             __sub_group, __v, __reduce_op, __sub_group_carry,
                             __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr, __use_subgroup_ops);
                         if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
-                            __tmp_ptr[__start_id + __reduction_scan_id] = __v;
+                            __temp_ptr[__start_id + __reduction_scan_id] = __v;
                     }
 
                     __sub_group_carry.__destroy();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1806,7 +1806,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 _InitValueType* __res_ptr =
                     _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
-
                 std::uint32_t __group_id = __ndi.get_group(0);
                 __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2097,12 +2097,18 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     constexpr bool __inclusive = _Inclusive::value;
     constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 
-    const bool __is_gpu = __q.get_device().is_gpu();
-
-    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 8192);
+    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 1024);
     // Round down to nearest multiple of the max subgroup size to ensure compatibility with all sub-group sizes
     const std::uint32_t __work_group_size = (__max_work_group_size / __max_sub_group_size) * __max_sub_group_size;
 
+    // TODO: Investigate potentially basing this on some scale of the number of compute units. 128 work-groups has been
+    // found to be reasonable number for most devices.
+    constexpr std::uint32_t __num_work_groups = 128;
+    // Allocate sufficient temporary storage for the worst case (smallest sub-group size = most sub-groups).
+    const std::uint32_t __max_num_sub_groups_local = __work_group_size / __min_sub_group_size;
+    const std::uint32_t __max_num_sub_groups_global = __max_num_sub_groups_local * __num_work_groups;
+    const std::uint32_t __max_inputs_per_work_group = __work_group_size * __max_inputs_per_item;
+    const std::uint32_t __max_inputs_per_block = __max_inputs_per_work_group * __num_work_groups;
     std::size_t __inputs_remaining = __n;
     if constexpr (__is_unique_pattern_v)
     {
@@ -2112,21 +2118,6 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     // reduce_then_scan kernel is not built to handle "empty" scans which includes `__n == 1` for unique patterns.
     // These trivial end cases should be handled at a higher level.
     assert(__inputs_remaining > 0);
-
-    // GPU: 128 work-groups is empirically a good balance.
-    // CPU: use enough work-groups to cover the entire input in a single block, avoiding extra
-    //      kernel-launch overhead.  Each block requires 2 kernel launches (reduce + scan), so
-    //      minimizing blocks is critical for CPU where launch overhead dominates.
-    const std::uint32_t __max_inputs_per_work_group = __work_group_size * __max_inputs_per_item;
-    const std::uint32_t __num_work_groups =
-        __is_gpu ? 128
-                 : std::max(std::uint32_t{1}, static_cast<std::uint32_t>(oneapi::dpl::__internal::__dpl_ceiling_div(
-                                                  __inputs_remaining, std::size_t{__max_inputs_per_work_group})));
-
-    // Allocate sufficient temporary storage for the worst case (smallest sub-group size = most sub-groups).
-    const std::uint32_t __max_num_sub_groups_local = __work_group_size / __min_sub_group_size;
-    const std::uint32_t __max_num_sub_groups_global = __max_num_sub_groups_local * __num_work_groups;
-    const std::uint32_t __max_inputs_per_block = __max_inputs_per_work_group * __num_work_groups;
     std::uint32_t __inputs_per_item =
         __inputs_remaining >= __max_inputs_per_block
             ? __max_inputs_per_item
@@ -2142,7 +2133,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
 
     // Use SLM-based sub-group communication for non-trivially-copyable types or CPU targets
     // (where native sub-group operations are slow).
-    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType> || !__is_gpu;
+    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType> || !__q.get_device().is_gpu();
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =
@@ -2175,8 +2166,8 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
                                     __write_op,
                                     __init};
 
-    // Data is processed in 2-kernel blocks to allow contiguous input segment to persist in LLC between the first and
-    // second kernel for accelerators with sufficiently large L2 / L3 caches.
+    // Data is processed in 2-kernel blocks to allow contiguous input segment to persist in LLC between the first and second kernel for accelerators
+    // with sufficiently large L2 / L3 caches.
     for (std::size_t __b = 0; __b < __num_blocks; ++__b)
     {
         std::uint32_t __workitems_in_block = oneapi::dpl::__internal::__dpl_ceiling_div(
@@ -2186,8 +2177,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
         auto __global_range = sycl::range<1>(__workitems_in_block_round_up_workgroup);
         auto __local_range = sycl::range<1>(__work_group_size);
         auto __kernel_nd_range = sycl::nd_range<1>(__global_range, __local_range);
-        // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to
-        //    global memory.
+        // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
         __prior_event = __reduce_submitter(__q, __kernel_nd_range, __in_rng, __result_and_scratch, __prior_event,
                                            __inputs_remaining, __b);
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1195,9 +1195,10 @@ struct __scan_by_seg_op
 
 // *** Main reduce then scan infrastructure ***
 
-// Sub-group communication wrappers that support non-trivially-copyable types.
-// For trivially copyable types, native SYCL sub-group operations are used.
-// For non-trivially-copyable types, shared local memory (SLM) with sub-group barriers is used.
+// Sub-group communication wrappers with SLM fallback.
+// When __comm_slm is nullptr, native SYCL sub-group operations are used (trivially copyable types only).
+// When __comm_slm is non-null, SLM-based communication is used. This path is required for
+// non-trivially-copyable types and preferred for CPU targets where sub-group ops are slow.
 // The __comm_slm parameter points to a work-group-sized SLM buffer; each sub-group uses its own
 // slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size).
 
@@ -1208,18 +1209,18 @@ __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __s
 {
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
-        return sycl::shift_group_right(__sub_group, __value, __shift);
+        if (__comm_slm == nullptr)
+            return sycl::shift_group_right(__sub_group, __value, __shift);
     }
-    else
-    {
-        std::uint32_t __local_id = __sub_group.get_local_linear_id();
-        std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group_size;
-        __comm_slm[__sg_base + __local_id] = __value;
-        sycl::group_barrier(__sub_group);
-        _ValueType __result = __comm_slm[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
-        sycl::group_barrier(__sub_group);
-        return __result;
-    }
+    // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
+    // preferred (e.g., CPU targets where sub-group ops are slow).
+    std::uint32_t __local_id = __sub_group.get_local_linear_id();
+    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group_size;
+    __comm_slm[__sg_base + __local_id] = __value;
+    sycl::group_barrier(__sub_group);
+    _ValueType __result = __comm_slm[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
+    sycl::group_barrier(__sub_group);
+    return __result;
 }
 
 template <typename _ValueType, typename _IdType>
@@ -1229,18 +1230,18 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub
 {
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
-        return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
+        if (__comm_slm == nullptr)
+            return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
     }
-    else
-    {
-        std::uint32_t __local_id = __sub_group.get_local_linear_id();
-        std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group_size;
-        __comm_slm[__sg_base + __local_id] = __value;
-        sycl::group_barrier(__sub_group);
-        _ValueType __result = __comm_slm[__sg_base + __broadcast_id];
-        sycl::group_barrier(__sub_group);
-        return __result;
-    }
+    // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
+    // preferred (e.g., CPU targets where sub-group ops are slow).
+    std::uint32_t __local_id = __sub_group.get_local_linear_id();
+    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group_size;
+    __comm_slm[__sg_base + __local_id] = __value;
+    sycl::group_barrier(__sub_group);
+    _ValueType __result = __comm_slm[__sg_base + __broadcast_id];
+    sycl::group_barrier(__sub_group);
+    return __result;
 }
 
 template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
@@ -1541,10 +1542,9 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
         using _InitValueType = typename _InitType::__value_type;
         return __q.submit([&, this](sycl::handler& __cgh) {
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
-            // SLM for sub-group communication (shift_group_right / group_broadcast) for non-trivially-copyable types.
-            // For trivially copyable types, native SYCL sub-group ops are used and this SLM is unused.
-            constexpr std::size_t __comm_slm_size =
-                std::is_trivially_copyable_v<_InitValueType> ? 0 : __work_group_size;
+            // SLM for sub-group communication (shift_group_right / group_broadcast).
+            // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
+            const std::size_t __comm_slm_size = __use_slm_for_comm ? __work_group_size : 0;
             __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__comm_slm_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
@@ -1664,6 +1664,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
     const std::uint32_t __max_block_size;
     const std::uint32_t __max_num_sub_groups_local;
     const std::size_t __n;
+    const bool __use_slm_for_comm;
 
     const _GenReduceInput __gen_reduce_input;
     const _ReduceOp __reduce_op;
@@ -1718,8 +1719,9 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             //   __num_sub_groups_local for each sub-group partial from the reduce kernel +
             //   1 element for the accumulated block-local carry-in from previous groups in the block
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
-            constexpr std::size_t __comm_slm_size =
-                std::is_trivially_copyable_v<_InitValueType> ? 0 : __work_group_size;
+            // SLM for sub-group communication (shift_group_right / group_broadcast).
+            // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
+            const std::size_t __comm_slm_size = __use_slm_for_comm ? __work_group_size : 0;
             __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__comm_slm_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
@@ -2013,6 +2015,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
     const std::uint32_t __max_num_sub_groups_global;
     const std::size_t __num_blocks;
     const std::size_t __n;
+    const bool __use_slm_for_comm;
 
     const _ReduceOp __reduce_op;
     const _GenScanInput __gen_scan_input;
@@ -2021,13 +2024,19 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
     _InitType __init;
 };
 
-// Enable reduce-then-scan on GPU devices with fast coordinated subgroup operations.
-// We do not want to run this scan on CPU targets, as they are not performant with this algorithm.
-// The sub-group size is determined at runtime within the kernel via get_max_local_range().
+// Reduce-then-scan is supported on all devices. Non-GPU targets and non-trivially-copyable types
+// use SLM-based sub-group communication instead of native sub-group operations.
+inline bool
+__is_reduce_then_scan_supported(const sycl::queue&)
+{
+    return true;
+}
+
+// Kept for backward compatibility; prefer __is_reduce_then_scan_supported.
 inline bool
 __is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
 {
-    return __q.get_device().is_gpu();
+    return __is_reduce_then_scan_supported(__q);
 }
 
 // General scan-like algorithm helpers
@@ -2104,6 +2113,10 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     // between reading and writing the block carry-out within a single kernel.
     __result_and_scratch_storage<_ValueType> __result_and_scratch{__q, __max_num_sub_groups_global + 2};
 
+    // Use SLM-based sub-group communication for non-trivially-copyable types or CPU targets
+    // (where native sub-group operations are slow).
+    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType> || !__q.get_device().is_gpu();
+
     // Reduce and scan step implementations
     using _ReduceSubmitter =
         __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __inclusive, __is_unique_pattern_v,
@@ -2117,6 +2130,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
                                         __max_inputs_per_block,
                                         __max_num_sub_groups_local,
                                         __n,
+                                        __use_slm_for_comm,
                                         __gen_reduce_input,
                                         __reduce_op,
                                         __init};
@@ -2127,6 +2141,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
                                     __max_num_sub_groups_global,
                                     __num_blocks,
                                     __n,
+                                    __use_slm_for_comm,
                                     __reduce_op,
                                     __gen_scan_input,
                                     __scan_input_transform,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1527,35 +1527,6 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                                                     _GenReduceInput, _ReduceOp, _InitType,
                                                     __internal::__optional_kernel_name<_KernelName...>>
 {
-    // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
-    // input buffer
-    template <typename _InRng, typename _TmpStorageAcc>
-    sycl::event
-    operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
-               _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
-               const std::size_t __inputs_remaining, const std::size_t __block_num) const
-    {
-        using _InitValueType = typename _InitType::__value_type;
-        return __q.submit([&, this](sycl::handler& __cgh) {
-            __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
-            // SLM for sub-group communication (shift_group_right / group_broadcast).
-            // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_slm_for_comm ? __work_group_size : 0, __cgh);
-            __cgh.depends_on(__prior_event);
-            oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
-            auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
-                __cgh, __dpl_sycl::__no_init{});
-            __cgh.parallel_for<_KernelName...>(
-                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
-                    if (!__use_slm_for_comm)
-                        __reduce_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __in_rng,
-                                                   __inputs_remaining, __block_num);
-                    else
-                        __reduce_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __in_rng,
-                                                    __inputs_remaining, __block_num);
-                });
-        });
-    }
 
     template <bool __use_subgroup_ops, typename _TmpStorageAcc, typename _InRng>
     void
@@ -1666,6 +1637,35 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             __sub_group_carry.__destroy();
         }
     }
+    // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
+    // input buffer
+    template <typename _InRng, typename _TmpStorageAcc>
+    sycl::event
+    operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
+               _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
+               const std::size_t __inputs_remaining, const std::size_t __block_num) const
+    {
+        using _InitValueType = typename _InitType::__value_type;
+        return __q.submit([&, this](sycl::handler& __cgh) {
+            __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
+            // SLM for sub-group communication (shift_group_right / group_broadcast).
+            // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
+            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_slm_for_comm ? __work_group_size : 0, __cgh);
+            __cgh.depends_on(__prior_event);
+            oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
+            auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
+                __cgh, __dpl_sycl::__no_init{});
+            __cgh.parallel_for<_KernelName...>(
+                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
+                    if (!__use_slm_for_comm)
+                        __reduce_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __in_rng,
+                                                   __inputs_remaining, __block_num);
+                    else
+                        __reduce_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __in_rng,
+                                                    __inputs_remaining, __block_num);
+                });
+        });
+    }
 
     // Constant parameters throughout all blocks
     const std::uint32_t __max_num_work_groups;
@@ -1707,48 +1707,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                           const std::size_t __num_sub_groups_global) const
     {
         __tmp_ptr[__num_sub_groups_global + 1 - (__block_num % 2)] = __block_carry_out;
-    }
-
-    template <typename _InRng, typename _OutRng, typename _TmpStorageAcc>
-    sycl::event
-    operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
-               _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
-               const std::size_t __inputs_remaining, const std::size_t __block_num) const
-    {
-        std::size_t __num_remaining = __n - __block_num * __max_block_size;
-        // for unique patterns, the first element is always copied to the output, so we need to skip it
-        if constexpr (__is_unique_pattern_v)
-        {
-            assert(__num_remaining > 0);
-            __num_remaining -= 1;
-        }
-        std::uint32_t __inputs_in_block = std::min(__num_remaining, std::size_t{__max_block_size});
-        return __q.submit([&, this](sycl::handler& __cgh) {
-            // We need __num_sub_groups_local + 1 temporary SLM locations to store intermediate results:
-            //   __num_sub_groups_local for each sub-group partial from the reduce kernel +
-            //   1 element for the accumulated block-local carry-in from previous groups in the block
-            __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
-            // SLM for sub-group communication (shift_group_right / group_broadcast).
-            // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_slm_for_comm ? __work_group_size : 0, __cgh);
-            __cgh.depends_on(__prior_event);
-            oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
-            auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::read_write>(__cgh);
-            auto __res_acc =
-                __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
-
-            __cgh.parallel_for<_KernelName...>(
-                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
-                    if (!__use_slm_for_comm)
-                        __scan_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __res_acc,
-                                                 __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
-                                                 __block_num);
-                    else
-                        __scan_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __res_acc,
-                                                  __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
-                                                  __block_num);
-                });
-        });
     }
 
     template <bool __use_subgroup_ops, typename _TmpStorageAcc, typename _ResStorageAcc, typename _InRng, typename _OutRng>
@@ -2020,6 +1978,48 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             }
         }
         __sub_group_carry.__destroy();
+    }
+
+    template <typename _InRng, typename _OutRng, typename _TmpStorageAcc>
+    sycl::event
+    operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
+               _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
+               const std::size_t __inputs_remaining, const std::size_t __block_num) const
+    {
+        std::size_t __num_remaining = __n - __block_num * __max_block_size;
+        // for unique patterns, the first element is always copied to the output, so we need to skip it
+        if constexpr (__is_unique_pattern_v)
+        {
+            assert(__num_remaining > 0);
+            __num_remaining -= 1;
+        }
+        std::uint32_t __inputs_in_block = std::min(__num_remaining, std::size_t{__max_block_size});
+        return __q.submit([&, this](sycl::handler& __cgh) {
+            // We need __num_sub_groups_local + 1 temporary SLM locations to store intermediate results:
+            //   __num_sub_groups_local for each sub-group partial from the reduce kernel +
+            //   1 element for the accumulated block-local carry-in from previous groups in the block
+            __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
+            // SLM for sub-group communication (shift_group_right / group_broadcast).
+            // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
+            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_slm_for_comm ? __work_group_size : 0, __cgh);
+            __cgh.depends_on(__prior_event);
+            oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
+            auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::read_write>(__cgh);
+            auto __res_acc =
+                __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
+
+            __cgh.parallel_for<_KernelName...>(
+                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
+                    if (!__use_slm_for_comm)
+                        __scan_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __res_acc,
+                                                 __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
+                                                 __block_num);
+                    else
+                        __scan_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __res_acc,
+                                                  __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
+                                                  __block_num);
+                });
+        });
     }
 
     const std::uint32_t __max_num_work_groups;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2097,7 +2097,9 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     constexpr bool __inclusive = _Inclusive::value;
     constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 
-    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 1024);
+    // empirical derived caps for workgroup size based upon target
+    const std::uint32_t __wg_size_cap = __q.is_gpu() ? 1024 : 256;
+    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, __wg_size_cap);
     // Round down to nearest multiple of the max subgroup size to ensure compatibility with all sub-group sizes
     const std::uint32_t __work_group_size = (__max_work_group_size / __max_sub_group_size) * __max_sub_group_size;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1544,8 +1544,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            const std::size_t __comm_slm_size = __use_slm_for_comm ? __work_group_size : 0;
-            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__comm_slm_size, __cgh);
+            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_slm_for_comm ? __work_group_size : 0, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
@@ -1558,7 +1557,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
                 _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                _InitValueType* __comm_slm_ptr = __comm_slm_size > 0 ? &__comm_slm[0] : nullptr;
+                _InitValueType* __comm_slm_ptr = __use_slm_for_comm ? &__comm_slm[0] : nullptr;
                 std::size_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -1721,8 +1720,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            const std::size_t __comm_slm_size = __use_slm_for_comm ? __work_group_size : 0;
-            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__comm_slm_size, __cgh);
+            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_slm_for_comm ? __work_group_size : 0, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::read_write>(__cgh);
@@ -1732,7 +1730,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) {
                 __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
                 const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
-                _InitValueType* __comm_slm_ptr = __comm_slm_size > 0 ? &__comm_slm[0] : nullptr;
+                _InitValueType* __comm_slm_ptr = __use_slm_for_comm ? &__comm_slm[0] : nullptr;
 
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1204,8 +1204,8 @@ struct __scan_by_seg_op
 
 template <typename _ValueType>
 _ValueType
-__shift_group_right(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType __value,
-                    std::uint32_t __shift, _ValueType* __comm_slm)
+__shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
+                    _ValueType* __comm_slm)
 {
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
@@ -1215,7 +1215,7 @@ __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __s
     // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
     // preferred (e.g., CPU targets where sub-group ops are slow).
     std::uint32_t __local_id = __sub_group.get_local_linear_id();
-    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group_size;
+    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
     __comm_slm[__sg_base + __local_id] = __value;
     sycl::group_barrier(__sub_group);
     _ValueType __result = __comm_slm[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
@@ -1225,8 +1225,8 @@ __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __s
 
 template <typename _ValueType, typename _IdType>
 _ValueType
-__group_broadcast(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType __value,
-                  _IdType __broadcast_id, _ValueType* __comm_slm)
+__group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
+                  _ValueType* __comm_slm)
 {
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
@@ -1236,7 +1236,7 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub
     // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
     // preferred (e.g., CPU targets where sub-group ops are slow).
     std::uint32_t __local_id = __sub_group.get_local_linear_id();
-    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group_size;
+    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
     __comm_slm[__sg_base + __local_id] = __value;
     sycl::group_barrier(__sub_group);
     _ValueType __result = __comm_slm[__sg_base + __broadcast_id];
@@ -1247,15 +1247,16 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub
 template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
           typename _LazyValueType>
 void
-__exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
-                                  _MaskOp __mask_fn, _InitBroadcastId __init_broadcast_id, _ValueType& __value,
-                                  _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+__exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
+                                  _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
+                                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+    _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in =
-            __shift_group_right(__sub_group, __sub_group_size, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1267,16 +1268,14 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, st
         __value = __binary_op(__init_and_carry.__v, __value);
         if (__sub_group_local_id == 0)
             __old_init.__setup(__init_and_carry.__v);
-        __init_and_carry.__v =
-            __group_broadcast(__sub_group, __sub_group_size, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(
-            __group_broadcast(__sub_group, __sub_group_size, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
 
-    __value = __shift_group_right(__sub_group, __sub_group_size, __value, 1, __comm_slm);
+    __value = __shift_group_right(__sub_group, __value, 1, __comm_slm);
     if constexpr (__init_present)
     {
         if (__sub_group_local_id == 0)
@@ -1291,15 +1290,16 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, st
 template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
           typename _LazyValueType>
 void
-__inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
-                                  _MaskOp __mask_fn, _InitBroadcastId __init_broadcast_id, _ValueType& __value,
-                                  _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+__inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
+                                  _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
+                                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+    _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in =
-            __shift_group_right(__sub_group, __sub_group_size, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1308,13 +1308,11 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, st
     if constexpr (__init_present)
     {
         __value = __binary_op(__init_and_carry.__v, __value);
-        __init_and_carry.__v =
-            __group_broadcast(__sub_group, __sub_group_size, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(
-            __group_broadcast(__sub_group, __sub_group_size, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
     //return by reference __value and __init_and_carry
 }
@@ -1322,64 +1320,61 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, st
 template <bool __is_inclusive, bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp,
           typename _ValueType, typename _LazyValueType>
 void
-__sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _MaskOp __mask_fn,
+__sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                         _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
                         _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     if constexpr (__is_inclusive)
     {
-        __inclusive_sub_group_masked_scan<__init_present>(__sub_group, __sub_group_size, __mask_fn, __init_broadcast_id,
-                                                          __value, __binary_op, __init_and_carry, __comm_slm);
+        __inclusive_sub_group_masked_scan<__init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
+                                                          __binary_op, __init_and_carry, __comm_slm);
     }
     else
     {
-        __exclusive_sub_group_masked_scan<__init_present>(__sub_group, __sub_group_size, __mask_fn, __init_broadcast_id,
-                                                          __value, __binary_op, __init_and_carry, __comm_slm);
+        __exclusive_sub_group_masked_scan<__init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
+                                                          __binary_op, __init_and_carry, __comm_slm);
     }
 }
 
 template <bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
 void
-__sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType& __value,
-                 _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+__sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
+                 _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
-    std::uint8_t __init_broadcast_id = __sub_group_size - 1;
-    __sub_group_masked_scan<__is_inclusive, __init_present>(__sub_group, __sub_group_size, __mask_fn,
-                                                            __init_broadcast_id, __value, __binary_op, __init_and_carry,
-                                                            __comm_slm);
+    std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
+    __sub_group_masked_scan<__is_inclusive, __init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
+                                                            __binary_op, __init_and_carry, __comm_slm);
 }
 
 template <bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
           typename _SizeType>
 void
-__sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType& __value,
-                         _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _SizeType __elements_to_process,
-                         _ValueType* __comm_slm)
+__sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
+                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ValueType* __comm_slm)
 {
     auto __mask_fn = [__elements_to_process](auto __sub_group_local_id, auto __offset) {
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    __sub_group_masked_scan<__is_inclusive, __init_present>(__sub_group, __sub_group_size, __mask_fn,
-                                                            __init_broadcast_id, __value, __binary_op, __init_and_carry,
-                                                            __comm_slm);
+    __sub_group_masked_scan<__is_inclusive, __init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
+                                                            __binary_op, __init_and_carry, __comm_slm);
 }
 
 template <bool __is_inclusive, bool __init_present, bool __capture_output, std::uint16_t __max_inputs_per_item,
           typename _GenInput, typename _ScanInputTransform, typename _BinaryOp, typename _WriteOp,
           typename _LazyValueType, typename _InRng, typename _OutRng, typename _ScanValueType>
 void
-__scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
-                               _GenInput __gen_input, _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op,
-                               _WriteOp __write_op, _LazyValueType& __sub_group_carry, const _InRng& __in_rng,
-                               _OutRng& __out_rng, std::size_t __start_id, std::size_t __n,
-                               std::uint32_t __iters_per_item, std::size_t __subgroup_start_id,
-                               std::uint32_t __sub_group_id, std::uint32_t __active_subgroups,
-                               _ScanValueType* __comm_slm)
+__scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
+                               _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
+                               _LazyValueType& __sub_group_carry, const _InRng& __in_rng, _OutRng& __out_rng,
+                               std::size_t __start_id, std::size_t __n, std::uint32_t __iters_per_item,
+                               std::size_t __subgroup_start_id, std::uint32_t __sub_group_id,
+                               std::uint32_t __active_subgroups, _ScanValueType* __comm_slm)
 {
     using _GenInputType = std::invoke_result_t<_GenInput, _InRng, std::size_t, typename _GenInput::TempData&>;
 
+    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
     bool __is_full_block = (__iters_per_item == __max_inputs_per_item);
     bool __is_full_thread = __subgroup_start_id + __iters_per_item * __sub_group_size <= __n;
     using _TempData = typename _GenInput::TempData;
@@ -1388,8 +1383,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__is_inclusive, __init_present>(__sub_group, __sub_group_size, __scan_input_transform(__v),
-                                                         __binary_op, __sub_group_carry, __comm_slm);
+        __sub_group_scan<__is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
+                                                         __sub_group_carry, __comm_slm);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1402,9 +1397,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
             for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __sub_group_size,
-                                                                          __scan_input_transform(__v), __binary_op,
-                                                                          __sub_group_carry, __comm_slm);
+                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __scan_input_transform(__v),
+                                                                          __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1418,9 +1412,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
             for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __sub_group_size,
-                                                                          __scan_input_transform(__v), __binary_op,
-                                                                          __sub_group_carry, __comm_slm);
+                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __scan_input_transform(__v),
+                                                                          __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1440,9 +1433,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
             {
                 std::size_t __local_id = (__start_id < __n) ? __start_id : __n - 1;
                 _GenInputType __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__is_inclusive, __init_present>(
-                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry,
-                    __n - __subgroup_start_id, __comm_slm);
+                __sub_group_scan_partial<__is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v),
+                                                                         __binary_op, __sub_group_carry,
+                                                                         __n - __subgroup_start_id, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     if (__start_id < __n)
@@ -1452,8 +1445,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
             else
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-                __sub_group_scan<__is_inclusive, __init_present>(__sub_group, __sub_group_size,
-                                                                 __scan_input_transform(__v), __binary_op,
+                __sub_group_scan<__is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
                                                                  __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1464,9 +1456,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
                 {
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
-                    __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __sub_group_size,
-                                                                              __scan_input_transform(__v), __binary_op,
-                                                                              __sub_group_carry, __comm_slm);
+                    __sub_group_scan<__is_inclusive, /*__init_present=*/true>(
+                        __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                     if constexpr (__capture_output)
                     {
                         __write_op(__out_rng, __local_id, __v, __temp_data);
@@ -1477,7 +1468,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
                 std::size_t __local_id = (__offset < __n) ? __offset : __n - 1;
                 __v = __gen_input(__in_rng, __local_id, __temp_data);
                 __sub_group_scan_partial<__is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry,
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
                     __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1588,8 +1579,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                     __scan_through_elements_helper<__is_inclusive,
                                                    /*__init_present=*/false,
                                                    /*__capture_output=*/false, __max_inputs_per_item>(
-                        __sub_group, __sub_group_size, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op,
-                        nullptr, __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
+                        __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
+                        __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
                         __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
                         __comm_slm_ptr);
                     if (__sub_group_local_id == 0)
@@ -1613,8 +1604,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial</*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry, __active_subgroups,
-                            __comm_slm_ptr);
+                            __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
                         if (__sub_group_local_id < __active_subgroups)
                             __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
@@ -1624,7 +1614,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // need to pull out first iteration tp avoid identity
                         _InitValueType __v = __sub_group_partials[__reduction_scan_id];
                         __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                            __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
                         __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         __reduction_scan_id += __sub_group_size;
 
@@ -1632,7 +1622,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         {
                             __v = __sub_group_partials[__reduction_scan_id];
                             __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/true>(
-                                __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
                         }
@@ -1645,7 +1635,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
 
                         __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial</*__is_inclusive=*/true, /*__init_present=*/true>(
-                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry,
+                            __sub_group, __v, __reduce_op, __sub_group_carry,
                             __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
                         if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
@@ -1821,9 +1811,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                                              : __subgroups_before_my_group - 1;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
                             __sub_group_scan_partial</*__is_inclusive=*/true,
-                                                     /*__init_present=*/false>(__sub_group, __sub_group_size, __value,
-                                                                               __reduce_op, __carry_last,
-                                                                               __remaining_elements, __comm_slm_ptr);
+                                                     /*__init_present=*/false>(
+                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
                         }
                         else
                         {
@@ -1835,14 +1824,14 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                 __sub_group_params.__num_sub_groups_local * __sub_group_size;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
                             __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/false>(
-                                __sub_group, __sub_group_size, __value, __reduce_op, __carry_last, __comm_slm_ptr);
+                                __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
                             __reduction_id += __reduction_id_increment;
                             // then some number of full iterations
                             for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                             {
                                 __value = __tmp_ptr[__reduction_id];
                                 __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __sub_group_size, __value, __reduce_op, __carry_last, __comm_slm_ptr);
+                                    __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
                                 __reduction_id += __reduction_id_increment;
                             }
 
@@ -1855,9 +1844,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                 std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
                             __value = __tmp_ptr[__final_reduction_id];
                             __sub_group_scan_partial</*__is_inclusive=*/true,
-                                                     /*__init_present=*/true>(__sub_group, __sub_group_size, __value,
-                                                                              __reduce_op, __carry_last,
-                                                                              __remaining_elements, __comm_slm_ptr);
+                                                     /*__init_present=*/true>(
+                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
                         }
 
                         // steps 3+4) load global carry in from neighbor work-group
@@ -1962,20 +1950,18 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     __scan_through_elements_helper<__is_inclusive,
                                                    /*__init_present=*/true,
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
-                        __sub_group, __sub_group_size, __gen_scan_input, __scan_input_transform, __reduce_op,
-                        __write_op, __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
-                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
-                        __comm_slm_ptr);
+                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
+                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr);
                 }
                 else // first group first block, no subgroup carry
                 {
                     __scan_through_elements_helper<__is_inclusive,
                                                    /*__init_present=*/false,
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
-                        __sub_group, __sub_group_size, __gen_scan_input, __scan_input_transform, __reduce_op,
-                        __write_op, __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
-                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
-                        __comm_slm_ptr);
+                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
+                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr);
                 }
                 // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
                 // to write out the last carry out for either the return value or the next block

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1561,7 +1561,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         using _InitValueType = typename _InitType::__value_type;
-        return __q.submit([&, this](sycl::handler& __cgh) {
+        return __q.submit([&, this](sycl::handler& __cgh) [[ _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32) ]] {
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
@@ -1733,7 +1733,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             __num_remaining -= 1;
         }
         std::uint32_t __inputs_in_block = std::min(__num_remaining, std::size_t{__max_block_size});
-        return __q.submit([&, this](sycl::handler& __cgh) {
+        return __q.submit([&, this](sycl::handler& __cgh) [[ _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32) ]] {
             // We need __num_sub_groups_local + 1 temporary SLM locations to store intermediate results:
             //   __num_sub_groups_local for each sub-group partial from the reduce kernel +
             //   1 element for the accumulated block-local carry-in from previous groups in the block

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1587,111 +1587,6 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
     using _InitValueType = typename _InitType::__value_type;
     static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
 
-    template <typename _TmpAcc, typename _InRng>
-    void
-    __reduce_kernel_body(sycl::nd_item<1> __ndi, __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
-                         __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpAcc __tmp_acc, _InRng __in_rng,
-                         const std::size_t __inputs_remaining, const std::size_t __block_num) const
-    {
-        __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-
-        __reduce_then_scan_sub_group_params __sub_group_params(
-            __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
-
-        _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
-        std::size_t __group_id = __ndi.get_group(0);
-        std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-        std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-
-        oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-        std::size_t __group_start_id =
-            (__block_num * __max_block_size) +
-            (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
-        if constexpr (__is_unique_pattern_v)
-        {
-            // for unique patterns, the first element is always copied to the output, so we need to skip it
-            __group_start_id += 1;
-        }
-        std::size_t __max_inputs_in_group =
-            __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-        std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-        std::uint32_t __active_subgroups =
-            oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-        std::size_t __subgroup_start_id =
-            __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
-
-        std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
-
-        if (__sub_group_id < __active_subgroups)
-        {
-            // adjust for lane-id
-            // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-            __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                           /*__init_present=*/false,
-                                           /*__capture_output=*/false, __max_inputs_per_item>(
-                __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr, __sub_group_carry,
-                __in_rng, /*unused*/ __in_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
-            if (__sub_group_local_id == 0)
-                __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
-            __sub_group_carry.__destroy();
-        }
-        __dpl_sycl::__group_barrier(__ndi);
-
-        // compute sub-group local prefix sums on (T0..63) carries
-        // and store to scratch space at the end of dst; next
-        // accumulator kernel takes M thread carries from scratch
-        // to compute a prefix sum on global carries
-        if (__sub_group_id == 0)
-        {
-            __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
-            std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-            if (__iters == 1)
-            {
-                // fill with unused dummy values to avoid overrunning input
-                std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
-                _InitValueType __v = __sub_group_partials[__load_id];
-                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>
-                                                     (__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                      __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
-                if (__sub_group_local_id < __active_subgroups)
-                    __tmp_acc[__start_id + __sub_group_local_id] = __v;
-            }
-            else
-            {
-                std::uint32_t __reduction_scan_id = __sub_group_local_id;
-                // need to pull out first iteration tp avoid identity
-                _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
-                __tmp_acc[__start_id + __reduction_scan_id] = __v;
-                __reduction_scan_id += __sub_group_size;
-
-                for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
-                {
-                    __v = __sub_group_partials[__reduction_scan_id];
-                    __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                        __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
-                    __tmp_acc[__start_id + __reduction_scan_id] = __v;
-                    __reduction_scan_id += __sub_group_size;
-                }
-                // If we are past the input range, then the previous value of v is passed to the sub-group scan.
-                // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
-
-                // fill with unused dummy values to avoid overrunning input
-                std::uint32_t __load_id = std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
-
-                __v = __sub_group_partials[__load_id];
-                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                    __sub_group, __v, __reduce_op, __sub_group_carry,
-                    __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr, __use_subgroup_ops);
-                if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
-                    __tmp_acc[__start_id + __reduction_scan_id] = __v;
-            }
-
-            __sub_group_carry.__destroy();
-        }
-    }
     // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
     // input buffer
     template <typename _InRng, typename _TmpStorageAcc>
@@ -1712,8 +1607,106 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             __cgh.parallel_for<_KernelName...>(
                 __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                     _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                    __reduce_kernel_body(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __in_rng,
-                                         __inputs_remaining, __block_num);
+
+                    __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+
+                    __reduce_then_scan_sub_group_params __sub_group_params(
+                        __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
+
+                    _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
+                    std::size_t __group_id = __ndi.get_group(0);
+                    std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+                    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+
+                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+                    std::size_t __group_start_id =
+                        (__block_num * __max_block_size) +
+                        (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+                    if constexpr (__is_unique_pattern_v)
+                    {
+                        // for unique patterns, the first element is always copied to the output, so we need to skip it
+                        __group_start_id += 1;
+                    }
+                    std::size_t __max_inputs_in_group =
+                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+                    std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                    std::uint32_t __active_subgroups =
+                        oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+                    std::size_t __subgroup_start_id =
+                        __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
+
+                    std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+
+                    if (__sub_group_id < __active_subgroups)
+                    {
+                        // adjust for lane-id
+                        // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
+                        __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                                                    /*__init_present=*/false,
+                                                    /*__capture_output=*/false, __max_inputs_per_item>(
+                            __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr, __sub_group_carry,
+                            __in_rng, /*unused*/ __in_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
+                            __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                        if (__sub_group_local_id == 0)
+                            __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
+                        __sub_group_carry.__destroy();
+                    }
+                    __dpl_sycl::__group_barrier(__ndi);
+
+                    // compute sub-group local prefix sums on (T0..63) carries
+                    // and store to scratch space at the end of dst; next
+                    // accumulator kernel takes M thread carries from scratch
+                    // to compute a prefix sum on global carries
+                    if (__sub_group_id == 0)
+                    {
+                        __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
+                        std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                        if (__iters == 1)
+                        {
+                            // fill with unused dummy values to avoid overrunning input
+                            std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
+                            _InitValueType __v = __sub_group_partials[__load_id];
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>
+                                                                (__sub_group, __v, __reduce_op, __sub_group_carry,
+                                                                __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                            if (__sub_group_local_id < __active_subgroups)
+                                __tmp_acc[__start_id + __sub_group_local_id] = __v;
+                        }
+                        else
+                        {
+                            std::uint32_t __reduction_scan_id = __sub_group_local_id;
+                            // need to pull out first iteration tp avoid identity
+                            _InitValueType __v = __sub_group_partials[__reduction_scan_id];
+                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
+                            __tmp_acc[__start_id + __reduction_scan_id] = __v;
+                            __reduction_scan_id += __sub_group_size;
+
+                            for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
+                            {
+                                __v = __sub_group_partials[__reduction_scan_id];
+                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
+                                __tmp_acc[__start_id + __reduction_scan_id] = __v;
+                                __reduction_scan_id += __sub_group_size;
+                            }
+                            // If we are past the input range, then the previous value of v is passed to the sub-group scan.
+                            // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
+
+                            // fill with unused dummy values to avoid overrunning input
+                            std::uint32_t __load_id = std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
+
+                            __v = __sub_group_partials[__load_id];
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                                __sub_group, __v, __reduce_op, __sub_group_carry,
+                                __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr, __use_subgroup_ops);
+                            if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
+                                __tmp_acc[__start_id + __reduction_scan_id] = __v;
+                        }
+
+                        __sub_group_carry.__destroy();
+                    }
+
                 });
         });
     }
@@ -1762,273 +1755,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
         __tmp_acc[__num_sub_groups_global + 1 - (__block_num % 2)] = __block_carry_out;
     }
 
-    template <typename _TmpAcc, typename _ResAcc, typename _InRng, typename _OutRng>
-    void
-    __scan_kernel_body(sycl::nd_item<1> __ndi, __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
-                       __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpAcc __tmp_acc, _ResAcc __res_acc,
-                       _InRng __in_rng, _OutRng __out_rng, std::uint32_t __inputs_in_block,
-                       const std::size_t __inputs_remaining, const std::size_t __block_num) const
-    {
-        __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-        _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
-
-        __reduce_then_scan_sub_group_params __sub_group_params(
-            __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
-
-        const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
-            __inputs_in_block, __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
-
-        std::uint32_t __group_id = __ndi.get_group(0);
-        std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-        std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-
-        std::size_t __group_start_id =
-            (__block_num * __max_block_size) +
-            (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
-        if constexpr (__is_unique_pattern_v)
-        {
-            // for unique patterns, the first element is always copied to the output, so we need to skip it
-            __group_start_id += 1;
-        }
-
-        std::size_t __max_inputs_in_group =
-            __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-        std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-        std::uint32_t __active_subgroups =
-            oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-        oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
-
-        // propagate carry in from previous block
-        oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-
-        // on the first sub-group in a work-group (assuming S subgroups in a work-group):
-        // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
-        // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
-        //    and then compute the prefix sum to generate global carry out
-        //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
-        // 3. on each WG select the adjacent neighboring WG carry in
-        // 4. on each WG add the global carry-in to S sub-group local prefix sums to
-        //    get a T-local global carry in
-        // 5. recompute T-local prefix values, add the T-local global carries,
-        //    and then write back the final values to memory
-        if (__sub_group_id == 0)
-        {
-            // step 1) load to SLM the WG-local S prefix sums
-            //         on WG T-local carries
-            //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
-            //           S: sum(T0 carry...TS carry)
-            std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-            std::size_t __subgroups_before_my_group = __group_id * __sub_group_params.__num_sub_groups_local;
-            std::uint32_t __load_reduction_id = __sub_group_local_id;
-            std::uint8_t __i = 0;
-            for (; __i < __iters - 1; __i++)
-            {
-                __sub_group_partials[__load_reduction_id] =
-                    __tmp_acc[__subgroups_before_my_group + __load_reduction_id];
-                __load_reduction_id += __sub_group_size;
-            }
-            if (__load_reduction_id < __active_subgroups)
-            {
-                __sub_group_partials[__load_reduction_id] =
-                    __tmp_acc[__subgroups_before_my_group + __load_reduction_id];
-            }
-
-            // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
-            //         compute the prefix in a sub-group to get global work-group carries
-            //         memory accesses: gather(63, 127, 191, 255, ...)
-            std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
-            // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
-            if (__group_id > 0)
-            {
-                // only need the last element from each scan of num_sub_groups_local subgroup reductions
-                const std::size_t __elements_to_process =
-                    __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
-                const std::size_t __pre_carry_iters =
-                    oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
-                if (__pre_carry_iters == 1)
-                {
-                    // single partial scan
-                    std::size_t __proposed_id =
-                        __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
-                    std::size_t __remaining_elements = __elements_to_process;
-                    std::size_t __reduction_id =
-                        (__proposed_id < __subgroups_before_my_group) ? __proposed_id : __subgroups_before_my_group - 1;
-                    _InitValueType __value = __tmp_acc[__reduction_id];
-                    __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                        __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
-                        __use_subgroup_ops);
-                }
-                else
-                {
-                    // multiple iterations
-                    // first 1 full
-                    std::uint32_t __reduction_id =
-                        __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
-                    std::uint32_t __reduction_id_increment =
-                        __sub_group_params.__num_sub_groups_local * __sub_group_size;
-                    _InitValueType __value = __tmp_acc[__reduction_id];
-                    __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                        __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
-                    __reduction_id += __reduction_id_increment;
-                    // then some number of full iterations
-                    for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
-                    {
-                        __value = __tmp_acc[__reduction_id];
-                        __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                            __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
-                        __reduction_id += __reduction_id_increment;
-                    }
-
-                    // final partial iteration
-
-                    std::size_t __remaining_elements =
-                        __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
-                    // fill with unused dummy values to avoid overrunning input
-                    std::size_t __final_reduction_id =
-                        std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
-                    __value = __tmp_acc[__final_reduction_id];
-                    __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                        __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
-                        __use_subgroup_ops);
-                }
-
-                // steps 3+4) load global carry in from neighbor work-group
-                //            and apply to local sub-group prefix carries
-                std::size_t __carry_offset = __sub_group_local_id;
-
-                std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-
-                std::uint8_t __i = 0;
-                for (; __i < __iters - 1; ++__i)
-                {
-                    __sub_group_partials[__carry_offset] =
-                        __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                    __carry_offset += __sub_group_size;
-                }
-                if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
-                {
-                    __sub_group_partials[__carry_offset] =
-                        __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                    __carry_offset += __sub_group_size;
-                }
-                if (__sub_group_local_id == 0)
-                    __sub_group_partials[__active_subgroups] = __carry_last.__v;
-                __carry_last.__destroy();
-            }
-        }
-
-        __dpl_sycl::__group_barrier(__ndi);
-
-        // Get inter-work group and adjusted for intra-work group prefix
-        bool __sub_group_carry_initialized = true;
-        if (__block_num == 0)
-        {
-            if (__sub_group_id > 0)
-            {
-                _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
-                __sub_group_carry.__setup(__value);
-            }
-            else if (__group_id > 0)
-            {
-                _InitValueType __value = __sub_group_partials[__active_subgroups];
-                oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
-                __sub_group_carry.__setup(__value);
-            }
-            else // zeroth block, group and subgroup
-            {
-                if constexpr (__is_unique_pattern_v)
-                {
-                    if (__sub_group_local_id == 0)
-                    {
-                        // For unique patterns, always copy the 0th element to the output
-                        __write_op.__assign(__in_rng[0], __out_rng[0]);
-                    }
-                }
-
-                if constexpr (std::is_same_v<_InitType, oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
-                {
-                    // This is the only case where we still don't have a carry in.  No init value, 0th block,
-                    // group, and subgroup. This changes the final scan through elements below.
-                    __sub_group_carry_initialized = false;
-                }
-                else
-                {
-                    __sub_group_carry.__setup(__init.__value);
-                }
-            }
-        }
-        else
-        {
-            if (__sub_group_id > 0)
-            {
-                _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                __sub_group_carry.__setup(__reduce_op(
-                    __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global), __value));
-            }
-            else if (__group_id > 0)
-            {
-                __sub_group_carry.__setup(__reduce_op(
-                    __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global),
-                    __sub_group_partials[__active_subgroups]));
-            }
-            else
-            {
-                __sub_group_carry.__setup(
-                    __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global));
-            }
-        }
-
-        // step 5) apply global carries
-        std::size_t __subgroup_start_id =
-            __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
-        std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
-
-        if (__sub_group_carry_initialized)
-        {
-            __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                           /*__init_present=*/true,
-                                           /*__capture_output=*/true, __max_inputs_per_item>(
-                __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
-                __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
-                __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
-        }
-        else // first group first block, no subgroup carry
-        {
-            __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                           /*__init_present=*/false,
-                                           /*__capture_output=*/true, __max_inputs_per_item>(
-                __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
-                __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
-                __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
-        }
-        // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
-        // to write out the last carry out for either the return value or the next block
-        if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
-            (__active_subgroups == __sub_group_id + 1))
-        {
-            if (__block_num + 1 == __num_blocks)
-            {
-                if constexpr (__is_unique_pattern_v)
-                {
-                    // unique patterns automatically copy the 0th element and scan starting at index 1
-                    __res_acc[0] = __sub_group_carry.__v + 1;
-                }
-                else
-                {
-                    __res_acc[0] = __sub_group_carry.__v;
-                }
-            }
-            else
-            {
-                // capture the last carry out for the next block
-                __set_block_carry_out(__block_num, __tmp_acc, __sub_group_carry.__v,
-                                      __sub_group_params.__num_sub_groups_global);
-            }
-        }
-        __sub_group_carry.__destroy();
-    }
-
     template <typename _InRng, typename _OutRng, typename _TmpStorageAcc>
     sycl::event
     operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
@@ -2063,8 +1789,264 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     _InitValueType* __res_ptr =
                         _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
 
-                    __scan_kernel_body(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __res_ptr, __in_rng,
-                                       __out_rng, __inputs_in_block, __inputs_remaining, __block_num);
+                    __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                    _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
+
+                    __reduce_then_scan_sub_group_params __sub_group_params(
+                        __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
+
+                    const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                        __inputs_in_block, __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+
+                    std::uint32_t __group_id = __ndi.get_group(0);
+                    std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+                    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+
+                    std::size_t __group_start_id =
+                        (__block_num * __max_block_size) +
+                        (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+                    if constexpr (__is_unique_pattern_v)
+                    {
+                        // for unique patterns, the first element is always copied to the output, so we need to skip it
+                        __group_start_id += 1;
+                    }
+
+                    std::size_t __max_inputs_in_group =
+                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+                    std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                    std::uint32_t __active_subgroups =
+                        oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
+
+                    // propagate carry in from previous block
+                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+
+                    // on the first sub-group in a work-group (assuming S subgroups in a work-group):
+                    // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
+                    // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
+                    //    and then compute the prefix sum to generate global carry out
+                    //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
+                    // 3. on each WG select the adjacent neighboring WG carry in
+                    // 4. on each WG add the global carry-in to S sub-group local prefix sums to
+                    //    get a T-local global carry in
+                    // 5. recompute T-local prefix values, add the T-local global carries,
+                    //    and then write back the final values to memory
+                    if (__sub_group_id == 0)
+                    {
+                        // step 1) load to SLM the WG-local S prefix sums
+                        //         on WG T-local carries
+                        //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
+                        //           S: sum(T0 carry...TS carry)
+                        std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                        std::size_t __subgroups_before_my_group = __group_id * __sub_group_params.__num_sub_groups_local;
+                        std::uint32_t __load_reduction_id = __sub_group_local_id;
+                        std::uint8_t __i = 0;
+                        for (; __i < __iters - 1; __i++)
+                        {
+                            __sub_group_partials[__load_reduction_id] =
+                                __tmp_acc[__subgroups_before_my_group + __load_reduction_id];
+                            __load_reduction_id += __sub_group_size;
+                        }
+                        if (__load_reduction_id < __active_subgroups)
+                        {
+                            __sub_group_partials[__load_reduction_id] =
+                                __tmp_acc[__subgroups_before_my_group + __load_reduction_id];
+                        }
+
+                        // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
+                        //         compute the prefix in a sub-group to get global work-group carries
+                        //         memory accesses: gather(63, 127, 191, 255, ...)
+                        std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
+                        // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
+                        if (__group_id > 0)
+                        {
+                            // only need the last element from each scan of num_sub_groups_local subgroup reductions
+                            const std::size_t __elements_to_process =
+                                __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
+                            const std::size_t __pre_carry_iters =
+                                oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
+                            if (__pre_carry_iters == 1)
+                            {
+                                // single partial scan
+                                std::size_t __proposed_id =
+                                    __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
+                                std::size_t __remaining_elements = __elements_to_process;
+                                std::size_t __reduction_id =
+                                    (__proposed_id < __subgroups_before_my_group) ? __proposed_id : __subgroups_before_my_group - 1;
+                                _InitValueType __value = __tmp_acc[__reduction_id];
+                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                                    __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
+                                    __use_subgroup_ops);
+                            }
+                            else
+                            {
+                                // multiple iterations
+                                // first 1 full
+                                std::uint32_t __reduction_id =
+                                    __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
+                                std::uint32_t __reduction_id_increment =
+                                    __sub_group_params.__num_sub_groups_local * __sub_group_size;
+                                _InitValueType __value = __tmp_acc[__reduction_id];
+                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                                    __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
+                                __reduction_id += __reduction_id_increment;
+                                // then some number of full iterations
+                                for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
+                                {
+                                    __value = __tmp_acc[__reduction_id];
+                                    __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                                        __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
+                                    __reduction_id += __reduction_id_increment;
+                                }
+
+                                // final partial iteration
+
+                                std::size_t __remaining_elements =
+                                    __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
+                                // fill with unused dummy values to avoid overrunning input
+                                std::size_t __final_reduction_id =
+                                    std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
+                                __value = __tmp_acc[__final_reduction_id];
+                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                                    __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
+                                    __use_subgroup_ops);
+                            }
+
+                            // steps 3+4) load global carry in from neighbor work-group
+                            //            and apply to local sub-group prefix carries
+                            std::size_t __carry_offset = __sub_group_local_id;
+
+                            std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+
+                            std::uint8_t __i = 0;
+                            for (; __i < __iters - 1; ++__i)
+                            {
+                                __sub_group_partials[__carry_offset] =
+                                    __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                                __carry_offset += __sub_group_size;
+                            }
+                            if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
+                            {
+                                __sub_group_partials[__carry_offset] =
+                                    __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                                __carry_offset += __sub_group_size;
+                            }
+                            if (__sub_group_local_id == 0)
+                                __sub_group_partials[__active_subgroups] = __carry_last.__v;
+                            __carry_last.__destroy();
+                        }
+                    }
+
+                    __dpl_sycl::__group_barrier(__ndi);
+
+                    // Get inter-work group and adjusted for intra-work group prefix
+                    bool __sub_group_carry_initialized = true;
+                    if (__block_num == 0)
+                    {
+                        if (__sub_group_id > 0)
+                        {
+                            _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                            oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
+                            __sub_group_carry.__setup(__value);
+                        }
+                        else if (__group_id > 0)
+                        {
+                            _InitValueType __value = __sub_group_partials[__active_subgroups];
+                            oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
+                            __sub_group_carry.__setup(__value);
+                        }
+                        else // zeroth block, group and subgroup
+                        {
+                            if constexpr (__is_unique_pattern_v)
+                            {
+                                if (__sub_group_local_id == 0)
+                                {
+                                    // For unique patterns, always copy the 0th element to the output
+                                    __write_op.__assign(__in_rng[0], __out_rng[0]);
+                                }
+                            }
+
+                            if constexpr (std::is_same_v<_InitType, oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
+                            {
+                                // This is the only case where we still don't have a carry in.  No init value, 0th block,
+                                // group, and subgroup. This changes the final scan through elements below.
+                                __sub_group_carry_initialized = false;
+                            }
+                            else
+                            {
+                                __sub_group_carry.__setup(__init.__value);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (__sub_group_id > 0)
+                        {
+                            _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                            __sub_group_carry.__setup(__reduce_op(
+                                __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global), __value));
+                        }
+                        else if (__group_id > 0)
+                        {
+                            __sub_group_carry.__setup(__reduce_op(
+                                __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global),
+                                __sub_group_partials[__active_subgroups]));
+                        }
+                        else
+                        {
+                            __sub_group_carry.__setup(
+                                __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global));
+                        }
+                    }
+
+                    // step 5) apply global carries
+                    std::size_t __subgroup_start_id =
+                        __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
+                    std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+
+                    if (__sub_group_carry_initialized)
+                    {
+                        __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                                                    /*__init_present=*/true,
+                                                    /*__capture_output=*/true, __max_inputs_per_item>(
+                            __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
+                            __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
+                            __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                    }
+                    else // first group first block, no subgroup carry
+                    {
+                        __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                                                    /*__init_present=*/false,
+                                                    /*__capture_output=*/true, __max_inputs_per_item>(
+                            __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
+                            __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
+                            __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                    }
+                    // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
+                    // to write out the last carry out for either the return value or the next block
+                    if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
+                        (__active_subgroups == __sub_group_id + 1))
+                    {
+                        if (__block_num + 1 == __num_blocks)
+                        {
+                            if constexpr (__is_unique_pattern_v)
+                            {
+                                // unique patterns automatically copy the 0th element and scan starting at index 1
+                                __res_ptr[0] = __sub_group_carry.__v + 1;
+                            }
+                            else
+                            {
+                                __res_ptr[0] = __sub_group_carry.__v;
+                            }
+                        }
+                        else
+                        {
+                            // capture the last carry out for the next block
+                            __set_block_carry_out(__block_num, __tmp_acc, __sub_group_carry.__v,
+                                                __sub_group_params.__num_sub_groups_global);
+                        }
+                    }
+                    __sub_group_carry.__destroy();
                 });
         });
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2097,18 +2097,12 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     constexpr bool __inclusive = _Inclusive::value;
     constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 
-    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 1024);
+    const bool __is_gpu = __q.get_device().is_gpu();
+
+    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 8192);
     // Round down to nearest multiple of the max subgroup size to ensure compatibility with all sub-group sizes
     const std::uint32_t __work_group_size = (__max_work_group_size / __max_sub_group_size) * __max_sub_group_size;
 
-    // TODO: Investigate potentially basing this on some scale of the number of compute units. 128 work-groups has been
-    // found to be reasonable number for most devices.
-    constexpr std::uint32_t __num_work_groups = 128;
-    // Allocate sufficient temporary storage for the worst case (smallest sub-group size = most sub-groups).
-    const std::uint32_t __max_num_sub_groups_local = __work_group_size / __min_sub_group_size;
-    const std::uint32_t __max_num_sub_groups_global = __max_num_sub_groups_local * __num_work_groups;
-    const std::uint32_t __max_inputs_per_work_group = __work_group_size * __max_inputs_per_item;
-    const std::uint32_t __max_inputs_per_block = __max_inputs_per_work_group * __num_work_groups;
     std::size_t __inputs_remaining = __n;
     if constexpr (__is_unique_pattern_v)
     {
@@ -2118,6 +2112,21 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     // reduce_then_scan kernel is not built to handle "empty" scans which includes `__n == 1` for unique patterns.
     // These trivial end cases should be handled at a higher level.
     assert(__inputs_remaining > 0);
+
+    // GPU: 128 work-groups is empirically a good balance.
+    // CPU: use enough work-groups to cover the entire input in a single block, avoiding extra
+    //      kernel-launch overhead.  Each block requires 2 kernel launches (reduce + scan), so
+    //      minimizing blocks is critical for CPU where launch overhead dominates.
+    const std::uint32_t __max_inputs_per_work_group = __work_group_size * __max_inputs_per_item;
+    const std::uint32_t __num_work_groups =
+        __is_gpu ? 128
+                 : std::max(std::uint32_t{1}, static_cast<std::uint32_t>(oneapi::dpl::__internal::__dpl_ceiling_div(
+                                                  __inputs_remaining, std::size_t{__max_inputs_per_work_group})));
+
+    // Allocate sufficient temporary storage for the worst case (smallest sub-group size = most sub-groups).
+    const std::uint32_t __max_num_sub_groups_local = __work_group_size / __min_sub_group_size;
+    const std::uint32_t __max_num_sub_groups_global = __max_num_sub_groups_local * __num_work_groups;
+    const std::uint32_t __max_inputs_per_block = __max_inputs_per_work_group * __num_work_groups;
     std::uint32_t __inputs_per_item =
         __inputs_remaining >= __max_inputs_per_block
             ? __max_inputs_per_item
@@ -2133,7 +2142,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
 
     // Use SLM-based sub-group communication for non-trivially-copyable types or CPU targets
     // (where native sub-group operations are slow).
-    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType> || !__q.get_device().is_gpu();
+    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType> || !__is_gpu;
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =
@@ -2166,8 +2175,8 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
                                     __write_op,
                                     __init};
 
-    // Data is processed in 2-kernel blocks to allow contiguous input segment to persist in LLC between the first and second kernel for accelerators
-    // with sufficiently large L2 / L3 caches.
+    // Data is processed in 2-kernel blocks to allow contiguous input segment to persist in LLC between the first and
+    // second kernel for accelerators with sufficiently large L2 / L3 caches.
     for (std::size_t __b = 0; __b < __num_blocks; ++__b)
     {
         std::uint32_t __workitems_in_block = oneapi::dpl::__internal::__dpl_ceiling_div(
@@ -2177,7 +2186,8 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
         auto __global_range = sycl::range<1>(__workitems_in_block_round_up_workgroup);
         auto __local_range = sycl::range<1>(__work_group_size);
         auto __kernel_nd_range = sycl::nd_range<1>(__global_range, __local_range);
-        // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
+        // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to
+        //    global memory.
         __prior_event = __reduce_submitter(__q, __kernel_nd_range, __in_rng, __result_and_scratch, __prior_event,
                                            __inputs_remaining, __b);
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1244,13 +1244,15 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value
     return __result;
 }
 
-// Compile-time-constant scan loop enabling unrolling. Called from the fast-path dispatch below.
-template <std::uint8_t __sub_group_size, typename _MaskOp, typename _BinaryOp, typename _ValueType>
+template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
+          typename _LazyValueType>
 void
-__sub_group_scan_unrolled_loop(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn, _ValueType& __value,
-                               _BinaryOp __binary_op, _ValueType* __comm_slm)
+__exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
+                                  _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
+                                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
-    const std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
@@ -1260,47 +1262,6 @@ __sub_group_scan_unrolled_loop(const __dpl_sycl::__sub_group& __sub_group, _Mask
             __value = __binary_op(__partial_carry_in, __value);
         }
     }
-}
-
-// Runtime scan loop fallback for uncommon sub-group sizes.
-template <typename _MaskOp, typename _BinaryOp, typename _ValueType>
-void
-__sub_group_scan_runtime_loop(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
-                              _MaskOp __mask_fn, _ValueType& __value, _BinaryOp __binary_op, _ValueType* __comm_slm)
-{
-    const std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-    for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
-    {
-        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
-        if (__mask_fn(__sub_group_local_id, __shift))
-        {
-            __value = __binary_op(__partial_carry_in, __value);
-        }
-    }
-}
-
-// Dispatch to compile-time-unrolled loop for known sub-group sizes, runtime fallback otherwise.
-template <typename _MaskOp, typename _BinaryOp, typename _ValueType>
-void
-__sub_group_scan_loop_dispatch(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn, _ValueType& __value,
-                               _BinaryOp __binary_op, _ValueType* __comm_slm)
-{
-    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
-    if (__sub_group_size == 32)
-        __sub_group_scan_unrolled_loop<32>(__sub_group, __mask_fn, __value, __binary_op, __comm_slm);
-    else
-        __sub_group_scan_runtime_loop(__sub_group, __sub_group_size, __mask_fn, __value, __binary_op, __comm_slm);
-}
-
-template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
-          typename _LazyValueType>
-void
-__exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
-                                  _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
-{
-    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-    __sub_group_scan_loop_dispatch(__sub_group, __mask_fn, __value, __binary_op, __comm_slm);
     _LazyValueType __old_init;
     if constexpr (__init_present)
     {
@@ -1334,7 +1295,16 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
                                   _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-    __sub_group_scan_loop_dispatch(__sub_group, __mask_fn, __value, __binary_op, __comm_slm);
+    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+    _ONEDPL_PRAGMA_UNROLL
+    for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
+    {
+        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
+        if (__mask_fn(__sub_group_local_id, __shift))
+        {
+            __value = __binary_op(__partial_carry_in, __value);
+        }
+    }
     if constexpr (__init_present)
     {
         __value = __binary_op(__init_and_carry.__v, __value);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1244,15 +1244,13 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value
     return __result;
 }
 
-template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
-          typename _LazyValueType>
+// Compile-time-constant scan loop enabling unrolling. Called from the fast-path dispatch below.
+template <std::uint8_t __sub_group_size, typename _MaskOp, typename _BinaryOp, typename _ValueType>
 void
-__exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
-                                  _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+__sub_group_scan_unrolled_loop(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn, _ValueType& __value,
+                               _BinaryOp __binary_op, _ValueType* __comm_slm)
 {
-    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+    const std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
@@ -1262,6 +1260,47 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
             __value = __binary_op(__partial_carry_in, __value);
         }
     }
+}
+
+// Runtime scan loop fallback for uncommon sub-group sizes.
+template <typename _MaskOp, typename _BinaryOp, typename _ValueType>
+void
+__sub_group_scan_runtime_loop(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
+                              _MaskOp __mask_fn, _ValueType& __value, _BinaryOp __binary_op, _ValueType* __comm_slm)
+{
+    const std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+    for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
+    {
+        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
+        if (__mask_fn(__sub_group_local_id, __shift))
+        {
+            __value = __binary_op(__partial_carry_in, __value);
+        }
+    }
+}
+
+// Dispatch to compile-time-unrolled loop for known sub-group sizes, runtime fallback otherwise.
+template <typename _MaskOp, typename _BinaryOp, typename _ValueType>
+void
+__sub_group_scan_loop_dispatch(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn, _ValueType& __value,
+                               _BinaryOp __binary_op, _ValueType* __comm_slm)
+{
+    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+    if (__sub_group_size == 32)
+        __sub_group_scan_unrolled_loop<32>(__sub_group, __mask_fn, __value, __binary_op, __comm_slm);
+    else
+        __sub_group_scan_runtime_loop(__sub_group, __sub_group_size, __mask_fn, __value, __binary_op, __comm_slm);
+}
+
+template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
+          typename _LazyValueType>
+void
+__exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
+                                  _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
+                                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+{
+    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+    __sub_group_scan_loop_dispatch(__sub_group, __mask_fn, __value, __binary_op, __comm_slm);
     _LazyValueType __old_init;
     if constexpr (__init_present)
     {
@@ -1295,16 +1334,7 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
                                   _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
-    _ONEDPL_PRAGMA_UNROLL
-    for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
-    {
-        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
-        if (__mask_fn(__sub_group_local_id, __shift))
-        {
-            __value = __binary_op(__partial_carry_in, __value);
-        }
-    }
+    __sub_group_scan_loop_dispatch(__sub_group, __mask_fn, __value, __binary_op, __comm_slm);
     if constexpr (__init_present)
     {
         __value = __binary_op(__init_and_carry.__v, __value);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2135,7 +2135,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
 
     // Use SLM-based sub-group communication for non-trivially-copyable types or CPU targets
     // (where native sub-group operations are slow).
-    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType> || !__q.get_device().is_gpu();
+    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType>;
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2098,7 +2098,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 
     // empirical derived caps for workgroup size based upon target
-    const std::uint32_t __wg_size_cap = __q.is_gpu() ? 1024 : 256;
+    const std::uint32_t __wg_size_cap = __q.get_device().is_gpu() ? 1024 : 256;
     const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, __wg_size_cap);
     // Round down to nearest multiple of the max subgroup size to ensure compatibility with all sub-group sizes
     const std::uint32_t __work_group_size = (__max_work_group_size / __max_sub_group_size) * __max_sub_group_size;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1195,17 +1195,66 @@ struct __scan_by_seg_op
 
 // *** Main reduce then scan infrastructure ***
 
+// Sub-group communication wrappers that support non-trivially-copyable types.
+// For trivially copyable types, native SYCL sub-group operations are used.
+// For non-trivially-copyable types, shared local memory (SLM) with sub-group barriers is used.
+// The __comm_slm parameter points to a work-group-sized SLM buffer; each sub-group uses its own
+// slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size).
+
+template <typename _ValueType>
+_ValueType
+__shift_group_right(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType __value,
+                    std::uint32_t __shift, _ValueType* __comm_slm)
+{
+    if constexpr (std::is_trivially_copyable_v<_ValueType>)
+    {
+        return sycl::shift_group_right(__sub_group, __value, __shift);
+    }
+    else
+    {
+        std::uint32_t __local_id = __sub_group.get_local_linear_id();
+        std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group_size;
+        __comm_slm[__sg_base + __local_id] = __value;
+        sycl::group_barrier(__sub_group);
+        _ValueType __result = __comm_slm[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
+        sycl::group_barrier(__sub_group);
+        return __result;
+    }
+}
+
+template <typename _ValueType, typename _IdType>
+_ValueType
+__group_broadcast(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType __value,
+                  _IdType __broadcast_id, _ValueType* __comm_slm)
+{
+    if constexpr (std::is_trivially_copyable_v<_ValueType>)
+    {
+        return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
+    }
+    else
+    {
+        std::uint32_t __local_id = __sub_group.get_local_linear_id();
+        std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group_size;
+        __comm_slm[__sg_base + __local_id] = __value;
+        sycl::group_barrier(__sub_group);
+        _ValueType __result = __comm_slm[__sg_base + __broadcast_id];
+        sycl::group_barrier(__sub_group);
+        return __result;
+    }
+}
+
 template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
           typename _LazyValueType>
 void
 __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
                                   _MaskOp __mask_fn, _InitBroadcastId __init_broadcast_id, _ValueType& __value,
-                                  _BinaryOp __binary_op, _LazyValueType& __init_and_carry)
+                                  _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in = sycl::shift_group_right(__sub_group, __value, __shift);
+        _ValueType __partial_carry_in =
+            __shift_group_right(__sub_group, __sub_group_size, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1217,14 +1266,16 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, st
         __value = __binary_op(__init_and_carry.__v, __value);
         if (__sub_group_local_id == 0)
             __old_init.__setup(__init_and_carry.__v);
-        __init_and_carry.__v = sycl::group_broadcast(__sub_group, __value, __init_broadcast_id);
+        __init_and_carry.__v =
+            __group_broadcast(__sub_group, __sub_group_size, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(sycl::group_broadcast(__sub_group, __value, __init_broadcast_id));
+        __init_and_carry.__setup(
+            __group_broadcast(__sub_group, __sub_group_size, __value, __init_broadcast_id, __comm_slm));
     }
 
-    __value = sycl::shift_group_right(__sub_group, __value, 1);
+    __value = __shift_group_right(__sub_group, __sub_group_size, __value, 1, __comm_slm);
     if constexpr (__init_present)
     {
         if (__sub_group_local_id == 0)
@@ -1241,12 +1292,13 @@ template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, type
 void
 __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
                                   _MaskOp __mask_fn, _InitBroadcastId __init_broadcast_id, _ValueType& __value,
-                                  _BinaryOp __binary_op, _LazyValueType& __init_and_carry)
+                                  _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in = sycl::shift_group_right(__sub_group, __value, __shift);
+        _ValueType __partial_carry_in =
+            __shift_group_right(__sub_group, __sub_group_size, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1255,11 +1307,13 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, st
     if constexpr (__init_present)
     {
         __value = __binary_op(__init_and_carry.__v, __value);
-        __init_and_carry.__v = sycl::group_broadcast(__sub_group, __value, __init_broadcast_id);
+        __init_and_carry.__v =
+            __group_broadcast(__sub_group, __sub_group_size, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(sycl::group_broadcast(__sub_group, __value, __init_broadcast_id));
+        __init_and_carry.__setup(
+            __group_broadcast(__sub_group, __sub_group_size, __value, __init_broadcast_id, __comm_slm));
     }
     //return by reference __value and __init_and_carry
 }
@@ -1269,55 +1323,59 @@ template <bool __is_inclusive, bool __init_present, typename _MaskOp, typename _
 void
 __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _MaskOp __mask_fn,
                         _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                        _LazyValueType& __init_and_carry)
+                        _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     if constexpr (__is_inclusive)
     {
         __inclusive_sub_group_masked_scan<__init_present>(__sub_group, __sub_group_size, __mask_fn, __init_broadcast_id,
-                                                          __value, __binary_op, __init_and_carry);
+                                                          __value, __binary_op, __init_and_carry, __comm_slm);
     }
     else
     {
         __exclusive_sub_group_masked_scan<__init_present>(__sub_group, __sub_group_size, __mask_fn, __init_broadcast_id,
-                                                          __value, __binary_op, __init_and_carry);
+                                                          __value, __binary_op, __init_and_carry, __comm_slm);
     }
 }
 
 template <bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType& __value,
-                 _BinaryOp __binary_op, _LazyValueType& __init_and_carry)
+                 _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
     std::uint8_t __init_broadcast_id = __sub_group_size - 1;
-    __sub_group_masked_scan<__is_inclusive, __init_present>(
-        __sub_group, __sub_group_size, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry);
+    __sub_group_masked_scan<__is_inclusive, __init_present>(__sub_group, __sub_group_size, __mask_fn,
+                                                            __init_broadcast_id, __value, __binary_op, __init_and_carry,
+                                                            __comm_slm);
 }
 
 template <bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
           typename _SizeType>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType& __value,
-                         _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _SizeType __elements_to_process)
+                         _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _SizeType __elements_to_process,
+                         _ValueType* __comm_slm)
 {
     auto __mask_fn = [__elements_to_process](auto __sub_group_local_id, auto __offset) {
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    __sub_group_masked_scan<__is_inclusive, __init_present>(
-        __sub_group, __sub_group_size, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry);
+    __sub_group_masked_scan<__is_inclusive, __init_present>(__sub_group, __sub_group_size, __mask_fn,
+                                                            __init_broadcast_id, __value, __binary_op, __init_and_carry,
+                                                            __comm_slm);
 }
 
 template <bool __is_inclusive, bool __init_present, bool __capture_output, std::uint16_t __max_inputs_per_item,
           typename _GenInput, typename _ScanInputTransform, typename _BinaryOp, typename _WriteOp,
-          typename _LazyValueType, typename _InRng, typename _OutRng>
+          typename _LazyValueType, typename _InRng, typename _OutRng, typename _ScanValueType>
 void
 __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
                                _GenInput __gen_input, _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op,
                                _WriteOp __write_op, _LazyValueType& __sub_group_carry, const _InRng& __in_rng,
                                _OutRng& __out_rng, std::size_t __start_id, std::size_t __n,
                                std::uint32_t __iters_per_item, std::size_t __subgroup_start_id,
-                               std::uint32_t __sub_group_id, std::uint32_t __active_subgroups)
+                               std::uint32_t __sub_group_id, std::uint32_t __active_subgroups,
+                               _ScanValueType* __comm_slm)
 {
     using _GenInputType = std::invoke_result_t<_GenInput, _InRng, std::size_t, typename _GenInput::TempData&>;
 
@@ -1330,7 +1388,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
         __sub_group_scan<__is_inclusive, __init_present>(__sub_group, __sub_group_size, __scan_input_transform(__v),
-                                                         __binary_op, __sub_group_carry);
+                                                         __binary_op, __sub_group_carry, __comm_slm);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1343,8 +1401,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
             for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry);
+                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __sub_group_size,
+                                                                          __scan_input_transform(__v), __binary_op,
+                                                                          __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1358,8 +1417,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
             for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry);
+                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __sub_group_size,
+                                                                          __scan_input_transform(__v), __binary_op,
+                                                                          __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1379,9 +1439,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
             {
                 std::size_t __local_id = (__start_id < __n) ? __start_id : __n - 1;
                 _GenInputType __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__is_inclusive, __init_present>(__sub_group, __sub_group_size,
-                                                                         __scan_input_transform(__v), __binary_op,
-                                                                         __sub_group_carry, __n - __subgroup_start_id);
+                __sub_group_scan_partial<__is_inclusive, __init_present>(
+                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry,
+                    __n - __subgroup_start_id, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     if (__start_id < __n)
@@ -1391,8 +1451,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
             else
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-                __sub_group_scan<__is_inclusive, __init_present>(
-                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry);
+                __sub_group_scan<__is_inclusive, __init_present>(__sub_group, __sub_group_size,
+                                                                 __scan_input_transform(__v), __binary_op,
+                                                                 __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1402,8 +1463,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
                 {
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
-                    __sub_group_scan<__is_inclusive, /*__init_present=*/true>(
-                        __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry);
+                    __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __sub_group_size,
+                                                                              __scan_input_transform(__v), __binary_op,
+                                                                              __sub_group_carry, __comm_slm);
                     if constexpr (__capture_output)
                     {
                         __write_op(__out_rng, __local_id, __v, __temp_data);
@@ -1415,7 +1477,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::
                 __v = __gen_input(__in_rng, __local_id, __temp_data);
                 __sub_group_scan_partial<__is_inclusive, /*__init_present=*/true>(
                     __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry,
-                    __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size));
+                    __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm);
                 if constexpr (__capture_output)
                 {
                     if (__offset < __n)
@@ -1479,6 +1541,11 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
         using _InitValueType = typename _InitType::__value_type;
         return __q.submit([&, this](sycl::handler& __cgh) {
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
+            // SLM for sub-group communication (shift_group_right / group_broadcast) for non-trivially-copyable types.
+            // For trivially copyable types, native SYCL sub-group ops are used and this SLM is unused.
+            constexpr std::size_t __comm_slm_size =
+                std::is_trivially_copyable_v<_InitValueType> ? 0 : __work_group_size;
+            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__comm_slm_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
@@ -1491,6 +1558,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
                 _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                _InitValueType* __comm_slm_ptr = __comm_slm_size > 0 ? &__comm_slm[0] : nullptr;
                 std::size_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -1523,7 +1591,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                                                    /*__capture_output=*/false, __max_inputs_per_item>(
                         __sub_group, __sub_group_size, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op,
                         nullptr, __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
-                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups);
+                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
+                        __comm_slm_ptr);
                     if (__sub_group_local_id == 0)
                         __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
                     __sub_group_carry.__destroy();
@@ -1545,7 +1614,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial</*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry, __active_subgroups);
+                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry, __active_subgroups,
+                            __comm_slm_ptr);
                         if (__sub_group_local_id < __active_subgroups)
                             __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
@@ -1555,7 +1625,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // need to pull out first iteration tp avoid identity
                         _InitValueType __v = __sub_group_partials[__reduction_scan_id];
                         __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry);
+                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
                         __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         __reduction_scan_id += __sub_group_size;
 
@@ -1563,7 +1633,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         {
                             __v = __sub_group_partials[__reduction_scan_id];
                             __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/true>(
-                                __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry);
+                                __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
                         }
@@ -1577,7 +1647,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial</*__is_inclusive=*/true, /*__init_present=*/true>(
                             __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry,
-                            __active_subgroups - ((__iters - 1) * __sub_group_size));
+                            __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
                         if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                     }
@@ -1648,6 +1718,9 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             //   __num_sub_groups_local for each sub-group partial from the reduce kernel +
             //   1 element for the accumulated block-local carry-in from previous groups in the block
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
+            constexpr std::size_t __comm_slm_size =
+                std::is_trivially_copyable_v<_InitValueType> ? 0 : __work_group_size;
+            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__comm_slm_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::read_write>(__cgh);
@@ -1657,6 +1730,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) {
                 __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
                 const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+                _InitValueType* __comm_slm_ptr = __comm_slm_size > 0 ? &__comm_slm[0] : nullptr;
 
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
@@ -1749,7 +1823,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             __sub_group_scan_partial</*__is_inclusive=*/true,
                                                      /*__init_present=*/false>(__sub_group, __sub_group_size, __value,
                                                                                __reduce_op, __carry_last,
-                                                                               __remaining_elements);
+                                                                               __remaining_elements, __comm_slm_ptr);
                         }
                         else
                         {
@@ -1761,14 +1835,14 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                 __sub_group_params.__num_sub_groups_local * __sub_group_size;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
                             __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/false>(
-                                __sub_group, __sub_group_size, __value, __reduce_op, __carry_last);
+                                __sub_group, __sub_group_size, __value, __reduce_op, __carry_last, __comm_slm_ptr);
                             __reduction_id += __reduction_id_increment;
                             // then some number of full iterations
                             for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                             {
                                 __value = __tmp_ptr[__reduction_id];
                                 __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __sub_group_size, __value, __reduce_op, __carry_last);
+                                    __sub_group, __sub_group_size, __value, __reduce_op, __carry_last, __comm_slm_ptr);
                                 __reduction_id += __reduction_id_increment;
                             }
 
@@ -1783,7 +1857,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             __sub_group_scan_partial</*__is_inclusive=*/true,
                                                      /*__init_present=*/true>(__sub_group, __sub_group_size, __value,
                                                                               __reduce_op, __carry_last,
-                                                                              __remaining_elements);
+                                                                              __remaining_elements, __comm_slm_ptr);
                         }
 
                         // steps 3+4) load global carry in from neighbor work-group
@@ -1890,7 +1964,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
                         __sub_group, __sub_group_size, __gen_scan_input, __scan_input_transform, __reduce_op,
                         __write_op, __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
-                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups);
+                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
+                        __comm_slm_ptr);
                 }
                 else // first group first block, no subgroup carry
                 {
@@ -1899,7 +1974,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
                         __sub_group, __sub_group_size, __gen_scan_input, __scan_input_transform, __reduce_op,
                         __write_op, __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
-                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups);
+                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
+                        __comm_slm_ptr);
                 }
                 // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
                 // to write out the last carry out for either the return value or the next block

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1195,15 +1195,14 @@ struct __scan_by_seg_op
 
 // *** Main reduce then scan infrastructure ***
 
-template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp, typename _InitBroadcastId,
-          typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
+          typename _LazyValueType>
 void
-__exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
-                                  _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                                  _LazyValueType& __init_and_carry)
+__exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
+                                  _MaskOp __mask_fn, _InitBroadcastId __init_broadcast_id, _ValueType& __value,
+                                  _BinaryOp __binary_op, _LazyValueType& __init_and_carry)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-    _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
         _ValueType __partial_carry_in = sycl::shift_group_right(__sub_group, __value, __shift);
@@ -1237,15 +1236,14 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     //return by reference __value and __init_and_carry
 }
 
-template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp, typename _InitBroadcastId,
-          typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
+          typename _LazyValueType>
 void
-__inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
-                                  _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                                  _LazyValueType& __init_and_carry)
+__inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
+                                  _MaskOp __mask_fn, _InitBroadcastId __init_broadcast_id, _ValueType& __value,
+                                  _BinaryOp __binary_op, _LazyValueType& __init_and_carry)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-    _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
         _ValueType __partial_carry_in = sycl::shift_group_right(__sub_group, __value, __shift);
@@ -1266,61 +1264,60 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     //return by reference __value and __init_and_carry
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _MaskOp,
-          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+template <bool __is_inclusive, bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp,
+          typename _ValueType, typename _LazyValueType>
 void
-__sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
+__sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _MaskOp __mask_fn,
                         _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
                         _LazyValueType& __init_and_carry)
 {
     if constexpr (__is_inclusive)
     {
-        __inclusive_sub_group_masked_scan<__sub_group_size, __init_present>(__sub_group, __mask_fn, __init_broadcast_id,
-                                                                            __value, __binary_op, __init_and_carry);
+        __inclusive_sub_group_masked_scan<__init_present>(__sub_group, __sub_group_size, __mask_fn, __init_broadcast_id,
+                                                          __value, __binary_op, __init_and_carry);
     }
     else
     {
-        __exclusive_sub_group_masked_scan<__sub_group_size, __init_present>(__sub_group, __mask_fn, __init_broadcast_id,
-                                                                            __value, __binary_op, __init_and_carry);
+        __exclusive_sub_group_masked_scan<__init_present>(__sub_group, __sub_group_size, __mask_fn, __init_broadcast_id,
+                                                          __value, __binary_op, __init_and_carry);
     }
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType>
+template <bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
 void
-__sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                 _LazyValueType& __init_and_carry)
+__sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType& __value,
+                 _BinaryOp __binary_op, _LazyValueType& __init_and_carry)
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
-    constexpr std::uint8_t __init_broadcast_id = __sub_group_size - 1;
-    __sub_group_masked_scan<__sub_group_size, __is_inclusive, __init_present>(
-        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry);
+    std::uint8_t __init_broadcast_id = __sub_group_size - 1;
+    __sub_group_masked_scan<__is_inclusive, __init_present>(
+        __sub_group, __sub_group_size, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry);
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType, typename _SizeType>
+template <bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
+          typename _SizeType>
 void
-__sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process)
+__sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size, _ValueType& __value,
+                         _BinaryOp __binary_op, _LazyValueType& __init_and_carry, _SizeType __elements_to_process)
 {
     auto __mask_fn = [__elements_to_process](auto __sub_group_local_id, auto __offset) {
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    __sub_group_masked_scan<__sub_group_size, __is_inclusive, __init_present>(
-        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry);
+    __sub_group_masked_scan<__is_inclusive, __init_present>(
+        __sub_group, __sub_group_size, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry);
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output,
-          std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform, typename _BinaryOp,
-          typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng>
+template <bool __is_inclusive, bool __init_present, bool __capture_output, std::uint16_t __max_inputs_per_item,
+          typename _GenInput, typename _ScanInputTransform, typename _BinaryOp, typename _WriteOp,
+          typename _LazyValueType, typename _InRng, typename _OutRng>
 void
-__scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
-                               _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
-                               _LazyValueType& __sub_group_carry, const _InRng& __in_rng, _OutRng& __out_rng,
-                               std::size_t __start_id, std::size_t __n, std::uint32_t __iters_per_item,
-                               std::size_t __subgroup_start_id, std::uint32_t __sub_group_id,
-                               std::uint32_t __active_subgroups)
+__scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, std::uint8_t __sub_group_size,
+                               _GenInput __gen_input, _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op,
+                               _WriteOp __write_op, _LazyValueType& __sub_group_carry, const _InRng& __in_rng,
+                               _OutRng& __out_rng, std::size_t __start_id, std::size_t __n,
+                               std::uint32_t __iters_per_item, std::size_t __subgroup_start_id,
+                               std::uint32_t __sub_group_id, std::uint32_t __active_subgroups)
 {
     using _GenInputType = std::invoke_result_t<_GenInput, _InRng, std::size_t, typename _GenInput::TempData&>;
 
@@ -1332,8 +1329,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v),
-                                                                           __binary_op, __sub_group_carry);
+        __sub_group_scan<__is_inclusive, __init_present>(__sub_group, __sub_group_size, __scan_input_transform(__v),
+                                                         __binary_op, __sub_group_carry);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1346,8 +1343,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry);
+                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(
+                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1361,8 +1358,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry);
+                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(
+                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1382,9 +1379,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 std::size_t __local_id = (__start_id < __n) ? __start_id : __n - 1;
                 _GenInputType __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
-                    __n - __subgroup_start_id);
+                __sub_group_scan_partial<__is_inclusive, __init_present>(__sub_group, __sub_group_size,
+                                                                         __scan_input_transform(__v), __binary_op,
+                                                                         __sub_group_carry, __n - __subgroup_start_id);
                 if constexpr (__capture_output)
                 {
                     if (__start_id < __n)
@@ -1394,8 +1391,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             else
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry);
+                __sub_group_scan<__is_inclusive, __init_present>(
+                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1405,8 +1402,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 {
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
-                    __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                        __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry);
+                    __sub_group_scan<__is_inclusive, /*__init_present=*/true>(
+                        __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry);
                     if constexpr (__capture_output)
                     {
                         __write_op(__out_rng, __local_id, __v, __temp_data);
@@ -1416,8 +1413,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 std::size_t __offset = __start_id + (__iters - 1) * __sub_group_size;
                 std::size_t __local_id = (__offset < __n) ? __offset : __n - 1;
                 __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
+                __sub_group_scan_partial<__is_inclusive, /*__init_present=*/true>(
+                    __sub_group, __sub_group_size, __scan_input_transform(__v), __binary_op, __sub_group_carry,
                     __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size));
                 if constexpr (__capture_output)
                 {
@@ -1427,41 +1424,6 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             }
         }
     }
-}
-
-constexpr inline std::uint8_t
-__get_reduce_then_scan_default_sg_sz()
-{
-    return 32;
-}
-
-constexpr inline std::uint8_t
-__get_reduce_then_scan_workaround_sg_sz()
-{
-    return 16;
-}
-
-// The default sub-group size for reduce-then-scan is 32, but we conditionally enable sub-group sizes of 16 on Intel
-// devices to workaround a hardware bug. From the host side, return 32 to assert that this sub-group size is supported
-// by an arbitrary device.
-constexpr inline std::uint8_t
-__get_reduce_then_scan_reqd_sg_sz_host()
-{
-    return __get_reduce_then_scan_default_sg_sz();
-}
-
-// To workaround a hardware bug on certain Intel iGPUs with older driver versions and -O0 device compilation, use a
-// sub-group size of 16. Note this function may only be called on the device as _ONEDPL_DETECT_SPIRV_COMPILATION is only
-// valid here.
-constexpr inline std::uint8_t
-__get_reduce_then_scan_actual_sg_sz_device()
-{
-    return
-#if _ONEDPL_DETECT_COMPILER_OPTIMIZATIONS_ENABLED || !_ONEDPL_DETECT_SPIRV_COMPILATION
-        __get_reduce_then_scan_default_sg_sz();
-#else
-        __get_reduce_then_scan_workaround_sg_sz();
-#endif
 }
 
 struct __reduce_then_scan_sub_group_params
@@ -1506,7 +1468,6 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                                                     _GenReduceInput, _ReduceOp, _InitType,
                                                     __internal::__optional_kernel_name<_KernelName...>>
 {
-    static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
     // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
     // input buffer
     template <typename _InRng, typename _TmpStorageAcc>
@@ -1522,17 +1483,15 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
-            __cgh.parallel_for<_KernelName...>(
-                    __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                // Compute work distribution fields dependent on sub-group size within the kernel. This is because we
-                // can only rely on the value of __sub_group_size provided in the device compilation phase within the
-                // kernel itself.
+            __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) {
+                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
                 _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 std::size_t __group_id = __ndi.get_group(0);
-                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 
@@ -1559,11 +1518,11 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 {
                     // adjust for lane-id
                     // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                    __scan_through_elements_helper<__is_inclusive,
                                                    /*__init_present=*/false,
                                                    /*__capture_output=*/false, __max_inputs_per_item>(
-                        __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
-                        __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
+                        __sub_group, __sub_group_size, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op,
+                        nullptr, __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
                         __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups);
                     if (__sub_group_local_id == 0)
                         __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
@@ -1585,8 +1544,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // fill with unused dummy values to avoid overrunning input
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups);
+                        __sub_group_scan_partial</*__is_inclusive=*/true, /*__init_present=*/false>(
+                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry, __active_subgroups);
                         if (__sub_group_local_id < __active_subgroups)
                             __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
@@ -1595,16 +1554,16 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         std::uint32_t __reduction_scan_id = __sub_group_local_id;
                         // need to pull out first iteration tp avoid identity
                         _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                        __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry);
+                        __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/false>(
+                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry);
                         __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         __reduction_scan_id += __sub_group_size;
 
                         for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
                         {
                             __v = __sub_group_partials[__reduction_scan_id];
-                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry);
+                            __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/true>(
+                                __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
                         }
@@ -1616,8 +1575,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                             std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
 
                         __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry,
+                        __sub_group_scan_partial</*__is_inclusive=*/true, /*__init_present=*/true>(
+                            __sub_group, __sub_group_size, __v, __reduce_op, __sub_group_carry,
                             __active_subgroups - ((__iters - 1) * __sub_group_size));
                         if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
@@ -1654,7 +1613,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                                   __internal::__optional_kernel_name<_KernelName...>>
 {
     using _InitValueType = typename _InitType::__value_type;
-    static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
 
     _InitValueType
     __get_block_carry_in(const std::size_t __block_num, _InitValueType* __tmp_ptr,
@@ -1696,11 +1654,10 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             auto __res_acc =
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
-            __cgh.parallel_for<_KernelName...>(
-                    __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                // Compute work distribution fields dependent on sub-group size within the kernel. This is because we
-                // can only rely on the value of __sub_group_size provided in the device compilation phase within the
-                // kernel itself.
+            __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) {
+                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
@@ -1712,7 +1669,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 _InitValueType* __res_ptr =
                     _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
                 std::uint32_t __group_id = __ndi.get_group(0);
-                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 
@@ -1790,9 +1746,10 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                                              ? __proposed_id
                                                              : __subgroups_before_my_group - 1;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                     /*__init_present=*/false>(__sub_group, __value, __reduce_op,
-                                                                               __carry_last, __remaining_elements);
+                            __sub_group_scan_partial</*__is_inclusive=*/true,
+                                                     /*__init_present=*/false>(__sub_group, __sub_group_size, __value,
+                                                                               __reduce_op, __carry_last,
+                                                                               __remaining_elements);
                         }
                         else
                         {
@@ -1803,15 +1760,15 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             std::uint32_t __reduction_id_increment =
                                 __sub_group_params.__num_sub_groups_local * __sub_group_size;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                                __sub_group, __value, __reduce_op, __carry_last);
+                            __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/false>(
+                                __sub_group, __sub_group_size, __value, __reduce_op, __carry_last);
                             __reduction_id += __reduction_id_increment;
                             // then some number of full iterations
                             for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                             {
                                 __value = __tmp_ptr[__reduction_id];
-                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __value, __reduce_op, __carry_last);
+                                __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/true>(
+                                    __sub_group, __sub_group_size, __value, __reduce_op, __carry_last);
                                 __reduction_id += __reduction_id_increment;
                             }
 
@@ -1823,9 +1780,10 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             std::size_t __final_reduction_id =
                                 std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
                             __value = __tmp_ptr[__final_reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                     /*__init_present=*/true>(__sub_group, __value, __reduce_op,
-                                                                              __carry_last, __remaining_elements);
+                            __sub_group_scan_partial</*__is_inclusive=*/true,
+                                                     /*__init_present=*/true>(__sub_group, __sub_group_size, __value,
+                                                                              __reduce_op, __carry_last,
+                                                                              __remaining_elements);
                         }
 
                         // steps 3+4) load global carry in from neighbor work-group
@@ -1927,21 +1885,21 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 
                 if (__sub_group_carry_initialized)
                 {
-                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                    __scan_through_elements_helper<__is_inclusive,
                                                    /*__init_present=*/true,
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
-                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
-                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups);
+                        __sub_group, __sub_group_size, __gen_scan_input, __scan_input_transform, __reduce_op,
+                        __write_op, __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
+                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups);
                 }
                 else // first group first block, no subgroup carry
                 {
-                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                    __scan_through_elements_helper<__is_inclusive,
                                                    /*__init_present=*/false,
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
-                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
-                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups);
+                        __sub_group, __sub_group_size, __gen_scan_input, __scan_input_transform, __reduce_op,
+                        __write_op, __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
+                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups);
                 }
                 // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
                 // to write out the last carry out for either the return value or the next block
@@ -1987,14 +1945,13 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
     _InitType __init;
 };
 
-// Enable reduce-then-scan if the device uses the required sub-group size and is ran on a device
-// with fast coordinated subgroup operations. We do not want to run this scan on CPU targets, as they are not
-// performant with this algorithm.
+// Enable reduce-then-scan on GPU devices with fast coordinated subgroup operations.
+// We do not want to run this scan on CPU targets, as they are not performant with this algorithm.
+// The sub-group size is determined at runtime within the kernel via get_max_local_range().
 inline bool
 __is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
 {
-    return (__q.get_device().is_gpu() &&
-            oneapi::dpl::__internal::__supports_sub_group_size(__q, __get_reduce_then_scan_reqd_sg_sz_host()));
+    return __q.get_device().is_gpu();
 }
 
 // General scan-like algorithm helpers
@@ -2023,8 +1980,14 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
         __reduce_then_scan_scan_kernel<_CustomName>>;
     using _ValueType = typename _InitType::__value_type;
 
-    constexpr std::uint8_t __min_sub_group_size = __get_reduce_then_scan_workaround_sg_sz();
-    constexpr std::uint8_t __max_sub_group_size = __get_reduce_then_scan_default_sg_sz();
+    // Query the device's supported sub-group sizes to allocate storage conservatively and round
+    // the work-group size appropriately. The actual sub-group size used by each kernel is determined
+    // at runtime via sub_group::get_max_local_range().
+    const auto __supported_sg_sizes = __q.get_device().template get_info<sycl::info::device::sub_group_sizes>();
+    const std::uint8_t __min_sub_group_size =
+        *std::min_element(__supported_sg_sizes.begin(), __supported_sg_sizes.end());
+    const std::uint8_t __max_sub_group_size =
+        *std::max_element(__supported_sg_sizes.begin(), __supported_sg_sizes.end());
     // Empirically determined maximum. May be less for non-full blocks.
     constexpr std::uint16_t __max_inputs_per_item =
         std::max(std::uint16_t{1}, std::uint16_t{512 / __bytes_per_work_item_iter});
@@ -2032,14 +1995,13 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 
     const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 8192);
-    // Round down to nearest multiple of the subgroup size
+    // Round down to nearest multiple of the max subgroup size to ensure compatibility with all sub-group sizes
     const std::uint32_t __work_group_size = (__max_work_group_size / __max_sub_group_size) * __max_sub_group_size;
 
     // TODO: Investigate potentially basing this on some scale of the number of compute units. 128 work-groups has been
     // found to be reasonable number for most devices.
     constexpr std::uint32_t __num_work_groups = 128;
-    // We may use a sub-group size of 16 or 32 depending on the compiler optimization level. Allocate sufficient
-    // temporary storage to handle both cases.
+    // Allocate sufficient temporary storage for the worst case (smallest sub-group size = most sub-groups).
     const std::uint32_t __max_num_sub_groups_local = __work_group_size / __min_sub_group_size;
     const std::uint32_t __max_num_sub_groups_global = __max_num_sub_groups_local * __num_work_groups;
     const std::uint32_t __max_inputs_per_work_group = __work_group_size * __max_inputs_per_item;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -417,15 +417,11 @@ struct __gen_set_mask
             //duplication in __set_b then a mask is 1
 
             const std::size_t __count_a_left =
-                __id -
-                oneapi::dpl::__internal::__pstl_left_bound_idx(__set_a, std::size_t{0}, __id, __set_a, __id, __comp,
-                                                               __proj1, __proj1) +
-                1;
+                __id - oneapi::dpl::__internal::__pstl_left_bound_idx(__set_a, std::size_t{0}, __id, __set_a, __id, __comp, __proj1, __proj1) + 1;
 
-            const std::size_t __count_b = oneapi::dpl::__internal::__pstl_right_bound_idx(
-                                              __set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
-                                          oneapi::dpl::__internal::__pstl_left_bound_idx(
-                                              __set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
+            const std::size_t __count_b = 
+                oneapi::dpl::__internal::__pstl_right_bound_idx(__set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
+                oneapi::dpl::__internal::__pstl_left_bound_idx(__set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -1405,6 +1401,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                                std::uint32_t __active_subgroups, _ScanValueType* __comm_slm)
 {
     using _GenInputType = std::invoke_result_t<_GenInput, _InRng, std::size_t, typename _GenInput::TempData&>;
+
     bool __is_full_block = (__iters_per_item == __max_inputs_per_item);
     bool __is_full_thread = __subgroup_start_id + __iters_per_item * __sub_group_size <= __n;
     using _TempData = typename _GenInput::TempData;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1606,108 +1606,108 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 __cgh, __dpl_sycl::__no_init{});
             __cgh.parallel_for<_KernelName...>(
                 __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                    _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
 
-                    __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
 
-                    __reduce_then_scan_sub_group_params __sub_group_params(
-                        __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
+                __reduce_then_scan_sub_group_params __sub_group_params(
+                    __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
-                    _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
-                    std::size_t __group_id = __ndi.get_group(0);
-                    std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-                    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+                _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
+                std::size_t __group_id = __ndi.get_group(0);
+                std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+                std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 
-                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-                    std::size_t __group_start_id =
-                        (__block_num * __max_block_size) +
-                        (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
-                    if constexpr (__is_unique_pattern_v)
+                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+                std::size_t __group_start_id =
+                (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
+                                                    __sub_group_params.__num_sub_groups_local);
+                if constexpr (__is_unique_pattern_v)
+                {
+                    // for unique patterns, the first element is always copied to the output, so we need to skip it
+                    __group_start_id += 1;
+                }
+                std::size_t __max_inputs_in_group =
+                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                    __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+                std::size_t __subgroup_start_id =
+                    __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
+
+                std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+
+                if (__sub_group_id < __active_subgroups)
+                {
+                    // adjust for lane-id
+                    // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
+                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                                                /*__init_present=*/false,
+                                                /*__capture_output=*/false, __max_inputs_per_item>(
+                        __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr, __sub_group_carry,
+                        __in_rng, /*unused*/ __in_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                    if (__sub_group_local_id == 0)
+                        __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
+                    __sub_group_carry.__destroy();
+                }
+                __dpl_sycl::__group_barrier(__ndi);
+
+                // compute sub-group local prefix sums on (T0..63) carries
+                // and store to scratch space at the end of dst; next
+                // accumulator kernel takes M thread carries from scratch
+                // to compute a prefix sum on global carries
+                if (__sub_group_id == 0)
+                {
+                    __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
+                    std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                    if (__iters == 1)
                     {
-                        // for unique patterns, the first element is always copied to the output, so we need to skip it
-                        __group_start_id += 1;
+                        // fill with unused dummy values to avoid overrunning input
+                        std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
+                        _InitValueType __v = __sub_group_partials[__load_id];
+                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>
+                                                            (__sub_group, __v, __reduce_op, __sub_group_carry,
+                                                            __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                        if (__sub_group_local_id < __active_subgroups)
+                            __tmp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
-                    std::size_t __max_inputs_in_group =
-                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-                    std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-                    std::uint32_t __active_subgroups =
-                        oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-                    std::size_t __subgroup_start_id =
-                        __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
-
-                    std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
-
-                    if (__sub_group_id < __active_subgroups)
+                    else
                     {
-                        // adjust for lane-id
-                        // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-                        __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                                    /*__init_present=*/false,
-                                                    /*__capture_output=*/false, __max_inputs_per_item>(
-                            __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr, __sub_group_carry,
-                            __in_rng, /*unused*/ __in_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                            __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
-                        if (__sub_group_local_id == 0)
-                            __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
-                        __sub_group_carry.__destroy();
-                    }
-                    __dpl_sycl::__group_barrier(__ndi);
+                        std::uint32_t __reduction_scan_id = __sub_group_local_id;
+                        // need to pull out first iteration tp avoid identity
+                        _InitValueType __v = __sub_group_partials[__reduction_scan_id];
+                        __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                            __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
+                        __tmp_ptr[__start_id + __reduction_scan_id] = __v;
+                        __reduction_scan_id += __sub_group_size;
 
-                    // compute sub-group local prefix sums on (T0..63) carries
-                    // and store to scratch space at the end of dst; next
-                    // accumulator kernel takes M thread carries from scratch
-                    // to compute a prefix sum on global carries
-                    if (__sub_group_id == 0)
-                    {
-                        __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
-                        std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-                        if (__iters == 1)
+                        for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
                         {
-                            // fill with unused dummy values to avoid overrunning input
-                            std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
-                            _InitValueType __v = __sub_group_partials[__load_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>
-                                                                (__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                                __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
-                            if (__sub_group_local_id < __active_subgroups)
-                                __tmp_acc[__start_id + __sub_group_local_id] = __v;
-                        }
-                        else
-                        {
-                            std::uint32_t __reduction_scan_id = __sub_group_local_id;
-                            // need to pull out first iteration tp avoid identity
-                            _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                            __v = __sub_group_partials[__reduction_scan_id];
+                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                                 __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
-                            __tmp_acc[__start_id + __reduction_scan_id] = __v;
+                            __tmp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
-
-                            for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
-                            {
-                                __v = __sub_group_partials[__reduction_scan_id];
-                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
-                                __tmp_acc[__start_id + __reduction_scan_id] = __v;
-                                __reduction_scan_id += __sub_group_size;
-                            }
-                            // If we are past the input range, then the previous value of v is passed to the sub-group scan.
-                            // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
-
-                            // fill with unused dummy values to avoid overrunning input
-                            std::uint32_t __load_id = std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
-
-                            __v = __sub_group_partials[__load_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry,
-                                __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr, __use_subgroup_ops);
-                            if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
-                                __tmp_acc[__start_id + __reduction_scan_id] = __v;
                         }
+                        // If we are past the input range, then the previous value of v is passed to the sub-group scan.
+                        // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
 
-                        __sub_group_carry.__destroy();
+                        // fill with unused dummy values to avoid overrunning input
+                        std::uint32_t __load_id = std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
+
+                        __v = __sub_group_partials[__load_id];
+                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                            __sub_group, __v, __reduce_op, __sub_group_carry,
+                            __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr, __use_subgroup_ops);
+                        if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
+                            __tmp_ptr[__start_id + __reduction_scan_id] = __v;
                     }
 
-                });
+                    __sub_group_carry.__destroy();
+                }
+
+            });
         });
     }
 
@@ -1785,269 +1785,269 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 
             __cgh.parallel_for<_KernelName...>(
                 __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                    _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                    _InitValueType* __res_ptr =
-                        _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
+                _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                _InitValueType* __res_ptr =
+                    _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
 
-                    __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-                    _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
+                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
 
-                    __reduce_then_scan_sub_group_params __sub_group_params(
-                        __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
+                __reduce_then_scan_sub_group_params __sub_group_params(
+                    __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
-                    const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                        __inputs_in_block, __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+                const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                    __inputs_in_block, __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
 
-                    std::uint32_t __group_id = __ndi.get_group(0);
-                    std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-                    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+                std::uint32_t __group_id = __ndi.get_group(0);
+                std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+                std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 
-                    std::size_t __group_start_id =
-                        (__block_num * __max_block_size) +
-                        (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
-                    if constexpr (__is_unique_pattern_v)
+                std::size_t __group_start_id =
+                    (__block_num * __max_block_size) +
+                    (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+                if constexpr (__is_unique_pattern_v)
+                {
+                    // for unique patterns, the first element is always copied to the output, so we need to skip it
+                    __group_start_id += 1;
+                }
+
+                std::size_t __max_inputs_in_group =
+                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                std::uint32_t __active_subgroups =
+                    oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
+
+                // propagate carry in from previous block
+                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+
+                // on the first sub-group in a work-group (assuming S subgroups in a work-group):
+                // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
+                // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
+                //    and then compute the prefix sum to generate global carry out
+                //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
+                // 3. on each WG select the adjacent neighboring WG carry in
+                // 4. on each WG add the global carry-in to S sub-group local prefix sums to
+                //    get a T-local global carry in
+                // 5. recompute T-local prefix values, add the T-local global carries,
+                //    and then write back the final values to memory
+                if (__sub_group_id == 0)
+                {
+                    // step 1) load to SLM the WG-local S prefix sums
+                    //         on WG T-local carries
+                    //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
+                    //           S: sum(T0 carry...TS carry)
+                    std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                    std::size_t __subgroups_before_my_group = __group_id * __sub_group_params.__num_sub_groups_local;
+                    std::uint32_t __load_reduction_id = __sub_group_local_id;
+                    std::uint8_t __i = 0;
+                    for (; __i < __iters - 1; __i++)
                     {
-                        // for unique patterns, the first element is always copied to the output, so we need to skip it
-                        __group_start_id += 1;
+                        __sub_group_partials[__load_reduction_id] =
+                            __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
+                        __load_reduction_id += __sub_group_size;
+                    }
+                    if (__load_reduction_id < __active_subgroups)
+                    {
+                        __sub_group_partials[__load_reduction_id] =
+                            __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
                     }
 
-                    std::size_t __max_inputs_in_group =
-                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-                    std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-                    std::uint32_t __active_subgroups =
-                        oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
-
-                    // propagate carry in from previous block
-                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-
-                    // on the first sub-group in a work-group (assuming S subgroups in a work-group):
-                    // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
-                    // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
-                    //    and then compute the prefix sum to generate global carry out
-                    //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
-                    // 3. on each WG select the adjacent neighboring WG carry in
-                    // 4. on each WG add the global carry-in to S sub-group local prefix sums to
-                    //    get a T-local global carry in
-                    // 5. recompute T-local prefix values, add the T-local global carries,
-                    //    and then write back the final values to memory
-                    if (__sub_group_id == 0)
+                    // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
+                    //         compute the prefix in a sub-group to get global work-group carries
+                    //         memory accesses: gather(63, 127, 191, 255, ...)
+                    std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
+                    // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
+                    if (__group_id > 0)
                     {
-                        // step 1) load to SLM the WG-local S prefix sums
-                        //         on WG T-local carries
-                        //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
-                        //           S: sum(T0 carry...TS carry)
-                        std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-                        std::size_t __subgroups_before_my_group = __group_id * __sub_group_params.__num_sub_groups_local;
-                        std::uint32_t __load_reduction_id = __sub_group_local_id;
-                        std::uint8_t __i = 0;
-                        for (; __i < __iters - 1; __i++)
+                        // only need the last element from each scan of num_sub_groups_local subgroup reductions
+                        const std::size_t __elements_to_process =
+                            __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
+                        const std::size_t __pre_carry_iters =
+                            oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
+                        if (__pre_carry_iters == 1)
                         {
-                            __sub_group_partials[__load_reduction_id] =
-                                __tmp_acc[__subgroups_before_my_group + __load_reduction_id];
-                            __load_reduction_id += __sub_group_size;
+                            // single partial scan
+                            std::size_t __proposed_id =
+                                __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
+                            std::size_t __remaining_elements = __elements_to_process;
+                            std::size_t __reduction_id =
+                                (__proposed_id < __subgroups_before_my_group) ? __proposed_id : __subgroups_before_my_group - 1;
+                            _InitValueType __value = __tmp_ptr[__reduction_id];
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
+                                __use_subgroup_ops);
                         }
-                        if (__load_reduction_id < __active_subgroups)
+                        else
                         {
-                            __sub_group_partials[__load_reduction_id] =
-                                __tmp_acc[__subgroups_before_my_group + __load_reduction_id];
-                        }
-
-                        // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
-                        //         compute the prefix in a sub-group to get global work-group carries
-                        //         memory accesses: gather(63, 127, 191, 255, ...)
-                        std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
-                        // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
-                        if (__group_id > 0)
-                        {
-                            // only need the last element from each scan of num_sub_groups_local subgroup reductions
-                            const std::size_t __elements_to_process =
-                                __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
-                            const std::size_t __pre_carry_iters =
-                                oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
-                            if (__pre_carry_iters == 1)
+                            // multiple iterations
+                            // first 1 full
+                            std::uint32_t __reduction_id =
+                                __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
+                            std::uint32_t __reduction_id_increment =
+                                __sub_group_params.__num_sub_groups_local * __sub_group_size;
+                            _InitValueType __value = __tmp_ptr[__reduction_id];
+                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                                __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
+                            __reduction_id += __reduction_id_increment;
+                            // then some number of full iterations
+                            for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                             {
-                                // single partial scan
-                                std::size_t __proposed_id =
-                                    __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
-                                std::size_t __remaining_elements = __elements_to_process;
-                                std::size_t __reduction_id =
-                                    (__proposed_id < __subgroups_before_my_group) ? __proposed_id : __subgroups_before_my_group - 1;
-                                _InitValueType __value = __tmp_acc[__reduction_id];
-                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                                    __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
-                                    __use_subgroup_ops);
-                            }
-                            else
-                            {
-                                // multiple iterations
-                                // first 1 full
-                                std::uint32_t __reduction_id =
-                                    __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
-                                std::uint32_t __reduction_id_increment =
-                                    __sub_group_params.__num_sub_groups_local * __sub_group_size;
-                                _InitValueType __value = __tmp_acc[__reduction_id];
-                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                                __value = __tmp_ptr[__reduction_id];
+                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                                     __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
                                 __reduction_id += __reduction_id_increment;
-                                // then some number of full iterations
-                                for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
-                                {
-                                    __value = __tmp_acc[__reduction_id];
-                                    __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                        __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
-                                    __reduction_id += __reduction_id_increment;
-                                }
-
-                                // final partial iteration
-
-                                std::size_t __remaining_elements =
-                                    __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
-                                // fill with unused dummy values to avoid overrunning input
-                                std::size_t __final_reduction_id =
-                                    std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
-                                __value = __tmp_acc[__final_reduction_id];
-                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
-                                    __use_subgroup_ops);
                             }
 
-                            // steps 3+4) load global carry in from neighbor work-group
-                            //            and apply to local sub-group prefix carries
-                            std::size_t __carry_offset = __sub_group_local_id;
+                            // final partial iteration
 
-                            std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                            std::size_t __remaining_elements =
+                                __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
+                            // fill with unused dummy values to avoid overrunning input
+                            std::size_t __final_reduction_id =
+                                std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
+                            __value = __tmp_ptr[__final_reduction_id];
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
+                                __use_subgroup_ops);
+                        }
 
-                            std::uint8_t __i = 0;
-                            for (; __i < __iters - 1; ++__i)
-                            {
-                                __sub_group_partials[__carry_offset] =
-                                    __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                                __carry_offset += __sub_group_size;
-                            }
-                            if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
-                            {
-                                __sub_group_partials[__carry_offset] =
-                                    __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                                __carry_offset += __sub_group_size;
-                            }
+                        // steps 3+4) load global carry in from neighbor work-group
+                        //            and apply to local sub-group prefix carries
+                        std::size_t __carry_offset = __sub_group_local_id;
+
+                        std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+
+                        std::uint8_t __i = 0;
+                        for (; __i < __iters - 1; ++__i)
+                        {
+                            __sub_group_partials[__carry_offset] =
+                                __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                            __carry_offset += __sub_group_size;
+                        }
+                        if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
+                        {
+                            __sub_group_partials[__carry_offset] =
+                                __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                            __carry_offset += __sub_group_size;
+                        }
+                        if (__sub_group_local_id == 0)
+                            __sub_group_partials[__active_subgroups] = __carry_last.__v;
+                        __carry_last.__destroy();
+                    }
+                }
+
+                __dpl_sycl::__group_barrier(__ndi);
+
+                // Get inter-work group and adjusted for intra-work group prefix
+                bool __sub_group_carry_initialized = true;
+                if (__block_num == 0)
+                {
+                    if (__sub_group_id > 0)
+                    {
+                        _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                        oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
+                        __sub_group_carry.__setup(__value);
+                    }
+                    else if (__group_id > 0)
+                    {
+                        _InitValueType __value = __sub_group_partials[__active_subgroups];
+                        oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
+                        __sub_group_carry.__setup(__value);
+                    }
+                    else // zeroth block, group and subgroup
+                    {
+                        if constexpr (__is_unique_pattern_v)
+                        {
                             if (__sub_group_local_id == 0)
-                                __sub_group_partials[__active_subgroups] = __carry_last.__v;
-                            __carry_last.__destroy();
+                            {
+                                // For unique patterns, always copy the 0th element to the output
+                                __write_op.__assign(__in_rng[0], __out_rng[0]);
+                            }
+                        }
+
+                        if constexpr (std::is_same_v<_InitType, oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
+                        {
+                            // This is the only case where we still don't have a carry in.  No init value, 0th block,
+                            // group, and subgroup. This changes the final scan through elements below.
+                            __sub_group_carry_initialized = false;
+                        }
+                        else
+                        {
+                            __sub_group_carry.__setup(__init.__value);
                         }
                     }
-
-                    __dpl_sycl::__group_barrier(__ndi);
-
-                    // Get inter-work group and adjusted for intra-work group prefix
-                    bool __sub_group_carry_initialized = true;
-                    if (__block_num == 0)
+                }
+                else
+                {
+                    if (__sub_group_id > 0)
                     {
-                        if (__sub_group_id > 0)
-                        {
-                            _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                            oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
-                            __sub_group_carry.__setup(__value);
-                        }
-                        else if (__group_id > 0)
-                        {
-                            _InitValueType __value = __sub_group_partials[__active_subgroups];
-                            oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
-                            __sub_group_carry.__setup(__value);
-                        }
-                        else // zeroth block, group and subgroup
-                        {
-                            if constexpr (__is_unique_pattern_v)
-                            {
-                                if (__sub_group_local_id == 0)
-                                {
-                                    // For unique patterns, always copy the 0th element to the output
-                                    __write_op.__assign(__in_rng[0], __out_rng[0]);
-                                }
-                            }
+                        _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                        __sub_group_carry.__setup(__reduce_op(
+                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global), __value));
+                    }
+                    else if (__group_id > 0)
+                    {
+                        __sub_group_carry.__setup(__reduce_op(
+                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
+                            __sub_group_partials[__active_subgroups]));
+                    }
+                    else
+                    {
+                        __sub_group_carry.__setup(
+                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global));
+                    }
+                }
 
-                            if constexpr (std::is_same_v<_InitType, oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
-                            {
-                                // This is the only case where we still don't have a carry in.  No init value, 0th block,
-                                // group, and subgroup. This changes the final scan through elements below.
-                                __sub_group_carry_initialized = false;
-                            }
-                            else
-                            {
-                                __sub_group_carry.__setup(__init.__value);
-                            }
+                // step 5) apply global carries
+                std::size_t __subgroup_start_id =
+                    __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
+                std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+
+                if (__sub_group_carry_initialized)
+                {
+                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                                                /*__init_present=*/true,
+                                                /*__capture_output=*/true, __max_inputs_per_item>(
+                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
+                        __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
+                        __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                }
+                else // first group first block, no subgroup carry
+                {
+                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                                                /*__init_present=*/false,
+                                                /*__capture_output=*/true, __max_inputs_per_item>(
+                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
+                        __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
+                        __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                }
+                // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
+                // to write out the last carry out for either the return value or the next block
+                if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
+                    (__active_subgroups == __sub_group_id + 1))
+                {
+                    if (__block_num + 1 == __num_blocks)
+                    {
+                        if constexpr (__is_unique_pattern_v)
+                        {
+                            // unique patterns automatically copy the 0th element and scan starting at index 1
+                            __res_ptr[0] = __sub_group_carry.__v + 1;
+                        }
+                        else
+                        {
+                            __res_ptr[0] = __sub_group_carry.__v;
                         }
                     }
                     else
                     {
-                        if (__sub_group_id > 0)
-                        {
-                            _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                            __sub_group_carry.__setup(__reduce_op(
-                                __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global), __value));
-                        }
-                        else if (__group_id > 0)
-                        {
-                            __sub_group_carry.__setup(__reduce_op(
-                                __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global),
-                                __sub_group_partials[__active_subgroups]));
-                        }
-                        else
-                        {
-                            __sub_group_carry.__setup(
-                                __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global));
-                        }
+                        // capture the last carry out for the next block
+                        __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v,
+                                            __sub_group_params.__num_sub_groups_global);
                     }
-
-                    // step 5) apply global carries
-                    std::size_t __subgroup_start_id =
-                        __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
-                    std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
-
-                    if (__sub_group_carry_initialized)
-                    {
-                        __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                                    /*__init_present=*/true,
-                                                    /*__capture_output=*/true, __max_inputs_per_item>(
-                            __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
-                            __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
-                            __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
-                    }
-                    else // first group first block, no subgroup carry
-                    {
-                        __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                                    /*__init_present=*/false,
-                                                    /*__capture_output=*/true, __max_inputs_per_item>(
-                            __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
-                            __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
-                            __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
-                    }
-                    // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
-                    // to write out the last carry out for either the return value or the next block
-                    if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
-                        (__active_subgroups == __sub_group_id + 1))
-                    {
-                        if (__block_num + 1 == __num_blocks)
-                        {
-                            if constexpr (__is_unique_pattern_v)
-                            {
-                                // unique patterns automatically copy the 0th element and scan starting at index 1
-                                __res_ptr[0] = __sub_group_carry.__v + 1;
-                            }
-                            else
-                            {
-                                __res_ptr[0] = __sub_group_carry.__v;
-                            }
-                        }
-                        else
-                        {
-                            // capture the last carry out for the next block
-                            __set_block_carry_out(__block_num, __tmp_acc, __sub_group_carry.__v,
-                                                __sub_group_params.__num_sub_groups_global);
-                        }
-                    }
-                    __sub_group_carry.__destroy();
-                });
+                }
+                __sub_group_carry.__destroy();
+            });
         });
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1202,50 +1202,54 @@ struct __scan_by_seg_op
 // The __comm_slm parameter points to a work-group-sized SLM buffer; each sub-group uses its own
 // slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size).
 
-template <typename _ValueType>
+template <bool __use_subgroup_ops, typename _ValueType>
 _ValueType
 __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
                     _ValueType* __comm_slm)
 {
-    if constexpr (std::is_trivially_copyable_v<_ValueType>)
+    if constexpr (__use_subgroup_ops)
     {
-        if (__comm_slm == nullptr)
-            return sycl::shift_group_right(__sub_group, __value, __shift);
+        return sycl::shift_group_right(__sub_group, __value, __shift);
     }
-    // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
-    // preferred (e.g., CPU targets where sub-group ops are slow).
-    std::uint32_t __local_id = __sub_group.get_local_linear_id();
-    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
-    __comm_slm[__sg_base + __local_id] = __value;
-    sycl::group_barrier(__sub_group);
-    _ValueType __result = __comm_slm[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
-    sycl::group_barrier(__sub_group);
-    return __result;
+    else
+    {
+        // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
+        // preferred (e.g., CPU targets where sub-group ops are slow).
+        std::uint32_t __local_id = __sub_group.get_local_linear_id();
+        std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
+        __comm_slm[__sg_base + __local_id] = __value;
+        sycl::group_barrier(__sub_group);
+        _ValueType __result = __comm_slm[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
+        sycl::group_barrier(__sub_group);
+        return __result;
+    }
 }
 
-template <typename _ValueType, typename _IdType>
+template <bool __use_subgroup_ops, typename _ValueType, typename _IdType>
 _ValueType
 __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
                   _ValueType* __comm_slm)
 {
-    if constexpr (std::is_trivially_copyable_v<_ValueType>)
+    if constexpr (__use_subgroup_ops)
     {
-        if (__comm_slm == nullptr)
-            return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
+        return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
     }
-    // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
-    // preferred (e.g., CPU targets where sub-group ops are slow).
-    std::uint32_t __local_id = __sub_group.get_local_linear_id();
-    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
-    __comm_slm[__sg_base + __local_id] = __value;
-    sycl::group_barrier(__sub_group);
-    _ValueType __result = __comm_slm[__sg_base + __broadcast_id];
-    sycl::group_barrier(__sub_group);
-    return __result;
+    else
+    {
+        // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
+        // preferred (e.g., CPU targets where sub-group ops are slow).
+        std::uint32_t __local_id = __sub_group.get_local_linear_id();
+        std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
+        __comm_slm[__sg_base + __local_id] = __value;
+        sycl::group_barrier(__sub_group);
+        _ValueType __result = __comm_slm[__sg_base + __broadcast_id];
+        sycl::group_barrier(__sub_group);
+        return __result;
+    }
 }
 
-template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
-          typename _LazyValueType>
+template <bool __use_subgroup_ops, bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp,
+          typename _ValueType, typename _LazyValueType>
 void
 __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
@@ -1256,7 +1260,7 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in = __shift_group_right<__use_subgroup_ops>(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1268,14 +1272,14 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
         __value = __binary_op(__init_and_carry.__v, __value);
         if (__sub_group_local_id == 0)
             __old_init.__setup(__init_and_carry.__v);
-        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v = __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(__group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
 
-    __value = __shift_group_right(__sub_group, __value, 1, __comm_slm);
+    __value = __shift_group_right<__use_subgroup_ops>(__sub_group, __value, 1, __comm_slm);
     if constexpr (__init_present)
     {
         if (__sub_group_local_id == 0)
@@ -1287,8 +1291,8 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     //return by reference __value and __init_and_carry
 }
 
-template <bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType,
-          typename _LazyValueType>
+template <bool __use_subgroup_ops, bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp,
+          typename _ValueType, typename _LazyValueType>
 void
 __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
@@ -1299,7 +1303,7 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in = __shift_group_right<__use_subgroup_ops>(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1308,17 +1312,17 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     if constexpr (__init_present)
     {
         __value = __binary_op(__init_and_carry.__v, __value);
-        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v = __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(__group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
     //return by reference __value and __init_and_carry
 }
 
-template <bool __is_inclusive, bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType>
+template <bool __use_subgroup_ops, bool __is_inclusive, bool __init_present, typename _MaskOp, typename _InitBroadcastId,
+          typename _BinaryOp, typename _ValueType, typename _LazyValueType>
 void
 __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                         _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
@@ -1326,29 +1330,30 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
 {
     if constexpr (__is_inclusive)
     {
-        __inclusive_sub_group_masked_scan<__init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
-                                                          __binary_op, __init_and_carry, __comm_slm);
+        __inclusive_sub_group_masked_scan<__use_subgroup_ops, __init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
+                                                                   __binary_op, __init_and_carry, __comm_slm);
     }
     else
     {
-        __exclusive_sub_group_masked_scan<__init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
-                                                          __binary_op, __init_and_carry, __comm_slm);
+        __exclusive_sub_group_masked_scan<__use_subgroup_ops, __init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
+                                                                   __binary_op, __init_and_carry, __comm_slm);
     }
 }
 
-template <bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+template <bool __use_subgroup_ops, bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType,
+          typename _LazyValueType>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
     std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
-    __sub_group_masked_scan<__is_inclusive, __init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
-                                                            __binary_op, __init_and_carry, __comm_slm);
+    __sub_group_masked_scan<__use_subgroup_ops, __is_inclusive, __init_present>(
+        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
-          typename _SizeType>
+template <bool __use_subgroup_ops, bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType,
+          typename _LazyValueType, typename _SizeType>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                          _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ValueType* __comm_slm)
@@ -1357,13 +1362,13 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    __sub_group_masked_scan<__is_inclusive, __init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
-                                                            __binary_op, __init_and_carry, __comm_slm);
+    __sub_group_masked_scan<__use_subgroup_ops, __is_inclusive, __init_present>(
+        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <bool __is_inclusive, bool __init_present, bool __capture_output, std::uint16_t __max_inputs_per_item,
-          typename _GenInput, typename _ScanInputTransform, typename _BinaryOp, typename _WriteOp,
-          typename _LazyValueType, typename _InRng, typename _OutRng, typename _ScanValueType>
+template <bool __use_subgroup_ops, bool __is_inclusive, bool __init_present, bool __capture_output,
+          std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform, typename _BinaryOp,
+          typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng, typename _ScanValueType>
 void
 __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
                                _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
@@ -1383,8 +1388,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
-                                                         __sub_group_carry, __comm_slm);
+        __sub_group_scan<__use_subgroup_ops, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
+                                                                  __sub_group_carry, __comm_slm);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1397,8 +1402,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __scan_input_transform(__v),
-                                                                          __binary_op, __sub_group_carry, __comm_slm);
+                __sub_group_scan<__use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1412,8 +1417,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__is_inclusive, /*__init_present=*/true>(__sub_group, __scan_input_transform(__v),
-                                                                          __binary_op, __sub_group_carry, __comm_slm);
+                __sub_group_scan<__use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1433,9 +1438,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 std::size_t __local_id = (__start_id < __n) ? __start_id : __n - 1;
                 _GenInputType __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v),
-                                                                         __binary_op, __sub_group_carry,
-                                                                         __n - __subgroup_start_id, __comm_slm);
+                __sub_group_scan_partial<__use_subgroup_ops, __is_inclusive, __init_present>(
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __n - __subgroup_start_id,
+                    __comm_slm);
                 if constexpr (__capture_output)
                 {
                     if (__start_id < __n)
@@ -1445,8 +1450,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             else
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-                __sub_group_scan<__is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
-                                                                 __sub_group_carry, __comm_slm);
+                __sub_group_scan<__use_subgroup_ops, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v),
+                                                                          __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1456,7 +1461,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 {
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
-                    __sub_group_scan<__is_inclusive, /*__init_present=*/true>(
+                    __sub_group_scan<__use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                         __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                     if constexpr (__capture_output)
                     {
@@ -1467,7 +1472,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 std::size_t __offset = __start_id + (__iters - 1) * __sub_group_size;
                 std::size_t __local_id = (__offset < __n) ? __offset : __n - 1;
                 __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan_partial<__use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
                     __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm);
                 if constexpr (__capture_output)
@@ -1540,111 +1545,126 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
-            __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) [[ _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32) ]] {
-                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-                const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
-
-                __reduce_then_scan_sub_group_params __sub_group_params(
-                    __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
-
-                _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                _InitValueType* __comm_slm_ptr = __use_slm_for_comm ? &__comm_slm[0] : nullptr;
-                std::size_t __group_id = __ndi.get_group(0);
-                std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-                std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-                std::size_t __group_start_id =
-                    (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
-                                                        __sub_group_params.__num_sub_groups_local);
-                if constexpr (__is_unique_pattern_v)
-                {
-                    // for unique patterns, the first element is always copied to the output, so we need to skip it
-                    __group_start_id += 1;
-                }
-                std::size_t __max_inputs_in_group =
-                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-                std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                    __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-                std::size_t __subgroup_start_id =
-                    __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
-
-                std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
-
-                if (__sub_group_id < __active_subgroups)
-                {
-                    // adjust for lane-id
-                    // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-                    __scan_through_elements_helper<__is_inclusive,
-                                                   /*__init_present=*/false,
-                                                   /*__capture_output=*/false, __max_inputs_per_item>(
-                        __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
-                        __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
-                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
-                        __comm_slm_ptr);
-                    if (__sub_group_local_id == 0)
-                        __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
-                    __sub_group_carry.__destroy();
-                }
-                __dpl_sycl::__group_barrier(__ndi);
-
-                // compute sub-group local prefix sums on (T0..63) carries
-                // and store to scratch space at the end of dst; next
-                // accumulator kernel takes M thread carries from scratch
-                // to compute a prefix sum on global carries
-                if (__sub_group_id == 0)
-                {
-                    __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
-                    std::uint8_t __iters =
-                        oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-                    if (__iters == 1)
-                    {
-                        // fill with unused dummy values to avoid overrunning input
-                        std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
-                        _InitValueType __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial</*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
-                        if (__sub_group_local_id < __active_subgroups)
-                            __temp_ptr[__start_id + __sub_group_local_id] = __v;
-                    }
+            __cgh.parallel_for<_KernelName...>(
+                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
+                    if (!__use_slm_for_comm)
+                        __reduce_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __in_rng,
+                                                   __inputs_remaining, __block_num);
                     else
-                    {
-                        std::uint32_t __reduction_scan_id = __sub_group_local_id;
-                        // need to pull out first iteration tp avoid identity
-                        _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                        __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
-                        __temp_ptr[__start_id + __reduction_scan_id] = __v;
-                        __reduction_scan_id += __sub_group_size;
-
-                        for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
-                        {
-                            __v = __sub_group_partials[__reduction_scan_id];
-                            __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/true>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
-                            __temp_ptr[__start_id + __reduction_scan_id] = __v;
-                            __reduction_scan_id += __sub_group_size;
-                        }
-                        // If we are past the input range, then the previous value of v is passed to the sub-group scan.
-                        // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
-
-                        // fill with unused dummy values to avoid overrunning input
-                        std::uint32_t __load_id =
-                            std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
-
-                        __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial</*__is_inclusive=*/true, /*__init_present=*/true>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry,
-                            __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
-                        if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
-                            __temp_ptr[__start_id + __reduction_scan_id] = __v;
-                    }
-
-                    __sub_group_carry.__destroy();
-                }
-            });
+                        __reduce_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __in_rng,
+                                                    __inputs_remaining, __block_num);
+                });
         });
+    }
+
+    template <bool __use_subgroup_ops, typename _TmpStorageAcc, typename _InRng>
+    void
+    __reduce_kernel_body(sycl::nd_item<1> __ndi,
+                         __dpl_sycl::__local_accessor<typename _InitType::__value_type> __sub_group_partials,
+                         __dpl_sycl::__local_accessor<typename _InitType::__value_type> __comm_slm,
+                         _TmpStorageAcc __temp_acc, _InRng __in_rng, const std::size_t __inputs_remaining,
+                         const std::size_t __block_num) const
+    {
+        using _InitValueType = typename _InitType::__value_type;
+        __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+        const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+
+        __reduce_then_scan_sub_group_params __sub_group_params(
+            __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
+
+        _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+        _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? &__comm_slm[0] : nullptr;
+        std::size_t __group_id = __ndi.get_group(0);
+        std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+        std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+
+        oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+        std::size_t __group_start_id =
+            (__block_num * __max_block_size) +
+            (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+        if constexpr (__is_unique_pattern_v)
+        {
+            // for unique patterns, the first element is always copied to the output, so we need to skip it
+            __group_start_id += 1;
+        }
+        std::size_t __max_inputs_in_group =
+            __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+        std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+        std::uint32_t __active_subgroups =
+            oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+        std::size_t __subgroup_start_id =
+            __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
+
+        std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+
+        if (__sub_group_id < __active_subgroups)
+        {
+            // adjust for lane-id
+            // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
+            __scan_through_elements_helper<__use_subgroup_ops, __is_inclusive,
+                                           /*__init_present=*/false,
+                                           /*__capture_output=*/false, __max_inputs_per_item>(
+                __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr, __sub_group_carry,
+                __in_rng, /*unused*/ __in_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
+                __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr);
+            if (__sub_group_local_id == 0)
+                __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
+            __sub_group_carry.__destroy();
+        }
+        __dpl_sycl::__group_barrier(__ndi);
+
+        // compute sub-group local prefix sums on (T0..63) carries
+        // and store to scratch space at the end of dst; next
+        // accumulator kernel takes M thread carries from scratch
+        // to compute a prefix sum on global carries
+        if (__sub_group_id == 0)
+        {
+            __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
+            std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+            if (__iters == 1)
+            {
+                // fill with unused dummy values to avoid overrunning input
+                std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
+                _InitValueType __v = __sub_group_partials[__load_id];
+                __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                    __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
+                if (__sub_group_local_id < __active_subgroups)
+                    __temp_ptr[__start_id + __sub_group_local_id] = __v;
+            }
+            else
+            {
+                std::uint32_t __reduction_scan_id = __sub_group_local_id;
+                // need to pull out first iteration tp avoid identity
+                _InitValueType __v = __sub_group_partials[__reduction_scan_id];
+                __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                __temp_ptr[__start_id + __reduction_scan_id] = __v;
+                __reduction_scan_id += __sub_group_size;
+
+                for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
+                {
+                    __v = __sub_group_partials[__reduction_scan_id];
+                    __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                        __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                    __temp_ptr[__start_id + __reduction_scan_id] = __v;
+                    __reduction_scan_id += __sub_group_size;
+                }
+                // If we are past the input range, then the previous value of v is passed to the sub-group scan.
+                // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
+
+                // fill with unused dummy values to avoid overrunning input
+                std::uint32_t __load_id = std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
+
+                __v = __sub_group_partials[__load_id];
+                __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                    __sub_group, __v, __reduce_op, __sub_group_carry,
+                    __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
+                if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
+                    __temp_ptr[__start_id + __reduction_scan_id] = __v;
+            }
+
+            __sub_group_carry.__destroy();
+        }
     }
 
     // Constant parameters throughout all blocks
@@ -1717,279 +1737,289 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             auto __res_acc =
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
-            __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi) [[ _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32) ]] {
-                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-                const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
-                _InitValueType* __comm_slm_ptr = __use_slm_for_comm ? &__comm_slm[0] : nullptr;
+            __cgh.parallel_for<_KernelName...>(
+                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
+                    if (!__use_slm_for_comm)
+                        __scan_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __res_acc,
+                                                 __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
+                                                 __block_num);
+                    else
+                        __scan_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __res_acc,
+                                                  __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
+                                                  __block_num);
+                });
+        });
+    }
 
-                __reduce_then_scan_sub_group_params __sub_group_params(
-                    __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
+    template <bool __use_subgroup_ops, typename _TmpStorageAcc, typename _ResStorageAcc, typename _InRng, typename _OutRng>
+    void
+    __scan_kernel_body(sycl::nd_item<1> __ndi, __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
+                       __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpStorageAcc __temp_acc,
+                       _ResStorageAcc __res_acc, _InRng __in_rng, _OutRng __out_rng, std::uint32_t __inputs_in_block,
+                       const std::size_t __inputs_remaining, const std::size_t __block_num) const
+    {
+        __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+        const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+        _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? &__comm_slm[0] : nullptr;
 
-                const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                    __inputs_in_block,
-                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+        __reduce_then_scan_sub_group_params __sub_group_params(
+            __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
-                _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                _InitValueType* __res_ptr =
-                    _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
-                std::uint32_t __group_id = __ndi.get_group(0);
-                std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-                std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+        const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
+            __inputs_in_block, __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
 
-                std::size_t __group_start_id =
-                    (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
-                                                        __sub_group_params.__num_sub_groups_local);
-                if constexpr (__is_unique_pattern_v)
+        _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+        _InitValueType* __res_ptr =
+            _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
+        std::uint32_t __group_id = __ndi.get_group(0);
+        std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+        std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+
+        std::size_t __group_start_id =
+            (__block_num * __max_block_size) +
+            (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+        if constexpr (__is_unique_pattern_v)
+        {
+            // for unique patterns, the first element is always copied to the output, so we need to skip it
+            __group_start_id += 1;
+        }
+
+        std::size_t __max_inputs_in_group =
+            __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+        std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+        std::uint32_t __active_subgroups =
+            oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+        oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
+
+        // propagate carry in from previous block
+        oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+
+        // on the first sub-group in a work-group (assuming S subgroups in a work-group):
+        // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
+        // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
+        //    and then compute the prefix sum to generate global carry out
+        //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
+        // 3. on each WG select the adjacent neighboring WG carry in
+        // 4. on each WG add the global carry-in to S sub-group local prefix sums to
+        //    get a T-local global carry in
+        // 5. recompute T-local prefix values, add the T-local global carries,
+        //    and then write back the final values to memory
+        if (__sub_group_id == 0)
+        {
+            // step 1) load to SLM the WG-local S prefix sums
+            //         on WG T-local carries
+            //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
+            //           S: sum(T0 carry...TS carry)
+            std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+            std::size_t __subgroups_before_my_group = __group_id * __sub_group_params.__num_sub_groups_local;
+            std::uint32_t __load_reduction_id = __sub_group_local_id;
+            std::uint8_t __i = 0;
+            for (; __i < __iters - 1; __i++)
+            {
+                __sub_group_partials[__load_reduction_id] =
+                    __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
+                __load_reduction_id += __sub_group_size;
+            }
+            if (__load_reduction_id < __active_subgroups)
+            {
+                __sub_group_partials[__load_reduction_id] =
+                    __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
+            }
+
+            // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
+            //         compute the prefix in a sub-group to get global work-group carries
+            //         memory accesses: gather(63, 127, 191, 255, ...)
+            std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
+            // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
+            if (__group_id > 0)
+            {
+                // only need the last element from each scan of num_sub_groups_local subgroup reductions
+                const std::size_t __elements_to_process =
+                    __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
+                const std::size_t __pre_carry_iters =
+                    oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
+                if (__pre_carry_iters == 1)
                 {
-                    // for unique patterns, the first element is always copied to the output, so we need to skip it
-                    __group_start_id += 1;
-                }
-
-                std::size_t __max_inputs_in_group =
-                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-                std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                    __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
-
-                // propagate carry in from previous block
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-
-                // on the first sub-group in a work-group (assuming S subgroups in a work-group):
-                // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
-                // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
-                //    and then compute the prefix sum to generate global carry out
-                //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
-                // 3. on each WG select the adjacent neighboring WG carry in
-                // 4. on each WG add the global carry-in to S sub-group local prefix sums to
-                //    get a T-local global carry in
-                // 5. recompute T-local prefix values, add the T-local global carries,
-                //    and then write back the final values to memory
-                if (__sub_group_id == 0)
-                {
-                    // step 1) load to SLM the WG-local S prefix sums
-                    //         on WG T-local carries
-                    //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
-                    //           S: sum(T0 carry...TS carry)
-                    std::uint8_t __iters =
-                        oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-                    std::size_t __subgroups_before_my_group = __group_id * __sub_group_params.__num_sub_groups_local;
-                    std::uint32_t __load_reduction_id = __sub_group_local_id;
-                    std::uint8_t __i = 0;
-                    for (; __i < __iters - 1; __i++)
-                    {
-                        __sub_group_partials[__load_reduction_id] =
-                            __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
-                        __load_reduction_id += __sub_group_size;
-                    }
-                    if (__load_reduction_id < __active_subgroups)
-                    {
-                        __sub_group_partials[__load_reduction_id] =
-                            __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
-                    }
-
-                    // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
-                    //         compute the prefix in a sub-group to get global work-group carries
-                    //         memory accesses: gather(63, 127, 191, 255, ...)
-                    std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
-                    // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
-                    if (__group_id > 0)
-                    {
-                        // only need the last element from each scan of num_sub_groups_local subgroup reductions
-                        const std::size_t __elements_to_process =
-                            __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
-                        const std::size_t __pre_carry_iters =
-                            oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
-                        if (__pre_carry_iters == 1)
-                        {
-                            // single partial scan
-                            std::size_t __proposed_id =
-                                __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
-                            std::size_t __remaining_elements = __elements_to_process;
-                            std::size_t __reduction_id = (__proposed_id < __subgroups_before_my_group)
-                                                             ? __proposed_id
-                                                             : __subgroups_before_my_group - 1;
-                            _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan_partial</*__is_inclusive=*/true,
-                                                     /*__init_present=*/false>(
-                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
-                        }
-                        else
-                        {
-                            // multiple iterations
-                            // first 1 full
-                            std::uint32_t __reduction_id =
-                                __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
-                            std::uint32_t __reduction_id_increment =
-                                __sub_group_params.__num_sub_groups_local * __sub_group_size;
-                            _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/false>(
-                                __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
-                            __reduction_id += __reduction_id_increment;
-                            // then some number of full iterations
-                            for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
-                            {
-                                __value = __tmp_ptr[__reduction_id];
-                                __sub_group_scan</*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
-                                __reduction_id += __reduction_id_increment;
-                            }
-
-                            // final partial iteration
-
-                            std::size_t __remaining_elements =
-                                __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
-                            // fill with unused dummy values to avoid overrunning input
-                            std::size_t __final_reduction_id =
-                                std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
-                            __value = __tmp_ptr[__final_reduction_id];
-                            __sub_group_scan_partial</*__is_inclusive=*/true,
-                                                     /*__init_present=*/true>(
-                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
-                        }
-
-                        // steps 3+4) load global carry in from neighbor work-group
-                        //            and apply to local sub-group prefix carries
-                        std::size_t __carry_offset = __sub_group_local_id;
-
-                        std::uint8_t __iters =
-                            oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-
-                        std::uint8_t __i = 0;
-                        for (; __i < __iters - 1; ++__i)
-                        {
-                            __sub_group_partials[__carry_offset] =
-                                __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                            __carry_offset += __sub_group_size;
-                        }
-                        if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
-                        {
-                            __sub_group_partials[__carry_offset] =
-                                __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                            __carry_offset += __sub_group_size;
-                        }
-                        if (__sub_group_local_id == 0)
-                            __sub_group_partials[__active_subgroups] = __carry_last.__v;
-                        __carry_last.__destroy();
-                    }
-                }
-
-                __dpl_sycl::__group_barrier(__ndi);
-
-                // Get inter-work group and adjusted for intra-work group prefix
-                bool __sub_group_carry_initialized = true;
-                if (__block_num == 0)
-                {
-                    if (__sub_group_id > 0)
-                    {
-                        _InitValueType __value =
-                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                        oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
-                        __sub_group_carry.__setup(__value);
-                    }
-                    else if (__group_id > 0)
-                    {
-                        _InitValueType __value = __sub_group_partials[__active_subgroups];
-                        oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
-                        __sub_group_carry.__setup(__value);
-                    }
-                    else // zeroth block, group and subgroup
-                    {
-                        if constexpr (__is_unique_pattern_v)
-                        {
-                            if (__sub_group_local_id == 0)
-                            {
-                                // For unique patterns, always copy the 0th element to the output
-                                __write_op.__assign(__in_rng[0], __out_rng[0]);
-                            }
-                        }
-
-                        if constexpr (std::is_same_v<_InitType,
-                                                     oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
-                        {
-                            // This is the only case where we still don't have a carry in.  No init value, 0th block,
-                            // group, and subgroup. This changes the final scan through elements below.
-                            __sub_group_carry_initialized = false;
-                        }
-                        else
-                        {
-                            __sub_group_carry.__setup(__init.__value);
-                        }
-                    }
+                    // single partial scan
+                    std::size_t __proposed_id =
+                        __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
+                    std::size_t __remaining_elements = __elements_to_process;
+                    std::size_t __reduction_id =
+                        (__proposed_id < __subgroups_before_my_group) ? __proposed_id : __subgroups_before_my_group - 1;
+                    _InitValueType __value = __tmp_ptr[__reduction_id];
+                    __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true,
+                                             /*__init_present=*/false>(__sub_group, __value, __reduce_op, __carry_last,
+                                                                       __remaining_elements, __comm_slm_ptr);
                 }
                 else
                 {
-                    if (__sub_group_id > 0)
+                    // multiple iterations
+                    // first 1 full
+                    std::uint32_t __reduction_id =
+                        __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
+                    std::uint32_t __reduction_id_increment =
+                        __sub_group_params.__num_sub_groups_local * __sub_group_size;
+                    _InitValueType __value = __tmp_ptr[__reduction_id];
+                    __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                        __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
+                    __reduction_id += __reduction_id_increment;
+                    // then some number of full iterations
+                    for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                     {
-                        _InitValueType __value =
-                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                        __sub_group_carry.__setup(__reduce_op(
-                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
-                            __value));
+                        __value = __tmp_ptr[__reduction_id];
+                        __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                            __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
+                        __reduction_id += __reduction_id_increment;
                     }
-                    else if (__group_id > 0)
+
+                    // final partial iteration
+
+                    std::size_t __remaining_elements =
+                        __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
+                    // fill with unused dummy values to avoid overrunning input
+                    std::size_t __final_reduction_id =
+                        std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
+                    __value = __tmp_ptr[__final_reduction_id];
+                    __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true,
+                                             /*__init_present=*/true>(__sub_group, __value, __reduce_op, __carry_last,
+                                                                      __remaining_elements, __comm_slm_ptr);
+                }
+
+                // steps 3+4) load global carry in from neighbor work-group
+                //            and apply to local sub-group prefix carries
+                std::size_t __carry_offset = __sub_group_local_id;
+
+                std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+
+                std::uint8_t __i = 0;
+                for (; __i < __iters - 1; ++__i)
+                {
+                    __sub_group_partials[__carry_offset] =
+                        __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                    __carry_offset += __sub_group_size;
+                }
+                if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
+                {
+                    __sub_group_partials[__carry_offset] =
+                        __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                    __carry_offset += __sub_group_size;
+                }
+                if (__sub_group_local_id == 0)
+                    __sub_group_partials[__active_subgroups] = __carry_last.__v;
+                __carry_last.__destroy();
+            }
+        }
+
+        __dpl_sycl::__group_barrier(__ndi);
+
+        // Get inter-work group and adjusted for intra-work group prefix
+        bool __sub_group_carry_initialized = true;
+        if (__block_num == 0)
+        {
+            if (__sub_group_id > 0)
+            {
+                _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
+                __sub_group_carry.__setup(__value);
+            }
+            else if (__group_id > 0)
+            {
+                _InitValueType __value = __sub_group_partials[__active_subgroups];
+                oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
+                __sub_group_carry.__setup(__value);
+            }
+            else // zeroth block, group and subgroup
+            {
+                if constexpr (__is_unique_pattern_v)
+                {
+                    if (__sub_group_local_id == 0)
                     {
-                        __sub_group_carry.__setup(__reduce_op(
-                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
-                            __sub_group_partials[__active_subgroups]));
-                    }
-                    else
-                    {
-                        __sub_group_carry.__setup(
-                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global));
+                        // For unique patterns, always copy the 0th element to the output
+                        __write_op.__assign(__in_rng[0], __out_rng[0]);
                     }
                 }
 
-                // step 5) apply global carries
-                std::size_t __subgroup_start_id =
-                    __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
-                std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+                if constexpr (std::is_same_v<_InitType, oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
+                {
+                    // This is the only case where we still don't have a carry in.  No init value, 0th block,
+                    // group, and subgroup. This changes the final scan through elements below.
+                    __sub_group_carry_initialized = false;
+                }
+                else
+                {
+                    __sub_group_carry.__setup(__init.__value);
+                }
+            }
+        }
+        else
+        {
+            if (__sub_group_id > 0)
+            {
+                _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                __sub_group_carry.__setup(__reduce_op(
+                    __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global), __value));
+            }
+            else if (__group_id > 0)
+            {
+                __sub_group_carry.__setup(__reduce_op(
+                    __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
+                    __sub_group_partials[__active_subgroups]));
+            }
+            else
+            {
+                __sub_group_carry.__setup(
+                    __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global));
+            }
+        }
 
-                if (__sub_group_carry_initialized)
+        // step 5) apply global carries
+        std::size_t __subgroup_start_id =
+            __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
+        std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+
+        if (__sub_group_carry_initialized)
+        {
+            __scan_through_elements_helper<__use_subgroup_ops, __is_inclusive,
+                                           /*__init_present=*/true,
+                                           /*__capture_output=*/true, __max_inputs_per_item>(
+                __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
+                __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
+                __sub_group_id, __active_subgroups, __comm_slm_ptr);
+        }
+        else // first group first block, no subgroup carry
+        {
+            __scan_through_elements_helper<__use_subgroup_ops, __is_inclusive,
+                                           /*__init_present=*/false,
+                                           /*__capture_output=*/true, __max_inputs_per_item>(
+                __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
+                __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
+                __sub_group_id, __active_subgroups, __comm_slm_ptr);
+        }
+        // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
+        // to write out the last carry out for either the return value or the next block
+        if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
+            (__active_subgroups == __sub_group_id + 1))
+        {
+            if (__block_num + 1 == __num_blocks)
+            {
+                if constexpr (__is_unique_pattern_v)
                 {
-                    __scan_through_elements_helper<__is_inclusive,
-                                                   /*__init_present=*/true,
-                                                   /*__capture_output=*/true, __max_inputs_per_item>(
-                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
-                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr);
+                    // unique patterns automatically copy the 0th element and scan starting at index 1
+                    __res_ptr[0] = __sub_group_carry.__v + 1;
                 }
-                else // first group first block, no subgroup carry
+                else
                 {
-                    __scan_through_elements_helper<__is_inclusive,
-                                                   /*__init_present=*/false,
-                                                   /*__capture_output=*/true, __max_inputs_per_item>(
-                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
-                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr);
+                    __res_ptr[0] = __sub_group_carry.__v;
                 }
-                // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
-                // to write out the last carry out for either the return value or the next block
-                if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
-                    (__active_subgroups == __sub_group_id + 1))
-                {
-                    if (__block_num + 1 == __num_blocks)
-                    {
-                        if constexpr (__is_unique_pattern_v)
-                        {
-                            // unique patterns automatically copy the 0th element and scan starting at index 1
-                            __res_ptr[0] = __sub_group_carry.__v + 1;
-                        }
-                        else
-                        {
-                            __res_ptr[0] = __sub_group_carry.__v;
-                        }
-                    }
-                    else
-                    {
-                        // capture the last carry out for the next block
-                        __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v,
-                                              __sub_group_params.__num_sub_groups_global);
-                    }
-                }
-                __sub_group_carry.__destroy();
-            });
-        });
+            }
+            else
+            {
+                // capture the last carry out for the next block
+                __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v,
+                                      __sub_group_params.__num_sub_groups_global);
+            }
+        }
+        __sub_group_carry.__destroy();
     }
 
     const std::uint32_t __max_num_work_groups;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1197,11 +1197,11 @@ struct __scan_by_seg_op
 // *** Main reduce then scan infrastructure ***
 
 // Sub-group communication wrappers with SLM fallback.
-// When __comm_slm is nullptr, native SYCL sub-group operations are used (trivially copyable types only).
-// When __comm_slm is non-null, SLM-based communication is used. This path is required for
+// When __use_subgroup_ops is true, native SYCL sub-group operations are used (trivially copyable types only).
+// When __use_subgroup_ops is false, SLM-based communication is used. This path is required for
 // non-trivially-copyable types and preferred for CPU targets where sub-group ops are slow.
 // The __comm_slm parameter points to a work-group-sized SLM buffer; each sub-group uses its own
-// slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size).
+// slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size].
 
 template <bool __use_subgroup_ops, typename _ValueType>
 _ValueType
@@ -1689,7 +1689,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_slm_for_comm ? __work_group_size : 0, __cgh);
+            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_subgroup_ops ? 0 : __work_group_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
@@ -1698,7 +1698,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                     _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
 
-                    if (!__use_slm_for_comm)
+                    if (__use_subgroup_ops)
                         __reduce_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __in_rng,
                                                    __inputs_remaining, __block_num);
                     else
@@ -1714,7 +1714,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
     const std::uint32_t __max_block_size;
     const std::uint32_t __max_num_sub_groups_local;
     const std::size_t __n;
-    const bool __use_slm_for_comm;
+    const bool __use_subgroup_ops;
 
     const _GenReduceInput __gen_reduce_input;
     const _ReduceOp __reduce_op;
@@ -2042,7 +2042,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_slm_for_comm ? __work_group_size : 0, __cgh);
+            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_subgroup_ops ? 0: __work_group_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::read_write>(__cgh);
@@ -2055,7 +2055,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     _InitValueType* __res_ptr =
                         _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
 
-                    if (!__use_slm_for_comm)
+                    if (__use_subgroup_ops)
                         __scan_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __res_ptr,
                                                  __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
                                                  __block_num);
@@ -2074,7 +2074,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
     const std::uint32_t __max_num_sub_groups_global;
     const std::size_t __num_blocks;
     const std::size_t __n;
-    const bool __use_slm_for_comm;
+    const bool __use_subgroup_ops;
 
     const _ReduceOp __reduce_op;
     const _GenScanInput __gen_scan_input;
@@ -2162,9 +2162,8 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     // between reading and writing the block carry-out within a single kernel.
     __result_and_scratch_storage<_ValueType> __result_and_scratch{__q, __max_num_sub_groups_global + 2};
 
-    // Use SLM-based sub-group communication for non-trivially-copyable types or CPU targets
-    // (where native sub-group operations are slow).
-    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType>;
+    // Native sycl sub-group operations can only be used on trivially copyable types.
+    const bool __use_subgroup_ops = std::is_trivially_copyable_v<_ValueType>;
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =
@@ -2179,7 +2178,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
                                         __max_inputs_per_block,
                                         __max_num_sub_groups_local,
                                         __n,
-                                        __use_slm_for_comm,
+                                        __use_subgroup_ops,
                                         __gen_reduce_input,
                                         __reduce_op,
                                         __init};
@@ -2190,7 +2189,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
                                     __max_num_sub_groups_global,
                                     __num_blocks,
                                     __n,
-                                    __use_slm_for_comm,
+                                    __use_subgroup_ops,
                                     __reduce_op,
                                     __gen_scan_input,
                                     __scan_input_transform,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1527,23 +1527,22 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                                                     _GenReduceInput, _ReduceOp, _InitType,
                                                     __internal::__optional_kernel_name<_KernelName...>>
 {
+    using _InitValueType = typename _InitType::__value_type;
 
-    template <bool __use_subgroup_ops, typename _TmpStorageAcc, typename _InRng>
+    template <bool __use_subgroup_ops, typename _TmpAcc, typename _InRng>
     void
     __reduce_kernel_body(sycl::nd_item<1> __ndi,
-                         __dpl_sycl::__local_accessor<typename _InitType::__value_type> __sub_group_partials,
-                         __dpl_sycl::__local_accessor<typename _InitType::__value_type> __comm_slm,
-                         _TmpStorageAcc __temp_acc, _InRng __in_rng, const std::size_t __inputs_remaining,
+                         __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
+                         __dpl_sycl::__local_accessor<_InitValueType> __comm_slm,
+                         _TmpAcc __tmp_acc, _InRng __in_rng, const std::size_t __inputs_remaining,
                          const std::size_t __block_num) const
     {
-        using _InitValueType = typename _InitType::__value_type;
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
         const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
 
         __reduce_then_scan_sub_group_params __sub_group_params(
             __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
-        _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
         _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? &__comm_slm[0] : nullptr;
         std::size_t __group_id = __ndi.get_group(0);
         std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
@@ -1600,7 +1599,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/false>(
                     __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
                 if (__sub_group_local_id < __active_subgroups)
-                    __temp_ptr[__start_id + __sub_group_local_id] = __v;
+                    __tmp_acc[__start_id + __sub_group_local_id] = __v;
             }
             else
             {
@@ -1609,7 +1608,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 _InitValueType __v = __sub_group_partials[__reduction_scan_id];
                 __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/false>(
                     __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
-                __temp_ptr[__start_id + __reduction_scan_id] = __v;
+                __tmp_acc[__start_id + __reduction_scan_id] = __v;
                 __reduction_scan_id += __sub_group_size;
 
                 for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
@@ -1617,7 +1616,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                     __v = __sub_group_partials[__reduction_scan_id];
                     __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/true>(
                         __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
-                    __temp_ptr[__start_id + __reduction_scan_id] = __v;
+                    __tmp_acc[__start_id + __reduction_scan_id] = __v;
                     __reduction_scan_id += __sub_group_size;
                 }
                 // If we are past the input range, then the previous value of v is passed to the sub-group scan.
@@ -1631,7 +1630,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                     __sub_group, __v, __reduce_op, __sub_group_carry,
                     __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
                 if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
-                    __temp_ptr[__start_id + __reduction_scan_id] = __v;
+                    __tmp_acc[__start_id + __reduction_scan_id] = __v;
             }
 
             __sub_group_carry.__destroy();
@@ -1645,7 +1644,6 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
-        using _InitValueType = typename _InitType::__value_type;
         return __q.submit([&, this](sycl::handler& __cgh) {
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
@@ -1657,11 +1655,13 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 __cgh, __dpl_sycl::__no_init{});
             __cgh.parallel_for<_KernelName...>(
                 __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
+                    _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+
                     if (!__use_slm_for_comm)
-                        __reduce_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __in_rng,
+                        __reduce_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __in_rng,
                                                    __inputs_remaining, __block_num);
                     else
-                        __reduce_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __in_rng,
+                        __reduce_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __in_rng,
                                                     __inputs_remaining, __block_num);
                 });
         });
@@ -1694,26 +1694,28 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 {
     using _InitValueType = typename _InitType::__value_type;
 
+    template <typename _TmpAcc>
     _InitValueType
-    __get_block_carry_in(const std::size_t __block_num, _InitValueType* __tmp_ptr,
+    __get_block_carry_in(const std::size_t __block_num, _TmpAcc __tmp_acc,
                          const std::size_t __num_sub_groups_global) const
     {
-        return __tmp_ptr[__num_sub_groups_global + (__block_num % 2)];
+        return __tmp_acc[__num_sub_groups_global + (__block_num % 2)];
     }
 
-    template <typename _ValueType>
+
+    template <typename _TmpAcc, typename _ValueType>
     void
-    __set_block_carry_out(const std::size_t __block_num, _InitValueType* __tmp_ptr, const _ValueType __block_carry_out,
+    __set_block_carry_out(const std::size_t __block_num, _TmpAcc __tmp_acc, const _ValueType __block_carry_out,
                           const std::size_t __num_sub_groups_global) const
     {
-        __tmp_ptr[__num_sub_groups_global + 1 - (__block_num % 2)] = __block_carry_out;
+        __tmp_acc[__num_sub_groups_global + 1 - (__block_num % 2)] = __block_carry_out;
     }
 
-    template <bool __use_subgroup_ops, typename _TmpStorageAcc, typename _ResStorageAcc, typename _InRng, typename _OutRng>
+    template <bool __use_subgroup_ops, typename _TmpAcc, typename _ResAcc, typename _InRng, typename _OutRng>
     void
     __scan_kernel_body(sycl::nd_item<1> __ndi, __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
-                       __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpStorageAcc __temp_acc,
-                       _ResStorageAcc __res_acc, _InRng __in_rng, _OutRng __out_rng, std::uint32_t __inputs_in_block,
+                       __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpAcc __tmp_acc,
+                       _ResAcc __res_acc, _InRng __in_rng, _OutRng __out_rng, std::uint32_t __inputs_in_block,
                        const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
@@ -1726,9 +1728,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
         const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
             __inputs_in_block, __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
 
-        _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-        _InitValueType* __res_ptr =
-            _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
+
         std::uint32_t __group_id = __ndi.get_group(0);
         std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
         std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -1775,13 +1775,13 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             for (; __i < __iters - 1; __i++)
             {
                 __sub_group_partials[__load_reduction_id] =
-                    __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
+                    __tmp_acc[__subgroups_before_my_group + __load_reduction_id];
                 __load_reduction_id += __sub_group_size;
             }
             if (__load_reduction_id < __active_subgroups)
             {
                 __sub_group_partials[__load_reduction_id] =
-                    __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
+                    __tmp_acc[__subgroups_before_my_group + __load_reduction_id];
             }
 
             // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
@@ -1804,7 +1804,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     std::size_t __remaining_elements = __elements_to_process;
                     std::size_t __reduction_id =
                         (__proposed_id < __subgroups_before_my_group) ? __proposed_id : __subgroups_before_my_group - 1;
-                    _InitValueType __value = __tmp_ptr[__reduction_id];
+                    _InitValueType __value = __tmp_acc[__reduction_id];
                     __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true,
                                              /*__init_present=*/false>(__sub_group, __value, __reduce_op, __carry_last,
                                                                        __remaining_elements, __comm_slm_ptr);
@@ -1817,14 +1817,14 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                         __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
                     std::uint32_t __reduction_id_increment =
                         __sub_group_params.__num_sub_groups_local * __sub_group_size;
-                    _InitValueType __value = __tmp_ptr[__reduction_id];
+                    _InitValueType __value = __tmp_acc[__reduction_id];
                     __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/false>(
                         __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
                     __reduction_id += __reduction_id_increment;
                     // then some number of full iterations
                     for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                     {
-                        __value = __tmp_ptr[__reduction_id];
+                        __value = __tmp_acc[__reduction_id];
                         __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/true>(
                             __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
                         __reduction_id += __reduction_id_increment;
@@ -1837,7 +1837,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     // fill with unused dummy values to avoid overrunning input
                     std::size_t __final_reduction_id =
                         std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
-                    __value = __tmp_ptr[__final_reduction_id];
+                    __value = __tmp_acc[__final_reduction_id];
                     __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true,
                                              /*__init_present=*/true>(__sub_group, __value, __reduce_op, __carry_last,
                                                                       __remaining_elements, __comm_slm_ptr);
@@ -1915,18 +1915,18 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             {
                 _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
                 __sub_group_carry.__setup(__reduce_op(
-                    __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global), __value));
+                    __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global), __value));
             }
             else if (__group_id > 0)
             {
                 __sub_group_carry.__setup(__reduce_op(
-                    __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
+                    __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global),
                     __sub_group_partials[__active_subgroups]));
             }
             else
             {
                 __sub_group_carry.__setup(
-                    __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global));
+                    __get_block_carry_in(__block_num, __tmp_acc, __sub_group_params.__num_sub_groups_global));
             }
         }
 
@@ -1963,17 +1963,17 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 if constexpr (__is_unique_pattern_v)
                 {
                     // unique patterns automatically copy the 0th element and scan starting at index 1
-                    __res_ptr[0] = __sub_group_carry.__v + 1;
+                    __res_acc[0] = __sub_group_carry.__v + 1;
                 }
                 else
                 {
-                    __res_ptr[0] = __sub_group_carry.__v;
+                    __res_acc[0] = __sub_group_carry.__v;
                 }
             }
             else
             {
                 // capture the last carry out for the next block
-                __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v,
+                __set_block_carry_out(__block_num, __tmp_acc, __sub_group_carry.__v,
                                       __sub_group_params.__num_sub_groups_global);
             }
         }
@@ -2010,12 +2010,16 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 
             __cgh.parallel_for<_KernelName...>(
                 __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
+                    _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                    _InitValueType* __res_ptr =
+                        _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
+
                     if (!__use_slm_for_comm)
-                        __scan_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __res_acc,
+                        __scan_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __res_ptr,
                                                  __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
                                                  __block_num);
                     else
-                        __scan_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __temp_acc, __res_acc,
+                        __scan_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __res_ptr,
                                                   __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
                                                   __block_num);
                 });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1567,6 +1567,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                                                     __internal::__optional_kernel_name<_KernelName...>>
 {
     using _InitValueType = typename _InitType::__value_type;
+    static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
 
     template <bool __use_subgroup_ops, typename _TmpAcc, typename _InRng>
     void
@@ -1575,7 +1576,6 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                          const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-        constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
 
         __reduce_then_scan_sub_group_params __sub_group_params(
             __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
@@ -1695,7 +1695,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
             __cgh.parallel_for<_KernelName...>(
-                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_sycl::reqd_sub_group_size(__sub_group_size)]] {
+                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                     _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
 
                     if (!__use_slm_for_comm)
@@ -1734,6 +1734,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                                   __internal::__optional_kernel_name<_KernelName...>>
 {
     using _InitValueType = typename _InitType::__value_type;
+    static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
 
     template <typename _TmpAcc>
     _InitValueType
@@ -1759,7 +1760,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                        const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-        constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
         _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
 
         __reduce_then_scan_sub_group_params __sub_group_params(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1575,7 +1575,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                          const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-        const std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
+        constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
 
         __reduce_then_scan_sub_group_params __sub_group_params(
             __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
@@ -1695,7 +1695,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
             __cgh.parallel_for<_KernelName...>(
-                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
+                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_sycl::reqd_sub_group_size(__sub_group_size)]] {
                     _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
 
                     if (!__use_slm_for_comm)
@@ -1759,7 +1759,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                        const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-        const std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
+        constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
         _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
 
         __reduce_then_scan_sub_group_params __sub_group_params(
@@ -2050,7 +2050,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
             __cgh.parallel_for<_KernelName...>(
-                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(32)]] {
+                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                     _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                     _InitValueType* __res_ptr =
                         _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1543,7 +1543,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
         __reduce_then_scan_sub_group_params __sub_group_params(
             __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
-        _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? &__comm_slm[0] : nullptr;
+        _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
         std::size_t __group_id = __ndi.get_group(0);
         std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
         std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -1720,7 +1720,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
         const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
-        _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? &__comm_slm[0] : nullptr;
+        _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
 
         __reduce_then_scan_sub_group_params __sub_group_params(
             __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1592,9 +1592,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                                                     _GenReduceInput, _ReduceOp, _InitType,
                                                     __internal::__optional_kernel_name<_KernelName...>>
 {
-    using _InitValueType = typename _InitType::__value_type;
     static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
-
     // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
     // input buffer
     template <typename _InRng, typename _TmpStorageAcc>
@@ -1603,6 +1601,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
                const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
+        using _InitValueType = typename _InitType::__value_type;
         return __q.submit([&, this](sycl::handler& __cgh) {
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
@@ -1794,12 +1793,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
             __cgh.parallel_for<_KernelName...>(
-                    __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                _InitValueType* __res_ptr =
-                    _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
-
-                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                    __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                 _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
 
                 __reduce_then_scan_sub_group_params __sub_group_params(
@@ -1809,7 +1803,12 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     __inputs_in_block,
                     __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
 
+                _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                _InitValueType* __res_ptr =
+                    _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
+
                 std::uint32_t __group_id = __ndi.get_group(0);
+                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1345,43 +1345,60 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
     }
 }
 
-template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
-          typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+// Entry points for per-scan dispatch: pick a sub-group-ops or SLM specialization at runtime, keeping
+// all code above a single instantiation. The branch executes once per scan (not per element).
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                 _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+                 _LazyValueType& __init_and_carry, _ValueType* __comm_slm, bool __use_subgroup_ops)
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
-    constexpr std::uint8_t __init_broadcast_id = __sub_group_size - 1;
-    __sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
-        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+    std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
+    if (__use_subgroup_ops)
+    {
+        __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
+            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+    }
+    else
+    {
+        __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/false, __is_inclusive, __init_present>(
+            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+    }
 }
 
-template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
-          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _SizeType>
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
+          typename _SizeType>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ValueType* __comm_slm)
+                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ValueType* __comm_slm,
+                         bool __use_subgroup_ops)
 {
     auto __mask_fn = [__elements_to_process](auto __sub_group_local_id, auto __offset) {
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    __sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
-        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+    if (__use_subgroup_ops)
+    {
+        __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
+            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+    }
+    else
+    {
+        __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/false, __is_inclusive, __init_present>(
+            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+    }
 }
 
-template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
-          bool __capture_output, std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform,
-          typename _BinaryOp, typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng,
-          typename _ScanValueType>
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output, std::uint16_t __max_inputs_per_item, typename _GenInput,
+         typename _ScanInputTransform, typename _BinaryOp, typename _WriteOp, typename _LazyValueType, typename _InRng,
+          typename _OutRng, typename _ScanValueType>
 void
 __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
                                _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
                                _LazyValueType& __sub_group_carry, const _InRng& __in_rng, _OutRng& __out_rng,
                                std::size_t __start_id, std::size_t __n, std::uint32_t __iters_per_item,
                                std::size_t __subgroup_start_id, std::uint32_t __sub_group_id,
-                               std::uint32_t __active_subgroups, _ScanValueType* __comm_slm)
+                               std::uint32_t __active_subgroups, _ScanValueType* __comm_slm, bool __use_subgroup_ops)
 {
     using _GenInputType = std::invoke_result_t<_GenInput, _InRng, std::size_t, typename _GenInput::TempData&>;
     bool __is_full_block = (__iters_per_item == __max_inputs_per_item);
@@ -1392,8 +1409,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
-            __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
+                                                         __sub_group_carry, __comm_slm, __use_subgroup_ops);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1406,8 +1423,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+                __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm, __use_subgroup_ops);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1421,8 +1438,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+                __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm, __use_subgroup_ops);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1442,9 +1459,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 std::size_t __local_id = (__start_id < __n) ? __start_id : __n - 1;
                 _GenInputType __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+                __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __n - __subgroup_start_id,
-                    __comm_slm);
+                    __comm_slm, __use_subgroup_ops);
                 if constexpr (__capture_output)
                 {
                     if (__start_id < __n)
@@ -1454,8 +1471,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             else
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
+                                                                 __sub_group_carry, __comm_slm, __use_subgroup_ops);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1465,8 +1482,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 {
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
-                    __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
-                        __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+                    __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __scan_input_transform(__v),
+                                                                              __binary_op, __sub_group_carry,
+                                                                              __comm_slm, __use_subgroup_ops);
                     if constexpr (__capture_output)
                     {
                         __write_op(__out_rng, __local_id, __v, __temp_data);
@@ -1476,9 +1494,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 std::size_t __offset = __start_id + (__iters - 1) * __sub_group_size;
                 std::size_t __local_id = (__offset < __n) ? __offset : __n - 1;
                 __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan_partial<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
-                    __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm);
+                    __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm, __use_subgroup_ops);
                 if constexpr (__capture_output)
                 {
                     if (__offset < __n)
@@ -1569,7 +1587,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
     using _InitValueType = typename _InitType::__value_type;
     static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
 
-    template <bool __use_subgroup_ops, typename _TmpAcc, typename _InRng>
+    template <typename _TmpAcc, typename _InRng>
     void
     __reduce_kernel_body(sycl::nd_item<1> __ndi, __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
                          __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpAcc __tmp_acc, _InRng __in_rng,
@@ -1608,12 +1626,12 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
         {
             // adjust for lane-id
             // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-            __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
+            __scan_through_elements_helper<__sub_group_size, __is_inclusive,
                                            /*__init_present=*/false,
                                            /*__capture_output=*/false, __max_inputs_per_item>(
                 __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr, __sub_group_carry,
                 __in_rng, /*unused*/ __in_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr);
+                __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
             if (__sub_group_local_id == 0)
                 __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
             __sub_group_carry.__destroy();
@@ -1633,9 +1651,9 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 // fill with unused dummy values to avoid overrunning input
                 std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                 _InitValueType __v = __sub_group_partials[__load_id];
-                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
-                                         /*__init_present=*/false>(__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                                   __active_subgroups, __comm_slm_ptr);
+                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>
+                                                     (__sub_group, __v, __reduce_op, __sub_group_carry,
+                                                      __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
                 if (__sub_group_local_id < __active_subgroups)
                     __tmp_acc[__start_id + __sub_group_local_id] = __v;
             }
@@ -1644,18 +1662,16 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 std::uint32_t __reduction_scan_id = __sub_group_local_id;
                 // need to pull out first iteration tp avoid identity
                 _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
-                                 /*__init_present=*/false>(__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                           __comm_slm_ptr);
+                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
                 __tmp_acc[__start_id + __reduction_scan_id] = __v;
                 __reduction_scan_id += __sub_group_size;
 
                 for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
                 {
                     __v = __sub_group_partials[__reduction_scan_id];
-                    __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
-                                     /*__init_present=*/true>(__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                              __comm_slm_ptr);
+                    __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                        __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
                     __tmp_acc[__start_id + __reduction_scan_id] = __v;
                     __reduction_scan_id += __sub_group_size;
                 }
@@ -1666,10 +1682,9 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 std::uint32_t __load_id = std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
 
                 __v = __sub_group_partials[__load_id];
-                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
-                                         /*__init_present=*/true>(
+                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                     __sub_group, __v, __reduce_op, __sub_group_carry,
-                    __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
+                    __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr, __use_subgroup_ops);
                 if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
                     __tmp_acc[__start_id + __reduction_scan_id] = __v;
             }
@@ -1697,13 +1712,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             __cgh.parallel_for<_KernelName...>(
                 __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                     _InitValueType* __tmp_acc = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-
-                    if (__use_subgroup_ops)
-                        __reduce_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __in_rng,
-                                                   __inputs_remaining, __block_num);
-                    else
-                        __reduce_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __in_rng,
-                                                    __inputs_remaining, __block_num);
+                    __reduce_kernel_body(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __in_rng,
+                                         __inputs_remaining, __block_num);
                 });
         });
     }
@@ -1752,7 +1762,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
         __tmp_acc[__num_sub_groups_global + 1 - (__block_num % 2)] = __block_carry_out;
     }
 
-    template <bool __use_subgroup_ops, typename _TmpAcc, typename _ResAcc, typename _InRng, typename _OutRng>
+    template <typename _TmpAcc, typename _ResAcc, typename _InRng, typename _OutRng>
     void
     __scan_kernel_body(sycl::nd_item<1> __ndi, __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
                        __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpAcc __tmp_acc, _ResAcc __res_acc,
@@ -1844,9 +1854,9 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     std::size_t __reduction_id =
                         (__proposed_id < __subgroups_before_my_group) ? __proposed_id : __subgroups_before_my_group - 1;
                     _InitValueType __value = __tmp_acc[__reduction_id];
-                    __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
-                                             /*__init_present=*/false>(__sub_group, __value, __reduce_op, __carry_last,
-                                                                       __remaining_elements, __comm_slm_ptr);
+                    __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                        __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
+                        __use_subgroup_ops);
                 }
                 else
                 {
@@ -1857,17 +1867,15 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     std::uint32_t __reduction_id_increment =
                         __sub_group_params.__num_sub_groups_local * __sub_group_size;
                     _InitValueType __value = __tmp_acc[__reduction_id];
-                    __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
-                                     /*__init_present=*/false>(__sub_group, __value, __reduce_op, __carry_last,
-                                                               __comm_slm_ptr);
+                    __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                        __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
                     __reduction_id += __reduction_id_increment;
                     // then some number of full iterations
                     for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                     {
                         __value = __tmp_acc[__reduction_id];
-                        __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
-                                         /*__init_present=*/true>(__sub_group, __value, __reduce_op, __carry_last,
-                                                                  __comm_slm_ptr);
+                        __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                            __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
                         __reduction_id += __reduction_id_increment;
                     }
 
@@ -1879,9 +1887,9 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     std::size_t __final_reduction_id =
                         std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
                     __value = __tmp_acc[__final_reduction_id];
-                    __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
-                                             /*__init_present=*/true>(__sub_group, __value, __reduce_op, __carry_last,
-                                                                      __remaining_elements, __comm_slm_ptr);
+                    __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                        __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
+                        __use_subgroup_ops);
                 }
 
                 // steps 3+4) load global carry in from neighbor work-group
@@ -1978,21 +1986,21 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 
         if (__sub_group_carry_initialized)
         {
-            __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
+            __scan_through_elements_helper<__sub_group_size, __is_inclusive,
                                            /*__init_present=*/true,
                                            /*__capture_output=*/true, __max_inputs_per_item>(
                 __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
                 __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
-                __sub_group_id, __active_subgroups, __comm_slm_ptr);
+                __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
         }
         else // first group first block, no subgroup carry
         {
-            __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
+            __scan_through_elements_helper<__sub_group_size, __is_inclusive,
                                            /*__init_present=*/false,
                                            /*__capture_output=*/true, __max_inputs_per_item>(
                 __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
                 __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
-                __sub_group_id, __active_subgroups, __comm_slm_ptr);
+                __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
         }
         // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
         // to write out the last carry out for either the return value or the next block
@@ -2055,14 +2063,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     _InitValueType* __res_ptr =
                         _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
 
-                    if (__use_subgroup_ops)
-                        __scan_kernel_body<true>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __res_ptr,
-                                                 __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
-                                                 __block_num);
-                    else
-                        __scan_kernel_body<false>(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __res_ptr,
-                                                  __in_rng, __out_rng, __inputs_in_block, __inputs_remaining,
-                                                  __block_num);
+                    __scan_kernel_body(__ndi, __sub_group_partials, __comm_slm, __tmp_acc, __res_ptr, __in_rng,
+                                       __out_rng, __inputs_in_block, __inputs_remaining, __block_num);
                 });
         });
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -417,11 +417,15 @@ struct __gen_set_mask
             //duplication in __set_b then a mask is 1
 
             const std::size_t __count_a_left =
-                __id - oneapi::dpl::__internal::__pstl_left_bound_idx(__set_a, std::size_t{0}, __id, __set_a, __id, __comp, __proj1, __proj1) + 1;
+                __id -
+                oneapi::dpl::__internal::__pstl_left_bound_idx(__set_a, std::size_t{0}, __id, __set_a, __id, __comp,
+                                                               __proj1, __proj1) +
+                1;
 
-            const std::size_t __count_b = 
-                oneapi::dpl::__internal::__pstl_right_bound_idx(__set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
-                oneapi::dpl::__internal::__pstl_left_bound_idx(__set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
+            const std::size_t __count_b = oneapi::dpl::__internal::__pstl_right_bound_idx(
+                                              __set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
+                                          oneapi::dpl::__internal::__pstl_left_bound_idx(
+                                              __set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -1347,7 +1351,8 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
 
 // Entry points for per-scan dispatch: pick a sub-group-ops or SLM specialization at runtime, keeping
 // all code above a single instantiation. The branch executes once per scan (not per element).
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
+          typename _ValueType, typename _LazyValueType>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm, bool __use_subgroup_ops)
@@ -1366,8 +1371,8 @@ __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value
     }
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
-          typename _SizeType>
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
+          typename _ValueType, typename _LazyValueType, typename _SizeType>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                          _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ValueType* __comm_slm,
@@ -1389,9 +1394,9 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
     }
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output, std::uint16_t __max_inputs_per_item, typename _GenInput,
-         typename _ScanInputTransform, typename _BinaryOp, typename _WriteOp, typename _LazyValueType, typename _InRng,
-          typename _OutRng, typename _ScanValueType>
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output,
+          std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform, typename _BinaryOp,
+          typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng, typename _ScanValueType>
 void
 __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
                                _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
@@ -1409,8 +1414,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
-                                                         __sub_group_carry, __comm_slm, __use_subgroup_ops);
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
+            __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm, __use_subgroup_ops);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1424,7 +1429,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
                 __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm, __use_subgroup_ops);
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm,
+                    __use_subgroup_ops);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1439,7 +1445,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
                 __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm, __use_subgroup_ops);
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm,
+                    __use_subgroup_ops);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1471,8 +1478,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             else
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
-                                                                 __sub_group_carry, __comm_slm, __use_subgroup_ops);
+                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm,
+                    __use_subgroup_ops);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1482,9 +1490,9 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 {
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
-                    __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __scan_input_transform(__v),
-                                                                              __binary_op, __sub_group_carry,
-                                                                              __comm_slm, __use_subgroup_ops);
+                    __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
+                        __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm,
+                        __use_subgroup_ops);
                     if constexpr (__capture_output)
                     {
                         __write_op(__out_rng, __local_id, __v, __temp_data);
@@ -1605,8 +1613,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
                 __cgh, __dpl_sycl::__no_init{});
             __cgh.parallel_for<_KernelName...>(
-                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-
+                    __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                 __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
 
                 __reduce_then_scan_sub_group_params __sub_group_params(
@@ -1620,8 +1627,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
 
                 oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
                 std::size_t __group_start_id =
-                (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
-                                                    __sub_group_params.__num_sub_groups_local);
+                    (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
+                                                        __sub_group_params.__num_sub_groups_local);
                 if constexpr (__is_unique_pattern_v)
                 {
                     // for unique patterns, the first element is always copied to the output, so we need to skip it
@@ -1642,11 +1649,12 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                     // adjust for lane-id
                     // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
                     __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                                /*__init_present=*/false,
-                                                /*__capture_output=*/false, __max_inputs_per_item>(
-                        __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr, __sub_group_carry,
-                        __in_rng, /*unused*/ __in_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                                                   /*__init_present=*/false,
+                                                   /*__capture_output=*/false, __max_inputs_per_item>(
+                        __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
+                        __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
+                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
+                        __comm_slm_ptr, __use_subgroup_ops);
                     if (__sub_group_local_id == 0)
                         __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
                     __sub_group_carry.__destroy();
@@ -1660,15 +1668,16 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 if (__sub_group_id == 0)
                 {
                     __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
-                    std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                    std::uint8_t __iters =
+                        oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
                     if (__iters == 1)
                     {
                         // fill with unused dummy values to avoid overrunning input
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>
-                                                            (__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                            __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                            __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr,
+                            __use_subgroup_ops);
                         if (__sub_group_local_id < __active_subgroups)
                             __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
@@ -1694,19 +1703,20 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
 
                         // fill with unused dummy values to avoid overrunning input
-                        std::uint32_t __load_id = std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
+                        std::uint32_t __load_id =
+                            std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
 
                         __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                             __sub_group, __v, __reduce_op, __sub_group_carry,
-                            __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr, __use_subgroup_ops);
+                            __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr,
+                            __use_subgroup_ops);
                         if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                     }
 
                     __sub_group_carry.__destroy();
                 }
-
             });
         });
     }
@@ -1776,7 +1786,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_subgroup_ops ? 0: __work_group_size, __cgh);
+            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_subgroup_ops ? 0 : __work_group_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::read_write>(__cgh);
@@ -1784,7 +1794,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
             __cgh.parallel_for<_KernelName...>(
-                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
+                    __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                 _InitValueType* __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 _InitValueType* __res_ptr =
                     _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __max_num_sub_groups_global + 2);
@@ -1796,15 +1806,16 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
                 const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                    __inputs_in_block, __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+                    __inputs_in_block,
+                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
 
                 std::uint32_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 
                 std::size_t __group_start_id =
-                    (__block_num * __max_block_size) +
-                    (__group_id * __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+                    (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
+                                                        __sub_group_params.__num_sub_groups_local);
                 if constexpr (__is_unique_pattern_v)
                 {
                     // for unique patterns, the first element is always copied to the output, so we need to skip it
@@ -1814,8 +1825,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 std::size_t __max_inputs_in_group =
                     __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
                 std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-                std::uint32_t __active_subgroups =
-                    oneapi::dpl::__internal::__dpl_ceiling_div(__inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+                std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                    __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
                 oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
 
                 // propagate carry in from previous block
@@ -1837,7 +1848,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     //         on WG T-local carries
                     //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
                     //           S: sum(T0 carry...TS carry)
-                    std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                    std::uint8_t __iters =
+                        oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
                     std::size_t __subgroups_before_my_group = __group_id * __sub_group_params.__num_sub_groups_local;
                     std::uint32_t __load_reduction_id = __sub_group_local_id;
                     std::uint8_t __i = 0;
@@ -1871,12 +1883,14 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             std::size_t __proposed_id =
                                 __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
                             std::size_t __remaining_elements = __elements_to_process;
-                            std::size_t __reduction_id =
-                                (__proposed_id < __subgroups_before_my_group) ? __proposed_id : __subgroups_before_my_group - 1;
+                            std::size_t __reduction_id = (__proposed_id < __subgroups_before_my_group)
+                                                             ? __proposed_id
+                                                             : __subgroups_before_my_group - 1;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
-                                __use_subgroup_ops);
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                     /*__init_present=*/false>(__sub_group, __value, __reduce_op,
+                                                                               __carry_last, __remaining_elements,
+                                                                               __comm_slm_ptr, __use_subgroup_ops);
                         }
                         else
                         {
@@ -1895,7 +1909,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             {
                                 __value = __tmp_ptr[__reduction_id];
                                 __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
+                                    __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr,
+                                    __use_subgroup_ops);
                                 __reduction_id += __reduction_id_increment;
                             }
 
@@ -1907,16 +1922,18 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             std::size_t __final_reduction_id =
                                 std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
                             __value = __tmp_ptr[__final_reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr,
-                                __use_subgroup_ops);
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                     /*__init_present=*/true>(__sub_group, __value, __reduce_op,
+                                                                              __carry_last, __remaining_elements,
+                                                                              __comm_slm_ptr, __use_subgroup_ops);
                         }
 
                         // steps 3+4) load global carry in from neighbor work-group
                         //            and apply to local sub-group prefix carries
                         std::size_t __carry_offset = __sub_group_local_id;
 
-                        std::uint8_t __iters = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                        std::uint8_t __iters =
+                            oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
 
                         std::uint8_t __i = 0;
                         for (; __i < __iters - 1; ++__i)
@@ -1945,7 +1962,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 {
                     if (__sub_group_id > 0)
                     {
-                        _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                        _InitValueType __value =
+                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
                         oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
                         __sub_group_carry.__setup(__value);
                     }
@@ -1966,7 +1984,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             }
                         }
 
-                        if constexpr (std::is_same_v<_InitType, oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
+                        if constexpr (std::is_same_v<_InitType,
+                                                     oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
                         {
                             // This is the only case where we still don't have a carry in.  No init value, 0th block,
                             // group, and subgroup. This changes the final scan through elements below.
@@ -1982,9 +2001,11 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 {
                     if (__sub_group_id > 0)
                     {
-                        _InitValueType __value = __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                        _InitValueType __value =
+                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
                         __sub_group_carry.__setup(__reduce_op(
-                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global), __value));
+                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
+                            __value));
                     }
                     else if (__group_id > 0)
                     {
@@ -2007,20 +2028,20 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 if (__sub_group_carry_initialized)
                 {
                     __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                                /*__init_present=*/true,
-                                                /*__capture_output=*/true, __max_inputs_per_item>(
-                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
-                        __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
-                        __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                                                   /*__init_present=*/true,
+                                                   /*__capture_output=*/true, __max_inputs_per_item>(
+                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
+                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
                 }
                 else // first group first block, no subgroup carry
                 {
                     __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                                /*__init_present=*/false,
-                                                /*__capture_output=*/true, __max_inputs_per_item>(
-                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
-                        __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item, __subgroup_start_id,
-                        __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                                                   /*__init_present=*/false,
+                                                   /*__capture_output=*/true, __max_inputs_per_item>(
+                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
+                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
                 }
                 // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
                 // to write out the last carry out for either the return value or the next block
@@ -2043,7 +2064,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     {
                         // capture the last carry out for the next block
                         __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v,
-                                            __sub_group_params.__num_sub_groups_global);
+                                              __sub_group_params.__num_sub_groups_global);
                     }
                 }
                 __sub_group_carry.__destroy();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2097,7 +2097,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     constexpr bool __inclusive = _Inclusive::value;
     constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 
-    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 8192);
+    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 1024);
     // Round down to nearest multiple of the max subgroup size to ensure compatibility with all sub-group sizes
     const std::uint32_t __work_group_size = (__max_work_group_size / __max_sub_group_size) * __max_sub_group_size;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -319,28 +319,28 @@ struct __gen_mask
 };
 
 // Wrapper for a mask generator, converting the mask generator to a counting operation.
-template <typename _GenMask>
+template <typename _GenMask, typename _RetType>
 struct __gen_count_mask
 {
     using TempData = __noop_temp_data;
-    template <typename _InRng, typename _SizeType>
-    _SizeType
-    operator()(_InRng&& __in_rng, _SizeType __id, TempData&) const
+    template <typename _InRng>
+    _RetType
+    operator()(_InRng&& __in_rng, _RetType __id, TempData&) const
     {
-        return __gen_mask(std::forward<_InRng>(__in_rng), __id) ? _SizeType{1} : _SizeType{0};
+        return __gen_mask(std::forward<_InRng>(__in_rng), __id) ? _RetType{1} : _RetType{0};
     }
     _GenMask __gen_mask;
 };
 
 // A generator which expands the mask generator to return a tuple containing the count, mask, and the element at the
 // specified index.
-template <typename _GenMask, typename _RangeTransform = oneapi::dpl::identity>
+template <typename _GenMask, typename _RetType, typename _RangeTransform = oneapi::dpl::identity>
 struct __gen_expand_count_mask
 {
     using TempData = __noop_temp_data;
-    template <typename _InRng, typename _SizeType>
+    template <typename _InRng>
     auto
-    operator()(_InRng&& __in_rng, _SizeType __id, TempData&) const
+    operator()(_InRng&& __in_rng, _RetType __id, TempData&) const
     {
         auto __transformed_input = __rng_transform(__in_rng);
         // Explicitly creating this element type is necessary to avoid modifying the input data when _InRng is a
@@ -349,7 +349,7 @@ struct __gen_expand_count_mask
         using _ElementType = oneapi::dpl::__internal::__value_t<decltype(__transformed_input)>;
         _ElementType ele = __transformed_input[__id];
         bool mask = __gen_mask(std::forward<_InRng>(__in_rng), __id);
-        return std::tuple(mask ? _SizeType{1} : _SizeType{0}, mask, ele);
+        return std::tuple(mask ? _RetType{1} : _RetType{0}, mask, ele);
     }
     _GenMask __gen_mask;
     _RangeTransform __rng_transform;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1355,11 +1355,11 @@ template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_presen
           typename _ValueType, typename _LazyValueType>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                 _LazyValueType& __init_and_carry, _ValueType* __comm_slm, bool __use_subgroup_ops)
+                 _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
     std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
-    if (__use_subgroup_ops)
+    if (__comm_slm == nullptr)
     {
         __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
             __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
@@ -1375,14 +1375,13 @@ template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_presen
           typename _ValueType, typename _LazyValueType, typename _SizeType>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ValueType* __comm_slm,
-                         bool __use_subgroup_ops)
+                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ValueType* __comm_slm)
 {
     auto __mask_fn = [__elements_to_process](auto __sub_group_local_id, auto __offset) {
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    if (__use_subgroup_ops)
+    if (__comm_slm == nullptr)
     {
         __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
             __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
@@ -1403,7 +1402,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                                _LazyValueType& __sub_group_carry, const _InRng& __in_rng, _OutRng& __out_rng,
                                std::size_t __start_id, std::size_t __n, std::uint32_t __iters_per_item,
                                std::size_t __subgroup_start_id, std::uint32_t __sub_group_id,
-                               std::uint32_t __active_subgroups, _ScanValueType* __comm_slm, bool __use_subgroup_ops)
+                               std::uint32_t __active_subgroups, _ScanValueType* __comm_slm)
 {
     using _GenInputType = std::invoke_result_t<_GenInput, _InRng, std::size_t, typename _GenInput::TempData&>;
     bool __is_full_block = (__iters_per_item == __max_inputs_per_item);
@@ -1415,7 +1414,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
         __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
-            __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm, __use_subgroup_ops);
+            __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1429,8 +1428,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
                 __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm,
-                    __use_subgroup_ops);
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1445,8 +1443,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
                 __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm,
-                    __use_subgroup_ops);
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id + __j * __sub_group_size, __v, __temp_data);
@@ -1468,7 +1465,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 _GenInputType __v = __gen_input(__in_rng, __local_id, __temp_data);
                 __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __n - __subgroup_start_id,
-                    __comm_slm, __use_subgroup_ops);
+                    __comm_slm);
                 if constexpr (__capture_output)
                 {
                     if (__start_id < __n)
@@ -1479,8 +1476,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
                 __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm,
-                    __use_subgroup_ops);
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1491,8 +1487,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
                     __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                        __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm,
-                        __use_subgroup_ops);
+                        __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                     if constexpr (__capture_output)
                     {
                         __write_op(__out_rng, __local_id, __v, __temp_data);
@@ -1504,7 +1499,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 __v = __gen_input(__in_rng, __local_id, __temp_data);
                 __sub_group_scan_partial<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
-                    __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm, __use_subgroup_ops);
+                    __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm);
                 if constexpr (__capture_output)
                 {
                     if (__offset < __n)
@@ -1653,7 +1648,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
                         __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
                         __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
-                        __comm_slm_ptr, __use_subgroup_ops);
+                        __comm_slm_ptr);
                     if (__sub_group_local_id == 0)
                         __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
                     __sub_group_carry.__destroy();
@@ -1675,8 +1670,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr,
-                            __use_subgroup_ops);
+                            __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
                         if (__sub_group_local_id < __active_subgroups)
                             __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
@@ -1686,7 +1680,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // need to pull out first iteration tp avoid identity
                         _InitValueType __v = __sub_group_partials[__reduction_scan_id];
                         __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
+                            __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
                         __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         __reduction_scan_id += __sub_group_size;
 
@@ -1694,7 +1688,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         {
                             __v = __sub_group_partials[__reduction_scan_id];
                             __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr, __use_subgroup_ops);
+                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
                         }
@@ -1708,8 +1702,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                             __sub_group, __v, __reduce_op, __sub_group_carry,
-                            __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr,
-                            __use_subgroup_ops);
+                            __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
                         if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                     }
@@ -1888,7 +1881,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                      /*__init_present=*/false>(__sub_group, __value, __reduce_op,
                                                                                __carry_last, __remaining_elements,
-                                                                               __comm_slm_ptr, __use_subgroup_ops);
+                                                                               __comm_slm_ptr);
                         }
                         else
                         {
@@ -1900,15 +1893,14 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                 __sub_group_params.__num_sub_groups_local * __sub_group_size;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
                             __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                                __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr, __use_subgroup_ops);
+                                __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
                             __reduction_id += __reduction_id_increment;
                             // then some number of full iterations
                             for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                             {
                                 __value = __tmp_ptr[__reduction_id];
                                 __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr,
-                                    __use_subgroup_ops);
+                                    __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
                                 __reduction_id += __reduction_id_increment;
                             }
 
@@ -1923,7 +1915,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                      /*__init_present=*/true>(__sub_group, __value, __reduce_op,
                                                                               __carry_last, __remaining_elements,
-                                                                              __comm_slm_ptr, __use_subgroup_ops);
+                                                                              __comm_slm_ptr);
                         }
 
                         // steps 3+4) load global carry in from neighbor work-group
@@ -2030,7 +2022,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
                         __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
                         __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr);
                 }
                 else // first group first block, no subgroup carry
                 {
@@ -2039,7 +2031,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
                         __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
                         __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr, __use_subgroup_ops);
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr);
                 }
                 // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
                 // to write out the last carry out for either the return value or the next block

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2135,7 +2135,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
 
     // Use SLM-based sub-group communication for non-trivially-copyable types or CPU targets
     // (where native sub-group operations are slow).
-    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType>;
+    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType> || !__q.get_device().is_gpu();
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1413,8 +1413,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
-            __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v),
+                                                                           __binary_op, __sub_group_carry, __comm_slm);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -692,7 +692,8 @@ struct __get_bounds_simple
 // Reduce then scan building block for set balanced path which is used in the reduction kernel to calculate the
 // balanced path intersection, store it to temporary data with "star" status, then count the number of elements to write
 // to the output for the reduction operation.
-template <typename _SetOpCount, typename _BoundsProvider, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _BoundsProvider, typename _RetType, typename _Compare, typename _Proj1,
+          typename _Proj2>
 struct __gen_set_balanced_path
 {
     using TempData = __noop_temp_data;
@@ -868,8 +869,8 @@ struct __gen_set_balanced_path
                      oneapi::dpl::__ranges::__size(__rng1) + oneapi::dpl::__ranges::__size(__rng2) -
                          _IndexT{__id * __diagonal_spacing - 1});
 
-        return __set_op_count(__rng1, __rng2, __rng1_balanced_pos, __rng2_balanced_pos,
-                                               __eles_to_process, __temp_data, __comp, __proj1, __proj2);
+        return __set_op_count(__rng1, __rng2, __rng1_balanced_pos, __rng2_balanced_pos, __eles_to_process, __temp_data,
+                              __comp, __proj1, __proj2);
     }
     _SetOpCount __set_op_count;
     std::uint16_t __diagonal_spacing;
@@ -882,7 +883,8 @@ struct __gen_set_balanced_path
 // Reduce then scan building block for set balanced path which is used in the scan kernel to decode the stored balanced
 // path intersection, perform the serial set operation for the diagonal, counting the number of elements and writing
 // the output to temporary data in registers to be ready for the scan and write operations to follow.
-template <typename _SetOpCount, typename _TempData, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _TempData, typename _RetType, typename _Compare, typename _Proj1,
+          typename _Proj2>
 struct __gen_set_op_from_known_balanced_path
 {
     using TempData = _TempData;
@@ -916,7 +918,7 @@ struct __gen_set_op_from_known_balanced_path
                                             oneapi::dpl::__ranges::__size(__rng2) - __i_elem + 1)));
 
         _RetType __count = __set_op_count(__rng1, __rng2, __rng1_idx, __rng2_idx, __eles_to_process, __output_data,
-                                               __comp, __proj1, __proj2);
+                                          __comp, __proj1, __proj2);
 
         return std::make_tuple(__count, __count);
     }
@@ -1258,7 +1260,8 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in = __shift_group_right<__use_subgroup_ops>(__sub_group, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in =
+            __shift_group_right<__use_subgroup_ops>(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1270,11 +1273,13 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
         __value = __binary_op(__init_and_carry.__v, __value);
         if (__sub_group_local_id == 0)
             __old_init.__setup(__init_and_carry.__v);
-        __init_and_carry.__v = __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v =
+            __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(__group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(
+            __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
 
     __value = __shift_group_right<__use_subgroup_ops>(__sub_group, __value, 1, __comm_slm);
@@ -1300,7 +1305,8 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in = __shift_group_right<__use_subgroup_ops>(__sub_group, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in =
+            __shift_group_right<__use_subgroup_ops>(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1309,11 +1315,13 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     if constexpr (__init_present)
     {
         __value = __binary_op(__init_and_carry.__v, __value);
-        __init_and_carry.__v = __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v =
+            __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(__group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(
+            __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
     //return by reference __value and __init_and_carry
 }
@@ -1562,11 +1570,9 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
 
     template <bool __use_subgroup_ops, typename _TmpAcc, typename _InRng>
     void
-    __reduce_kernel_body(sycl::nd_item<1> __ndi,
-                         __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
-                         __dpl_sycl::__local_accessor<_InitValueType> __comm_slm,
-                         _TmpAcc __tmp_acc, _InRng __in_rng, const std::size_t __inputs_remaining,
-                         const std::size_t __block_num) const
+    __reduce_kernel_body(sycl::nd_item<1> __ndi, __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
+                         __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpAcc __tmp_acc, _InRng __in_rng,
+                         const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
         const std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
@@ -1737,7 +1743,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
         return __tmp_acc[__num_sub_groups_global + (__block_num % 2)];
     }
 
-
     template <typename _TmpAcc, typename _ValueType>
     void
     __set_block_carry_out(const std::size_t __block_num, _TmpAcc __tmp_acc, const _ValueType __block_carry_out,
@@ -1749,8 +1754,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
     template <bool __use_subgroup_ops, typename _TmpAcc, typename _ResAcc, typename _InRng, typename _OutRng>
     void
     __scan_kernel_body(sycl::nd_item<1> __ndi, __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials,
-                       __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpAcc __tmp_acc,
-                       _ResAcc __res_acc, _InRng __in_rng, _OutRng __out_rng, std::uint32_t __inputs_in_block,
+                       __dpl_sycl::__local_accessor<_InitValueType> __comm_slm, _TmpAcc __tmp_acc, _ResAcc __res_acc,
+                       _InRng __in_rng, _OutRng __out_rng, std::uint32_t __inputs_in_block,
                        const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
@@ -1762,7 +1767,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 
         const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
             __inputs_in_block, __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
-
 
         std::uint32_t __group_id = __ndi.get_group(0);
         std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -445,7 +445,7 @@ template <bool _CopyMatch, bool _CopyDiffSetA, bool _CopyDiffSetB, bool _CheckBo
 void
 __set_generic_operation_iteration(const _InRng1& __in_rng1, const _InRng2& __in_rng2, std::size_t& __idx1,
                                   std::size_t& __idx2, const _SizeType __num_eles_min, _TempOutput& __temp_out,
-                                  _SizeType& __idx, std::uint16_t& __count, const _Compare __comp, _Proj1 __proj1,
+                                  _SizeType& __idx, _SizeType& __count, const _Compare __comp, _Proj1 __proj1,
                                   _Proj2 __proj2)
 {
     using _ValueTypeRng1 = typename oneapi::dpl::__internal::__value_t<_InRng1>;
@@ -525,13 +525,13 @@ struct __set_generic_operation
 {
     template <typename _InRng1, typename _InRng2, typename _SizeType, typename _TempOutput, typename _Compare,
               typename _Proj1, typename _Proj2>
-    std::uint16_t
+    _SizeType
     operator()(const _InRng1& __in_rng1, const _InRng2& __in_rng2, std::size_t __idx1, std::size_t __idx2,
                const _SizeType __num_eles_min, _TempOutput& __temp_out, const _Compare __comp, _Proj1 __proj1,
                _Proj2 __proj2) const
     {
 
-        std::uint16_t __count = 0;
+        _SizeType __count = 0;
         _SizeType __idx = 0;
         bool __can_reach_rng1_end = __idx1 + __num_eles_min >= oneapi::dpl::__ranges::__size(__in_rng1);
         bool __can_reach_rng2_end = __idx2 + __num_eles_min >= oneapi::dpl::__ranges::__size(__in_rng2);
@@ -692,7 +692,7 @@ struct __get_bounds_simple
 // Reduce then scan building block for set balanced path which is used in the reduction kernel to calculate the
 // balanced path intersection, store it to temporary data with "star" status, then count the number of elements to write
 // to the output for the reduction operation.
-template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
 struct __gen_set_balanced_path
 {
     using TempData = __noop_temp_data;
@@ -815,7 +815,7 @@ struct __gen_set_balanced_path
 
     // Entry point for reduce then scan reduce input
     template <typename _InRng, typename _IndexT>
-    std::uint16_t
+    _RetType
     operator()(const _InRng& __in_rng, _IndexT __id, TempData& __temp_data) const
     {
         // Get source tuple
@@ -868,9 +868,8 @@ struct __gen_set_balanced_path
                      oneapi::dpl::__ranges::__size(__rng1) + oneapi::dpl::__ranges::__size(__rng2) -
                          _IndexT{__id * __diagonal_spacing - 1});
 
-        std::uint16_t __count = __set_op_count(__rng1, __rng2, __rng1_balanced_pos, __rng2_balanced_pos,
+        return __set_op_count(__rng1, __rng2, __rng1_balanced_pos, __rng2_balanced_pos,
                                                __eles_to_process, __temp_data, __comp, __proj1, __proj2);
-        return __count;
     }
     _SetOpCount __set_op_count;
     std::uint16_t __diagonal_spacing;
@@ -883,12 +882,12 @@ struct __gen_set_balanced_path
 // Reduce then scan building block for set balanced path which is used in the scan kernel to decode the stored balanced
 // path intersection, perform the serial set operation for the diagonal, counting the number of elements and writing
 // the output to temporary data in registers to be ready for the scan and write operations to follow.
-template <typename _SetOpCount, typename _TempData, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _TempData, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
 struct __gen_set_op_from_known_balanced_path
 {
     using TempData = _TempData;
     template <typename _InRng, typename _IndexT>
-    std::tuple<std::uint32_t, std::uint16_t>
+    std::tuple<_RetType, _RetType>
     operator()(const _InRng& __in_rng, _IndexT __id, _TempData& __output_data) const
     {
         // Get source tuple
@@ -906,20 +905,20 @@ struct __gen_set_op_from_known_balanced_path
             oneapi::dpl::__ranges::__common_size_t<decltype(__rng1), decltype(__rng2), decltype(__rng1_temp_diag)>;
         _SizeType __i_elem = __id * __diagonal_spacing;
         if (__i_elem >= oneapi::dpl::__ranges::__size(__rng1) + oneapi::dpl::__ranges::__size(__rng2))
-            return std::make_tuple(std::uint32_t{0}, std::uint16_t{0});
+            return std::make_tuple(_RetType{0}, _RetType{0});
         auto [__rng1_idx, __rng2_idx, __star_offset] =
             oneapi::dpl::__par_backend_hetero::__decode_balanced_path_temp_data(__rng1_temp_diag, __id,
                                                                                 __diagonal_spacing);
 
-        std::uint16_t __eles_to_process = static_cast<std::uint16_t>(
+        _RetType __eles_to_process = static_cast<_RetType>(
             std::min(static_cast<_SizeType>(__diagonal_spacing - __star_offset),
                      static_cast<_SizeType>(oneapi::dpl::__ranges::__size(__rng1) +
                                             oneapi::dpl::__ranges::__size(__rng2) - __i_elem + 1)));
 
-        std::uint16_t __count = __set_op_count(__rng1, __rng2, __rng1_idx, __rng2_idx, __eles_to_process, __output_data,
+        _RetType __count = __set_op_count(__rng1, __rng2, __rng1_idx, __rng2_idx, __eles_to_process, __output_data,
                                                __comp, __proj1, __proj2);
 
-        return std::make_tuple(std::uint32_t{__count}, __count);
+        return std::make_tuple(__count, __count);
     }
     _SetOpCount __set_op_count;
     std::uint16_t __diagonal_spacing;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1247,15 +1247,14 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value
     }
 }
 
-template <bool __use_subgroup_ops, bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType>
+template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __init_present, typename _MaskOp,
+          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
 void
 __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
                                   _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
@@ -1290,15 +1289,14 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     //return by reference __value and __init_and_carry
 }
 
-template <bool __use_subgroup_ops, bool __init_present, typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType>
+template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __init_present, typename _MaskOp,
+          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
 void
 __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
                                   _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
@@ -1320,8 +1318,8 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     //return by reference __value and __init_and_carry
 }
 
-template <bool __use_subgroup_ops, bool __is_inclusive, bool __init_present, typename _MaskOp, typename _InitBroadcastId,
-          typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+          typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
 void
 __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                         _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
@@ -1329,30 +1327,30 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
 {
     if constexpr (__is_inclusive)
     {
-        __inclusive_sub_group_masked_scan<__use_subgroup_ops, __init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
-                                                                   __binary_op, __init_and_carry, __comm_slm);
+        __inclusive_sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __init_present>(
+            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
     }
     else
     {
-        __exclusive_sub_group_masked_scan<__use_subgroup_ops, __init_present>(__sub_group, __mask_fn, __init_broadcast_id, __value,
-                                                                   __binary_op, __init_and_carry, __comm_slm);
+        __exclusive_sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __init_present>(
+            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
     }
 }
 
-template <bool __use_subgroup_ops, bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType,
-          typename _LazyValueType>
+template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+          typename _BinaryOp, typename _ValueType, typename _LazyValueType>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
-    std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
-    __sub_group_masked_scan<__use_subgroup_ops, __is_inclusive, __init_present>(
+    constexpr std::uint8_t __init_broadcast_id = __sub_group_size - 1;
+    __sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
         __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <bool __use_subgroup_ops, bool __is_inclusive, bool __init_present, typename _BinaryOp, typename _ValueType,
-          typename _LazyValueType, typename _SizeType>
+template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _SizeType>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                          _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ValueType* __comm_slm)
@@ -1361,13 +1359,14 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    __sub_group_masked_scan<__use_subgroup_ops, __is_inclusive, __init_present>(
+    __sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
         __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <bool __use_subgroup_ops, bool __is_inclusive, bool __init_present, bool __capture_output,
-          std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform, typename _BinaryOp,
-          typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng, typename _ScanValueType>
+template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+          bool __capture_output, std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform,
+          typename _BinaryOp, typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng,
+          typename _ScanValueType>
 void
 __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
                                _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
@@ -1377,8 +1376,6 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                                std::uint32_t __active_subgroups, _ScanValueType* __comm_slm)
 {
     using _GenInputType = std::invoke_result_t<_GenInput, _InRng, std::size_t, typename _GenInput::TempData&>;
-
-    const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
     bool __is_full_block = (__iters_per_item == __max_inputs_per_item);
     bool __is_full_thread = __subgroup_start_id + __iters_per_item * __sub_group_size <= __n;
     using _TempData = typename _GenInput::TempData;
@@ -1387,8 +1384,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__use_subgroup_ops, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v), __binary_op,
-                                                                  __sub_group_carry, __comm_slm);
+        __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+            __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1401,7 +1398,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1416,7 +1413,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1437,7 +1434,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 std::size_t __local_id = (__start_id < __n) ? __start_id : __n - 1;
                 _GenInputType __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__use_subgroup_ops, __is_inclusive, __init_present>(
+                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __n - __subgroup_start_id,
                     __comm_slm);
                 if constexpr (__capture_output)
@@ -1449,8 +1446,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             else
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-                __sub_group_scan<__use_subgroup_ops, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v),
-                                                                          __binary_op, __sub_group_carry, __comm_slm);
+                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
                     __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1460,7 +1457,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 {
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
-                    __sub_group_scan<__use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                    __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                         __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                     if constexpr (__capture_output)
                     {
@@ -1471,7 +1468,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 std::size_t __offset = __start_id + (__iters - 1) * __sub_group_size;
                 std::size_t __local_id = (__offset < __n) ? __offset : __n - 1;
                 __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
                     __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm);
                 if constexpr (__capture_output)
@@ -1482,6 +1479,41 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             }
         }
     }
+}
+
+constexpr inline std::uint8_t
+__get_reduce_then_scan_default_sg_sz()
+{
+    return 32;
+}
+
+constexpr inline std::uint8_t
+__get_reduce_then_scan_workaround_sg_sz()
+{
+    return 16;
+}
+
+// The default sub-group size for reduce-then-scan is 32, but we conditionally enable sub-group sizes of 16 on Intel
+// devices to workaround a hardware bug. From the host side, return 32 to assert that this sub-group size is supported
+// by an arbitrary device.
+constexpr inline std::uint8_t
+__get_reduce_then_scan_reqd_sg_sz_host()
+{
+    return __get_reduce_then_scan_default_sg_sz();
+}
+
+// To workaround a hardware bug on certain Intel iGPUs with older driver versions and -O0 device compilation, use a
+// sub-group size of 16. Note this function may only be called on the device as _ONEDPL_DETECT_SPIRV_COMPILATION is only
+// valid here.
+constexpr inline std::uint8_t
+__get_reduce_then_scan_actual_sg_sz_device()
+{
+    return
+#if _ONEDPL_DETECT_COMPILER_OPTIMIZATIONS_ENABLED || !_ONEDPL_DETECT_SPIRV_COMPILATION
+        __get_reduce_then_scan_default_sg_sz();
+#else
+        __get_reduce_then_scan_workaround_sg_sz();
+#endif
 }
 
 struct __reduce_then_scan_sub_group_params
@@ -1537,7 +1569,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                          const std::size_t __block_num) const
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-        const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+        const std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
 
         __reduce_then_scan_sub_group_params __sub_group_params(
             __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
@@ -1570,7 +1602,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
         {
             // adjust for lane-id
             // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-            __scan_through_elements_helper<__use_subgroup_ops, __is_inclusive,
+            __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
                                            /*__init_present=*/false,
                                            /*__capture_output=*/false, __max_inputs_per_item>(
                 __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr, __sub_group_carry,
@@ -1595,8 +1627,9 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 // fill with unused dummy values to avoid overrunning input
                 std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                 _InitValueType __v = __sub_group_partials[__load_id];
-                __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                    __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
+                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                         /*__init_present=*/false>(__sub_group, __v, __reduce_op, __sub_group_carry,
+                                                                   __active_subgroups, __comm_slm_ptr);
                 if (__sub_group_local_id < __active_subgroups)
                     __tmp_acc[__start_id + __sub_group_local_id] = __v;
             }
@@ -1605,16 +1638,18 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 std::uint32_t __reduction_scan_id = __sub_group_local_id;
                 // need to pull out first iteration tp avoid identity
                 _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                 /*__init_present=*/false>(__sub_group, __v, __reduce_op, __sub_group_carry,
+                                                           __comm_slm_ptr);
                 __tmp_acc[__start_id + __reduction_scan_id] = __v;
                 __reduction_scan_id += __sub_group_size;
 
                 for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
                 {
                     __v = __sub_group_partials[__reduction_scan_id];
-                    __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                        __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                    __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                     /*__init_present=*/true>(__sub_group, __v, __reduce_op, __sub_group_carry,
+                                                              __comm_slm_ptr);
                     __tmp_acc[__start_id + __reduction_scan_id] = __v;
                     __reduction_scan_id += __sub_group_size;
                 }
@@ -1625,7 +1660,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 std::uint32_t __load_id = std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
 
                 __v = __sub_group_partials[__load_id];
-                __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                         /*__init_present=*/true>(
                     __sub_group, __v, __reduce_op, __sub_group_carry,
                     __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
                 if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
@@ -1718,7 +1754,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                        const std::size_t __inputs_remaining, const std::size_t __block_num) const
     {
         __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-        const std::uint8_t __sub_group_size = __sub_group.get_max_local_range()[0];
+        const std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
         _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
 
         __reduce_then_scan_sub_group_params __sub_group_params(
@@ -1804,7 +1840,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     std::size_t __reduction_id =
                         (__proposed_id < __subgroups_before_my_group) ? __proposed_id : __subgroups_before_my_group - 1;
                     _InitValueType __value = __tmp_acc[__reduction_id];
-                    __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true,
+                    __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
                                              /*__init_present=*/false>(__sub_group, __value, __reduce_op, __carry_last,
                                                                        __remaining_elements, __comm_slm_ptr);
                 }
@@ -1817,15 +1853,17 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     std::uint32_t __reduction_id_increment =
                         __sub_group_params.__num_sub_groups_local * __sub_group_size;
                     _InitValueType __value = __tmp_acc[__reduction_id];
-                    __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                        __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
+                    __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                     /*__init_present=*/false>(__sub_group, __value, __reduce_op, __carry_last,
+                                                               __comm_slm_ptr);
                     __reduction_id += __reduction_id_increment;
                     // then some number of full iterations
                     for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                     {
                         __value = __tmp_acc[__reduction_id];
-                        __sub_group_scan<__use_subgroup_ops, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                            __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
+                        __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                         /*__init_present=*/true>(__sub_group, __value, __reduce_op, __carry_last,
+                                                                  __comm_slm_ptr);
                         __reduction_id += __reduction_id_increment;
                     }
 
@@ -1837,7 +1875,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                     std::size_t __final_reduction_id =
                         std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
                     __value = __tmp_acc[__final_reduction_id];
-                    __sub_group_scan_partial<__use_subgroup_ops, /*__is_inclusive=*/true,
+                    __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
                                              /*__init_present=*/true>(__sub_group, __value, __reduce_op, __carry_last,
                                                                       __remaining_elements, __comm_slm_ptr);
                 }
@@ -1936,7 +1974,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 
         if (__sub_group_carry_initialized)
         {
-            __scan_through_elements_helper<__use_subgroup_ops, __is_inclusive,
+            __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
                                            /*__init_present=*/true,
                                            /*__capture_output=*/true, __max_inputs_per_item>(
                 __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
@@ -1945,7 +1983,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
         }
         else // first group first block, no subgroup carry
         {
-            __scan_through_elements_helper<__use_subgroup_ops, __is_inclusive,
+            __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
                                            /*__init_present=*/false,
                                            /*__capture_output=*/true, __max_inputs_per_item>(
                 __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
@@ -2041,6 +2079,16 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
     _InitType __init;
 };
 
+// Enable reduce-then-scan if the device uses the required sub-group size and is ran on a device
+// with fast coordinated subgroup operations. We do not want to run this scan on CPU targets, as they are not
+// performant with this algorithm.
+inline bool
+__is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
+{
+    return (__q.get_device().is_gpu() &&
+            oneapi::dpl::__internal::__supports_sub_group_size(__q, __get_reduce_then_scan_reqd_sg_sz_host()));
+}
+
 // General scan-like algorithm helpers
 // _GenReduceInput - a function which accepts the input range and index to generate the data needed by the main output
 //                   used in the reduction operation (to calculate the global carries)
@@ -2067,30 +2115,23 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
         __reduce_then_scan_scan_kernel<_CustomName>>;
     using _ValueType = typename _InitType::__value_type;
 
-    // Query the device's supported sub-group sizes to allocate storage conservatively and round
-    // the work-group size appropriately. The actual sub-group size used by each kernel is determined
-    // at runtime via sub_group::get_max_local_range().
-    const auto __supported_sg_sizes = __q.get_device().template get_info<sycl::info::device::sub_group_sizes>();
-    const std::uint8_t __min_sub_group_size =
-        *std::min_element(__supported_sg_sizes.begin(), __supported_sg_sizes.end());
-    const std::uint8_t __max_sub_group_size =
-        *std::max_element(__supported_sg_sizes.begin(), __supported_sg_sizes.end());
+    constexpr std::uint8_t __min_sub_group_size = __get_reduce_then_scan_workaround_sg_sz();
+    constexpr std::uint8_t __max_sub_group_size = __get_reduce_then_scan_default_sg_sz();
     // Empirically determined maximum. May be less for non-full blocks.
     constexpr std::uint16_t __max_inputs_per_item =
         std::max(std::uint16_t{1}, std::uint16_t{512 / __bytes_per_work_item_iter});
     constexpr bool __inclusive = _Inclusive::value;
     constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 
-    // empirical derived caps for workgroup size based upon target
-    const std::uint32_t __wg_size_cap = __q.get_device().is_gpu() ? 1024 : 256;
-    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, __wg_size_cap);
-    // Round down to nearest multiple of the max subgroup size to ensure compatibility with all sub-group sizes
+    const std::uint32_t __max_work_group_size = oneapi::dpl::__internal::__max_work_group_size(__q, 8192);
+    // Round down to nearest multiple of the subgroup size
     const std::uint32_t __work_group_size = (__max_work_group_size / __max_sub_group_size) * __max_sub_group_size;
 
     // TODO: Investigate potentially basing this on some scale of the number of compute units. 128 work-groups has been
     // found to be reasonable number for most devices.
     constexpr std::uint32_t __num_work_groups = 128;
-    // Allocate sufficient temporary storage for the worst case (smallest sub-group size = most sub-groups).
+    // We may use a sub-group size of 16 or 32 depending on the compiler optimization level. Allocate sufficient
+    // temporary storage to handle both cases.
     const std::uint32_t __max_num_sub_groups_local = __work_group_size / __min_sub_group_size;
     const std::uint32_t __max_num_sub_groups_global = __max_num_sub_groups_local * __num_work_groups;
     const std::uint32_t __max_inputs_per_work_group = __work_group_size * __max_inputs_per_item;
@@ -2119,7 +2160,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
 
     // Use SLM-based sub-group communication for non-trivially-copyable types or CPU targets
     // (where native sub-group operations are slow).
-    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType> || !__q.get_device().is_gpu();
+    const bool __use_slm_for_comm = !std::is_trivially_copyable_v<_ValueType>;
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -480,10 +480,12 @@ struct __red_by_seg_op;
 template <typename _BinaryOp>
 struct __scan_by_seg_op;
 
-template <typename _SetOpCount, typename _BoundsProvider, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _BoundsProvider, typename _RetType, typename _Compare, typename _Proj1,
+          typename _Proj2>
 struct __gen_set_balanced_path;
 
-template <typename _SetOpCount, typename _TempData, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _TempData, typename _RetType, typename _Compare, typename _Proj1,
+          typename _Proj2>
 struct __gen_set_op_from_known_balanced_path;
 
 template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
@@ -549,7 +551,8 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 template <typename _GenMask, typename _RetType>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_count_mask, _GenMask, _RetType)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_count_mask, _GenMask,
+                                                       _RetType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_GenMask>
 {
 };
@@ -621,17 +624,20 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 
-template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
+template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2,
+          typename _RetType>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path,
-                                                       _SetOpCount, _BoundsProvider, _RetType, _Compare, _Proj1, _Proj2)>
+                                                       _SetOpCount, _BoundsProvider, _RetType, _Compare, _Proj1,
+                                                       _Proj2)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_SetOpCount, _BoundsProvider, _Compare, _Proj1, _Proj2>
 {
 };
 
-template <typename _SetOpCount, typename _TempData, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
-struct sycl::is_device_copyable<
-    _ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path,
-                           _SetOpCount, _TempData, _RetType, _Compare, _Proj1, _Proj2)>
+template <typename _SetOpCount, typename _TempData, typename _RetType, typename _Compare, typename _Proj1,
+          typename _Proj2>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
+    oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path, _SetOpCount, _TempData, _RetType,
+    _Compare, _Proj1, _Proj2)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_SetOpCount, _Compare, _Proj1, _Proj2>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -447,10 +447,10 @@ struct __gen_mask;
 template <typename _BinaryPredicate>
 struct __gen_unique_mask;
 
-template <typename _GenMask>
+template <typename _GenMask, typename _RetType>
 struct __gen_count_mask;
 
-template <typename _GenMask, typename _RangeTransform>
+template <typename _GenMask, typename _RetType, typename _RangeTransform>
 struct __gen_expand_count_mask;
 
 template <int32_t __offset, typename _Assign>
@@ -548,15 +548,15 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
     : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryPredicate>
 {
 };
-template <typename _GenMask>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_count_mask, _GenMask)>
+template <typename _GenMask, typename _RetType>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_count_mask, _GenMask, _RetType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_GenMask>
 {
 };
 
-template <typename _GenMask, typename _RangeTransform>
+template <typename _GenMask, typename _RetType, typename _RangeTransform>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask,
-                                                       _GenMask, _RangeTransform)>
+                                                       _GenMask, _RetType, _RangeTransform)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_GenMask>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -480,10 +480,10 @@ struct __red_by_seg_op;
 template <typename _BinaryOp>
 struct __scan_by_seg_op;
 
-template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
 struct __gen_set_balanced_path;
 
-template <typename _SetOpCount, typename _TempData, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _TempData, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
 struct __gen_set_op_from_known_balanced_path;
 
 template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
@@ -621,17 +621,17 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 
-template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path,
-                                                       _SetOpCount, _BoundsProvider, _Compare, _Proj1, _Proj2)>
+                                                       _SetOpCount, _BoundsProvider, _Compare, _Proj1, _Proj2, _RetType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_SetOpCount, _BoundsProvider, _Compare, _Proj1, _Proj2>
 {
 };
 
-template <typename _SetOpCount, typename _TempData, typename _Compare, typename _Proj1, typename _Proj2>
+template <typename _SetOpCount, typename _TempData, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
 struct sycl::is_device_copyable<
     _ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path,
-                           _SetOpCount, _TempData, _Compare, _Proj1, _Proj2)>
+                           _SetOpCount, _TempData, _Compare, _Proj1, _Proj2, _RetType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_SetOpCount, _Compare, _Proj1, _Proj2>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -480,10 +480,10 @@ struct __red_by_seg_op;
 template <typename _BinaryOp>
 struct __scan_by_seg_op;
 
-template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
+template <typename _SetOpCount, typename _BoundsProvider, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
 struct __gen_set_balanced_path;
 
-template <typename _SetOpCount, typename _TempData, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
+template <typename _SetOpCount, typename _TempData, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
 struct __gen_set_op_from_known_balanced_path;
 
 template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
@@ -623,15 +623,15 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 
 template <typename _SetOpCount, typename _BoundsProvider, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path,
-                                                       _SetOpCount, _BoundsProvider, _Compare, _Proj1, _Proj2, _RetType)>
+                                                       _SetOpCount, _BoundsProvider, _RetType, _Compare, _Proj1, _Proj2)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_SetOpCount, _BoundsProvider, _Compare, _Proj1, _Proj2>
 {
 };
 
-template <typename _SetOpCount, typename _TempData, typename _Compare, typename _Proj1, typename _Proj2, typename _RetType>
+template <typename _SetOpCount, typename _TempData, typename _RetType, typename _Compare, typename _Proj1, typename _Proj2>
 struct sycl::is_device_copyable<
     _ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path,
-                           _SetOpCount, _TempData, _Compare, _Proj1, _Proj2, _RetType)>
+                           _SetOpCount, _TempData, _RetType, _Compare, _Proj1, _Proj2)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_SetOpCount, _Compare, _Proj1, _Proj2>
 {
 };

--- a/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
+++ b/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
@@ -361,7 +361,7 @@ test_find_balanced_path_impl(_Rng1 __rng1, _Rng2 __rng2, _Comp __comp)
     using _BoundsProvider = oneapi::dpl::__par_backend_hetero::__get_bounds_simple;
 
     using _GenReduceInput =
-        oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider, _Comp, oneapi::dpl::identity, oneapi::dpl::identity, std::size_t>;
+        oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider, std::size_t, _Comp, oneapi::dpl::identity, oneapi::dpl::identity>;
 
     std::uint16_t __diagonal_spacing = 16; // arbitrary value, should not matter for the test
 

--- a/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
+++ b/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
@@ -361,7 +361,7 @@ test_find_balanced_path_impl(_Rng1 __rng1, _Rng2 __rng2, _Comp __comp)
     using _BoundsProvider = oneapi::dpl::__par_backend_hetero::__get_bounds_simple;
 
     using _GenReduceInput =
-        oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider, _Comp, oneapi::dpl::identity, oneapi::dpl::identity>;
+        oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider, _Comp, oneapi::dpl::identity, oneapi::dpl::identity, std::size_t>;
 
     std::uint16_t __diagonal_spacing = 16; // arbitrary value, should not matter for the test
 

--- a/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
+++ b/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
@@ -361,7 +361,8 @@ test_find_balanced_path_impl(_Rng1 __rng1, _Rng2 __rng2, _Comp __comp)
     using _BoundsProvider = oneapi::dpl::__par_backend_hetero::__get_bounds_simple;
 
     using _GenReduceInput =
-        oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider, std::size_t, _Comp, oneapi::dpl::identity, oneapi::dpl::identity>;
+        oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<_SetOperation, _BoundsProvider, std::size_t, _Comp,
+                                                                   oneapi::dpl::identity, oneapi::dpl::identity>;
 
     std::uint16_t __diagonal_spacing = 16; // arbitrary value, should not matter for the test
 

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -191,12 +191,12 @@ test_device_copyable()
 
     //__gen_count_mask
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_count_mask<
-                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>>,
+                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>, int>>,
                   "__gen_count_mask is not device copyable with device copyable types");
 
     //__gen_expand_count_mask
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<
-                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>>,
+                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>,int>>,
                   "__gen_expand_count_mask is not device copyable with device copyable types");
 
     //__gen_set_balanced_path
@@ -523,12 +523,12 @@ test_non_device_copyable()
 
     //__gen_count_mask
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_count_mask<
-                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_non_device_copyable>>>,
+                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_non_device_copyable>, int>>,
                   "__gen_count_mask is device copyable with non device copyable types");
 
     //__gen_expand_count_mask
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<
-                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_non_device_copyable>>>,
+                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_non_device_copyable>, int>>,
                   "__gen_expand_count_mask is device copyable with non device copyable types");
 
     //__gen_set_balanced_path

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -203,7 +203,7 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
                       oneapi::dpl::__par_backend_hetero::__set_intersection,
                       oneapi::dpl::__par_backend_hetero::__get_bounds_simple, binary_op_device_copyable,
-                      binary_op_device_copyable, binary_op_device_copyable>>,
+                      binary_op_device_copyable, binary_op_device_copyable, int>>,
                   "__gen_set_balanced_path is not device copyable with device copyable types");
 
 #if !_PSTL_ICPX_DEVICE_COPYABLE_SUBMITTER_BROKEN
@@ -212,7 +212,7 @@ test_device_copyable()
                       oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
                           oneapi::dpl::__par_backend_hetero::__set_intersection,
                           oneapi::dpl::__par_backend_hetero::__get_bounds_simple, binary_op_device_copyable,
-                          binary_op_device_copyable, binary_op_device_copyable>,
+                          binary_op_device_copyable, binary_op_device_copyable, int>,
                       oneapi::dpl::execution::DefaultKernelName>>,
                   "__partition_set_balanced_path_submitter is not device copyable with device copyable types");
 #endif
@@ -221,7 +221,7 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
                       oneapi::dpl::__par_backend_hetero::__set_intersection,
                       oneapi::dpl::__par_backend_hetero::__noop_temp_data,
-                      binary_op_device_copyable, binary_op_device_copyable, binary_op_device_copyable>>,
+                      binary_op_device_copyable, binary_op_device_copyable, binary_op_device_copyable, int>>,
                   "__gen_set_op_from_known_balanced_path is not device copyable with device copyable types");
 
     //__write_to_id_if
@@ -535,7 +535,7 @@ test_non_device_copyable()
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
                       oneapi::dpl::__par_backend_hetero::__set_intersection,
                       oneapi::dpl::__par_backend_hetero::__get_bounds_simple, binary_op_non_device_copyable,
-                      binary_op_non_device_copyable, binary_op_non_device_copyable>>,
+                      binary_op_non_device_copyable, binary_op_non_device_copyable, int>>,
                   "__gen_set_balanced_path is device copyable with non device copyable types");
 
 #if !_PSTL_ICPX_DEVICE_COPYABLE_SUBMITTER_BROKEN
@@ -545,7 +545,7 @@ test_non_device_copyable()
             oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
                 oneapi::dpl::__par_backend_hetero::__set_intersection,
                 oneapi::dpl::__par_backend_hetero::__get_bounds_simple, binary_op_non_device_copyable,
-                binary_op_non_device_copyable, binary_op_non_device_copyable>,
+                binary_op_non_device_copyable, binary_op_non_device_copyable, int>,
             oneapi::dpl::execution::DefaultKernelName>>,
         "__partition_set_balanced_path_submitter is device copyable with non device copyable types");
 #endif
@@ -554,7 +554,7 @@ test_non_device_copyable()
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
             oneapi::dpl::__par_backend_hetero::__set_intersection, oneapi::dpl::__par_backend_hetero::__noop_temp_data,
-            binary_op_non_device_copyable, binary_op_non_device_copyable, binary_op_non_device_copyable>>,
+            binary_op_non_device_copyable, binary_op_non_device_copyable, binary_op_non_device_copyable, int>>,
                   "__gen_set_op_from_known_balanced_path is device copyable with non device copyable types");
 
     //__write_to_id_if

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -220,7 +220,7 @@ test_device_copyable()
     //__gen_set_op_from_known_balanced_path
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
                       oneapi::dpl::__par_backend_hetero::__set_intersection,
-                      oneapi::dpl::__par_backend_hetero::__noop_temp_data, int,int
+                      oneapi::dpl::__par_backend_hetero::__noop_temp_data, int,
                       binary_op_device_copyable, binary_op_device_copyable, binary_op_device_copyable>>,
                   "__gen_set_op_from_known_balanced_path is not device copyable with device copyable types");
 

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -196,7 +196,7 @@ test_device_copyable()
 
     //__gen_expand_count_mask
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<
-                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>,int>>,
+                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>, int>>,
                   "__gen_expand_count_mask is not device copyable with device copyable types");
 
     //__gen_set_balanced_path
@@ -218,11 +218,11 @@ test_device_copyable()
 #endif
 
     //__gen_set_op_from_known_balanced_path
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
-                      oneapi::dpl::__par_backend_hetero::__set_intersection,
-                      oneapi::dpl::__par_backend_hetero::__noop_temp_data, int,
-                      binary_op_device_copyable, binary_op_device_copyable, binary_op_device_copyable>>,
-                  "__gen_set_op_from_known_balanced_path is not device copyable with device copyable types");
+    static_assert(
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
+            oneapi::dpl::__par_backend_hetero::__set_intersection, oneapi::dpl::__par_backend_hetero::__noop_temp_data,
+            int, binary_op_device_copyable, binary_op_device_copyable, binary_op_device_copyable>>,
+        "__gen_set_op_from_known_balanced_path is not device copyable with device copyable types");
 
     //__write_to_id_if
     static_assert(
@@ -553,9 +553,9 @@ test_non_device_copyable()
     //__gen_set_op_from_known_balanced_path
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
-            oneapi::dpl::__par_backend_hetero::__set_intersection, oneapi::dpl::__par_backend_hetero::__noop_temp_data, int,
-            binary_op_non_device_copyable, binary_op_non_device_copyable, binary_op_non_device_copyable>>,
-                  "__gen_set_op_from_known_balanced_path is device copyable with non device copyable types");
+            oneapi::dpl::__par_backend_hetero::__set_intersection, oneapi::dpl::__par_backend_hetero::__noop_temp_data,
+            int, binary_op_non_device_copyable, binary_op_non_device_copyable, binary_op_non_device_copyable>>,
+        "__gen_set_op_from_known_balanced_path is device copyable with non device copyable types");
 
     //__write_to_id_if
     static_assert(

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -202,8 +202,8 @@ test_device_copyable()
     //__gen_set_balanced_path
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
                       oneapi::dpl::__par_backend_hetero::__set_intersection,
-                      oneapi::dpl::__par_backend_hetero::__get_bounds_simple, binary_op_device_copyable,
-                      binary_op_device_copyable, binary_op_device_copyable, int>>,
+                      oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_device_copyable,
+                      binary_op_device_copyable, binary_op_device_copyable>>,
                   "__gen_set_balanced_path is not device copyable with device copyable types");
 
 #if !_PSTL_ICPX_DEVICE_COPYABLE_SUBMITTER_BROKEN
@@ -211,8 +211,8 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__partition_set_balanced_path_submitter<
                       oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
                           oneapi::dpl::__par_backend_hetero::__set_intersection,
-                          oneapi::dpl::__par_backend_hetero::__get_bounds_simple, binary_op_device_copyable,
-                          binary_op_device_copyable, binary_op_device_copyable, int>,
+                          oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_device_copyable,
+                          binary_op_device_copyable, binary_op_device_copyable>,
                       oneapi::dpl::execution::DefaultKernelName>>,
                   "__partition_set_balanced_path_submitter is not device copyable with device copyable types");
 #endif
@@ -220,8 +220,8 @@ test_device_copyable()
     //__gen_set_op_from_known_balanced_path
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
                       oneapi::dpl::__par_backend_hetero::__set_intersection,
-                      oneapi::dpl::__par_backend_hetero::__noop_temp_data,
-                      binary_op_device_copyable, binary_op_device_copyable, binary_op_device_copyable, int>>,
+                      oneapi::dpl::__par_backend_hetero::__noop_temp_data, int,int
+                      binary_op_device_copyable, binary_op_device_copyable, binary_op_device_copyable>>,
                   "__gen_set_op_from_known_balanced_path is not device copyable with device copyable types");
 
     //__write_to_id_if
@@ -534,8 +534,8 @@ test_non_device_copyable()
     //__gen_set_balanced_path
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
                       oneapi::dpl::__par_backend_hetero::__set_intersection,
-                      oneapi::dpl::__par_backend_hetero::__get_bounds_simple, binary_op_non_device_copyable,
-                      binary_op_non_device_copyable, binary_op_non_device_copyable, int>>,
+                      oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_non_device_copyable,
+                      binary_op_non_device_copyable, binary_op_non_device_copyable>>,
                   "__gen_set_balanced_path is device copyable with non device copyable types");
 
 #if !_PSTL_ICPX_DEVICE_COPYABLE_SUBMITTER_BROKEN
@@ -544,8 +544,8 @@ test_non_device_copyable()
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__partition_set_balanced_path_submitter<
             oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
                 oneapi::dpl::__par_backend_hetero::__set_intersection,
-                oneapi::dpl::__par_backend_hetero::__get_bounds_simple, binary_op_non_device_copyable,
-                binary_op_non_device_copyable, binary_op_non_device_copyable, int>,
+                oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_non_device_copyable,
+                binary_op_non_device_copyable, binary_op_non_device_copyable>,
             oneapi::dpl::execution::DefaultKernelName>>,
         "__partition_set_balanced_path_submitter is device copyable with non device copyable types");
 #endif
@@ -553,8 +553,8 @@ test_non_device_copyable()
     //__gen_set_op_from_known_balanced_path
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
-            oneapi::dpl::__par_backend_hetero::__set_intersection, oneapi::dpl::__par_backend_hetero::__noop_temp_data,
-            binary_op_non_device_copyable, binary_op_non_device_copyable, binary_op_non_device_copyable, int>>,
+            oneapi::dpl::__par_backend_hetero::__set_intersection, oneapi::dpl::__par_backend_hetero::__noop_temp_data, int,
+            binary_op_non_device_copyable, binary_op_non_device_copyable, binary_op_non_device_copyable>>,
                   "__gen_set_op_from_known_balanced_path is device copyable with non device copyable types");
 
     //__write_to_id_if


### PR DESCRIPTION
This pull request relaxes the requirement of trivially copyable value types for reduce_then_scan, taking the first step toward enabling it for all cases.

- Implements SLM and barrier-based fallback implementations for `__group_broadcast` and `__shift_group_right`.  This requires extra SLM data to be allocated and passed. 
- To avoid many repeated branches in inner loops, this extracts the kernel bodies into member functions to branch once for SLM vs sycl-builtin implementations. This is the biggest change from a LOC standpoint, but is mostly just moving code.
- Removes trivially copyable restriction in code dispatching to reduce_then_scan
- Adds explicit return type to `__gen_count_mask`, `__gen_expand_count_mask`, `__gen_set_balanced_path`,
   `__gen_set_op_from_known_balanced_path` to correct intermediate type to be better controlled and resolve ambiguity with SLM pointer type.
 

Full picture:
* [Relax trivially copyable requirement](https://github.com/uxlfoundation/oneDPL/pull/2656)  <------
* [Relax subgroup size requirements](https://github.com/uxlfoundation/oneDPL/pull/2657)
* Implement output limited scan_copy
* Remove dead code implementations (scan_then_propagate, reduce_by_segment_fallback, scan_by_segment_fallback)