### PR TITLE
Define begin() and end() methods in simple views

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -363,13 +363,13 @@ class zip_view
     auto
     begin() const
     {
-        return __make_begin(::std::make_index_sequence<__num_ranges>());
+        return __make_begin(std::make_index_sequence<__num_ranges>());
     }
 
     auto
     end() const
     {
-        return __make_end(::std::make_index_sequence<__num_ranges>());
+        return __make_end(std::make_index_sequence<__num_ranges>());
     }
 
     auto
@@ -399,16 +399,16 @@ class zip_view
     }
 
   private:
-    template <::std::size_t... _Ip>
+    template <std::size_t... _Ip>
     auto
-    __make_begin(::std::index_sequence<_Ip...>) const
+    __make_begin(std::index_sequence<_Ip...>) const
     {
         return oneapi::dpl::make_zip_iterator(oneapi::dpl::__ranges::__begin(std::get<_Ip>(__m_ranges))...);
     }
 
-    template <::std::size_t... _Ip>
+    template <std::size_t... _Ip>
     auto
-    __make_end(::std::index_sequence<_Ip...>) const
+    __make_end(std::index_sequence<_Ip...>) const
     {
         return oneapi::dpl::make_zip_iterator(oneapi::dpl::__ranges::__end(std::get<_Ip>(__m_ranges))...);
     }
@@ -483,13 +483,13 @@ struct reverse_view_simple
     auto
     begin() const
     {
-        return ::std::make_reverse_iterator(__begin(__r) + size());
+        return std::make_reverse_iterator(__begin(__r) + size());
     }
 
     auto
     end() const
     {
-        return ::std::make_reverse_iterator(__begin(__r));
+        return std::make_reverse_iterator(__begin(__r));
     }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -537,14 +537,16 @@ struct drop_view_simple
         assert(__n >= 0 && __n <= oneapi::dpl::__ranges::__size(__r));
     }
 
+    template <typename _Rng = _R>
     auto
-    begin() const -> decltype(__begin(__r) + __n)
+    begin() const -> decltype(__begin(std::declval<const _Rng&>()) + __n)
     {
         return __begin(__r) + __n;
     }
 
+    template <typename _Rng = _R>
     auto
-    end() const -> decltype(__end(__r))
+    end() const -> decltype(__end(std::declval<const _Rng&>()))
     {
         return __end(__r);
     }

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -538,13 +538,13 @@ struct drop_view_simple
     }
 
     auto
-    begin() const
+    begin() const -> decltype(__begin(__r) + __n)
     {
         return __begin(__r) + __n;
     }
 
     auto
-    end() const
+    end() const -> decltype(__end(__r))
     {
         return __end(__r);
     }

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -480,6 +480,18 @@ struct reverse_view_simple
 
     reverse_view_simple(_R __rng) : __r(__rng) {}
 
+    auto
+    begin() const
+    {
+        return ::std::make_reverse_iterator(__begin(__r) + size());
+    }
+
+    auto
+    end() const
+    {
+        return ::std::make_reverse_iterator(__begin(__r));
+    }
+
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__r[__i])
@@ -519,6 +531,18 @@ struct take_view_simple
     take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size)
     {
         assert(__n >= 0 && __n <= oneapi::dpl::__ranges::__size(__r));
+    }
+
+    auto
+    begin() const
+    {
+        return __begin(__r);
+    }
+
+    auto
+    end() const
+    {
+        return __begin(__r) + __n;
     }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -747,6 +747,21 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<oneapi::dpl::__in
 
     permutation_view_simple(_Source __data, _M __m, _Size __s) : __src(__data), __map_fn(__m), __size(__s) {}
 
+    auto
+    begin() const
+    {
+        if constexpr (oneapi::dpl::__internal::__is_random_access_iterator_v<_Source>)
+            return oneapi::dpl::make_permutation_iterator(__src, __map_fn);
+        else
+            return oneapi::dpl::make_permutation_iterator(__begin(__src), __map_fn);
+    }
+
+    auto
+    end() const
+    {
+        return begin() + __size;
+    }
+
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     decltype(auto)
@@ -785,6 +800,21 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<is_map_view<_M>::
     _M __map;      //permutation range
 
     permutation_view_simple(_Source __data, _M __m) : __src(__data), __map(__m) {}
+
+    auto
+    begin() const
+    {
+        if constexpr (oneapi::dpl::__internal::__is_random_access_iterator_v<_Source>)
+            return oneapi::dpl::make_permutation_iterator(__src, __begin(__map));
+        else
+            return oneapi::dpl::make_permutation_iterator(__begin(__src), __begin(__map));
+    }
+
+    auto
+    end() const
+    {
+        return begin() + size();
+    }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -361,6 +361,18 @@ class zip_view
     explicit zip_view(_Ranges... __args) : __m_ranges(__args...) {}
 
     auto
+    begin() const
+    {
+        return __make_begin(::std::make_index_sequence<__num_ranges>());
+    }
+
+    auto
+    end() const
+    {
+        return __make_end(::std::make_index_sequence<__num_ranges>());
+    }
+
+    auto
     size() const
     {
         return oneapi::dpl::__ranges::__size(std::get<0>(__m_ranges));
@@ -387,6 +399,20 @@ class zip_view
     }
 
   private:
+    template <::std::size_t... _Ip>
+    auto
+    __make_begin(::std::index_sequence<_Ip...>) const
+    {
+        return oneapi::dpl::make_zip_iterator(oneapi::dpl::__ranges::__begin(std::get<_Ip>(__m_ranges))...);
+    }
+
+    template <::std::size_t... _Ip>
+    auto
+    __make_end(::std::index_sequence<_Ip...>) const
+    {
+        return oneapi::dpl::make_zip_iterator(oneapi::dpl::__ranges::__end(std::get<_Ip>(__m_ranges))...);
+    }
+
     _tuple_ranges_t __m_ranges;
 };
 
@@ -537,16 +563,14 @@ struct drop_view_simple
         assert(__n >= 0 && __n <= oneapi::dpl::__ranges::__size(__r));
     }
 
-    template <typename _Rng = _R>
     auto
-    begin() const -> decltype(__begin(std::declval<const _Rng&>()) + __n)
+    begin() const
     {
         return __begin(__r) + __n;
     }
 
-    template <typename _Rng = _R>
     auto
-    end() const -> decltype(__end(std::declval<const _Rng&>()))
+    end() const
     {
         return __end(__r);
     }

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -641,6 +641,21 @@ struct replicate_start_view_simple
         assert(__repl_count >= 0);
     }
 
+    auto
+    begin() const
+    {
+        auto __map_fn = [__c = __repl_count](auto __i) -> decltype(__i) {
+            return __i < __c ? decltype(__i)(0) : __i - __c;
+        };
+        return oneapi::dpl::make_permutation_iterator(__begin(__r), __map_fn);
+    }
+
+    auto
+    end() const
+    {
+        return begin() + size();
+    }
+
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__r[__i])

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -677,6 +677,18 @@ struct transform_view_simple
     _R __r;
     _F __f;
 
+    auto
+    begin() const
+    {
+        return oneapi::dpl::make_transform_iterator(__begin(__r), __f);
+    }
+
+    auto
+    end() const
+    {
+        return begin() + size();
+    }
+
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__f(__r[__i]))


### PR DESCRIPTION
It fixes a regression in inclusive_scan_by_segment_zip.pass, exclusive_scan_by_segment_zip.pass and shift_left_right.pass caused by #2618, which added these methods into drop_view_simple. 

Example of an issue:

```c++
Building CXX object test/CMakeFiles/exclusive_scan_by_segment_zip.pass.dir/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_zip.pass.cpp.o
In file included from oneDPL/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_zip.pass.cpp:18:
In file included from oneDPL/include/oneapi/dpl/execution:75:
In file included from oneDPL/include/oneapi/dpl/pstl/algorithm_impl.h:29:
In file included from oneDPL/include/oneapi/dpl/pstl/execution_impl.h:22:
In file included from oneDPL/include/oneapi/dpl/pstl/parallel_backend.h:32:
In file included from oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:35:
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/../../utils_ranges.h:543:16: error: no matching function for call to '__begin'
  543 |         return __begin(__r) + __n;
      |                ^~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/iterator_concepts.h:979:23: note: in instantiation of member function 'oneapi::dpl::__ranges::drop_view_simple<oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>,
      oneapi::dpl::__ranges::guard_view<int *>>, int>::begin' requested here
  979 |           { __decay_copy(__t.begin()) } -> input_or_output_iterator;
      |                              ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/iterator_concepts.h:979:6: note: in instantiation of requirement here
  979 |           { __decay_copy(__t.begin()) } -> input_or_output_iterator;
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/iterator_concepts.h:977:32: note: while substituting template arguments into constraint expression here
  977 |       concept __member_begin = requires(_Tp& __t)
      |                                ^~~~~~~~~~~~~~~~~~
  978 |         {
      |         ~
  979 |           { __decay_copy(__t.begin()) } -> input_or_output_iterator;
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  980 |         };
      |         ~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/ranges_base.h:112:50: note: while checking the satisfaction of concept
      '__member_begin<oneapi::dpl::__ranges::drop_view_simple<oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, int> &>' requested here
  112 |         requires is_array_v<remove_reference_t<_Tp>> || __member_begin<_Tp>
      |                                                         ^~~~~~~~~~~~~~~~~~~
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/../../utils_ranges.h:44:37: note: while checking constraint satisfaction for template
      'operator()<oneapi::dpl::__ranges::drop_view_simple<oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, int> &>' required here
   44 | __begin(_Range&& __rng) -> decltype(std::ranges::begin(std::forward<_Range>(__rng)))
      |                                     ^~~
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/../../utils_ranges.h:44:37: note: while substituting deduced template arguments into function template 'operator()' [with _Tp =
      oneapi::dpl::__ranges::drop_view_simple<oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, int> &]
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/../../utils_ranges.h:151:48: note: while substituting deduced template arguments into function template '__begin' [with _Range =
      oneapi::dpl::__ranges::drop_view_simple<oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, int> &]
  151 |                          std::decay_t<decltype(oneapi::dpl::__ranges::__begin(std::declval<_R&>()))>>::value_type;
      |                                                ^
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/../../utils_ranges.h:168:28: note: while substituting explicitly-specified template arguments into function template 'get_value_type'
  168 | using __value_t = decltype(oneapi::dpl::__internal::get_value_type<_R>(0));
      |                            ^
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h:46:61: note: in instantiation of template type alias '__value_t' requested here
   46 |     using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
      |                                                             ^
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h:252:19: note: in instantiation of template class 'oneapi::dpl::__par_backend_hetero::__pfor_params<true,
      oneapi::dpl::unseq_backend::walk_n_vectors_or_scalars<oneapi::dpl::__internal::__transform_functor<oneapi::dpl::__internal::__not_pred<std::equal_to<void>>>>, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>,
      oneapi::dpl::__ranges::guard_view<int *>> &, oneapi::dpl::__ranges::drop_view_simple<oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, int> &,
      oneapi::dpl::__ranges::all_view<unsigned int, sycl::access::mode::read_write> &>' requested here
  252 |     if constexpr (__params_t::__iters_per_item > 1 || __params_t::__vector_size > 1)
      |                   ^
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h:271:47: note: in instantiation of function template specialization
      'oneapi::dpl::__par_backend_hetero::__parallel_for_impl<oneapi::dpl::__par_backend_hetero::__scan_by_seg_transform_wrapper1<oneapi::dpl::__par_backend_hetero::__scan_by_seg_fallback<oneapi::dpl::execution::DefaultKernelName>>,
      oneapi::dpl::unseq_backend::walk_n_vectors_or_scalars<oneapi::dpl::__internal::__transform_functor<oneapi::dpl::__internal::__not_pred<std::equal_to<void>>>>, unsigned long, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>,
      oneapi::dpl::__ranges::guard_view<int *>> &, oneapi::dpl::__ranges::drop_view_simple<oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, int> &,
      oneapi::dpl::__ranges::all_view<unsigned int, sycl::access::mode::read_write> &>' requested here
  271 |     return oneapi::dpl::__par_backend_hetero::__parallel_for_impl<_CustomName>(__q_local, __brick, __count,
      |                                               ^
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:2418:9: note: in instantiation of function template specialization
      'oneapi::dpl::__par_backend_hetero::__parallel_for<oneapi::dpl::execution::device_policy<oneapi::dpl::__par_backend_hetero::__scan_by_seg_transform_wrapper1<oneapi::dpl::__par_backend_hetero::__scan_by_seg_fallback<oneapi::dpl::execution::DefaultKernelName>>>,
      oneapi::dpl::unseq_backend::walk_n_vectors_or_scalars<oneapi::dpl::__internal::__transform_functor<oneapi::dpl::__internal::__not_pred<std::equal_to<void>>>>, unsigned long, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>,
      oneapi::dpl::__ranges::guard_view<int *>> &, oneapi::dpl::__ranges::drop_view_simple<oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, int> &,
      oneapi::dpl::__ranges::all_view<unsigned int, sycl::access::mode::read_write> &>' requested here
 2418 |         __parallel_for(oneapi::dpl::__internal::__device_backend_tag{},
      |         ^
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:2509:5: note: in instantiation of function template specialization
      'oneapi::dpl::__par_backend_hetero::__parallel_scan_by_segment_fallback<oneapi::dpl::execution::DefaultKernelName, false,
      oneapi::dpl::execution::device_policy<oneapi::dpl::__par_backend_hetero::__scan_by_seg_fallback<oneapi::dpl::execution::DefaultKernelName>>, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>,
      oneapi::dpl::__ranges::guard_view<int *>>, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>,
      oneapi::dpl::__ranges::guard_view<int *>>, std::equal_to<void>, TestUtils::TupleAddFunctor1, oneapi::dpl::unseq_backend::__init_value<std::tuple<int, int>>>' requested here
 2509 |     __parallel_scan_by_segment_fallback<_CustomName, __is_inclusive>(
      |     ^
oneDPL/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h:338:13: note: in instantiation of function template specialization 'oneapi::dpl::__par_backend_hetero::__parallel_scan_by_segment<false, const
      oneapi::dpl::execution::device_policy<> &, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>,
      oneapi::dpl::__ranges::guard_view<int *>>, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::guard_view<int *>>, std::equal_to<void>, TestUtils::TupleAddFunctor1,
      oneapi::dpl::unseq_backend::__init_value<std::tuple<int, int>>>' requested here
  338 |     __bknd::__parallel_scan_by_segment<_Inclusive::value>(
      |             ^
oneDPL/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h:351:12: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__pattern_scan_by_segment_impl<oneapi::dpl::__internal::__device_backend_tag,
      const oneapi::dpl::execution::device_policy<> &, oneapi::dpl::zip_iterator<int *, int *>, oneapi::dpl::zip_iterator<int *, int *>, oneapi::dpl::zip_iterator<int *, int *>, std::equal_to<void>, TestUtils::TupleAddFunctor1,
      std::integral_constant<bool, false>, oneapi::dpl::unseq_backend::__init_value<std::tuple<int, int>>>' requested here
  351 |     return __pattern_scan_by_segment_impl(__tag, std::forward<_Policy>(__policy), __first1, __last1, __first2, __result,
      |            ^
oneDPL/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h:104:24: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__pattern_scan_by_segment<oneapi::dpl::__internal::__device_backend_tag,
      const oneapi::dpl::execution::device_policy<> &, oneapi::dpl::zip_iterator<int *, int *>, oneapi::dpl::zip_iterator<int *, int *>, oneapi::dpl::zip_iterator<int *, int *>, std::equal_to<void>, TestUtils::TupleAddFunctor1,
      std::integral_constant<bool, false>, std::tuple<int, int>>' requested here
  104 |     return __internal::__pattern_scan_by_segment(__tag, std::forward<Policy>(policy), first1, last1, first2, result,
      |                        ^
oneDPL/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h:119:24: note: in instantiation of function template specialization
      'oneapi::dpl::__internal::__pattern_exclusive_scan_by_segment<oneapi::dpl::__internal::__device_backend_tag, const oneapi::dpl::execution::device_policy<> &, oneapi::dpl::zip_iterator<int *, int *>, oneapi::dpl::zip_iterator<int *, int *>,
      oneapi::dpl::zip_iterator<int *, int *>, std::tuple<int, int>, std::equal_to<void>, TestUtils::TupleAddFunctor1>' requested here
  119 |     return __internal::__pattern_exclusive_scan_by_segment(__dispatch_tag, std::forward<Policy>(policy), first1, last1,
      |                        ^
oneDPL/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_zip.pass.cpp:70:18: note: in instantiation of function template specialization 'oneapi::dpl::exclusive_scan_by_segment<const oneapi::dpl::execution::device_policy<>
      &, oneapi::dpl::zip_iterator<int *, int *>, oneapi::dpl::zip_iterator<int *, int *>, oneapi::dpl::zip_iterator<int *, int *>, std::tuple<int, int>, std::equal_to<void>, TestUtils::TupleAddFunctor1>' requested here
   70 |     oneapi::dpl::exclusive_scan_by_segment(
      |                  ^
oneDPL/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_zip.pass.cpp:97:5: note: in instantiation of function template specialization 'test_with_usm<sycl::usm::alloc::shared, KernelName1, const
      oneapi::dpl::execution::device_policy<> &>' requested here
   97 |     test_with_usm<sycl::usm::alloc::shared, KernelName1>(CLONE_TEST_POLICY(exec));
      |     ^
oneDPL/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_zip.pass.cpp:108:5: note: in instantiation of function template specialization 'test_impl<oneapi::dpl::execution::device_policy<> &>' requested here
  108 |     test_impl(policy);
      |     ^
oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/../../utils_ranges.h:44:1: note: candidate template ignored: substitution failure [with _Range = const oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<int *>,
      oneapi::dpl::__ranges::guard_view<int *>> &]: no matching function for call to object of type 'const __cust_access::_Begin'
   44 | __begin(_Range&& __rng) -> decltype(std::ranges::begin(std::forward<_Range>(__rng)))
      | ^                                   ~~~
1 error generated.
```

Alternative approaches:
- Add a trailing return type to begin()/end() from drop_view_simple with immediate context, see f6616eb5c630ee520160c924fc5332ca7298ac88. It lets
> get_value_type(long) -> typename std::iterator_traits<
                         std::decay_t<decltype(oneapi::dpl::__ranges::__begin(std::declval<_R&>()))>>::value_type;

deduce `__begin`'s return type without instantiating its body. Instantiation of a body will lead the the issue above. 
- Remove begin()/end() from drop_view_simple, and probably use something else in `struct __internal::__ends_with_fn`.

I added begin()/end() to the rest views, assuming a view must have them.