### PR TITLE
add SFINAE to drop_view_simple begin/end

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -537,14 +537,16 @@ struct drop_view_simple
         assert(__n >= 0 && __n <= oneapi::dpl::__ranges::__size(__r));
     }
 
+    template <typename _Rng = _R>
     auto
-    begin() const
+    begin() const -> decltype(__begin(std::declval<const _Rng&>()) + std::declval<_Size>())
     {
         return __begin(__r) + __n;
     }
 
+    template <typename _Rng = _R>
     auto
-    end() const
+    end() const -> decltype(__end(std::declval<const _Rng&>()))
     {
         return __end(__r);
     }


### PR DESCRIPTION
#2618 added `begin`/`end` support for `drop_view_simple`, but not all existing usages provide support for `__begin`/`__end`.  
This PR adds SFINAE to these methods to only instantiate if the underlying range supports it, allowing the new functionality where it is available and fixing support for ranges like `zip_view` and `reverse_view_simple` which dont have `begin`/`end`.