### PR TITLE
Add ranges::lexicographical_compare

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -720,8 +720,7 @@ __find_subrange(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _
         // then we can exit the loop (b_first == true) or keep the position
         // (b_first == false)
         if (__first != __last && (__global_last - __first >= __n2) &&
-            __internal::__brick_equal(__s_first + 1, __s_last, __first + 1,
-                                      oneapi::dpl::__internal::__reorder_pred(__pred), __is_vector))
+            __internal::__brick_equal(__first + 1, __first + __n2, __s_first + 1, __pred, __is_vector))
         {
             if (__b_first)
             {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -4263,14 +4263,14 @@ __pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, _ExecutionPol
     {
         using _RefType1 = typename std::iterator_traits<_RandomAccessIterator1>::reference;
         using _RefType2 = typename std::iterator_traits<_RandomAccessIterator2>::reference;
-        __internal::__reorder_pred<_Compare> __reordered_comp{__comp};
 
         return __internal::__except_handler([&]() {
             --__last1;
             --__last2;
-            auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
+            auto __n = std::min(__last1 - __first1, __last2 - __first2);
+            __internal::__reorder_pred<_Compare> __reordered_comp{__comp};
             auto __result = __internal::__parallel_find(
-                __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
+                __tag, std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
                 [__first1, __first2, &__comp, &__reordered_comp](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j)
                 {
                     return __internal::__brick_mismatch(
@@ -4281,7 +4281,7 @@ __pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, _ExecutionPol
                                _IsVector{})
                         .first;
                 },
-                ::std::true_type{});
+                std::true_type{});
 
             if (__result == __last1 && __first2 + (__result - __first1) != __last2)
             { // if first sequence shorter than second

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -4264,6 +4264,7 @@ __pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, _ExecutionPol
     {
         using _RefType1 = typename std::iterator_traits<_RandomAccessIterator1>::reference;
         using _RefType2 = typename std::iterator_traits<_RandomAccessIterator2>::reference;
+        __internal::__reorder_pred<_Compare> __reordered_comp{__comp};
 
         return __internal::__except_handler([&]() {
             --__last1;
@@ -4271,11 +4272,12 @@ __pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, _ExecutionPol
             auto __n = ::std::min(__last1 - __first1, __last2 - __first2);
             auto __result = __internal::__parallel_find(
                 __tag, ::std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
-                [__first1, __first2, &__comp](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+                [__first1, __first2, &__comp, &__reordered_comp](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j)
+                {
                     return __internal::__brick_mismatch(
                                __i, __j, __first2 + (__i - __first1), __first2 + (__j - __first1),
-                               [&__comp](const _RefType1 __x, const _RefType2 __y) {
-                                   return !std::invoke(__comp, __x, __y) && !std::invoke(__comp, __y, __x);
+                               [&__comp, &__reordered_comp](const _RefType1 __x, const _RefType2 __y) {
+                                   return !std::invoke(__comp, __x, __y) && !__reordered_comp(__x, __y);
                                },
                                _IsVector{})
                         .first;
@@ -4284,7 +4286,7 @@ __pattern_lexicographical_compare(__parallel_tag<_IsVector> __tag, _ExecutionPol
 
             if (__result == __last1 && __first2 + (__result - __first1) != __last2)
             { // if first sequence shorter than second
-                return !std::invoke(__comp, *(__first2 + (__result - __first1)), *__result);
+                return !__reordered_comp(*__result, *(__first2 + (__result - __first1)));
             }
             else
             { // if second sequence shorter than first or both have the same number of elements

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -386,8 +386,8 @@ __pattern_equal(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _
 //---------------------------------------------------------------------------------------------------------------------
 // pattern_lexicographical_compare
 //---------------------------------------------------------------------------------------------------------------------
-template<typename _Tag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1,
-         typename _Proj2>
+template <typename _Tag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1,
+          typename _Proj2>
 bool
 __pattern_lexicographical_compare(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Comp __comp,
                                   _Proj1 __proj1, _Proj2 __proj2)
@@ -401,7 +401,7 @@ __pattern_lexicographical_compare(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& _
         oneapi::dpl::__internal::__binary_op<_Comp, _Proj1, _Proj2>{__comp, __proj1, __proj2});
 }
 
-template<typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1, typename _Proj2>
+template <typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1, typename _Proj2>
 bool
 __pattern_lexicographical_compare(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R1&& __r1, _R2&& __r2,
                                   _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -384,6 +384,33 @@ __pattern_equal(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// pattern_lexicographical_compare
+//---------------------------------------------------------------------------------------------------------------------
+template<typename _Tag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1,
+         typename _Proj2>
+bool
+__pattern_lexicographical_compare(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Comp __comp,
+                                  _Proj1 __proj1, _Proj2 __proj2)
+{
+    static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
+
+    return oneapi::dpl::__internal::__pattern_lexicographical_compare(
+        __tag, std::forward<_ExecutionPolicy>(__exec),
+        std::ranges::begin(__r1), std::ranges::begin(__r1) + std::ranges::size(__r1),
+        std::ranges::begin(__r2), std::ranges::begin(__r2) + std::ranges::size(__r2),
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj1, _Proj2>{__comp, __proj1, __proj2});
+}
+
+template<typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1, typename _Proj2>
+bool
+__pattern_lexicographical_compare(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&&, _R1&& __r1, _R2&& __r2,
+                                  _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
+{
+    return std::ranges::lexicographical_compare(std::forward<_R1>(__r1), std::forward<_R2>(__r2),
+                                                __comp, __proj1, __proj2);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // pattern_is_sorted
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -47,6 +47,7 @@ struct __search_n_fn;
 struct __count_if_fn;
 struct __count_fn;
 struct __equal_fn;
+struct __lex_compare_fn;
 struct __is_sorted_fn;
 struct __is_sorted_until_fn;
 struct __stable_sort_leaf;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -457,11 +457,11 @@ inline constexpr __internal::__equal_fn equal;
 
 struct __internal::__lex_compare_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-             typename _Proj1 = std::identity, typename _Proj2 = std::identity,
-             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
-                                             std::projected<std::ranges::iterator_t<_R2>, _Proj2>>
-                 _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
+              typename _Proj1 = std::identity, typename _Proj2 = std::identity,
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
+                                              std::projected<std::ranges::iterator_t<_R2>, _Proj2>>
+                  _Comp = std::ranges::less>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
              && std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2>
     bool
@@ -469,8 +469,8 @@ struct __internal::__lex_compare_fn
                _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_lexicographical_compare(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
+        return oneapi::dpl::__internal::__ranges::__pattern_lexicographical_compare(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
             __comp, __proj1, __proj2);
     }
 };

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -453,6 +453,29 @@ struct __internal::__equal_fn
 }; //__equal_fn
 inline constexpr __internal::__equal_fn equal;
 
+// [alg.lex.comparison]
+
+struct __internal::__lex_compare_fn
+{
+    template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
+             typename _Proj1 = std::identity, typename _Proj2 = std::identity,
+             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
+                                             std::projected<std::ranges::iterator_t<_R2>, _Proj2>>
+                 _Comp = std::ranges::less>
+    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
+             && std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2>
+    bool
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Comp __comp = {}, _Proj1 __proj1 = {},
+               _Proj2 __proj2 = {}) const
+    {
+        const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        return oneapi::dpl::__internal::__ranges::__pattern_lexicographical_compare(__dispatch_tag,
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
+            __comp, __proj1, __proj2);
+    }
+};
+inline constexpr __internal::__lex_compare_fn lexicographical_compare;
+
 // [is.sorted]
 
 struct __internal::__is_sorted_fn

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1356,37 +1356,6 @@ __pattern_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 // lexicographical_compare
 //------------------------------------------------------------------------
 
-template <typename _ReduceValueType>
-struct __pattern_lexicographical_compare_reduce_fn
-{
-    auto
-    operator()(_ReduceValueType __a, _ReduceValueType __b) const
-    {
-        bool __is_mismatched = __a != 0;
-        return __a * __is_mismatched + __b * !__is_mismatched;
-    }
-};
-
-template <typename _Compare, typename _ReduceValueType>
-struct __pattern_lexicographical_compare_transform_fn
-{
-    _Compare __comp;
-
-    template <typename _TGroupIdx, typename _TAcc1, typename _TAcc2>
-    _ReduceValueType
-    operator()(_TGroupIdx __gidx, _TAcc1 __acc1, _TAcc2 __acc2) const
-    {
-        auto const& __s1_val = __acc1[__gidx];
-        auto const& __s2_val = __acc2[__gidx];
-
-        std::int32_t __is_s1_val_less = std::invoke(__comp, __s1_val, __s2_val);
-        std::int32_t __is_s1_val_greater = std::invoke(__comp, __s2_val, __s1_val);
-
-        // 1 if __s1_val <  __s2_val, -1 if __s1_val <  __s2_val, 0 if __s1_val == __s2_val
-        return _ReduceValueType{1 * __is_s1_val_less - 1 * __is_s1_val_greater};
-    }
-};
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Compare>
 bool
 __pattern_lexicographical_compare(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first1,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -251,6 +251,42 @@ __pattern_equal(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R1&
 #endif //_ONEDPL_CPP20_RANGES_PRESENT
 
 //------------------------------------------------------------------------
+// pattern_lexicographical_compare
+//------------------------------------------------------------------------
+
+#if _ONEDPL_CPP20_RANGES_PRESENT
+template<typename _BackendTag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1,
+         typename _Proj2>
+bool
+__pattern_lexicographical_compare(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2,
+                                  _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
+{
+    namespace __dplr = oneapi::dpl::__ranges;
+    using _CommonSize = __dplr::__common_size_t<_R1, _R2>;
+    const _CommonSize __n2 = __dplr::__size(__r2);
+    if (__n2 == 0)
+        return false;
+    const _CommonSize __n1 = __dplr::__size(__r1);
+    if (__n1 == 0)
+        return true;
+    _CommonSize __shared_size = std::min<_CommonSize>(__n1, __n2);
+
+    using _ReduceValueType = std::int32_t;
+    __pattern_lexicographical_compare_reduce_fn<_ReduceValueType> __reduce_fn;
+    __pattern_lexicographical_compare_transform_fn<__binary_op<_Comp, _Proj1, _Proj2>, _ReduceValueType>
+        __transform_fn{__binary_op{__comp, __proj1, __proj2}};
+
+    auto __ret_idx = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+                                                                                    std::false_type /*is_commutative*/>(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn, unseq_backend::__no_init_value{},
+        __dplr::take_view_simple(__dplr::views::all_read(std::forward<_R1>(__r1)), __shared_size),
+        __dplr::take_view_simple(__dplr::views::all_read(std::forward<_R2>(__r2)), __shared_size)).get(); // blocking
+
+    return __ret_idx ? __ret_idx == 1 : __n1 < __n2;
+}
+#endif //_ONEDPL_CPP20_RANGES_PRESENT
+
+//------------------------------------------------------------------------
 // find_if
 //------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -258,7 +258,7 @@ __pattern_equal(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R1&
 template <typename _BackendTag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1,
           typename _Proj2>
 bool
-__pattern_lexicographical_compare(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2,
+__pattern_lexicographical_compare(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2,
                                   _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
 {
     namespace __dplr = oneapi::dpl::__ranges;
@@ -278,9 +278,11 @@ __pattern_lexicographical_compare(__hetero_tag<_BackendTag> __tag, _ExecutionPol
 
     auto __ret_idx = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
                                                                                     std::false_type /*is_commutative*/>(
-        __tag, std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn, unseq_backend::__no_init_value{},
-        __dplr::take_view_simple(__dplr::views::all_read(std::forward<_R1>(__r1)), __shared_size),
-        __dplr::take_view_simple(__dplr::views::all_read(std::forward<_R2>(__r2)), __shared_size)).get(); // blocking
+                         _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+                         unseq_backend::__no_init_value{},
+                         __dplr::take_view_simple(__dplr::views::all_read(std::forward<_R1>(__r1)), __shared_size),
+                         __dplr::take_view_simple(__dplr::views::all_read(std::forward<_R2>(__r2)), __shared_size))
+                     .get(); // blocking
 
     return __ret_idx ? __ret_idx == 1 : __n1 < __n2;
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -255,8 +255,8 @@ __pattern_equal(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R1&
 //------------------------------------------------------------------------
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
-template<typename _BackendTag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1,
-         typename _Proj2>
+template <typename _BackendTag, typename _ExecutionPolicy, typename _R1, typename _R2, typename _Comp, typename _Proj1,
+          typename _Proj2>
 bool
 __pattern_lexicographical_compare(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2,
                                   _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -150,7 +150,7 @@ struct __pattern_lexicographical_compare_transform_fn
 template <typename _ReduceValueType>
 struct __pattern_lexicographical_compare_reduce_fn
 {
-    auto
+    _ReduceValueType
     operator()(_ReduceValueType __left, _ReduceValueType __right) const
     {
         return (__left == 0) ? __right : __left; // non-commutative

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -139,7 +139,8 @@ struct __pattern_lexicographical_compare_transform_fn
         auto const& __s2_val = __acc2[__gidx];
 
         _ReduceValueType __is_s1_val_less = bool(std::invoke(__comp, __s1_val, __s2_val));
-        _ReduceValueType __is_s1_val_greater = bool(std::invoke(__comp, __s2_val, __s1_val));
+        _ReduceValueType __is_s1_val_greater =
+            bool(oneapi::dpl::__internal::__reorder_pred<_Compare>{__comp}(__s1_val, __s2_val));
 
         // 1 if __s1_val <  __s2_val, -1 if __s2_val <  __s1_val, 0 if __s1_val == __s2_val
         return __is_s1_val_less - __is_s1_val_greater;

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -126,6 +126,36 @@ struct __pattern_min_element_transform_fn
     }
 };
 
+template <typename _Compare, typename _ReduceValueType>
+struct __pattern_lexicographical_compare_transform_fn
+{
+    _Compare __comp;
+
+    template <typename _TGroupIdx, typename _TAcc1, typename _TAcc2>
+    _ReduceValueType
+    operator()(_TGroupIdx __gidx, _TAcc1 __acc1, _TAcc2 __acc2) const
+    {
+        auto const& __s1_val = __acc1[__gidx];
+        auto const& __s2_val = __acc2[__gidx];
+
+        _ReduceValueType __is_s1_val_less = bool(std::invoke(__comp, __s1_val, __s2_val));
+        _ReduceValueType __is_s1_val_greater = bool(std::invoke(__comp, __s2_val, __s1_val));
+
+        // 1 if __s1_val <  __s2_val, -1 if __s2_val <  __s1_val, 0 if __s1_val == __s2_val
+        return __is_s1_val_less - __is_s1_val_greater;
+    }
+};
+
+template <typename _ReduceValueType>
+struct __pattern_lexicographical_compare_reduce_fn
+{
+    auto
+    operator()(_ReduceValueType __left, _ReduceValueType __right) const
+    {
+        return (__left == 0) ? __right : __left; // non-commutative
+    }
+};
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -204,6 +204,16 @@ struct __binary_op
     }
 };
 
+//! Specialization of __reorder_pred over __binary_op should change the order of calls
+template <typename _Pred, typename _Proj1, typename _Proj2>
+class __reorder_pred<__binary_op<_Pred, _Proj1, _Proj2>> : public __binary_op<__reorder_pred<_Pred>, _Proj1, _Proj2>
+{
+  public:
+    using __base = __binary_op<__reorder_pred<_Pred>, _Proj1, _Proj2>;
+    explicit __reorder_pred(__binary_op<_Pred, _Proj1, _Proj2> __op)
+        : __base(__reorder_pred<_Pred>{__op.__f}, __op.__proj1, __op.__proj2) {}
+};
+
 //! "==" comparison.
 /** Not called "equal" to avoid (possibly unfounded) concerns about accidental invocation via
     argument-dependent name lookup by code expecting to find the usual ::std::equal. */

--- a/test/parallel_api/ranges/std_ranges_lexicographical_compare.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_lexicographical_compare.pass.cpp
@@ -23,14 +23,15 @@ main()
     namespace dpl_ranges = oneapi::dpl::ranges;
 
     auto checker = TEST_PREPARE_CALLABLE(std::ranges::lexicographical_compare);
+    auto plus_one = [](auto i){ return i + 1; };
     auto almost_always_i = [](auto i){ return (i == medium_size/2 + 19)? 0 : i; };
     using data_gen_needle = decltype(almost_always_i);
 
     launcher<0, int>{big_sz}(dpl_ranges::lexicographical_compare, checker);
-    launcher<1, int>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::greater{}, proj);
+    launcher<1, int>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::greater{}, plus_one);
     launcher<2, P2>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::greater{}, &P2::x, &P2::proj);
     launcher<3, P2>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::less{}, &P2::proj, &P2::x);
-    launcher<4, int, decltype(proj)>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::less{}, proj);
+    launcher<4, int, decltype(plus_one)>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::less{}, plus_one);
     launcher<5, int, data_gen_needle>{}(dpl_ranges::lexicographical_compare, checker);
     launcher<6, int, data_gen_needle>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::greater{});
 #endif //_ENABLE_STD_RANGES_TESTING

--- a/test/parallel_api/ranges/std_ranges_lexicographical_compare.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_lexicographical_compare.pass.cpp
@@ -26,12 +26,13 @@ main()
     auto almost_always_i = [](auto i){ return (i == medium_size/2 + 19)? 0 : i; };
     using data_gen_needle = decltype(almost_always_i);
 
-    launcher<0, int>{big_sz}(dpl_ranges::lexicographical_compare, checker, binary_pred_const);
-    launcher<1, int>{}(dpl_ranges::lexicographical_compare, checker, binary_pred, proj);
-    launcher<2, P2>{}(dpl_ranges::lexicographical_compare, checker, binary_pred, &P2::x, &P2::proj);
-    launcher<3, P2>{}(dpl_ranges::lexicographical_compare, checker, binary_pred, &P2::proj, &P2::x);
-    launcher<4, int, decltype(proj)>{}(dpl_ranges::lexicographical_compare, checker, binary_pred, proj);
+    launcher<0, int>{big_sz}(dpl_ranges::lexicographical_compare, checker);
+    launcher<1, int>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::greater{}, proj);
+    launcher<2, P2>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::greater{}, &P2::x, &P2::proj);
+    launcher<3, P2>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::less{}, &P2::proj, &P2::x);
+    launcher<4, int, decltype(proj)>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::less{}, proj);
     launcher<5, int, data_gen_needle>{}(dpl_ranges::lexicographical_compare, checker);
+    launcher<6, int, data_gen_needle>{}(dpl_ranges::lexicographical_compare, checker, std::ranges::greater{});
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_lexicographical_compare.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_lexicographical_compare.pass.cpp
@@ -1,0 +1,38 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 UXL Foundation Contributors
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+#if _ENABLE_STD_RANGES_TESTING
+    template<int call_id, typename T, typename DataGen2 = std::identity>
+    using launcher = test_std_ranges::test_range_algo<call_id, T, test_std_ranges::data_in_in,
+                                                      /*DataGen1*/ std::identity, DataGen2>;
+#endif
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    auto checker = TEST_PREPARE_CALLABLE(std::ranges::lexicographical_compare);
+    auto almost_always_i = [](auto i){ return (i == medium_size/2 + 19)? 0 : i; };
+    using data_gen_needle = decltype(almost_always_i);
+
+    launcher<0, int>{big_sz}(dpl_ranges::lexicographical_compare, checker, binary_pred_const);
+    launcher<1, int>{}(dpl_ranges::lexicographical_compare, checker, binary_pred, proj);
+    launcher<2, P2>{}(dpl_ranges::lexicographical_compare, checker, binary_pred, &P2::x, &P2::proj);
+    launcher<3, P2>{}(dpl_ranges::lexicographical_compare, checker, binary_pred, &P2::proj, &P2::x);
+    launcher<4, int, decltype(proj)>{}(dpl_ranges::lexicographical_compare, checker, binary_pred, proj);
+    launcher<5, int, data_gen_needle>{}(dpl_ranges::lexicographical_compare, checker);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}


### PR DESCRIPTION
The implementation redirects to the iterator-based pattern for CPU policies and reuses key parts of that and the same underlying `__parallel_transform_reduce` pattern for device policies, with necessary adjustments.

Per its semantics, the algorithm must use the provided predicate twice for a pair of input elements, changing the order of arguments for the second call. That creates a risk to apply projections to wrong input elements. Previously we addressed that by passing projections down the call stack till the point of use.

This PR proposes an alternative solution with a proper combination of `__binary_op` (which encapsulates the user-provided predicate and projections) and `__reorder_pred` (which changes the order of arguments to a binary predicate). For this combination to work as expected, we need to ensure projections are applied before reordering. For that, the composition of `__reorder_pred<__binary_op<Pred, Proj1, Proj2>>` is specialized as a class derived from `__binary_op<__reorder_pred<Pred>, Proj1, Proj2>`. It allows the implementation to use `__reorder_pred` even when its input predicate is a binary operation with projections, including in the common code for range-based and iterator-based algorithms.