### PR TITLE
Update release documentation with #2649 and apply edits from review

### DIFF
--- a/documentation/_auxiliary/common_cross_document_links.txt
+++ b/documentation/_auxiliary/common_cross_document_links.txt
@@ -1,5 +1,5 @@
 .. |onedpl_library_guide| replace:: oneAPI DPC++ Library Guide
-.. _onesdpl_library_guide: https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/2022.12.0/overview.html
+.. _onedpl_library_guide: https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/2022.12.0/overview.html
 
 .. |onedpl_requirements| replace:: oneDPL System Requirements
 .. _onedpl_requirements: https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/2022.12.0/intel-oneapi-dpc-library-introduction.html

--- a/documentation/_auxiliary/common_cross_document_links.txt
+++ b/documentation/_auxiliary/common_cross_document_links.txt
@@ -1,6 +1,8 @@
-.. |onedpl_library_guide| replace:: :doc:`oneAPI DPC++ Library Guide </library_guide/introduction>`
+.. |onedpl_library_guide| replace:: oneAPI DPC++ Library Guide
+.. _onesdpl_library_guide: https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/2022.12.0/overview.html
 
 .. |onedpl_requirements| replace:: :ref:`oneDPL System Requirements <library-requirements>`
+.. _onedpl_requirements: https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/2022.12.0/intel-oneapi-dpc-library-introduction.html
 
 .. |onedpl_specification| replace:: oneDPL Specification
 .. _onedpl_specification: https://uxlfoundation.github.io/oneDPL/specification/index.html

--- a/documentation/_auxiliary/common_cross_document_links.txt
+++ b/documentation/_auxiliary/common_cross_document_links.txt
@@ -1,7 +1,7 @@
 .. |onedpl_library_guide| replace:: oneAPI DPC++ Library Guide
 .. _onesdpl_library_guide: https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/2022.12.0/overview.html
 
-.. |onedpl_requirements| replace:: :ref:`oneDPL System Requirements <library-requirements>`
+.. |onedpl_requirements| replace:: oneDPL System Requirements
 .. _onedpl_requirements: https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/2022.12.0/intel-oneapi-dpc-library-introduction.html
 
 .. |onedpl_specification| replace:: oneDPL Specification

--- a/documentation/get_started/onedpl_gsg.rst
+++ b/documentation/get_started/onedpl_gsg.rst
@@ -25,10 +25,10 @@ page for:
 * Fixed Issues
 * Known Issues and Limitations
 
-Install the `Intel® oneAPI Toolkit <https://www.intel.com/content/www/us/en/developer/tools/oneapi/oneapi-toolkit.html>`_
+Install the `Intel® oneAPI Toolkit <https://www.intel.com/content/www/us/en/developer/tools/oneapi/oneapi-toolkit-download.html>`_
 to use |onedpl_short|.
 
-Additionally, to use |onedpl_short| and other Base Kit components on non-Intel GPUs install either the
+Additionally, to use |onedpl_short| and other oneAPI Toolkit components on non-Intel GPUs install either the
 `oneAPI for NVIDIA® GPUs plugin <https://developer.codeplay.com/products/oneapi/nvidia/home/>`_ or the
 `oneAPI for AMD GPUs plugin <https://developer.codeplay.com/products/oneapi/amd/home/>`_.
 

--- a/documentation/get_started/onedpl_gsg.rst
+++ b/documentation/get_started/onedpl_gsg.rst
@@ -25,7 +25,7 @@ page for:
 * Fixed Issues
 * Known Issues and Limitations
 
-Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html>`_
+Install the `Intel® oneAPI Toolkit <https://www.intel.com/content/www/us/en/developer/tools/oneapi/oneapi-toolkit.html>`_
 to use |onedpl_short|.
 
 Additionally, to use |onedpl_short| and other Base Kit components on non-Intel GPUs install either the

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -23,7 +23,7 @@ page for:
 * Known Issues and Limitations
 * Previous Release Notes
 
-Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html>`_
+Install the `Intel® oneAPI Toolkit <https://www.intel.com/content/www/us/en/developer/tools/oneapi/oneapi-toolkit.html>`_
 to use |onedpl_short|.
 
 .. _library-requirements:

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -203,7 +203,7 @@ Known Limitations
   As a result, customizations targeting ``std::ranges::iter_swap`` will not be respected.
 * Passing rvalue views to ``ranges::zip_view`` requires standard library support for views with ownership (P2415R2).
   This can be detected using the ``__cpp_lib_ranges`` feature macro (value ``202110L`` or higher).
-- Incorrect results may be produced by ``exclusive_scan``, ``inclusive_scan``, ``transform_exclusive_scan``,
+* Incorrect results may be produced by ``exclusive_scan``, ``inclusive_scan``, ``transform_exclusive_scan``,
   ``transform_inclusive_scan``, ``exclusive_scan_by_segment``, ``inclusive_scan_by_segment``, ``reduce_by_segment``
   with ``unseq`` or ``par_unseq`` policy when compiled by Intel® oneAPI DPC++/C++ Compiler 2024.1 or earlier
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.


### PR DESCRIPTION
This PR cherry-picks #2649 to the release branch so released documentation is inline with the main branch.  Additionally, in preparing the documentation for publication updates to the toolkit name from oneAPI Base Toolkit to oneAPI Toolkit and other small edits have been made so links are used where needed.