### PR TITLE
Bugfix for trivially copyable types and test coverage

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -342,7 +342,7 @@ struct __cooperative_lookback
             if (__is_full_ballot_bits)
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
-                    __sub_group_size, /*__use_subgroup_ops*/ true,
+                    __sub_group_size,
                     /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(
                     __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1, nullptr);
@@ -351,7 +351,7 @@ struct __cooperative_lookback
             else
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<
-                    __sub_group_size, /*__use_subgroup_ops*/ true,
+                    __sub_group_size,
                     /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
                                                                           __running, nullptr);

--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -342,8 +342,7 @@ struct __cooperative_lookback
             if (__is_full_ballot_bits)
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
-                    __sub_group_size,
-                    /*__is_inclusive*/ true,
+                    __sub_group_size, /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
                                                                           __running, __lowest_item_with_full + 1);
                 return true;
@@ -351,8 +350,7 @@ struct __cooperative_lookback
             else
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<
-                    __sub_group_size,
-                    /*__is_inclusive*/ true,
+                    __sub_group_size, /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
                                                                           __running);
                 return false;

--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -341,19 +341,20 @@ struct __cooperative_lookback
             // recomputed the prefix using partial values
             if (__is_full_ballot_bits)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
+                    __sub_group_size, /*__use_subgroup_ops*/ true,
                     /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(
-                    __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1,
-                    static_cast<decltype(__tile_value)*>(nullptr));
+                    __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1, nullptr);
                 return true;
             }
             else
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<
-                    __sub_group_size, /*__is_inclusive*/ true,
-                    /*__init_present*/ decltype(__is_initialized)::value>(
-                    __subgroup, __tile_value, __binary_op, __running, static_cast<decltype(__tile_value)*>(nullptr));
+                    __sub_group_size, /*__use_subgroup_ops*/ true,
+                    /*__is_inclusive*/ true,
+                    /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
+                                                                          __running, nullptr);
                 return false;
             }
         };

--- a/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
+++ b/include/oneapi/dpl/experimental/kt/internal/cooperative_lookback.h
@@ -344,8 +344,8 @@ struct __cooperative_lookback
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<
                     __sub_group_size,
                     /*__is_inclusive*/ true,
-                    /*__init_present*/ decltype(__is_initialized)::value>(
-                    __subgroup, __tile_value, __binary_op, __running, __lowest_item_with_full + 1, nullptr);
+                    /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
+                                                                          __running, __lowest_item_with_full + 1);
                 return true;
             }
             else
@@ -354,7 +354,7 @@ struct __cooperative_lookback
                     __sub_group_size,
                     /*__is_inclusive*/ true,
                     /*__init_present*/ decltype(__is_initialized)::value>(__subgroup, __tile_value, __binary_op,
-                                                                          __running, nullptr);
+                                                                          __running);
                 return false;
             }
         };

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -90,15 +90,13 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     using _ScanValueType = _InputType;
     if (__is_full)
     {
-        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                            /*__is_inclusive*/ true,
+        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                             /*__init_present*/ false>(
             __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, nullptr);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                                /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                 /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, nullptr);
         }
@@ -110,8 +108,7 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         std::uint16_t __i = 0;
         if (__limited_iters_per_item == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                        /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, nullptr);
@@ -124,13 +121,11 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
                 __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, nullptr);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                                    /*__is_inclusive*/ true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
                     __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, nullptr);
             }
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                        /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
                 __items_in_scan - __i * __sub_group_size, nullptr);

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -87,7 +87,6 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     const bool __is_full = __items_in_scan == __sub_group_size * __iters_per_item;
     oneapi::dpl::__internal::__lazy_ctor_storage<_InputType> __carry;
     oneapi::dpl::__internal::__scoped_destroyer<_InputType> __destroy_when_leaving_scope{__carry};
-    using _ScanValueType = _InputType;
     if (__is_full)
     {
         oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
@@ -115,8 +114,7 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         }
         else if (__limited_iters_per_item > 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                                /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry);
             for (; __i < __limited_iters_per_item - 1; ++__i)

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -90,14 +90,14 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     using _ScanValueType = _InputType;
     if (__is_full)
     {
-        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                             /*__is_inclusive*/ true,
                                                             /*__init_present*/ false>(
             __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, nullptr);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                 /*__is_inclusive*/ true,
                                                                 /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, nullptr);
@@ -110,7 +110,7 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         std::uint16_t __i = 0;
         if (__limited_iters_per_item == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
@@ -118,18 +118,18 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         }
         else if (__limited_iters_per_item > 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                 /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, nullptr);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                     /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
                     __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, nullptr);
             }
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -88,18 +88,19 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     oneapi::dpl::__internal::__lazy_ctor_storage<_InputType> __carry;
     oneapi::dpl::__internal::__scoped_destroyer<_InputType> __destroy_when_leaving_scope{__carry};
     using _ScanValueType = _InputType;
-    constexpr _ScanValueType* __no_slm = nullptr;
     if (__is_full)
     {
-        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
+        oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+                                                            /*__is_inclusive*/ true,
                                                             /*__init_present*/ false>(
-            __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, __no_slm);
+            __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, nullptr);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+                                                                /*__is_inclusive*/ true,
                                                                 /*__init_present*/ true>(
-                __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
+                __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, nullptr);
         }
     }
     else
@@ -109,26 +110,30 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
         std::uint16_t __i = 0;
         if (__limited_iters_per_item == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops*/ true,
+                                                                        /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
-                __items_in_scan - __i * __sub_group_size, __no_slm);
+                __items_in_scan - __i * __sub_group_size, nullptr);
         }
         else if (__limited_iters_per_item > 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+                                                                /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(
-                __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, __no_slm);
+                __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, nullptr);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+                                                                    /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
-                    __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, __no_slm);
+                    __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, nullptr);
             }
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops*/ true,
+                                                                        /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
-                __items_in_scan - __i * __sub_group_size, __no_slm);
+                __items_in_scan - __i * __sub_group_size, nullptr);
         }
     }
     return __carry.__v;

--- a/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sub_group/sub_group_scan.h
@@ -92,13 +92,13 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
     {
         oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                             /*__init_present*/ false>(
-            __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry, nullptr);
+            __sub_group, __extract_scan_input(__input[0]), __binary_op, __carry);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint16_t __i = 1; __i < __iters_per_item; ++__i)
         {
             oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                 /*__init_present*/ true>(
-                __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, nullptr);
+                __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry);
         }
     }
     else
@@ -111,24 +111,24 @@ __sub_group_scan(const _SubGroup& __sub_group, _InputTypeWrapped __input[__iters
             oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
-                __items_in_scan - __i * __sub_group_size, nullptr);
+                __items_in_scan - __i * __sub_group_size);
         }
         else if (__limited_iters_per_item > 1)
         {
             oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                 /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(
-                __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry, nullptr);
+                __sub_group, __extract_scan_input(__input[__i++]), __binary_op, __carry);
             for (; __i < __limited_iters_per_item - 1; ++__i)
             {
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
-                    __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry, nullptr);
+                    __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry);
             }
             oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __extract_scan_input(__input[__i]), __binary_op, __carry,
-                __items_in_scan - __i * __sub_group_size, nullptr);
+                __items_in_scan - __i * __sub_group_size);
         }
     }
     return __carry.__v;

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -72,7 +72,7 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         _InputType __val = __local_acc[__idx];
         if (__num_iters == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups, nullptr);
@@ -80,7 +80,7 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         }
         else
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                 /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, nullptr);
@@ -89,7 +89,7 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
             {
                 __val = __local_acc[__idx];
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                     /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(
                     __sub_group, __val, __binary_op, __wg_carry, nullptr);
@@ -97,7 +97,7 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                          /*__is_inclusive*/ true,
                                                                          /*__init_present*/ true>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -98,8 +98,8 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
             }
             __val = __local_acc[__idx];
             oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                         /*__is_inclusive*/ true,
-                                                                         /*__init_present*/ true>(
+                                                                        /*__is_inclusive*/ true,
+                                                                        /*__init_present*/ true>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,
                 nullptr);
             __local_acc[__idx] = __val;

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -70,43 +70,38 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         oneapi::dpl::__internal::__lazy_ctor_storage<_InputType> __wg_carry;
         std::uint8_t __idx = __sub_group.get_local_linear_id();
         _InputType __val = __local_acc[__idx];
-        constexpr _InputType* __no_slm = nullptr;
         if (__num_iters == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops*/ true,
                                                                         /*__is_inclusive*/ true,
-                                                                        /*__init_present*/ false>(__sub_group, __val,
-                                                                                                  __binary_op,
-                                                                                                  __wg_carry,
-                                                                                                  __active_sub_groups,
-                                                                                                  __no_slm);
+                                                                        /*__init_present*/ false>(
+                __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups, nullptr);
             __local_acc[__idx] = __val;
         }
         else
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, 
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
                                                                 /*__is_inclusive*/ true,
-                                                                /*__init_present*/ false>(__sub_group, __val,
-                                                                                          __binary_op, __wg_carry,
-                                                                                          __no_slm);
+                                                                /*__init_present*/ false>(
+                __sub_group, __val, __binary_op, __wg_carry, nullptr);
             __local_acc[__idx] = __val;
             __idx += __sub_group_size;
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
             {
                 __val = __local_acc[__idx];
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, 
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__use_subgroup_ops*/ true,
                                                                     /*__is_inclusive*/ true,
-                                                                    /*__init_present*/ true>(__sub_group, __val,
-                                                                                             __binary_op, __wg_carry,
-                                                                                             __no_slm);
+                                                                    /*__init_present*/ true>(
+                    __sub_group, __val, __binary_op, __wg_carry, nullptr);
                 __local_acc[__idx] = __val;
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
-                                                                        /*__init_present*/ true>(
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__use_subgroup_ops*/ true,
+                                                                         /*__is_inclusive*/ true,
+                                                                         /*__init_present*/ true>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,
-                __no_slm);
+                nullptr);
             __local_acc[__idx] = __val;
         }
         // Init callback, most common case is expected to be a decoupled lookback to achieve a global scan between

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -72,16 +72,14 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         _InputType __val = __local_acc[__idx];
         if (__num_iters == 1)
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                        /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
                 __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups);
             __local_acc[__idx] = __val;
         }
         else
         {
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                                /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                 /*__init_present*/ false>(__sub_group, __val,
                                                                                           __binary_op, __wg_carry);
             __local_acc[__idx] = __val;
@@ -89,16 +87,14 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
             {
                 __val = __local_acc[__idx];
-                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
-                                                                    /*__is_inclusive*/ true,
+                oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size, /*__is_inclusive*/ true,
                                                                     /*__init_present*/ true>(__sub_group, __val,
                                                                                              __binary_op, __wg_carry);
                 __local_acc[__idx] = __val;
                 __idx += __sub_group_size;
             }
             __val = __local_acc[__idx];
-            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
-                                                                        /*__is_inclusive*/ true,
+            oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size, /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
                 __sub_group, __val, __binary_op, __wg_carry,
                 __active_sub_groups - (__num_iters - 1) * __sub_group_size);

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -75,15 +75,15 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
             oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ false>(
-                __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups, nullptr);
+                __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups);
             __local_acc[__idx] = __val;
         }
         else
         {
             oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                 /*__is_inclusive*/ true,
-                                                                /*__init_present*/ false>(
-                __sub_group, __val, __binary_op, __wg_carry, nullptr);
+                                                                /*__init_present*/ false>(__sub_group, __val,
+                                                                                          __binary_op, __wg_carry);
             __local_acc[__idx] = __val;
             __idx += __sub_group_size;
             for (std::uint8_t __i = 1; __i < __num_iters - 1; ++__i)
@@ -91,8 +91,8 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
                 __val = __local_acc[__idx];
                 oneapi::dpl::__par_backend_hetero::__sub_group_scan<__sub_group_size,
                                                                     /*__is_inclusive*/ true,
-                                                                    /*__init_present*/ true>(
-                    __sub_group, __val, __binary_op, __wg_carry, nullptr);
+                                                                    /*__init_present*/ true>(__sub_group, __val,
+                                                                                             __binary_op, __wg_carry);
                 __local_acc[__idx] = __val;
                 __idx += __sub_group_size;
             }
@@ -100,8 +100,8 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
             oneapi::dpl::__par_backend_hetero::__sub_group_scan_partial<__sub_group_size,
                                                                         /*__is_inclusive*/ true,
                                                                         /*__init_present*/ true>(
-                __sub_group, __val, __binary_op, __wg_carry, __active_sub_groups - (__num_iters - 1) * __sub_group_size,
-                nullptr);
+                __sub_group, __val, __binary_op, __wg_carry,
+                __active_sub_groups - (__num_iters - 1) * __sub_group_size);
             __local_acc[__idx] = __val;
         }
         // Init callback, most common case is expected to be a decoupled lookback to achieve a global scan between

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1684,7 +1684,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op,__sub_group_carry, __active_subgroups, __comm_slm_ptr);
+                            __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
                         if (__sub_group_local_id < __active_subgroups)
                             __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1796,7 +1796,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_subgroup_ops ? 0 : __work_group_size, __cgh);
+            auto __comm_slm = __create_comm_slm_acc_opt<__use_subgroup_ops, _InitValueType>(__work_group_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::read_write>(__cgh);
@@ -1804,8 +1804,8 @@ struct __parallel_reduce_then_scan_scan_submitter<
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
             __cgh.parallel_for<_KernelName...>(
-                    __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
+                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
+                auto __comm_slm_ptr = __get_comm_slm_acc_data(__comm_slm);
 
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1795,7 +1795,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                 __scratch_container.template __get_result_acc<sycl::access_mode::write>(__cgh, __dpl_sycl::__no_init{});
 
             __cgh.parallel_for<_KernelName...>(
-                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
+                    __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                 auto __comm_slm_ptr = __get_comm_slm_acc_data(__comm_slm);
 
                 __reduce_then_scan_sub_group_params __sub_group_params(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1203,10 +1203,13 @@ struct __scan_by_seg_op
 // The __comm_slm parameter points to a work-group-sized SLM buffer; each sub-group uses its own
 // slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size].
 
+// structure to signify no slm has been allocated, and native subgroup ops should be used
+struct __no_slm_t{};
+
 template <typename _ValueType>
 _ValueType
 __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
-                    std::nullptr_t)
+                    __no_slm_t)
 {
     return sycl::shift_group_right(__sub_group, __value, __shift);
 }
@@ -1230,7 +1233,7 @@ __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __val
 template <typename _ValueType, typename _IdType>
 _ValueType
 __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
-                  std::nullptr_t)
+                  __no_slm_t)
 {
     return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
 }
@@ -1343,10 +1346,10 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType, typename _CommSLMPtr>
+          typename _ValueType, typename _LazyValueType, typename _CommSLMPtr = __no_slm_t>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                 _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm)
+                 _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm = {})
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
     std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
@@ -1355,10 +1358,10 @@ __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType, typename _SizeType, typename _CommSLMPtr>
+          typename _ValueType, typename _LazyValueType, typename _SizeType, typename _CommSLMPtr = __no_slm_t>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _CommSLMPtr __comm_slm)
+                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _CommSLMPtr __comm_slm = {})
 {
     auto __mask_fn = [__elements_to_process](auto __sub_group_local_id, auto __offset) {
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
@@ -1545,11 +1548,11 @@ struct __reduce_then_scan_sub_group_params
 };
 
 template <bool __use_subgroup_ops, typename _InitValueType>
-std::enable_if_t<__use_subgroup_ops, std::nullptr_t>
+std::enable_if_t<__use_subgroup_ops, __no_slm_t>
 __create_comm_slm_acc_opt(const std::uint32_t /*__work_group_size*/, sycl::handler& /*__cgh*/)
 {
     //embed the __use_subgroup_ops information into the type of the slm accessor & pointer
-    return nullptr;
+    return __no_slm_t{};
 }
 
 template <bool __use_subgroup_ops, typename _InitValueType>
@@ -1559,13 +1562,13 @@ __create_comm_slm_acc_opt(const std::uint32_t __work_group_size, sycl::handler& 
     return __dpl_sycl::__local_accessor<_InitValueType>(__work_group_size, __cgh);
 }
 
-inline std::nullptr_t
-__get_comm_slm_acc_data(std::nullptr_t)
+inline __no_slm_t
+__get_comm_slm_acc_data(__no_slm_t)
 {
     // embed the __use_subgroup_ops information into the type of the slm accessor & pointer
     // this allows us to avoid adding many bool template argments into leaf nodes, as we can encode this in the type
     // of the SLM pointer we are already sending.
-    return nullptr;
+    return __no_slm_t{};
 }
 
 template <typename CommSlmAcc>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1203,10 +1203,10 @@ struct __scan_by_seg_op
 // The __comm_slm parameter points to a work-group-sized SLM buffer; each sub-group uses its own
 // slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size].
 
-template <bool __use_subgroup_ops, typename _ValueType>
+template <bool __use_subgroup_ops, typename _ValueType, typename _CommSLMPtr>
 _ValueType
 __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
-                    _ValueType* __comm_slm)
+                    _CommSLMPtr __comm_slm)
 {
     if constexpr (__use_subgroup_ops)
     {
@@ -1226,10 +1226,10 @@ __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __val
     }
 }
 
-template <bool __use_subgroup_ops, typename _ValueType, typename _IdType>
+template <bool __use_subgroup_ops, typename _ValueType, typename _IdType, typename _CommSLMPtr>
 _ValueType
 __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
-                  _ValueType* __comm_slm)
+                  _CommSLMPtr __comm_slm)
 {
     if constexpr (__use_subgroup_ops)
     {
@@ -1250,11 +1250,12 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value
 }
 
 template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __init_present, typename _MaskOp,
-          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
+          typename _CommSLMPtr>
 void
 __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+                                  _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
     _ONEDPL_PRAGMA_UNROLL
@@ -1295,11 +1296,12 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
 }
 
 template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __init_present, typename _MaskOp,
-          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
+          typename _CommSLMPtr>
 void
 __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                                  _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+                                  _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
     _ONEDPL_PRAGMA_UNROLL
@@ -1327,11 +1329,12 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
 }
 
 template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
-          typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType>
+          typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
+          typename _CommSLMPtr>
 void
 __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                         _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                        _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+                        _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm)
 {
     if constexpr (__is_inclusive)
     {
@@ -1345,63 +1348,36 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
     }
 }
 
-// Entry points for per-scan dispatch: pick a sub-group-ops or SLM specialization at runtime, keeping
-// all code above a single instantiation. The branch executes once per scan (not per element).
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType>
+template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _CommSLMPtr>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                 _LazyValueType& __init_and_carry, _ValueType* __comm_slm)
+                 _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm)
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
     std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
-    if constexpr (std::is_trivially_copyable_v<_ValueType>)
-    {
-        if (__comm_slm == nullptr)
-        {
-            // use native subgroup operations for scan (best for GPU & trivially copyable types)
-            __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
-                __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
-            return;
-        }
-    }
-    //else
-    {
-        __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/false, __is_inclusive, __init_present>(
-            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
-    }
+    __sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType, typename _SizeType>
+template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _SizeType, typename _CommSLMPtr>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ValueType* __comm_slm)
+                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _CommSLMPtr __comm_slm)
 {
     auto __mask_fn = [__elements_to_process](auto __sub_group_local_id, auto __offset) {
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    if constexpr (std::is_trivially_copyable_v<_ValueType>)
-    {
-        if (__comm_slm == nullptr)
-        {
-            // use native subgroup operations for scan (best for GPU & trivially copyable types)
-            __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
-                __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
-            return;
-        }
-    }
-    //else
-    {
-        __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/false, __is_inclusive, __init_present>(
-            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
-    }
+    __sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output,
-          std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform, typename _BinaryOp,
-          typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng, typename _ScanValueType>
+template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+          bool __capture_output, std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform,
+          typename _BinaryOp, typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng,
+          typename _ScanValueType>
 void
 __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
                                _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
@@ -1420,8 +1396,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v),
-                                                                           __binary_op, __sub_group_carry, __comm_slm);
+        __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+            __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1434,7 +1410,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1449,7 +1425,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1470,7 +1446,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 std::size_t __local_id = (__start_id < __n) ? __start_id : __n - 1;
                 _GenInputType __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
+                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __n - __subgroup_start_id,
                     __comm_slm);
                 if constexpr (__capture_output)
@@ -1482,7 +1458,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             else
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
+                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1493,7 +1469,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 {
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
-                    __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
+                    __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                         __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                     if constexpr (__capture_output)
                     {
@@ -1504,7 +1480,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 std::size_t __offset = __start_id + (__iters - 1) * __sub_group_size;
                 std::size_t __local_id = (__offset < __n) ? __offset : __n - 1;
                 __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
                     __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm);
                 if constexpr (__capture_output)
@@ -1584,14 +1560,19 @@ class __reduce_then_scan_reduce_kernel;
 template <typename... _Name>
 class __reduce_then_scan_scan_kernel;
 
-template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
+// Type tag used to differentiate kernel name instantiations between the sub-group-ops and SLM-based
+// dispatch paths so the two paths don't collide on a default kernel name.
+template <bool __use_subgroup_ops>
+struct __reduce_then_scan_subgroup_ops_tag;
+
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, bool __use_subgroup_ops,
           typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename _KernelName>
 struct __parallel_reduce_then_scan_reduce_submitter;
 
-template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, bool __use_subgroup_ops,
           typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename... _KernelName>
 struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_inclusive, __is_unique_pattern_v,
-                                                    _GenReduceInput, _ReduceOp, _InitType,
+                                                    __use_subgroup_ops, _GenReduceInput, _ReduceOp, _InitType,
                                                     __internal::__optional_kernel_name<_KernelName...>>
 {
     static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
@@ -1649,7 +1630,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 {
                     // adjust for lane-id
                     // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                    __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
                                                    /*__init_present=*/false,
                                                    /*__capture_output=*/false, __max_inputs_per_item>(
                         __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
@@ -1676,8 +1657,10 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // fill with unused dummy values to avoid overrunning input
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
+                        __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                                 /*__init_present=*/false>(__sub_group, __v, __reduce_op,
+                                                                           __sub_group_carry,__active_subgroups,
+                                                                           __comm_slm_ptr);
                         if (__sub_group_local_id < __active_subgroups)
                             __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
@@ -1686,16 +1669,18 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         std::uint32_t __reduction_scan_id = __sub_group_local_id;
                         // need to pull out first iteration tp avoid identity
                         _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                        __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                        __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                         /*__init_present=*/false>(__sub_group, __v, __reduce_op, __sub_group_carry,
+                                                                   __comm_slm_ptr);
                         __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         __reduction_scan_id += __sub_group_size;
 
                         for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
                         {
                             __v = __sub_group_partials[__reduction_scan_id];
-                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                            __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                             /*__init_present=*/true>(__sub_group, __v, __reduce_op, __sub_group_carry,
+                                                                      __comm_slm_ptr);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
                         }
@@ -1707,7 +1692,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                             std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
 
                         __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                        __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                                 /*__init_present=*/true>(
                             __sub_group, __v, __reduce_op, __sub_group_carry,
                             __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
                         if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
@@ -1726,24 +1712,23 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
     const std::uint32_t __max_block_size;
     const std::uint32_t __max_num_sub_groups_local;
     const std::size_t __n;
-    const bool __use_subgroup_ops;
 
     const _GenReduceInput __gen_reduce_input;
     const _ReduceOp __reduce_op;
     _InitType __init;
 };
 
-template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, typename _ReduceOp,
-          typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
-          typename _KernelName>
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, bool __use_subgroup_ops,
+          typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp,
+          typename _InitType, typename _KernelName>
 struct __parallel_reduce_then_scan_scan_submitter;
 
-template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, typename _ReduceOp,
-          typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
-          typename... _KernelName>
-struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_inclusive, __is_unique_pattern_v,
-                                                  _ReduceOp, _GenScanInput, _ScanInputTransform, _WriteOp, _InitType,
-                                                  __internal::__optional_kernel_name<_KernelName...>>
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, bool __use_subgroup_ops,
+          typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp,
+          typename _InitType, typename... _KernelName>
+struct __parallel_reduce_then_scan_scan_submitter<
+    __max_inputs_per_item, __is_inclusive, __is_unique_pattern_v, __use_subgroup_ops, _ReduceOp, _GenScanInput,
+    _ScanInputTransform, _WriteOp, _InitType, __internal::__optional_kernel_name<_KernelName...>>
 {
     using _InitValueType = typename _InitType::__value_type;
     static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
@@ -1885,10 +1870,9 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                                                              ? __proposed_id
                                                              : __subgroups_before_my_group - 1;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                     /*__init_present=*/false>(__sub_group, __value, __reduce_op,
-                                                                               __carry_last, __remaining_elements,
-                                                                               __comm_slm_ptr);
+                            __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                                     /*__init_present=*/false>(
+                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
                         }
                         else
                         {
@@ -1899,15 +1883,17 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             std::uint32_t __reduction_id_increment =
                                 __sub_group_params.__num_sub_groups_local * __sub_group_size;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                                __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
+                            __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                             /*__init_present=*/false>(__sub_group, __value, __reduce_op, __carry_last,
+                                                                       __comm_slm_ptr);
                             __reduction_id += __reduction_id_increment;
                             // then some number of full iterations
                             for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                             {
                                 __value = __tmp_ptr[__reduction_id];
-                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __value, __reduce_op, __carry_last, __comm_slm_ptr);
+                                __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                                 /*__init_present=*/true>(__sub_group, __value, __reduce_op,
+                                                                          __carry_last, __comm_slm_ptr);
                                 __reduction_id += __reduction_id_increment;
                             }
 
@@ -1919,10 +1905,9 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                             std::size_t __final_reduction_id =
                                 std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
                             __value = __tmp_ptr[__final_reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                     /*__init_present=*/true>(__sub_group, __value, __reduce_op,
-                                                                              __carry_last, __remaining_elements,
-                                                                              __comm_slm_ptr);
+                            __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                                     /*__init_present=*/true>(
+                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
                         }
 
                         // steps 3+4) load global carry in from neighbor work-group
@@ -2024,7 +2009,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
 
                 if (__sub_group_carry_initialized)
                 {
-                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                    __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
                                                    /*__init_present=*/true,
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
                         __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
@@ -2033,7 +2018,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
                 }
                 else // first group first block, no subgroup carry
                 {
-                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
+                    __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
                                                    /*__init_present=*/false,
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
                         __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
@@ -2076,7 +2061,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __is_in
     const std::uint32_t __max_num_sub_groups_global;
     const std::size_t __num_blocks;
     const std::size_t __n;
-    const bool __use_subgroup_ops;
 
     const _ReduceOp __reduce_op;
     const _GenScanInput __gen_scan_input;
@@ -2095,30 +2079,24 @@ __is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
             oneapi::dpl::__internal::__supports_sub_group_size(__q, __get_reduce_then_scan_reqd_sg_sz_host()));
 }
 
-// General scan-like algorithm helpers
-// _GenReduceInput - a function which accepts the input range and index to generate the data needed by the main output
-//                   used in the reduction operation (to calculate the global carries)
-// _GenScanInput - a function which accepts the input range and index to generate the data needed by the final scan
-//                 and write operations, for scan patterns
-// _ScanInputTransform - a unary function applied to the output of `_GenScanInput` to extract the component used in the
-//             scan, but not the part only required for the final write operation
-// _ReduceOp - a binary function which is used in the reduction and scan operations
-// _WriteOp - a function which accepts output range, index, and output of `_GenScanInput` applied to the input range
-//            and performs the final write to output operation
-template <std::uint32_t __bytes_per_work_item_iter, typename _CustomName, typename _InRng, typename _OutRng,
-          typename _GenReduceInput, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
-          typename _WriteOp, typename _InitType, typename _Inclusive, typename _IsUniquePattern>
+// Helper for __parallel_transform_reduce_then_scan templated on the choice of sub-group communication
+// strategy. When __use_subgroup_ops is true, native SYCL sub-group operations are used; when false,
+// SLM-based fallback is used.
+template <bool __use_subgroup_ops, std::uint32_t __bytes_per_work_item_iter, typename _CustomName, typename _InRng,
+          typename _OutRng, typename _GenReduceInput, typename _ReduceOp, typename _GenScanInput,
+          typename _ScanInputTransform, typename _WriteOp, typename _InitType, typename _Inclusive,
+          typename _IsUniquePattern>
 __future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
-__parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _InRng&& __in_rng, _OutRng&& __out_rng,
-                                      _GenReduceInput __gen_reduce_input, _ReduceOp __reduce_op,
-                                      _GenScanInput __gen_scan_input, _ScanInputTransform __scan_input_transform,
-                                      _WriteOp __write_op, _InitType __init, _Inclusive, _IsUniquePattern,
-                                      sycl::event __prior_event = {})
+__parallel_transform_reduce_then_scan_impl(sycl::queue& __q, const std::size_t __n, _InRng&& __in_rng,
+                                           _OutRng&& __out_rng, _GenReduceInput __gen_reduce_input,
+                                           _ReduceOp __reduce_op, _GenScanInput __gen_scan_input,
+                                           _ScanInputTransform __scan_input_transform, _WriteOp __write_op,
+                                           _InitType __init, _Inclusive, _IsUniquePattern, sycl::event __prior_event)
 {
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_then_scan_reduce_kernel<_CustomName>>;
+        __reduce_then_scan_reduce_kernel<__reduce_then_scan_subgroup_ops_tag<__use_subgroup_ops>, _CustomName>>;
     using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_then_scan_scan_kernel<_CustomName>>;
+        __reduce_then_scan_scan_kernel<__reduce_then_scan_subgroup_ops_tag<__use_subgroup_ops>, _CustomName>>;
     using _ValueType = typename _InitType::__value_type;
 
     constexpr std::uint8_t __min_sub_group_size = __get_reduce_then_scan_workaround_sg_sz();
@@ -2164,23 +2142,20 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     // between reading and writing the block carry-out within a single kernel.
     __result_and_scratch_storage<_ValueType> __result_and_scratch{__q, __max_num_sub_groups_global + 2};
 
-    // Native sycl sub-group operations can only be used on trivially copyable types.
-    const bool __use_subgroup_ops = std::is_trivially_copyable_v<_ValueType>;
-
     // Reduce and scan step implementations
     using _ReduceSubmitter =
         __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __inclusive, __is_unique_pattern_v,
-                                                     _GenReduceInput, _ReduceOp, _InitType, _ReduceKernel>;
+                                                     __use_subgroup_ops, _GenReduceInput, _ReduceOp, _InitType,
+                                                     _ReduceKernel>;
     using _ScanSubmitter =
-        __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __inclusive, __is_unique_pattern_v, _ReduceOp,
-                                                   _GenScanInput, _ScanInputTransform, _WriteOp, _InitType,
-                                                   _ScanKernel>;
+        __parallel_reduce_then_scan_scan_submitter<__max_inputs_per_item, __inclusive, __is_unique_pattern_v,
+                                                   __use_subgroup_ops, _ReduceOp, _GenScanInput, _ScanInputTransform,
+                                                   _WriteOp, _InitType, _ScanKernel>;
     _ReduceSubmitter __reduce_submitter{__num_work_groups,
                                         __work_group_size,
                                         __max_inputs_per_block,
                                         __max_num_sub_groups_local,
                                         __n,
-                                        __use_subgroup_ops,
                                         __gen_reduce_input,
                                         __reduce_op,
                                         __init};
@@ -2191,7 +2166,6 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
                                     __max_num_sub_groups_global,
                                     __num_blocks,
                                     __n,
-                                    __use_subgroup_ops,
                                     __reduce_op,
                                     __gen_scan_input,
                                     __scan_input_transform,
@@ -2226,6 +2200,52 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
         }
     }
     return __future{std::move(__prior_event), std::move(__result_and_scratch)};
+}
+
+// General scan-like algorithm helpers
+// _GenReduceInput - a function which accepts the input range and index to generate the data needed by the main output
+//                   used in the reduction operation (to calculate the global carries)
+// _GenScanInput - a function which accepts the input range and index to generate the data needed by the final scan
+//                 and write operations, for scan patterns
+// _ScanInputTransform - a unary function applied to the output of `_GenScanInput` to extract the component used in the
+//             scan, but not the part only required for the final write operation
+// _ReduceOp - a binary function which is used in the reduction and scan operations
+// _WriteOp - a function which accepts output range, index, and output of `_GenScanInput` applied to the input range
+//            and performs the final write to output operation
+template <std::uint32_t __bytes_per_work_item_iter, typename _CustomName, typename _InRng, typename _OutRng,
+          typename _GenReduceInput, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
+          typename _WriteOp, typename _InitType, typename _Inclusive, typename _IsUniquePattern>
+__future<sycl::event, __result_and_scratch_storage<typename _InitType::__value_type>>
+__parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _InRng&& __in_rng, _OutRng&& __out_rng,
+                                      _GenReduceInput __gen_reduce_input, _ReduceOp __reduce_op,
+                                      _GenScanInput __gen_scan_input, _ScanInputTransform __scan_input_transform,
+                                      _WriteOp __write_op, _InitType __init, _Inclusive __inclusive,
+                                      _IsUniquePattern __is_unique_pattern, sycl::event __prior_event = {})
+{
+    using _ValueType = typename _InitType::__value_type;
+    // Native sycl sub-group operations can only be used on trivially copyable types. Dispatch above the
+    // kernel here so the kernel itself is instantiated with a fixed __use_subgroup_ops template arg.
+
+    if constexpr (std::is_trivially_copyable_v<_ValueType>)
+    {
+        //CPU targets should use the SLM-based approach, as they do not perform well with the native sub-group operations used in the GPU-optimized approach.
+        if (__q.get_device().is_gpu())
+        {
+            return __parallel_transform_reduce_then_scan_impl</*__use_subgroup_ops=*/true, __bytes_per_work_item_iter,
+                                                              _CustomName>(
+                __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input,
+                __reduce_op, __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive,
+                __is_unique_pattern, std::move(__prior_event));
+        }
+    }
+    // if CPU target or non-trivially-copyable type, use SLM-based approach
+    {
+        return __parallel_transform_reduce_then_scan_impl</*__use_subgroup_ops=*/false, __bytes_per_work_item_iter,
+                                                          _CustomName>(
+            __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
+            __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
+            std::move(__prior_event));
+    }
 }
 
 template <typename _CustomName, typename _InInOutRng, typename _GenReduceInput>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1227,7 +1227,6 @@ __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __val
     return __result;
 }
 
-
 template <typename _ValueType, typename _IdType>
 _ValueType
 __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
@@ -1252,9 +1251,8 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value
     return __result;
 }
 
-template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp,
-          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
-          typename _CommSLMPtr>
+template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp, typename _InitBroadcastId,
+          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _CommSLMPtr>
 void
 __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
@@ -1264,8 +1262,7 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in =
-            __shift_group_right(__sub_group, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1277,13 +1274,11 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
         __value = __binary_op(__init_and_carry.__v, __value);
         if (__sub_group_local_id == 0)
             __old_init.__setup(__init_and_carry.__v);
-        __init_and_carry.__v =
-            __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(
-            __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
 
     __value = __shift_group_right(__sub_group, __value, 1, __comm_slm);
@@ -1298,9 +1293,8 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     //return by reference __value and __init_and_carry
 }
 
-template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp,
-          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
-          typename _CommSLMPtr>
+template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp, typename _InitBroadcastId,
+          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _CommSLMPtr>
 void
 __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
@@ -1310,8 +1304,7 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in =
-            __shift_group_right(__sub_group, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1320,19 +1313,17 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     if constexpr (__init_present)
     {
         __value = __binary_op(__init_and_carry.__v, __value);
-        __init_and_carry.__v =
-            __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
-        __init_and_carry.__setup(
-            __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
     //return by reference __value and __init_and_carry
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present,
-          typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _MaskOp,
+          typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
           typename _CommSLMPtr>
 void
 __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
@@ -1351,8 +1342,8 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
     }
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present,
-          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _CommSLMPtr>
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
+          typename _ValueType, typename _LazyValueType, typename _CommSLMPtr>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                  _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm)
@@ -1363,8 +1354,8 @@ __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value
         __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present,
-          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _SizeType, typename _CommSLMPtr>
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
+          typename _ValueType, typename _LazyValueType, typename _SizeType, typename _CommSLMPtr>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                          _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _CommSLMPtr __comm_slm)
@@ -1377,10 +1368,9 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
         __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present,
-          bool __capture_output, std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform,
-          typename _BinaryOp, typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng,
-          typename _CommSLMPtr>
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output,
+          std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform, typename _BinaryOp,
+          typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng, typename _CommSLMPtr>
 void
 __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
                                _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
@@ -1399,8 +1389,8 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
-            __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v),
+                                                                           __binary_op, __sub_group_carry, __comm_slm);
         if constexpr (__capture_output)
         {
             __write_op(__out_rng, __start_id, __v, __temp_data);
@@ -1554,7 +1544,6 @@ struct __reduce_then_scan_sub_group_params
     std::uint32_t __inputs_per_item;
 };
 
-
 template <bool __use_subgroup_ops, typename _InitValueType>
 std::enable_if_t<__use_subgroup_ops, std::nullptr_t>
 __create_comm_slm_acc_opt(const std::uint32_t /*__work_group_size*/, sycl::handler& /*__cgh*/)
@@ -1585,7 +1574,6 @@ __get_comm_slm_acc_data(const CommSlmAcc& __comm_slm_acc_opt)
 {
     return __dpl_sycl::__get_accessor_ptr(__comm_slm_acc_opt);
 }
-
 
 template <typename... _Name>
 class __reduce_then_scan_partition_kernel;
@@ -1667,8 +1655,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                     // adjust for lane-id
                     // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
                     __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                                   /*__init_present=*/false,
-                                                   /*__capture_output=*/false, __max_inputs_per_item>(
+                                                    /*__init_present=*/false, /*__capture_output=*/false,
+                                                    __max_inputs_per_item>(
                         __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
                         __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
                         __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
@@ -1694,9 +1682,9 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                 /*__init_present=*/false>(__sub_group, __v, __reduce_op,
-                                                                           __sub_group_carry,__active_subgroups,
-                                                                           __comm_slm_ptr);
+                                                    /*__init_present=*/false>(__sub_group, __v, __reduce_op,
+                                                                              __sub_group_carry, __active_subgroups,
+                                                                              __comm_slm_ptr);
                         if (__sub_group_local_id < __active_subgroups)
                             __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
@@ -1706,8 +1694,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // need to pull out first iteration tp avoid identity
                         _InitValueType __v = __sub_group_partials[__reduction_scan_id];
                         __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
-                                         /*__init_present=*/false>(__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                                   __comm_slm_ptr);
+                                            /*__init_present=*/false>(__sub_group, __v, __reduce_op, __sub_group_carry,
+                                                                    __comm_slm_ptr);
                         __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         __reduction_scan_id += __sub_group_size;
 
@@ -1716,7 +1704,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                             __v = __sub_group_partials[__reduction_scan_id];
                             __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                              /*__init_present=*/true>(__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                                      __comm_slm_ptr);
+                                                                __comm_slm_ptr);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
                         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1390,7 +1390,6 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
             __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
                 __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
             return;
-        
         }
     }
     //else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2242,6 +2242,8 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     using _ValueType = typename _InitType::__value_type;
     // Native sycl sub-group operations can only be used on trivially copyable types. Dispatch above the
     // kernel here so the kernel itself is instantiated with a fixed __use_subgroup_ops template arg.
+    // The icpx compiler is able to avoid JIT compilation for kernels for platform types which are not
+    // in the real runtime path of the program, so we can branch like this without JIT-time penalty.
 
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1657,8 +1657,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                     // adjust for lane-id
                     // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
                     __scan_through_elements_helper<__sub_group_size, __is_inclusive,
-                                                    /*__init_present=*/false, /*__capture_output=*/false,
-                                                    __max_inputs_per_item>(
+                                                   /*__init_present=*/false,
+                                                   /*__capture_output=*/false, __max_inputs_per_item>(
                         __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
                         __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
                         __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
@@ -1683,10 +1683,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // fill with unused dummy values to avoid overrunning input
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                    /*__init_present=*/false>(__sub_group, __v, __reduce_op,
-                                                                              __sub_group_carry, __active_subgroups,
-                                                                              __comm_slm_ptr);
+                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                            __sub_group, __v, __reduce_op,__sub_group_carry, __active_subgroups, __comm_slm_ptr);
                         if (__sub_group_local_id < __active_subgroups)
                             __temp_ptr[__start_id + __sub_group_local_id] = __v;
                     }
@@ -1695,18 +1693,16 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         std::uint32_t __reduction_scan_id = __sub_group_local_id;
                         // need to pull out first iteration tp avoid identity
                         _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                        __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
-                                            /*__init_present=*/false>(__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                                    __comm_slm_ptr);
+                        __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                            __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
                         __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         __reduction_scan_id += __sub_group_size;
 
                         for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
                         {
                             __v = __sub_group_partials[__reduction_scan_id];
-                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
-                                             /*__init_present=*/true>(__sub_group, __v, __reduce_op, __sub_group_carry,
-                                                                __comm_slm_ptr);
+                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
                         }
@@ -1718,8 +1714,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                             std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
 
                         __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                 /*__init_present=*/true>(
+                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                             __sub_group, __v, __reduce_op, __sub_group_carry,
                             __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
                         if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1355,12 +1355,17 @@ __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
     std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
-    if (__comm_slm == nullptr)
+    if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
-        __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
-            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+        if (__comm_slm == nullptr)
+        {
+            // use native subgroup operations for scan (best for GPU & trivially copyable types)
+            __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
+                __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+            return;
+        }
     }
-    else
+    //else
     {
         __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/false, __is_inclusive, __init_present>(
             __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
@@ -1377,12 +1382,18 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    if (__comm_slm == nullptr)
+    if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
-        __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
-            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+        if (__comm_slm == nullptr)
+        {
+            // use native subgroup operations for scan (best for GPU & trivially copyable types)
+            __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/true, __is_inclusive, __init_present>(
+                __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+            return;
+        
+        }
     }
-    else
+    //else
     {
         __sub_group_masked_scan<__sub_group_size, /*__use_subgroup_ops=*/false, __is_inclusive, __init_present>(
             __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1208,8 +1208,7 @@ struct __no_slm_tag{};
 
 template <typename _ValueType>
 _ValueType
-__shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
-                    __no_slm_tag)
+__shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift, __no_slm_tag)
 {
     return sycl::shift_group_right(__sub_group, __value, __shift);
 }
@@ -1232,8 +1231,7 @@ __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __val
 
 template <typename _ValueType, typename _IdType>
 _ValueType
-__group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
-                  __no_slm_tag)
+__group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id, __no_slm_tag)
 {
     return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
 }
@@ -2247,7 +2245,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
 
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
-        // CPU targets should use the SLM-based approach, as they do not perform well with the native sub-group 
+        // CPU targets should use the SLM-based approach, as they do not perform well with the native sub-group
         // operations used in the GPU-optimized approach.
         if (__q.get_device().is_gpu())
         {
@@ -2261,7 +2259,7 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
 
     // if CPU target or non-trivially-copyable type, use SLM-based approach
     return __parallel_transform_reduce_then_scan_impl</*__use_subgroup_ops=*/false, __bytes_per_work_item_iter,
-                                                        _CustomName>(
+                                                      _CustomName>(
         __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
         __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
         std::move(__prior_event));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1564,9 +1564,7 @@ __create_comm_slm_acc_opt(const std::uint32_t __work_group_size, sycl::handler& 
 inline __no_slm_tag
 __get_comm_slm_acc_data(__no_slm_tag)
 {
-    // Embed the __use_subgroup_ops information into the type of the SLM argument.
-    // This allows us to avoid adding bool flag template arguments into helper functions,
-    // as we can utilize this type to provide either the SLM pointer or an explicit tag.
+    // Noop, type carries dispatch info for broadcast and shift left subgroup ops
     return __no_slm_tag{};
 }
 
@@ -2249,7 +2247,8 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
 
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
-        //CPU targets should use the SLM-based approach, as they do not perform well with the native sub-group operations used in the GPU-optimized approach.
+        // CPU targets should use the SLM-based approach, as they do not perform well with the native sub-group 
+        // operations used in the GPU-optimized approach.
         if (__q.get_device().is_gpu())
         {
             return __parallel_transform_reduce_then_scan_impl</*__use_subgroup_ops=*/true, __bytes_per_work_item_iter,
@@ -2259,14 +2258,13 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
                 __is_unique_pattern, std::move(__prior_event));
         }
     }
+
     // if CPU target or non-trivially-copyable type, use SLM-based approach
-    {
-        return __parallel_transform_reduce_then_scan_impl</*__use_subgroup_ops=*/false, __bytes_per_work_item_iter,
-                                                          _CustomName>(
-            __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
-            __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
-            std::move(__prior_event));
-    }
+    return __parallel_transform_reduce_then_scan_impl</*__use_subgroup_ops=*/false, __bytes_per_work_item_iter,
+                                                        _CustomName>(
+        __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
+        __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
+        std::move(__prior_event));
 }
 
 template <typename _CustomName, typename _InInOutRng, typename _GenReduceInput>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1551,7 +1551,6 @@ template <bool __use_subgroup_ops, typename _InitValueType>
 std::enable_if_t<__use_subgroup_ops, __no_slm_tag>
 __create_comm_slm_acc_opt(const std::uint32_t /*__work_group_size*/, sycl::handler& /*__cgh*/)
 {
-    //embed the __use_subgroup_ops information into the type of the slm accessor & pointer
     return __no_slm_tag{};
 }
 
@@ -1565,9 +1564,9 @@ __create_comm_slm_acc_opt(const std::uint32_t __work_group_size, sycl::handler& 
 inline __no_slm_tag
 __get_comm_slm_acc_data(__no_slm_tag)
 {
-    // embed the __use_subgroup_ops information into the type of the slm accessor & pointer
-    // this allows us to avoid adding many bool template argments into leaf nodes, as we can encode this in the type
-    // of the SLM pointer we are already sending.
+    // Embed the __use_subgroup_ops information into the type of the SLM argument.
+    // This allows us to avoid adding bool flag template arguments into helper functions,
+    // as we can utilize this type to provide either the SLM pointer or an explicit tag.
     return __no_slm_tag{};
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1204,12 +1204,12 @@ struct __scan_by_seg_op
 // slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size].
 
 // structure to signify no slm has been allocated, and native subgroup ops should be used
-struct __no_slm_t{};
+struct __no_slm_tag{};
 
 template <typename _ValueType>
 _ValueType
 __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
-                    __no_slm_t)
+                    __no_slm_tag)
 {
     return sycl::shift_group_right(__sub_group, __value, __shift);
 }
@@ -1233,7 +1233,7 @@ __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __val
 template <typename _ValueType, typename _IdType>
 _ValueType
 __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
-                  __no_slm_t)
+                  __no_slm_tag)
 {
     return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
 }
@@ -1346,7 +1346,7 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType, typename _CommSLMPtr = __no_slm_t>
+          typename _ValueType, typename _LazyValueType, typename _CommSLMPtr = __no_slm_tag>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                  _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm = {})
@@ -1358,7 +1358,7 @@ __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType, typename _SizeType, typename _CommSLMPtr = __no_slm_t>
+          typename _ValueType, typename _LazyValueType, typename _SizeType, typename _CommSLMPtr = __no_slm_tag>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                          _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _CommSLMPtr __comm_slm = {})
@@ -1548,11 +1548,11 @@ struct __reduce_then_scan_sub_group_params
 };
 
 template <bool __use_subgroup_ops, typename _InitValueType>
-std::enable_if_t<__use_subgroup_ops, __no_slm_t>
+std::enable_if_t<__use_subgroup_ops, __no_slm_tag>
 __create_comm_slm_acc_opt(const std::uint32_t /*__work_group_size*/, sycl::handler& /*__cgh*/)
 {
     //embed the __use_subgroup_ops information into the type of the slm accessor & pointer
-    return __no_slm_t{};
+    return __no_slm_tag{};
 }
 
 template <bool __use_subgroup_ops, typename _InitValueType>
@@ -1562,13 +1562,13 @@ __create_comm_slm_acc_opt(const std::uint32_t __work_group_size, sycl::handler& 
     return __dpl_sycl::__local_accessor<_InitValueType>(__work_group_size, __cgh);
 }
 
-inline __no_slm_t
-__get_comm_slm_acc_data(__no_slm_t)
+inline __no_slm_tag
+__get_comm_slm_acc_data(__no_slm_tag)
 {
     // embed the __use_subgroup_ops information into the type of the slm accessor & pointer
     // this allows us to avoid adding many bool template argments into leaf nodes, as we can encode this in the type
     // of the SLM pointer we are already sending.
-    return __no_slm_t{};
+    return __no_slm_tag{};
 }
 
 template <typename CommSlmAcc>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1203,53 +1203,56 @@ struct __scan_by_seg_op
 // The __comm_slm parameter points to a work-group-sized SLM buffer; each sub-group uses its own
 // slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size].
 
-template <bool __use_subgroup_ops, typename _ValueType, typename _CommSLMPtr>
+template <typename _ValueType>
 _ValueType
 __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
-                    _CommSLMPtr __comm_slm)
+                    std::nullptr_t)
 {
-    if constexpr (__use_subgroup_ops)
-    {
-        return sycl::shift_group_right(__sub_group, __value, __shift);
-    }
-    else
-    {
-        // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
-        // preferred (e.g., CPU targets where sub-group ops are slow).
-        std::uint32_t __local_id = __sub_group.get_local_linear_id();
-        std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
-        __comm_slm[__sg_base + __local_id] = __value;
-        sycl::group_barrier(__sub_group);
-        _ValueType __result = __comm_slm[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
-        sycl::group_barrier(__sub_group);
-        return __result;
-    }
+    return sycl::shift_group_right(__sub_group, __value, __shift);
 }
 
-template <bool __use_subgroup_ops, typename _ValueType, typename _IdType, typename _CommSLMPtr>
+template <typename _ValueType>
+_ValueType
+__shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
+                    _ValueType* __comm_slm)
+{
+    // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
+    // preferred (e.g., CPU targets where sub-group ops are slow).
+    std::uint32_t __local_id = __sub_group.get_local_linear_id();
+    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
+    __comm_slm[__sg_base + __local_id] = __value;
+    sycl::group_barrier(__sub_group);
+    _ValueType __result = __comm_slm[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
+    sycl::group_barrier(__sub_group);
+    return __result;
+}
+
+
+template <typename _ValueType, typename _IdType>
 _ValueType
 __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
-                  _CommSLMPtr __comm_slm)
+                  std::nullptr_t)
 {
-    if constexpr (__use_subgroup_ops)
-    {
-        return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
-    }
-    else
-    {
-        // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
-        // preferred (e.g., CPU targets where sub-group ops are slow).
-        std::uint32_t __local_id = __sub_group.get_local_linear_id();
-        std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
-        __comm_slm[__sg_base + __local_id] = __value;
-        sycl::group_barrier(__sub_group);
-        _ValueType __result = __comm_slm[__sg_base + __broadcast_id];
-        sycl::group_barrier(__sub_group);
-        return __result;
-    }
+    return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
 }
 
-template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __init_present, typename _MaskOp,
+template <typename _ValueType, typename _IdType>
+_ValueType
+__group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
+                  _ValueType* __comm_slm)
+{
+    // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
+    // preferred (e.g., CPU targets where sub-group ops are slow).
+    std::uint32_t __local_id = __sub_group.get_local_linear_id();
+    std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
+    __comm_slm[__sg_base + __local_id] = __value;
+    sycl::group_barrier(__sub_group);
+    _ValueType __result = __comm_slm[__sg_base + __broadcast_id];
+    sycl::group_barrier(__sub_group);
+    return __result;
+}
+
+template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp,
           typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
           typename _CommSLMPtr>
 void
@@ -1262,7 +1265,7 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
         _ValueType __partial_carry_in =
-            __shift_group_right<__use_subgroup_ops>(__sub_group, __value, __shift, __comm_slm);
+            __shift_group_right(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1275,15 +1278,15 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
         if (__sub_group_local_id == 0)
             __old_init.__setup(__init_and_carry.__v);
         __init_and_carry.__v =
-            __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm);
+            __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
         __init_and_carry.__setup(
-            __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm));
+            __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
 
-    __value = __shift_group_right<__use_subgroup_ops>(__sub_group, __value, 1, __comm_slm);
+    __value = __shift_group_right(__sub_group, __value, 1, __comm_slm);
     if constexpr (__init_present)
     {
         if (__sub_group_local_id == 0)
@@ -1295,7 +1298,7 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     //return by reference __value and __init_and_carry
 }
 
-template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __init_present, typename _MaskOp,
+template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp,
           typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
           typename _CommSLMPtr>
 void
@@ -1308,7 +1311,7 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
         _ValueType __partial_carry_in =
-            __shift_group_right<__use_subgroup_ops>(__sub_group, __value, __shift, __comm_slm);
+            __shift_group_right(__sub_group, __value, __shift, __comm_slm);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1318,17 +1321,17 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     {
         __value = __binary_op(__init_and_carry.__v, __value);
         __init_and_carry.__v =
-            __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm);
+            __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
     }
     else
     {
         __init_and_carry.__setup(
-            __group_broadcast<__use_subgroup_ops>(__sub_group, __value, __init_broadcast_id, __comm_slm));
+            __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
     }
     //return by reference __value and __init_and_carry
 }
 
-template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present,
           typename _MaskOp, typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
           typename _CommSLMPtr>
 void
@@ -1338,17 +1341,17 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
 {
     if constexpr (__is_inclusive)
     {
-        __inclusive_sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __init_present>(
+        __inclusive_sub_group_masked_scan<__sub_group_size, __init_present>(
             __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
     }
     else
     {
-        __exclusive_sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __init_present>(
+        __exclusive_sub_group_masked_scan<__sub_group_size, __init_present>(
             __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
     }
 }
 
-template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present,
           typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _CommSLMPtr>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
@@ -1356,11 +1359,11 @@ __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
     std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
-    __sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+    __sub_group_masked_scan<__sub_group_size, __is_inclusive, __init_present>(
         __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present,
           typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _SizeType, typename _CommSLMPtr>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
@@ -1370,21 +1373,21 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
-    __sub_group_masked_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+    __sub_group_masked_scan<__sub_group_size, __is_inclusive, __init_present>(
         __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
 }
 
-template <std::uint8_t __sub_group_size, bool __use_subgroup_ops, bool __is_inclusive, bool __init_present,
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present,
           bool __capture_output, std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform,
           typename _BinaryOp, typename _WriteOp, typename _LazyValueType, typename _InRng, typename _OutRng,
-          typename _ScanValueType>
+          typename _CommSLMPtr>
 void
 __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
                                _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
                                _LazyValueType& __sub_group_carry, const _InRng& __in_rng, _OutRng& __out_rng,
                                std::size_t __start_id, std::size_t __n, std::uint32_t __iters_per_item,
                                std::size_t __subgroup_start_id, std::uint32_t __sub_group_id,
-                               std::uint32_t __active_subgroups, _ScanValueType* __comm_slm)
+                               std::uint32_t __active_subgroups, _CommSLMPtr __comm_slm)
 {
     using _GenInputType = std::invoke_result_t<_GenInput, _InRng, std::size_t, typename _GenInput::TempData&>;
 
@@ -1396,7 +1399,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
     {
 
         _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-        __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
             __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
         if constexpr (__capture_output)
         {
@@ -1410,7 +1413,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1425,7 +1428,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size, __temp_data);
-                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1446,7 +1449,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             {
                 std::size_t __local_id = (__start_id < __n) ? __start_id : __n - 1;
                 _GenInputType __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+                __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __n - __subgroup_start_id,
                     __comm_slm);
                 if constexpr (__capture_output)
@@ -1458,7 +1461,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
             else
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id, __temp_data);
-                __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, __init_present>(
+                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                 if constexpr (__capture_output)
                 {
@@ -1469,7 +1472,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 {
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id, __temp_data);
-                    __sub_group_scan<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                    __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
                         __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
                     if constexpr (__capture_output)
                     {
@@ -1480,7 +1483,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                 std::size_t __offset = __start_id + (__iters - 1) * __sub_group_size;
                 std::size_t __local_id = (__offset < __n) ? __offset : __n - 1;
                 __v = __gen_input(__in_rng, __local_id, __temp_data);
-                __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, __is_inclusive, /*__init_present=*/true>(
+                __sub_group_scan_partial<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
                     __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm);
                 if constexpr (__capture_output)
@@ -1551,6 +1554,39 @@ struct __reduce_then_scan_sub_group_params
     std::uint32_t __inputs_per_item;
 };
 
+
+template <bool __use_subgroup_ops, typename _InitValueType>
+std::enable_if_t<__use_subgroup_ops, std::nullptr_t>
+__create_comm_slm_acc_opt(const std::uint32_t /*__work_group_size*/, sycl::handler& /*__cgh*/)
+{
+    //embed the __use_subgroup_ops information into the type of the slm accessor & pointer
+    return nullptr;
+}
+
+template <bool __use_subgroup_ops, typename _InitValueType>
+std::enable_if_t<!__use_subgroup_ops, __dpl_sycl::__local_accessor<_InitValueType>>
+__create_comm_slm_acc_opt(const std::uint32_t __work_group_size, sycl::handler& __cgh)
+{
+    return __dpl_sycl::__local_accessor<_InitValueType>(__work_group_size, __cgh);
+}
+
+inline std::nullptr_t
+__get_comm_slm_acc_data(std::nullptr_t)
+{
+    // embed the __use_subgroup_ops information into the type of the slm accessor & pointer
+    // this allows us to avoid adding many bool template argments into leaf nodes, as we can encode this in the type
+    // of the SLM pointer we are already sending.
+    return nullptr;
+}
+
+template <typename CommSlmAcc>
+auto
+__get_comm_slm_acc_data(const CommSlmAcc& __comm_slm_acc_opt)
+{
+    return __dpl_sycl::__get_accessor_ptr(__comm_slm_acc_opt);
+}
+
+
 template <typename... _Name>
 class __reduce_then_scan_partition_kernel;
 
@@ -1589,7 +1625,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            __dpl_sycl::__local_accessor<_InitValueType> __comm_slm(__use_subgroup_ops ? 0 : __work_group_size, __cgh);
+            auto __comm_slm = __create_comm_slm_acc_opt<__use_subgroup_ops, _InitValueType>(__work_group_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.template __get_scratch_acc<sycl::access_mode::write>(
@@ -1602,7 +1638,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
                 _InitValueType* __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                _InitValueType* __comm_slm_ptr = __use_subgroup_ops ? nullptr : &__comm_slm[0];
+                auto __comm_slm_ptr = __get_comm_slm_acc_data(__comm_slm);
                 std::size_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -1630,7 +1666,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                 {
                     // adjust for lane-id
                     // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-                    __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
+                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
                                                    /*__init_present=*/false,
                                                    /*__capture_output=*/false, __max_inputs_per_item>(
                         __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
@@ -1657,7 +1693,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         // fill with unused dummy values to avoid overrunning input
                         std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                         _InitValueType __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                  /*__init_present=*/false>(__sub_group, __v, __reduce_op,
                                                                            __sub_group_carry,__active_subgroups,
                                                                            __comm_slm_ptr);
@@ -1669,7 +1705,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         std::uint32_t __reduction_scan_id = __sub_group_local_id;
                         // need to pull out first iteration tp avoid identity
                         _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                        __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                        __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                          /*__init_present=*/false>(__sub_group, __v, __reduce_op, __sub_group_carry,
                                                                    __comm_slm_ptr);
                         __temp_ptr[__start_id + __reduction_scan_id] = __v;
@@ -1678,7 +1714,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                         for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
                         {
                             __v = __sub_group_partials[__reduction_scan_id];
-                            __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                              /*__init_present=*/true>(__sub_group, __v, __reduce_op, __sub_group_carry,
                                                                       __comm_slm_ptr);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
@@ -1692,7 +1728,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__max_inputs_per_item, __is_
                             std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
 
                         __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                  /*__init_present=*/true>(
                             __sub_group, __v, __reduce_op, __sub_group_carry,
                             __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
@@ -1870,7 +1906,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                                              ? __proposed_id
                                                              : __subgroups_before_my_group - 1;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                      /*__init_present=*/false>(
                                 __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
                         }
@@ -1883,7 +1919,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                             std::uint32_t __reduction_id_increment =
                                 __sub_group_params.__num_sub_groups_local * __sub_group_size;
                             _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                              /*__init_present=*/false>(__sub_group, __value, __reduce_op, __carry_last,
                                                                        __comm_slm_ptr);
                             __reduction_id += __reduction_id_increment;
@@ -1891,7 +1927,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                             for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
                             {
                                 __value = __tmp_ptr[__reduction_id];
-                                __sub_group_scan<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                                  /*__init_present=*/true>(__sub_group, __value, __reduce_op,
                                                                           __carry_last, __comm_slm_ptr);
                                 __reduction_id += __reduction_id_increment;
@@ -1905,7 +1941,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                             std::size_t __final_reduction_id =
                                 std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
                             __value = __tmp_ptr[__final_reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, __use_subgroup_ops, /*__is_inclusive=*/true,
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                      /*__init_present=*/true>(
                                 __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
                         }
@@ -2009,7 +2045,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
 
                 if (__sub_group_carry_initialized)
                 {
-                    __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
+                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
                                                    /*__init_present=*/true,
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
                         __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
@@ -2018,7 +2054,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                 }
                 else // first group first block, no subgroup carry
                 {
-                    __scan_through_elements_helper<__sub_group_size, __use_subgroup_ops, __is_inclusive,
+                    __scan_through_elements_helper<__sub_group_size, __is_inclusive,
                                                    /*__init_present=*/false,
                                                    /*__capture_output=*/true, __max_inputs_per_item>(
                         __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -488,13 +488,13 @@ template <typename _SetOpCount, typename _TempData, typename _RetType, typename 
           typename _Proj2>
 struct __gen_set_op_from_known_balanced_path;
 
-template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, bool __use_subgroup_ops,
           typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename _KernelName>
 struct __parallel_reduce_then_scan_reduce_submitter;
 
-template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, typename _ReduceOp,
-          typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
-          typename _KernelName>
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, bool __use_subgroup_ops,
+          typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp,
+          typename _InitType, typename _KernelName>
 struct __parallel_reduce_then_scan_scan_submitter;
 
 template <typename _GenInput, typename _KernelName>
@@ -644,23 +644,24 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
 
 // Submitters that capture member variables via *this into the kernel lambda must have device copyable specializations
 // if their members may not be trivially copyable.
-template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, bool __use_subgroup_ops,
           typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename... _KernelName>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
     oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_reduce_submitter, __max_inputs_per_item,
-    __is_inclusive, __is_unique_pattern_v, _GenReduceInput, _ReduceOp, _InitType, _KernelName...)>
+    __is_inclusive, __is_unique_pattern_v, __use_subgroup_ops, _GenReduceInput, _ReduceOp, _InitType, _KernelName...)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_GenReduceInput, _ReduceOp, _InitType>
 {
 };
 
-template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, typename _ReduceOp,
-          typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
-          typename... _KernelName>
+template <std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v, bool __use_subgroup_ops,
+          typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp,
+          typename _InitType, typename... _KernelName>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
     oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_scan_submitter, __max_inputs_per_item,
-    __is_inclusive, __is_unique_pattern_v, _ReduceOp, _GenScanInput, _ScanInputTransform, _WriteOp, _InitType,
-    _KernelName...)> : oneapi::dpl::__internal::__are_all_device_copyable<_ReduceOp, _GenScanInput, _ScanInputTransform,
-                                                                          _WriteOp, _InitType>
+    __is_inclusive, __is_unique_pattern_v, __use_subgroup_ops, _ReduceOp, _GenScanInput, _ScanInputTransform, _WriteOp,
+    _InitType, _KernelName...)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_ReduceOp, _GenScanInput, _ScanInputTransform, _WriteOp,
+                                                         _InitType>
 {
 };
 template <typename _GenInput, typename KernelName>

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -297,7 +297,7 @@ test_device_copyable()
             oneapi::dpl::unseq_backend::__no_init_value<int_device_copyable>,
             oneapi::dpl::execution::DefaultKernelName>>,
         "__parallel_reduce_then_scan_scan_submitter is not device copyable with device copyable types");
-#    endif
+#endif
 
     //__not_pred
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_device_copyable>>,

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -279,7 +279,7 @@ test_device_copyable()
     //__parallel_reduce_then_scan_reduce_submitter
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_reduce_submitter<
-            16, true, false,
+            16, true, false, false,
             oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_reduce_input<binary_op_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>,
             oneapi::dpl::unseq_backend::__no_init_value<int_device_copyable>,
@@ -289,7 +289,7 @@ test_device_copyable()
     //__parallel_reduce_then_scan_scan_submitter
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_scan_submitter<
-            16, true, false, oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>,
+            16, true, false, false, oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_scan_input<binary_op_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__get_zeroth_element,
             oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<
@@ -297,7 +297,7 @@ test_device_copyable()
             oneapi::dpl::unseq_backend::__no_init_value<int_device_copyable>,
             oneapi::dpl::execution::DefaultKernelName>>,
         "__parallel_reduce_then_scan_scan_submitter is not device copyable with device copyable types");
-#endif
+#    endif
 
     //__not_pred
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_device_copyable>>,
@@ -607,7 +607,7 @@ test_non_device_copyable()
     //__parallel_reduce_then_scan_reduce_submitter
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_reduce_submitter<
-            16, true, false,
+            16, true, false, false,
             oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_reduce_input<binary_op_non_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>,
             oneapi::dpl::unseq_backend::__no_init_value<int_non_device_copyable>,
@@ -617,7 +617,7 @@ test_non_device_copyable()
     //__parallel_reduce_then_scan_scan_submitter
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_scan_submitter<
-            16, true, false, oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>,
+            16, true, false, false, oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_scan_input<binary_op_non_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__get_zeroth_element,
             oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<
@@ -625,7 +625,7 @@ test_non_device_copyable()
             oneapi::dpl::unseq_backend::__no_init_value<int_non_device_copyable>,
             oneapi::dpl::execution::DefaultKernelName>>,
         "__parallel_reduce_then_scan_scan_submitter is device copyable with non device copyable types");
-#endif
+#    endif
 
     //__not_pred
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_non_device_copyable>>,

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_usm.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_usm.pass.cpp
@@ -23,21 +23,21 @@ using namespace TestUtils;
 static const char kMsgExclusiveScanNormal [] = "Wrong effect from exclusive scan (non-inplace)";
 static const char kMsgExclusiveScanInplace[] = "Wrong effect from exclusive scan (inplace)";
 
-template <int InitValue>
+template <int InitValue, typename InitT = int>
 struct TestingAlgoritmExclusiveScan
 {
     template <typename... TArgs>
     void
     call_onedpl(TArgs&&... args)
     {
-        oneapi::dpl::exclusive_scan(std::forward<TArgs>(args)..., InitValue);
+        oneapi::dpl::exclusive_scan(std::forward<TArgs>(args)..., InitT(InitValue));
     }
 
     template <typename... TArgs>
     void
     call_serial(TArgs&&... args)
     {
-        exclusive_scan_serial(std::forward<TArgs>(args)..., InitValue);
+        exclusive_scan_serial(std::forward<TArgs>(args)..., InitT(InitValue));
     }
 
     const char*
@@ -47,21 +47,21 @@ struct TestingAlgoritmExclusiveScan
     }
 };
 
-template <int InitValue, typename BinaryOp>
+template <int InitValue, typename BinaryOp, typename InitT = int>
 struct TestingAlgoritmExclusiveScanExt
 {
     template <typename... TArgs>
     void
     call_onedpl(TArgs&&... args)
     {
-        oneapi::dpl::exclusive_scan(std::forward<TArgs>(args)..., InitValue, BinaryOp());
+        oneapi::dpl::exclusive_scan(std::forward<TArgs>(args)..., InitT(InitValue), BinaryOp());
     }
 
     template <typename... TArgs>
     void
     call_serial(TArgs&&... args)
     {
-        exclusive_scan_serial(std::forward<TArgs>(args)..., InitValue, BinaryOp());
+        exclusive_scan_serial(std::forward<TArgs>(args)..., InitT(InitValue), BinaryOp());
     }
 
     const char*
@@ -76,12 +76,14 @@ void
 run_test()
 {
     // Non inplace
-    test2buffers<alloc_type, test_scan_non_inplace<ValueType, TestingAlgoritmExclusiveScan<2>>>();
-    test2buffers<alloc_type, test_scan_non_inplace<ValueType, TestingAlgoritmExclusiveScanExt<2, BinaryOperation>>>();
+    test2buffers<alloc_type, test_scan_non_inplace<ValueType, TestingAlgoritmExclusiveScan<2, ValueType>>>();
+    test2buffers<alloc_type,
+                 test_scan_non_inplace<ValueType, TestingAlgoritmExclusiveScanExt<2, BinaryOperation, ValueType>>>();
 
     // Inplace
-    test1buffer<alloc_type, test_scan_inplace<ValueType, TestingAlgoritmExclusiveScan<2>>>();
-    test1buffer<alloc_type, test_scan_inplace<ValueType, TestingAlgoritmExclusiveScanExt<2, BinaryOperation>>>();
+    test1buffer<alloc_type, test_scan_inplace<ValueType, TestingAlgoritmExclusiveScan<2, ValueType>>>();
+    test1buffer<alloc_type,
+                test_scan_inplace<ValueType, TestingAlgoritmExclusiveScanExt<2, BinaryOperation, ValueType>>>();
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
@@ -97,6 +99,12 @@ main()
     run_test<sycl::usm::alloc::shared, ValueType, BinaryOperation>();
     // Run tests for USM device memory
     run_test<sycl::usm::alloc::device, ValueType, BinaryOperation>();
+
+    // Run tests with a non-trivially-copyable but device-copyable value type
+    using NonTrivialValueType = arith_device_copyable;
+    using NonTrivialBinaryOperation = std::plus<NonTrivialValueType>;
+    run_test<sycl::usm::alloc::shared, NonTrivialValueType, NonTrivialBinaryOperation>();
+    run_test<sycl::usm::alloc::device, NonTrivialValueType, NonTrivialBinaryOperation>();
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
 

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_usm.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_usm.pass.cpp
@@ -45,21 +45,21 @@ struct TestingAlgoritmInclusiveScan
     }
 };
 
-template <typename BinaryOp, int InitValue>
+template <typename BinaryOp, int InitValue, typename InitT = int>
 struct TestingAlgoritmInclusiveScanExt
 {
     template <typename... TArgs>
     void
     call_onedpl(TArgs&&... args)
     {
-        oneapi::dpl::inclusive_scan(std::forward<TArgs>(args)..., BinaryOp(), InitValue);
+        oneapi::dpl::inclusive_scan(std::forward<TArgs>(args)..., BinaryOp(), InitT(InitValue));
     }
 
     template <typename... TArgs>
     void
     call_serial(TArgs&&... args)
     {
-        inclusive_scan_serial(std::forward<TArgs>(args)..., BinaryOp(), InitValue);
+        inclusive_scan_serial(std::forward<TArgs>(args)..., BinaryOp(), InitT(InitValue));
     }
 
     const char*
@@ -74,12 +74,14 @@ void
 run_test()
 {
     // Non inplace
-    test2buffers<alloc_type, test_scan_non_inplace<ValueType, TestingAlgoritmInclusiveScan> >();
-    test2buffers<alloc_type, test_scan_non_inplace<ValueType, TestingAlgoritmInclusiveScanExt<BinaryOperation, 2 > > >();
+    test2buffers<alloc_type, test_scan_non_inplace<ValueType, TestingAlgoritmInclusiveScan>>();
+    test2buffers<alloc_type,
+                 test_scan_non_inplace<ValueType, TestingAlgoritmInclusiveScanExt<BinaryOperation, 2, ValueType>>>();
 
     // Inplace
     test1buffer<alloc_type, test_scan_inplace<ValueType, TestingAlgoritmInclusiveScan>>();
-    test1buffer<alloc_type, test_scan_inplace<ValueType, TestingAlgoritmInclusiveScanExt<BinaryOperation, 2 > > >();
+    test1buffer<alloc_type,
+                test_scan_inplace<ValueType, TestingAlgoritmInclusiveScanExt<BinaryOperation, 2, ValueType>>>();
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
@@ -95,6 +97,12 @@ main()
     run_test<sycl::usm::alloc::shared, ValueType, BinaryOperation>();
     // Run tests for USM device memory
     run_test<sycl::usm::alloc::device, ValueType, BinaryOperation>();
+
+    // Run tests with a non-trivially-copyable but device-copyable value type
+    using NonTrivialValueType = arith_device_copyable;
+    using NonTrivialBinaryOperation = std::plus<NonTrivialValueType>;
+    run_test<sycl::usm::alloc::shared, NonTrivialValueType, NonTrivialBinaryOperation>();
+    run_test<sycl::usm::alloc::device, NonTrivialValueType, NonTrivialBinaryOperation>();
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1421,37 +1421,6 @@ struct DefaultInitializedToOne
     }
 };
 
-// Device copyable arithmetic wrapper supporting the operations required by scan-style algorithms.
-// Intentionally non-trivially copyable to test that device_copyable specialization works and we are not
-// relying on trivial copyability.
-struct arith_device_copyable
-{
-    int i;
-    arith_device_copyable() = default;
-    arith_device_copyable(int __i) : i(__i) {}
-    // Intentionally user-provided so the type is not trivially copy constructible. No I/O here
-    // because copies happen inside SYCL kernels.
-    arith_device_copyable(const arith_device_copyable& other) : i(other.i) {}
-    arith_device_copyable&
-    operator=(const arith_device_copyable&) = default;
-
-    friend arith_device_copyable
-    operator+(const arith_device_copyable& a, const arith_device_copyable& b)
-    {
-        return arith_device_copyable(a.i + b.i);
-    }
-    friend bool
-    operator==(const arith_device_copyable& a, const arith_device_copyable& b)
-    {
-        return a.i == b.i;
-    }
-    friend bool
-    operator!=(const arith_device_copyable& a, const arith_device_copyable& b)
-    {
-        return !(a == b);
-    }
-};
-
 } /* namespace TestUtils */
 
 #if _ENABLE_STD_RANGES_TESTING
@@ -1466,10 +1435,6 @@ inline constexpr bool enable_borrowed_range<TestUtils::MinimalisticRange<RandomI
 } // namespace ranges
 } // namespace std
 
-template <>
-struct sycl::is_device_copyable<TestUtils::arith_device_copyable> : std::true_type
-{
-};
 
 #endif // _ENABLE_STD_RANGES_TESTING
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1435,7 +1435,6 @@ inline constexpr bool enable_borrowed_range<TestUtils::MinimalisticRange<RandomI
 } // namespace ranges
 } // namespace std
 
-
 #endif // _ENABLE_STD_RANGES_TESTING
 
 #endif // _UTILS_H

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1421,6 +1421,37 @@ struct DefaultInitializedToOne
     }
 };
 
+// Device copyable arithmetic wrapper supporting the operations required by scan-style algorithms.
+// Intentionally non-trivially copyable to test that device_copyable specialization works and we are not
+// relying on trivial copyability.
+struct arith_device_copyable
+{
+    int i;
+    arith_device_copyable() = default;
+    arith_device_copyable(int __i) : i(__i) {}
+    // Intentionally user-provided so the type is not trivially copy constructible. No I/O here
+    // because copies happen inside SYCL kernels.
+    arith_device_copyable(const arith_device_copyable& other) : i(other.i) {}
+    arith_device_copyable&
+    operator=(const arith_device_copyable&) = default;
+
+    friend arith_device_copyable
+    operator+(const arith_device_copyable& a, const arith_device_copyable& b)
+    {
+        return arith_device_copyable(a.i + b.i);
+    }
+    friend bool
+    operator==(const arith_device_copyable& a, const arith_device_copyable& b)
+    {
+        return a.i == b.i;
+    }
+    friend bool
+    operator!=(const arith_device_copyable& a, const arith_device_copyable& b)
+    {
+        return !(a == b);
+    }
+};
+
 } /* namespace TestUtils */
 
 #if _ENABLE_STD_RANGES_TESTING
@@ -1434,6 +1465,11 @@ template <typename RandomIt>
 inline constexpr bool enable_borrowed_range<TestUtils::MinimalisticRange<RandomIt>> = true;
 } // namespace ranges
 } // namespace std
+
+template <>
+struct sycl::is_device_copyable<TestUtils::arith_device_copyable> : std::true_type
+{
+};
 
 #endif // _ENABLE_STD_RANGES_TESTING
 

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -40,6 +40,49 @@
 namespace TestUtils
 {
 
+// Device copyable arithmetic wrapper supporting the operations required by scan-style algorithms.
+// Intentionally non-trivially copyable to test that device_copyable specialization works and we are not
+// relying on trivial copyability. Defined here (rather than in utils_device_copyable.h) so that the
+// sycl::is_device_copyable specialization below is visible before any sycl::buffer<arith_device_copyable>
+// instantiation in utility templates such as test1buffer/test2buffers.
+struct arith_device_copyable
+{
+    int i;
+    arith_device_copyable() = default;
+    arith_device_copyable(int __i) : i(__i) {}
+    // Intentionally user-provided so the type is not trivially copy constructible. No I/O here
+    // because copies happen inside SYCL kernels.
+    arith_device_copyable(const arith_device_copyable& other) : i(other.i) {}
+    arith_device_copyable&
+    operator=(const arith_device_copyable&) = default;
+
+    friend arith_device_copyable
+    operator+(const arith_device_copyable& a, const arith_device_copyable& b)
+    {
+        return arith_device_copyable(a.i + b.i);
+    }
+    friend bool
+    operator==(const arith_device_copyable& a, const arith_device_copyable& b)
+    {
+        return a.i == b.i;
+    }
+    friend bool
+    operator!=(const arith_device_copyable& a, const arith_device_copyable& b)
+    {
+        return !(a == b);
+    }
+};
+
+} // namespace TestUtils
+
+template <>
+struct sycl::is_device_copyable<TestUtils::arith_device_copyable> : std::true_type
+{
+};
+
+namespace TestUtils
+{
+
 #define PRINT_DEBUG(message) ::TestUtils::print_debug(message)
 
 inline void
@@ -426,42 +469,6 @@ test4buffers(int mult = kDefaultMultValue)
     test4buffers<alloc_type, typename TestName::UsedValueType, TestName, TestSyclBuffer>(mult, TestName::ScaleStep, TestName::ScaleMax);
 }
 
-// Device copyable arithmetic wrapper supporting the operations required by scan-style algorithms.
-// Intentionally non-trivially copyable to test that device_copyable specialization works and we are not
-// relying on trivial copyability.
-struct arith_device_copyable
-{
-    int i;
-    arith_device_copyable() = default;
-    arith_device_copyable(int __i) : i(__i) {}
-    // Intentionally user-provided so the type is not trivially copy constructible. No I/O here
-    // because copies happen inside SYCL kernels.
-    arith_device_copyable(const arith_device_copyable& other) : i(other.i) {}
-    arith_device_copyable&
-    operator=(const arith_device_copyable&) = default;
-
-    friend arith_device_copyable
-    operator+(const arith_device_copyable& a, const arith_device_copyable& b)
-    {
-        return arith_device_copyable(a.i + b.i);
-    }
-    friend bool
-    operator==(const arith_device_copyable& a, const arith_device_copyable& b)
-    {
-        return a.i == b.i;
-    }
-    friend bool
-    operator!=(const arith_device_copyable& a, const arith_device_copyable& b)
-    {
-        return !(a == b);
-    }
-};
-
 } /* namespace TestUtils */
-
-template <>
-struct sycl::is_device_copyable<TestUtils::arith_device_copyable> : std::true_type
-{
-};
 
 #endif // _UTILS_SYCL_H

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -470,5 +470,4 @@ test4buffers(int mult = kDefaultMultValue)
 }
 
 } /* namespace TestUtils */
-
 #endif // _UTILS_SYCL_H

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -426,5 +426,42 @@ test4buffers(int mult = kDefaultMultValue)
     test4buffers<alloc_type, typename TestName::UsedValueType, TestName, TestSyclBuffer>(mult, TestName::ScaleStep, TestName::ScaleMax);
 }
 
+// Device copyable arithmetic wrapper supporting the operations required by scan-style algorithms.
+// Intentionally non-trivially copyable to test that device_copyable specialization works and we are not
+// relying on trivial copyability.
+struct arith_device_copyable
+{
+    int i;
+    arith_device_copyable() = default;
+    arith_device_copyable(int __i) : i(__i) {}
+    // Intentionally user-provided so the type is not trivially copy constructible. No I/O here
+    // because copies happen inside SYCL kernels.
+    arith_device_copyable(const arith_device_copyable& other) : i(other.i) {}
+    arith_device_copyable&
+    operator=(const arith_device_copyable&) = default;
+
+    friend arith_device_copyable
+    operator+(const arith_device_copyable& a, const arith_device_copyable& b)
+    {
+        return arith_device_copyable(a.i + b.i);
+    }
+    friend bool
+    operator==(const arith_device_copyable& a, const arith_device_copyable& b)
+    {
+        return a.i == b.i;
+    }
+    friend bool
+    operator!=(const arith_device_copyable& a, const arith_device_copyable& b)
+    {
+        return !(a == b);
+    }
+};
+
 } /* namespace TestUtils */
+
+template <>
+struct sycl::is_device_copyable<TestUtils::arith_device_copyable> : std::true_type
+{
+};
+
 #endif // _UTILS_SYCL_H


### PR DESCRIPTION
Fix for trivially copyable types and adding coverage to test this.
We were never attempting to run the runtime branch with a trivially copyable type, but we were compiling it, which is an error.

Edit:
After some investigation showing that compilers are able to successfully avoid JIT compilation of kernels gated by runtime branches based upon target devices (CPU vs GPU), I've decided to hoist the SLM decision above the kernel, and remove all runtime branching for this purpose within the kernel. This results in a decent number of code changes, but a better overall product. 