### PR TITLE
[Testing] Limiting scan test sizes CPU targets

### DIFF
--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
@@ -145,7 +145,7 @@ void
 test(T trash, Predicate pred, Convert convert, bool check_weakness = true)
 {
     // Try sequences of various lengths.
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
 #if !TEST_DPCPP_BACKEND_PRESENT
         // count is number of output elements, plus a handful

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -95,7 +95,7 @@ test_by_type(Generator generator, UnaryPred pred)
 {
 
     using namespace std;
-    size_t max_size = 100000;
+    size_t max_size = TestUtils::get_scan_test_max_n();
     Sequence<T> in(max_size, [](size_t v) { return T(v); });
     Sequence<T> exp(max_size, [](size_t v) { return T(v); });
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
@@ -70,7 +70,7 @@ void
 test(UnaryPred pred)
 {
 
-    const ::std::size_t max_size = 100000;
+    const std::size_t max_size = TestUtils::get_scan_test_max_n();
     Sequence<T> in(max_size, [](::std::size_t v) -> T { return T(v); });
     Sequence<T> actual_true(max_size);
     Sequence<T> actual_false(max_size);

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -99,7 +99,7 @@ test_by_type(Generator generator, UnaryPred pred)
 {
 
     using namespace std;
-    size_t max_size = 100000;
+    size_t max_size = TestUtils::get_scan_test_max_n();
     Sequence<T> in(max_size, [](size_t v) { return T(v); });
     Sequence<T> exp(max_size, [](size_t v) { return T(v); });
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
@@ -75,7 +75,7 @@ template <typename T, typename Predicate, typename Convert>
 void
 test(T trash, const T& value, Predicate pred, Convert convert)
 {
-    const ::std::size_t max_size = 100000;
+    const std::size_t max_size = TestUtils::get_scan_test_max_n();
     Sequence<T> out(max_size, [trash](size_t) { return trash; });
     Sequence<T> expected(max_size, [trash](size_t) { return trash; });
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
@@ -63,7 +63,7 @@ void
 test(T trash, const T& value, Convert convert, bool check_weakness = true)
 {
     // Try sequences of various lengths.
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
 #if !TEST_DPCPP_BACKEND_PRESENT
         // count is number of output elements, plus a handful

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
@@ -72,7 +72,7 @@ template <typename T, typename Generator, typename Predicate>
 void
 test(Generator generator, Predicate pred)
 {
-    const ::std::size_t max_size = 1000000;
+    const std::size_t max_size = TestUtils::get_scan_test_unique_max_n();
     Sequence<T> in(max_size, [](size_t v) { return T(v); });
     Sequence<T> exp(max_size, [](size_t v) { return T(v); });
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
@@ -143,7 +143,7 @@ void
 test(T trash, BinaryPredicate pred, Convert convert, bool check_weakness = true)
 {
     // Try sequences of various lengths.
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         // count is number of output elements, plus a handful
         // more for sake of detecting buffer overruns.

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -308,7 +308,7 @@ template <template <typename T> typename TestType, typename T1, typename T2, typ
 void
 test_set(Compare compare, bool comp_flag)
 {
-    const ::std::size_t n_max = 100000;
+    const std::size_t n_max = TestUtils::get_scan_test_set_max_n();
 
     // The rand()%(2*n+1) encourages generation of some duplicates.
     ::std::srand(4200);

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -59,7 +59,7 @@ template <typename In, typename Init, typename Out, typename Convert>
 void
 test_with_plus(Init init, Out trash, Convert convert)
 {
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<In> in(n, convert);
         Sequence<Out> expected(n);
@@ -74,11 +74,13 @@ test_with_plus(Init init, Out trash, Convert convert)
 #if TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
     // testing of large number of items may take too much time in debug mode
     unsigned long n =
-#if PSTL_USE_DEBUG
+#    if ONEDPL_TEST_LIMIT_SCAN_SIZE
+        TestUtils::get_scan_test_max_n();
+#    elif PSTL_USE_DEBUG
         1000000;
-#else
+#    else
         100000000;
-#endif
+#    endif
 
     Sequence<In> in(n, convert);
     Sequence<Out> expected(n);

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -73,13 +73,11 @@ test_with_plus(Init init, Out trash, Convert convert)
 
 #if TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
     // testing of large number of items may take too much time in debug mode
-    unsigned long n =
-#    if ONEDPL_TEST_LIMIT_SCAN_SIZE
-        TestUtils::get_scan_test_max_n();
-#    elif PSTL_USE_DEBUG
-        1000000;
+    unsigned long n = TestUtils::test_queue_is_cpu() ? TestUtils::get_scan_test_max_n() :
+#    if PSTL_USE_DEBUG
+                                                     1000000;
 #    else
-        100000000;
+                                                     100000000;
 #    endif
 
     Sequence<In> in(n, convert);

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -73,7 +73,7 @@ test_with_plus(Init init, Out trash, Convert convert)
 
 #if TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
     // testing of large number of items may take too much time in debug mode
-    unsigned long n = TestUtils::test_queue_is_cpu() ? TestUtils::get_scan_test_max_n() :
+    std::size_t n = TestUtils::test_queue_is_cpu() ? TestUtils::get_scan_test_max_n() :
 #    if PSTL_USE_DEBUG
                                                      1000000;
 #    else

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_matrix.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_matrix.pass.cpp
@@ -25,7 +25,7 @@ template <typename In, typename Out, typename BinaryOp>
 void
 test_matrix(Out init, BinaryOp binary_op, Out trash)
 {
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<In> in(n, [](size_t k) { return In(k, k + 1); });
 

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_multiplies.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_multiplies.pass.cpp
@@ -33,7 +33,7 @@ test_with_multiplies()
     T init = 1;
     const std::size_t custom_item_count = 10;
 
-    for (size_t n = custom_item_count; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = custom_item_count; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<T> out(n, [&](size_t) { return trash; });
         Sequence<T> expected(n, [&](size_t) { return trash; });

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -61,7 +61,7 @@ template <typename In, typename Init, typename Out, typename Convert>
 void
 test_with_plus(Init init, Out trash, Convert convert)
 {
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<In> in(n, convert);
         Sequence<Out> expected(n);
@@ -76,11 +76,13 @@ test_with_plus(Init init, Out trash, Convert convert)
 #if TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
     // testing of large number of items may take too much time in debug mode
     unsigned long n =
-#if PSTL_USE_DEBUG
+#    if ONEDPL_TEST_LIMIT_SCAN_SIZE
+        TestUtils::get_scan_test_max_n();
+#    elif PSTL_USE_DEBUG
         1000000;
-#else
+#    else
         100000000;
-#endif
+#    endif
 
     Sequence<In> in(n, convert);
     Sequence<Out> expected(n);

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -75,13 +75,11 @@ test_with_plus(Init init, Out trash, Convert convert)
 
 #if TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
     // testing of large number of items may take too much time in debug mode
-    unsigned long n =
-#    if ONEDPL_TEST_LIMIT_SCAN_SIZE
-        TestUtils::get_scan_test_max_n();
-#    elif PSTL_USE_DEBUG
-        1000000;
+    unsigned long n = TestUtils::test_queue_is_cpu() ? TestUtils::get_scan_test_max_n() :
+#    if PSTL_USE_DEBUG
+                                                     1000000;
 #    else
-        100000000;
+                                                     100000000;
 #    endif
 
     Sequence<In> in(n, convert);

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -75,7 +75,7 @@ test_with_plus(Init init, Out trash, Convert convert)
 
 #if TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
     // testing of large number of items may take too much time in debug mode
-    unsigned long n = TestUtils::test_queue_is_cpu() ? TestUtils::get_scan_test_max_n() :
+    std::size_t n = TestUtils::test_queue_is_cpu() ? TestUtils::get_scan_test_max_n() :
 #    if PSTL_USE_DEBUG
                                                      1000000;
 #    else

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_matrix.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_matrix.pass.cpp
@@ -25,7 +25,7 @@ template <typename In, typename Out, typename BinaryOp>
 void
 test_matrix(Out init, BinaryOp binary_op, Out trash)
 {
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<In> in(n, [](size_t k) { return In(k, k + 1); });
 

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_multiplies.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_multiplies.pass.cpp
@@ -31,7 +31,7 @@ test_with_multiplies()
     T init = 1;
     const std::size_t custom_item_count = 10;
 
-    for (size_t n = custom_item_count; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = custom_item_count; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<T> out(n, [&](size_t) { return trash; });
         Sequence<T> expected(n, [&](size_t) { return trash; });

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -164,7 +164,7 @@ template <typename In, typename Out, typename UnaryOp, typename BinaryOp>
 void
 test(UnaryOp unary_op, Out init, BinaryOp binary_op, Out trash)
 {
-    for (size_t n = 1; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 1; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<In> in(n, [](size_t k) { return In(k ^ encryption_mask); });
 
@@ -221,7 +221,7 @@ template <typename In, typename Out, typename UnaryOp, typename BinaryOp>
 void
 test_matrix(UnaryOp unary_op, Out init, BinaryOp binary_op, Out trash)
 {
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    for (size_t n = 0; n <= TestUtils::get_scan_test_max_n(); n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<In> in(n, [](size_t k) { return In(k, k + 1); });
 

--- a/test/parallel_api/ranges/std_ranges_copy_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_copy_if.pass.cpp
@@ -54,8 +54,8 @@ main()
     test_range_algo<2, int, data_in_out_lim>{}(dpl_ranges::copy_if, copy_if_checker, select_many, proj);
     test_range_algo<3, P2, data_in_out_lim>{}(dpl_ranges::copy_if, copy_if_checker, pred, &P2::x);
     test_range_algo<4, P2, data_in_out_lim>{}(dpl_ranges::copy_if, copy_if_checker, pred, &P2::proj);
-    test_range_algo<5, int, data_in_out_lim>{big_sz}(dpl_ranges::copy_if, copy_if_checker, pred);
-    test_range_algo<6, int, data_in_out_lim>{big_sz}(dpl_ranges::copy_if, copy_if_checker, select_many);
+    test_range_algo<5, int, data_in_out_lim>{get_scan_big_sz()}(dpl_ranges::copy_if, copy_if_checker, pred);
+    test_range_algo<6, int, data_in_out_lim>{get_scan_big_sz()}(dpl_ranges::copy_if, copy_if_checker, select_many);
 #endif // _ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_remove.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_remove.pass.cpp
@@ -35,7 +35,7 @@ main()
 
     auto remove_checker = TEST_PREPARE_CALLABLE(std::ranges::remove);
 
-    test_range_algo<0>{big_sz}(dpl_ranges::remove, remove_checker, 0);
+    test_range_algo<0>{get_scan_big_sz()}(dpl_ranges::remove, remove_checker, 0);
     test_range_algo<1>{}(dpl_ranges::remove, remove_checker, 0, proj);
     test_range_algo<2, P2>{}(dpl_ranges::remove, remove_checker, 0, &P2::x);
     test_range_algo<3, P2>{}(dpl_ranges::remove, remove_checker, 0, &P2::proj);

--- a/test/parallel_api/ranges/std_ranges_remove_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_remove_copy.pass.cpp
@@ -112,8 +112,8 @@ main()
     test_range_algo<2, int, data_in_out_lim>{}(dpl_ranges::remove_copy, remove_copy_checker, 1, proj);
     test_range_algo<3, P2, data_in_out_lim, many_twos>{}(dpl_ranges::remove_copy, remove_copy_checker, 2, &P2::x);
     test_range_algo<4, P2, data_in_out_lim>{}(dpl_ranges::remove_copy, remove_copy_checker, 0, &P2::proj);
-    test_range_algo<5, int, data_in_out_lim>{big_sz}(dpl_ranges::remove_copy, remove_copy_checker, 1);
-    test_range_algo<6, int, data_in_out_lim, many_twos>{big_sz}(dpl_ranges::remove_copy, remove_copy_checker, 2);
+    test_range_algo<5, int, data_in_out_lim>{get_scan_big_sz()}(dpl_ranges::remove_copy, remove_copy_checker, 1);
+    test_range_algo<6, int, data_in_out_lim, many_twos>{get_scan_big_sz()}(dpl_ranges::remove_copy, remove_copy_checker, 2);
 #endif // _ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_remove_copy_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_remove_copy_if.pass.cpp
@@ -117,8 +117,8 @@ main()
     test_range_algo<2, int, data_in_out_lim>{}(dpl_ranges::remove_copy_if, remove_copy_if_checker, select_many, proj);
     test_range_algo<3, P2, data_in_out_lim, repeating_gen>{}(dpl_ranges::remove_copy_if, remove_copy_if_checker, modulo_3_is_1, &P2::x);
     test_range_algo<4, P2, data_in_out_lim>{}(dpl_ranges::remove_copy_if, remove_copy_if_checker, pred, &P2::proj);
-    test_range_algo<5, int, data_in_out_lim>{big_sz}(dpl_ranges::remove_copy_if, remove_copy_if_checker, pred);
-    test_range_algo<6, int, data_in_out_lim, repeating_gen>{big_sz}(dpl_ranges::remove_copy_if, remove_copy_if_checker, select_many);
+    test_range_algo<5, int, data_in_out_lim>{get_scan_big_sz()}(dpl_ranges::remove_copy_if, remove_copy_if_checker, pred);
+    test_range_algo<6, int, data_in_out_lim, repeating_gen>{get_scan_big_sz()}(dpl_ranges::remove_copy_if, remove_copy_if_checker, select_many);
 #endif // _ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_remove_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_remove_if.pass.cpp
@@ -35,7 +35,7 @@ main()
 
     auto remove_if_checker = TEST_PREPARE_CALLABLE(std::ranges::remove_if);
 
-    test_range_algo<0>{big_sz}(dpl_ranges::remove_if, remove_if_checker, pred);
+    test_range_algo<0>{get_scan_big_sz()}(dpl_ranges::remove_if, remove_if_checker, pred);
     test_range_algo<1>{}(dpl_ranges::remove_if, remove_if_checker, pred, proj);
     test_range_algo<2, P2>{}(dpl_ranges::remove_if, remove_if_checker, pred, &P2::x);
     test_range_algo<3, P2>{}(dpl_ranges::remove_if, remove_if_checker, pred, &P2::proj);

--- a/test/parallel_api/ranges/std_ranges_replace_copy_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_replace_copy_if.pass.cpp
@@ -32,7 +32,7 @@ main()
         return ret_type{std::ranges::begin(r_in) + size, std::ranges::begin(r_out) +  size};
     };
 
-    test_range_algo<0, int, data_in_out_lim>{big_sz}(dpl_ranges::replace_copy_if, replace_copy_if_checker, pred, -29);
+    test_range_algo<0, int, data_in_out_lim>{get_scan_big_sz()}(dpl_ranges::replace_copy_if, replace_copy_if_checker, pred, -29);
     test_range_algo<1, int, data_in_out_lim>{}(dpl_ranges::replace_copy_if, replace_copy_if_checker, pred1, -277, proj);
     test_range_algo<2, P2, data_in_out_lim>{}(dpl_ranges::replace_copy_if, replace_copy_if_checker, pred2, -43, &P2::x);
     test_range_algo<3, P2, data_in_out_lim>{}(dpl_ranges::replace_copy_if, replace_copy_if_checker, pred3, -817, &P2::proj);

--- a/test/parallel_api/ranges/std_ranges_set_difference.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_set_difference.pass.cpp
@@ -106,8 +106,8 @@ main()
         return ret_type{res.in, res.out};
     };
 
-    test_range_algo<0, int, data_in_in_out, div3_t, mul1_t>{big_sz}(dpl_ranges::set_difference, checker);
-    test_range_algo<1, int, data_in_in_out, div3_t, mul1_t>{big_sz}(dpl_ranges::set_difference, checker, std::ranges::less{}, proj);
+    test_range_algo<0, int, data_in_in_out, div3_t, mul1_t>{get_scan_big_sz()}(dpl_ranges::set_difference, checker);
+    test_range_algo<1, int, data_in_in_out, div3_t, mul1_t>{get_scan_big_sz()}(dpl_ranges::set_difference, checker, std::ranges::less{}, proj);
 
     // Testing the cut-off with the serial implementation (less than __set_algo_cut_off)
     test_range_algo<2, int, data_in_in_out, div3_t, mul1_t>{100}(dpl_ranges::set_difference, checker, std::ranges::less{}, proj, proj);

--- a/test/parallel_api/ranges/std_ranges_set_intersection.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_set_intersection.pass.cpp
@@ -95,8 +95,8 @@ main()
         return ret_type{res.in1, res.in2, res.out};
     };
 
-    test_range_algo<0, int, data_in_in_out, mul1_t, div3_t>{big_sz}(dpl_ranges::set_intersection, set_intersection_checker);
-    test_range_algo<1, int, data_in_in_out, mul1_t, div3_t>{big_sz}(dpl_ranges::set_intersection, set_intersection_checker, std::ranges::less{}, proj);
+    test_range_algo<0, int, data_in_in_out, mul1_t, div3_t>{get_scan_big_sz()}(dpl_ranges::set_intersection, set_intersection_checker);
+    test_range_algo<1, int, data_in_in_out, mul1_t, div3_t>{get_scan_big_sz()}(dpl_ranges::set_intersection, set_intersection_checker, std::ranges::less{}, proj);
 
     // Testing the cut-off with the serial implementation (less than __set_algo_cut_off)
     test_range_algo<2, int, data_in_in_out, mul1_t, div3_t>{100}(dpl_ranges::set_intersection, set_intersection_checker, std::ranges::less{}, proj, proj);

--- a/test/parallel_api/ranges/std_ranges_set_symmetric_difference.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_set_symmetric_difference.pass.cpp
@@ -112,8 +112,8 @@ main()
         return ret_type{res.in1, res.in2, res.out};
     };
 
-    test_range_algo<0, int, data_in_in_out, div3_t, mul1_t>{big_sz}(dpl_ranges::set_symmetric_difference, checker);
-    test_range_algo<1, int, data_in_in_out, mul1_t, div3_t>{big_sz}(dpl_ranges::set_symmetric_difference, checker, std::ranges::less{}, proj);
+    test_range_algo<0, int, data_in_in_out, div3_t, mul1_t>{get_scan_big_sz()}(dpl_ranges::set_symmetric_difference, checker);
+    test_range_algo<1, int, data_in_in_out, mul1_t, div3_t>{get_scan_big_sz()}(dpl_ranges::set_symmetric_difference, checker, std::ranges::less{}, proj);
 
     // Testing the cut-off with the serial implementation (less than __set_algo_cut_off)
     test_range_algo<2, int, data_in_in_out, mul1_t, mul1_t>{100}(dpl_ranges::set_symmetric_difference, checker, std::ranges::less{}, proj, proj);

--- a/test/parallel_api/ranges/std_ranges_set_union.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_set_union.pass.cpp
@@ -107,8 +107,8 @@ main()
         return ret_type{res.in1, res.in2, res.out};
     };
 
-    test_range_algo<0, int, data_in_in_out, mul1_t, div3_t>{big_sz}(dpl_ranges::set_union, set_union_checker);
-    test_range_algo<1, int, data_in_in_out, mul1_t, div3_t>{big_sz}(dpl_ranges::set_union, set_union_checker, std::ranges::less{}, proj);
+    test_range_algo<0, int, data_in_in_out, mul1_t, div3_t>{get_scan_big_sz()}(dpl_ranges::set_union, set_union_checker);
+    test_range_algo<1, int, data_in_in_out, mul1_t, div3_t>{get_scan_big_sz()}(dpl_ranges::set_union, set_union_checker, std::ranges::less{}, proj);
 
     // Testing the cut-off with the serial implementation (less than __set_algo_cut_off)
     test_range_algo<2, int, data_in_in_out, mul1_t, div3_t>{100}(dpl_ranges::set_union, set_union_checker, std::ranges::less{}, proj, proj);

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -54,6 +54,10 @@ inline constexpr int big_size = (1<<22) + 37; //4M
 inline constexpr int big_size = (1<<24) + 10; //16M
 #endif
 
+// Cap used for the device tier of scan-based std_ranges tests when the dpcpp
+// backend targets a CPU device.
+inline constexpr int big_size_scan_cpu = (1 << 20) + 10; //1M
+
 // ~100K is sufficient for parallel policies.
 // It also usually results in using multiple-work-group specializations for device policies.
 inline constexpr int medium_size = (1<<17) + 10; //128K
@@ -64,8 +68,23 @@ inline constexpr int small_size = 2025;
 
 #if TEST_DPCPP_BACKEND_PRESENT
 inline constexpr std::array<int, 3> big_sz = {/*serial*/ small_size, /*par*/ medium_size, /*device*/ big_size};
+
+// Size tuple for scan-based std_ranges tests (copy_if, remove*, unique*,
+// set_*). Shrinks the device tier for CPU+dpcpp at runtime.
+inline std::array<int, 3>
+get_scan_big_sz()
+{
+    const int device_size = TestUtils::test_queue_is_cpu() ? big_size_scan_cpu : big_size;
+    return {/*serial*/ small_size, /*par*/ medium_size, /*device*/ device_size};
+}
 #else
 inline constexpr std::array<int, 2> big_sz = {/*serial*/ small_size, /*par*/ medium_size};
+
+inline std::array<int, 2>
+get_scan_big_sz()
+{
+    return {/*serial*/ small_size, /*par*/ medium_size};
+}
 #endif
 
 enum TestDataMode

--- a/test/parallel_api/ranges/std_ranges_unique.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_unique.pass.cpp
@@ -35,7 +35,7 @@ main()
 
     auto unique_checker = TEST_PREPARE_CALLABLE(std::ranges::unique);
 
-    test_range_algo<0>{big_sz}(dpl_ranges::unique, unique_checker);
+    test_range_algo<0>{get_scan_big_sz()}(dpl_ranges::unique, unique_checker);
     test_range_algo<1>{}(dpl_ranges::unique, unique_checker, std::ranges::equal_to{});
     test_range_algo<2>{}(dpl_ranges::unique, unique_checker, std::not_equal_to{});
     test_range_algo<3>{}(dpl_ranges::unique, unique_checker, std::ranges::equal_to{}, proj);

--- a/test/parallel_api/ranges/std_ranges_unique_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_unique_copy.pass.cpp
@@ -125,7 +125,7 @@ main()
     test_range_algo<3, int, data_in_out_lim, repeating_gen>{}(dpl_ranges::unique_copy, unique_copy_checker, std::ranges::equal_to{}, proj);
     test_range_algo<4, P2, data_in_out_lim>{}(dpl_ranges::unique_copy, unique_copy_checker, equal_tens, &P2::x);
     test_range_algo<5, P2, data_in_out_lim>{}(dpl_ranges::unique_copy, unique_copy_checker, std::ranges::equal_to{}, &P2::proj);
-    test_range_algo<6, int, data_in_out_lim, repeating_gen>{big_sz}(dpl_ranges::unique_copy, unique_copy_checker, std::ranges::equal_to{});
+    test_range_algo<6, int, data_in_out_lim, repeating_gen>{get_scan_big_sz()}(dpl_ranges::unique_copy, unique_copy_checker, std::ranges::equal_to{});
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/support/utils_const.h
+++ b/test/support/utils_const.h
@@ -35,9 +35,10 @@ test_queue_is_cpu();
 constexpr ::std::size_t max_n = 100000;
 
 // Default caps used by scan-based tests (scan, copy_if, unique, partition,
-// set_*, etc.). The runtime helpers below (defined in utils_sycl.h when the
-// dpcpp backend is present) shrink these when the test queue targets a CPU
-// device, where the default sizes are too slow.
+// set_*, etc.). The get_scan_test_*_max_n() helpers defined below in this
+// header shrink these when the test queue targets a CPU device, using
+// test_queue_is_cpu() when the dpcpp backend is present, where the default
+// sizes are too slow.
 constexpr std::size_t scan_test_max_n_default = 100000;
 constexpr std::size_t scan_test_set_max_n_default = 100000;
 constexpr std::size_t scan_test_unique_max_n_default = 1000000;

--- a/test/support/utils_const.h
+++ b/test/support/utils_const.h
@@ -16,12 +16,67 @@
 #ifndef _UTILS_CONST_H
 #define _UTILS_CONST_H
 
+#include <cstddef>
+
+#include "test_config.h"
+
 namespace TestUtils
 {
+#if TEST_DPCPP_BACKEND_PRESENT
+// Defined in utils_invoke.h; declared here so the get_scan_test_*_max_n
+// helpers below can be defined without including SYCL.
+bool
+test_queue_is_cpu();
+#endif
+
 #define _SKIP_RETURN_CODE 77
 
 // Test data ranges other than those that start at the beginning of an input.
 constexpr ::std::size_t max_n = 100000;
+
+// Default caps used by scan-based tests (scan, copy_if, unique, partition,
+// set_*, etc.). The runtime helpers below (defined in utils_sycl.h when the
+// dpcpp backend is present) shrink these when the test queue targets a CPU
+// device, where the default sizes are too slow.
+constexpr std::size_t scan_test_max_n_default = 100000;
+constexpr std::size_t scan_test_set_max_n_default = 100000;
+constexpr std::size_t scan_test_unique_max_n_default = 1000000;
+
+// Shrunken caps applied for CPU+dpcpp runs. Sized to still exercise
+// multi-work-group code paths in the geometric n walk used by the tests.
+constexpr std::size_t scan_test_max_n_cpu = 32000;
+constexpr std::size_t scan_test_set_max_n_cpu = 24000;
+constexpr std::size_t scan_test_unique_max_n_cpu = 32000;
+
+inline std::size_t
+get_scan_test_max_n()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    if (test_queue_is_cpu())
+        return scan_test_max_n_cpu;
+#endif
+    return scan_test_max_n_default;
+}
+
+inline std::size_t
+get_scan_test_set_max_n()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    if (test_queue_is_cpu())
+        return scan_test_set_max_n_cpu;
+#endif
+    return scan_test_set_max_n_default;
+}
+
+inline std::size_t
+get_scan_test_unique_max_n()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    if (test_queue_is_cpu())
+        return scan_test_unique_max_n_cpu;
+#endif
+    return scan_test_unique_max_n_default;
+}
 
 // All these offset consts used for indirect testing of calculation an offset parameter
 // (as a result dpl::begin(buf) + offset) for further passing within sycl::accessor constructor.

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -40,6 +40,14 @@ namespace TestUtils
 // Implemented in utils_sycl.h, required to include this file.
 sycl::queue get_test_queue();
 
+// Returns true if the queue used by tests targets a CPU device.
+inline bool
+test_queue_is_cpu()
+{
+    static const bool is_cpu = get_test_queue().get_device().is_cpu();
+    return is_cpu;
+}
+
 /**
  * make_policy functions test wrappers
  * The main purpose of this function wrapper in TestUtils namespace - to cut template params from


### PR DESCRIPTION
As mentioned https://github.com/uxlfoundation/oneDPL/pull/2657#issuecomment-4502532518 , we see a degradation of cpu testing times with changes to switch to reduce then scan for CPUs with few cores.  This PR adjusts the testing suite to be more conservative with scan tests sizes on CPU targets to avoid timeouts, especially on the per-commit CI.