### PR TITLE
[Draft] Bugfix for GPU debug issues

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1609,6 +1609,18 @@ template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusiv
           typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename _KernelName>
 struct __parallel_reduce_then_scan_reduce_submitter;
 
+// Sentinel type used as a stand-in for the OOB-position accessor when _Bounded=false.
+// Capturing a std::nullptr_t value into a SYCL kernel lambda has been observed to cause
+// kernel-argument-index mismatches under DPC++ Debug builds (-O0), surfacing as
+// UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX on Level Zero. An empty tag struct is
+// captured cleanly and gives us a distinct type to detect at compile time.
+struct __no_oob_pos_acc_tag
+{
+};
+
+template <typename _T>
+inline constexpr bool __is_no_oob_pos_acc_v = std::is_same_v<std::remove_cv_t<_T>, __no_oob_pos_acc_tag>;
+
 template <bool _Bounded, typename _OOBPosStorage>
 auto
 __get_oob_pos_accessor_opt([[maybe_unused]] sycl::handler& __cgh, [[maybe_unused]] _OOBPosStorage& __oob_pos_storage)
@@ -1620,7 +1632,7 @@ __get_oob_pos_accessor_opt([[maybe_unused]] sycl::handler& __cgh, [[maybe_unused
     }
     else
     {
-        return nullptr;
+        return __no_oob_pos_acc_tag{};
     }
 }
 
@@ -1754,7 +1766,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                     __sub_group_carry.__destroy();
                 }
 
-                if constexpr (!std::is_same_v<std::remove_cv_t<_OOBPosStorage>, std::nullptr_t>)
+                if constexpr (!__is_no_oob_pos_acc_v<decltype(__oob_pos_acc)>)
                 {
                     if (__block_num == 0 && __ndi.get_global_linear_id() == 0)
                     {
@@ -2191,13 +2203,13 @@ __is_gpu_with_reduce_then_scan_sg_sz(const sycl::queue& __q)
 }
 
 template <bool _Bounded, typename _Range>
-std::conditional_t<_Bounded, __result_storage<oneapi::dpl::__internal::__difference_t<_Range>>, std::nullptr_t>
+std::conditional_t<_Bounded, __result_storage<oneapi::dpl::__internal::__difference_t<_Range>>, __no_oob_pos_acc_tag>
 __create_oob_pos_storage_opt([[maybe_unused]] sycl::queue& __q)
 {
     if constexpr (_Bounded)
         return __result_storage<oneapi::dpl::__internal::__difference_t<_Range>>(__q, 1);
     else
-        return nullptr;
+        return __no_oob_pos_acc_tag{};
 }
 
 // General scan-like algorithm helpers

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1610,10 +1610,6 @@ template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusiv
 struct __parallel_reduce_then_scan_reduce_submitter;
 
 // Sentinel type used as a stand-in for the OOB-position accessor when _Bounded=false.
-// Capturing a std::nullptr_t value into a SYCL kernel lambda has been observed to cause
-// kernel-argument-index mismatches under DPC++ Debug builds (-O0), surfacing as
-// UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX on Level Zero. An empty tag struct is
-// captured cleanly and gives us a distinct type to detect at compile time.
 struct __no_oob_pos_acc_tag
 {
 };


### PR DESCRIPTION
It seems this likely fixes some issues we see in GPU debug for #2684 .

I believe there may be issues in the size of a `nullptr_t` when capturing it in a kernel.  
This is also better for reasons we discussed creating #2687, since a tag type is not able to be confused or assigned to a real pointer.

We *may* be able to extend this work to have this tag replace the `Bounded` template argument entirely, cleaning up the diff considerably as well.