### PR TITLE
Bump up _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -34,7 +34,7 @@
 // When such an issue is fixed, we must replace the usage of these "Latest" macros with the appropriate version number
 // before updating to the newest version in this section.
 
-#define _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER 20260000
+#define _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER 20260100
 
 #define _PSTL_TEST_LATEST_MSVC_STL_VERSION 145
 


### PR DESCRIPTION
The issues guarded by the previous version of this macro are still relevant - checked manually.