### PR TITLE
Avoid vector calls in SYCL kernels

### DIFF
--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
@@ -12,6 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER) && _MSC_VER >= 1950
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include <oneapi/dpl/algorithm>
 
 #include "support/utils.h"

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
@@ -12,6 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER) && _MSC_VER >= 1950
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
@@ -12,6 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER) && _MSC_VER >= 1950
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include <oneapi/dpl/algorithm>
 
 #include "support/utils.h"

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
@@ -12,6 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER) && _MSC_VER >= 1950
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
@@ -12,6 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER) && _MSC_VER >= 1950
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 


### PR DESCRIPTION
VS 2026 added vectorization to several algorithms. Let's turn it off to test them in SYCL kernels. 

Issue example:
```c++
In file included from oneDPL\test\xpu_api\algorithms\alg.sorting\alg.sort\is.sorted\xpu_is_sorted_comp.pass.cpp:15:
In file included from oneDPL\include\oneapi\dpl\algorithm:21:
C:\Program Files\Microsoft Visual Studio\18\Professional\VC\Tools\MSVC\14.50.35717\include\algorithm(243,63): error: SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute
  243 |             return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_is_sorted_until_4i(_First, _Last, _Greater)));
      |                                                               ^
C:\Program Files\Microsoft Visual Studio\18\Professional\VC\Tools\MSVC\14.50.35717\include\algorithm(81,23): note: '__std_is_sorted_until_4i' declared here
   81 | const void* __stdcall __std_is_sorted_until_4i(const void* _First, const void* _Last, bool _Greater) noexcept;
      |                       ^
C:\Program Files\Microsoft Visual Studio\18\Professional\VC\Tools\MSVC\14.50.35717\include\algorithm(222,6): note: called by '_Is_sorted_until_vectorized<const int>'
  222 | _Ty* _Is_sorted_until_vectorized(_Ty* const _First, _Ty* const _Last, const bool _Greater) noexcept {
      |      ^
C:\Program Files\Microsoft Visual Studio\18\Professional\VC\Tools\MSVC\14.50.35717\include\algorithm(226,59): error: SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute
  226 |         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_is_sorted_until_f(_First, _Last, _Greater)));
      |                                                           ^
C:\Program Files\Microsoft Visual Studio\18\Professional\VC\Tools\MSVC\14.50.35717\include\algorithm(85,23): note: '__std_is_sorted_until_f' declared here
   85 | const void* __stdcall __std_is_sorted_until_f(const void* _First, const void* _Last, bool _Greater) noexcept;
      |                       ^
C:\Program Files\Microsoft Visual Studio\18\Professional\VC\Tools\MSVC\14.50.35717\include\algorithm(222,6): note: called by '_Is_sorted_until_vectorized<const float>'
  222 | _Ty* _Is_sorted_until_vectorized(_Ty* const _First, _Ty* const _Last, const bool _Greater) noexcept {
      |      ^
2 errors generated.
```

Similar PR: #766. 