### PR TITLE
Remove Dead CPU & trivially_copyable type RTS kernels

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2414,15 +2414,15 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
         return __parallel_transform_reduce_then_scan_impl<_Bounded, /*__use_subgroup_ops=*/true,
-                                                            __bytes_per_work_item_iter, _CustomName>(
-            __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input,
-            __reduce_op, __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive,
-            __is_unique_pattern, __transform_result, std::move(__prior_event));
+                                                          __bytes_per_work_item_iter, _CustomName>(
+            __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
+            __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
+            __transform_result, std::move(__prior_event));
     }
     else
     {
         return __parallel_transform_reduce_then_scan_impl<_Bounded, /*__use_subgroup_ops=*/false,
-                                                        __bytes_per_work_item_iter, _CustomName>(
+                                                          __bytes_per_work_item_iter, _CustomName>(
             __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
             __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
             __transform_result, std::move(__prior_event));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2410,31 +2410,23 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
                                       sycl::event __prior_event = {})
 {
     using _ValueType = typename _InitType::__value_type;
-    // Native sycl sub-group operations can only be used on trivially copyable types. Dispatch above the
-    // kernel here so the kernel itself is instantiated with a fixed __use_subgroup_ops template arg.
-    // The icpx compiler is able to avoid JIT compilation for kernels for platform types which are not
-    // in the real runtime path of the program, so we can branch like this without JIT-time penalty.
-
+    // Native sycl sub-group operations can only be used on trivially copyable types, for other types, use SLM variant
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
-        // CPU targets should use the SLM-based approach, as they do not perform well with the native sub-group
-        // operations used in the GPU-optimized approach.
-        if (__q.get_device().is_gpu())
-        {
-            return __parallel_transform_reduce_then_scan_impl<_Bounded, /*__use_subgroup_ops=*/true,
-                                                              __bytes_per_work_item_iter, _CustomName>(
-                __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input,
-                __reduce_op, __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive,
-                __is_unique_pattern, __transform_result, std::move(__prior_event));
-        }
+        return __parallel_transform_reduce_then_scan_impl<_Bounded, /*__use_subgroup_ops=*/true,
+                                                            __bytes_per_work_item_iter, _CustomName>(
+            __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input,
+            __reduce_op, __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive,
+            __is_unique_pattern, __transform_result, std::move(__prior_event));
     }
-
-    // if CPU target or non-trivially-copyable type, use SLM-based approach
-    return __parallel_transform_reduce_then_scan_impl<_Bounded, /*__use_subgroup_ops=*/false,
-                                                      __bytes_per_work_item_iter, _CustomName>(
-        __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
-        __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
-        __transform_result, std::move(__prior_event));
+    else
+    {
+        return __parallel_transform_reduce_then_scan_impl<_Bounded, /*__use_subgroup_ops=*/false,
+                                                        __bytes_per_work_item_iter, _CustomName>(
+            __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
+            __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
+            __transform_result, std::move(__prior_event));
+    }
 }
 
 template <typename _CustomName, typename _InInOutRng, typename _GenReduceInput>


### PR DESCRIPTION
This PR removes the dead set of CPU reduce_then_scan kernels introduced by #2687.  
No path currently reaches reduce_then_scan with a CPU target, so this is dead code, and results in extra unnecessary JIT time. 

I had included this expecting #2657 would land enabling CPU paths, and with an incorrect understanding that the compiler could eliminate the CPU kernels never reached at runtime.  

This PR should be merged prior to release to remove this unnecessary extra JIT cost.  After the release, we can discuss whether this extra JIT cost is worth it, or if we should partially revert #2657, and lower the runtime SLM branch back into the kernel to unify.  

--
Details of my mistaken investigation:
I was mistaken in my original investigation of JIT compilation, my method was operating off using `SYCL_UR_TRACE=2` and a flawed understanding of `urCreateKernel`.  This command is not associated with the bulk of the JIT compilation cost of a kernel but rather the runtime submission of an already compiled kernel. Examining the size of the SYCL kernel dumps using `SYCL_DUMP_IMAGES=1` shows a doubling of the size of the compiled kernel images with that commit (and we see elevated JIT time for kernel heavy tests like std_ranges_set_intersection.pass). 