### PR TITLE
Note extra memory usage by set algorithms

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -107,7 +107,9 @@ Difference with Standard C++ Parallel Algorithms
   ``set_symmetric_difference``, ``set_union``, ``stable_partition``, ``unique``.
 * The following algorithms require additional O(n) memory space for parallel execution:
   ``copy_if``, ``inplace_merge``, ``partial_sort``, ``partial_sort_copy``, ``partition_copy``,
-  ``remove``, ``remove_if``, ``rotate``, ``sort``, ``stable_sort``, ``unique``, ``unique_copy``.
+  ``remove``, ``remove_if``, ``rotate``, ``sort``, ``stable_sort``,
+  ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union``,
+  ``unique``, ``unique_copy``.
 
 Restrictions
 ************


### PR DESCRIPTION
Set algorithms also allocate extra memory:
- Temporary buffer for output (bounded and unbounded versions): https://github.com/uxlfoundation/oneDPL/blob/f0bebb95a2f605b03a4930ff1b21586395d7d61e/include/oneapi/dpl/pstl/algorithm_impl.h#L4002
- Temporary buffer with masks (unbounded versions): https://github.com/uxlfoundation/oneDPL/blob/f0bebb95a2f605b03a4930ff1b21586395d7d61e/include/oneapi/dpl/pstl/algorithm_impl.h#L3622

I've checked other algorithms allocating O(n) and more space. Not mentioned ones are `sort_by_key` and `stable_sort_by_key`, but they are not present in the C++ standard, so we should not add them into "Difference with Standard C++ Parallel Algorithms" chapter.