### PR TITLE
Remove SYCL 1.2.1 barrier

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
@@ -90,7 +90,7 @@ struct __global_histogram<__sycl_tag, __is_ascending, __radix_bits, __hist_work_
             }
         }
 
-        __dpl_sycl::__group_barrier(__idx);
+        sycl::group_barrier(__idx.get_group());
 
         for (_GlobOffsetT __wi_offset = __sub_group_start + __sub_group_local_id; __wi_offset < __n;
              __wi_offset += __device_wide_step)
@@ -140,7 +140,7 @@ struct __global_histogram<__sycl_tag, __is_ascending, __radix_bits, __hist_work_
             }
         }
 
-        __dpl_sycl::__group_barrier(__idx);
+        sycl::group_barrier(__idx.get_group());
 
         // 4. Reduce group-local histograms from SLM into global histograms in global memory
         for (_LocIdxT __i = __local_id; __i < __hist_buffer_size; __i += __hist_work_group_size)
@@ -374,7 +374,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
             }
             __ranks[__i] = __rank_after;
         }
-        __dpl_sycl::__group_barrier(__idx);
+        sycl::group_barrier(__idx.get_group());
     }
 
     inline void
@@ -382,6 +382,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
                   std::uint32_t __sub_group_id, std::uint32_t __sub_group_local_id, _LocOffsetT* __slm_subgroup_hists,
                   _LocOffsetT* __slm_group_hist, _GlobOffsetT* __slm_global_incoming) const
     {
+        auto __group = __idx.get_group();
         _GlobOffsetT* __p_this_group_hist = __p_group_hists + __bin_count * __tile_id;
         _GlobOffsetT* __p_prev_group_hist = __p_this_group_hist - __bin_count;
 
@@ -418,7 +419,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
             __inter_bin_scan_bin_width_totals<__bin_process_width>(__sub_group, __sub_group_id, __sub_group_local_id,
                                                                    __item_grf_hist_summary_arr, __slm_group_hist);
         }
-        __dpl_sycl::__group_barrier(__idx);
+        sycl::group_barrier(__group);
 
         // 1.4. Finalize the partial scans from step 1.3 by connecting the independent sub-group segments
         // together, propagating prefixes across the "__bin_process_width"-sized segments and converting
@@ -429,7 +430,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
                 __sub_group, __sub_group_local_id, __slm_group_hist);
         }
 
-        __dpl_sycl::__group_barrier(__idx);
+        sycl::group_barrier(__group);
 
         // 2. Chained scan. Synchronization between work-groups.
         if (__sub_group_id < __bin_summary_sub_group_size && __tile_id != 0)
@@ -439,7 +440,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
                 __slm_global_incoming);
         }
 
-        __dpl_sycl::__group_barrier(__idx);
+        sycl::group_barrier(__group);
     }
 
     template <std::uint32_t __bin_process_width>
@@ -620,7 +621,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
         {
             __slm_global_incoming[__i] -= __slm_group_hist[__i];
         }
-        __dpl_sycl::__group_barrier(__idx);
+        sycl::group_barrier(__idx.get_group());
     }
 
     template <typename _KVPack>
@@ -646,7 +647,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
                 __slm_vals[__ranks[__i]] = __pack.__vals[__i];
             }
         }
-        __dpl_sycl::__group_barrier(__idx);
+        sycl::group_barrier(__idx.get_group());
     }
 
     template <typename _KVPack>
@@ -691,12 +692,13 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
     void
     operator()(sycl::nd_item<1> __idx) const
     {
+        sycl::group __group = __idx.get_group();
         sycl::sub_group __sub_group = __idx.get_sub_group();
         const std::uint32_t __sg_id = __sub_group.get_group_linear_id();
         const std::uint32_t __sg_local_id = __sub_group.get_local_id();
 
         const std::uint32_t __sub_group_slm_offset = __sg_id * __bin_count;
-        std::uint32_t __tile_id = __idx.get_group().get_group_linear_id();
+        std::uint32_t __tile_id = __group.get_group_linear_id();
         std::uint32_t __num_wgs = __idx.get_group_range(0);
         for (; __tile_id < __num_tiles; __tile_id += __num_wgs)
         {
@@ -741,7 +743,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
             __reorder_slm_to_glob(__idx, __values_pack, __sg_id, __sg_local_id, __slm_global_incoming, __slm_keys,
                                   __slm_vals);
 
-            sycl::group_barrier(__idx.get_group());
+            sycl::group_barrier(__group);
             // Make sure our atomic updates are pushed to other groups
             sycl::atomic_fence(sycl::memory_order::release, sycl::memory_scope::device);
         }

--- a/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
+++ b/include/oneapi/dpl/experimental/kt/internal/work_group/work_group_scan.h
@@ -40,6 +40,7 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
                        oneapi::dpl::__internal::__lazy_ctor_storage<_InputType> __input[__iters_per_item],
                        _BinaryOperation __binary_op, _InitCallback __init_callback, std::uint32_t __items_in_scan)
 {
+    sycl::group __group = __item.get_group();
     sycl::sub_group __sub_group = __item.get_sub_group();
     const std::uint8_t __sub_group_group_id = __sub_group.get_group_linear_id();
     const std::uint8_t __active_sub_groups =
@@ -60,7 +61,7 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
     {
         __local_acc[__sub_group.get_group_linear_id()] = __sub_group_carry;
     }
-    __dpl_sycl::__group_barrier(__item);
+    sycl::group_barrier(__group);
     // Scan over sub-group level reductions to compute incoming prefixes for a sub-group. Guard against
     // applying prefixes of non active sub-groups as there is no guarantee it is an identity.
     if (__sub_group_group_id == 0)
@@ -105,11 +106,11 @@ __work_group_scan_impl(const _NdItem& __item, _SlmAcc __local_acc,
         __init_callback(__wg_init, __sub_group, __wg_carry.__v);
         __wg_carry.__destroy();
     }
-    __dpl_sycl::__group_barrier(__item);
+    sycl::group_barrier(__group);
     // Determine incoming prefix from previous sub-groups and / or work-groups, and update results in __input
     if constexpr (_InitCallback::__apply_prefix)
     {
-        __wg_init = __dpl_sycl::__group_broadcast(__item.get_group(), __wg_init);
+        __wg_init = __dpl_sycl::__group_broadcast(__group, __wg_init);
         if (__sub_group_group_id < __active_sub_groups)
         {
             _InputType __sub_group_carry_in =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -312,7 +312,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
                                  __wgroup_size, __iters_per_witem, __init);
                     if (__n_groups == 1)
                     {
-                        __dpl_sycl::__group_barrier(__item);
+                        sycl::group_barrier(__item.get_group());
                         if (__item.get_local_id(0) == 0)
                             __apex(__res_acc.__data(), __temp_ptr[0], __n_out, __n);
                     }
@@ -340,7 +340,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
                         auto __temp_ptr = __temp_acc.__data();
                         __group_scan(__item, __n_groups, __n_groups, __local_acc, __temp_ptr, __temp_ptr,
                                      /*dummy*/ __temp_ptr, __n_groups, __wgroup_size, __iters_per_single_wg);
-                        __dpl_sycl::__group_barrier(__item);
+                        sycl::group_barrier(__item.get_group());
                         if (__item.get_local_id(0) == 0)
                             __apex(__res_acc.__data(), __temp_ptr[__n_groups - 1], __n_out, __n);
                     });
@@ -534,7 +534,7 @@ struct __parallel_copy_if_single_group_functor<__internal::__optional_kernel_nam
 
             __hdl.parallel_for<_ScanKernelName...>(sycl::nd_range<1>(__wg_size, __wg_size),
                 [=](sycl::nd_item<1> __self_item) {
-                    const auto& __group = __self_item.get_group();
+                    sycl::group __group = __self_item.get_group();
                     // This kernel is only launched for sizes less than 2^16
                     const std::uint16_t __item_id = __self_item.get_local_linear_id();
                     _ValueType* __lacc_ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
@@ -561,7 +561,7 @@ struct __parallel_copy_if_single_group_functor<__internal::__optional_kernel_nam
                                 __lacc[2 * __n_uniform] = __idx; // the actual stop position in the input
                         }
                     }
-                    __dpl_sycl::__group_barrier(__self_item);
+                    sycl::group_barrier(__group);
 
                     if (__item_id == 0)
                     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -145,7 +145,7 @@ __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _Offset
     {
         __local_histogram[__offset + __gSize * __k + __self_lidx] = 0;
     }
-    __dpl_sycl::__group_barrier(__self_item);
+    sycl::group_barrier(__self_item.get_group());
 }
 
 // Atomically increment the bin for __x in a histogram with generalized addressing:
@@ -245,7 +245,7 @@ struct __histogram_general_local_atomics_submitter<__iters_per_work_item,
                         }
                     }
 
-                    __dpl_sycl::__group_barrier(__self_item);
+                    sycl::group_barrier(__self_item.get_group());
 
                     // Merge SLM histogram copies into global output via atomic add per bin.
                     // Iterate strided so all bins are covered when __num_bins exceeds work-group size.
@@ -355,7 +355,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                         }
                     }
 
-                    __dpl_sycl::__group_barrier(__self_item);
+                    sycl::group_barrier(__self_item.get_group());
                     const std::size_t __offset = __wgroup_idx * __num_bins;
                     for (std::size_t __bin = __self_lidx; __bin < __num_bins; __bin += __work_group_size)
                     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -127,8 +127,7 @@ class __histo_kernel_private_glocal_atomics;
 template <typename _HistAccessor, typename _OffsetT, typename _Size>
 void
 __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _OffsetT& __offset, _Size __num_bins,
-                           const sycl::nd_item<1>& __self_item,
-                           __dpl_sycl::__fence_space_t __fence_space = __dpl_sycl::__fence_space_local)
+                           const sycl::nd_item<1>& __self_item)
 {
     using _BinUint_t =
         ::std::conditional_t<(sizeof(_Size) >= sizeof(::std::uint32_t)), ::std::uint64_t, ::std::uint32_t>;
@@ -146,7 +145,7 @@ __clear_wglocal_histograms(const _HistAccessor& __local_histogram, const _Offset
     {
         __local_histogram[__offset + __gSize * __k + __self_lidx] = 0;
     }
-    __dpl_sycl::__group_barrier(__self_item, __fence_space);
+    __dpl_sycl::__group_barrier(__self_item);
 }
 
 // Atomically increment the bin for __x in a histogram with generalized addressing:
@@ -330,8 +329,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                     const ::std::size_t __wgroup_idx = __self_item.get_group(0);
                     const ::std::size_t __seg_start = __work_group_size * __iters_per_work_item * __wgroup_idx;
 
-                    __clear_wglocal_histograms(__hacc_private, __wgroup_idx * __num_bins, __num_bins, __self_item,
-                                               __dpl_sycl::__fence_space_global);
+                    __clear_wglocal_histograms(__hacc_private, __wgroup_idx * __num_bins, __num_bins, __self_item);
 
                     if (__seg_start + __work_group_size * __iters_per_work_item < __n)
                     {
@@ -357,7 +355,7 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
                         }
                     }
 
-                    __dpl_sycl::__group_barrier(__self_item, __dpl_sycl::__fence_space_global);
+                    __dpl_sycl::__group_barrier(__self_item);
                     const std::size_t __offset = __wgroup_idx * __num_bins;
                     for (std::size_t __bin = __self_lidx; __bin < __num_bins; __bin += __work_group_size)
                     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -23,7 +23,7 @@
 #include <algorithm>   // std::min, std::max_element
 #include <type_traits> // std::decay_t, std::integral_constant
 
-#include "sycl_defs.h"                   // __dpl_sycl::__local_accessor, __dpl_sycl::__group_barrier
+#include "sycl_defs.h"                   // __dpl_sycl::__local_accessor
 #include "sycl_traits.h"                 // SYCL traits specialization for some oneDPL types.
 #include "../../utils.h"                 // __dpl_bit_floor, __dpl_bit_ceil
 #include "../../utils_ranges.h"          // __difference_t
@@ -95,7 +95,7 @@ struct __group_merge_path_sorter
             // TODO: copy the data into registers before the merge to halve the required amount of SLM
             __serial_merge(__in_ptr1, __in_ptr2, __out_ptr, __start.first, __start.second, __id, __data_per_workitem,
                            __n1, __n2, __comp);
-            __dpl_sycl::__group_barrier(__item);
+            sycl::group_barrier(__item.get_group());
 
             __sorted = __next_sorted;
             __next_sorted *= 2;
@@ -173,7 +173,7 @@ struct __leaf_sorter
         __item_start = std::min(__item_start, __adjusted_process_size);
         __item_end = std::min(__item_end, __adjusted_process_size);
         __sub_group_sorter.sort(__storage_acc, __comp, __item_start, __item_end);
-        __dpl_sycl::__group_barrier(__item);
+        sycl::group_barrier(__item.get_group());
 
         // 3. Sort on work-group level
         bool __data_in_temp =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -280,6 +280,7 @@ __radix_sort_count_submit(sycl::queue& __q, std::size_t __segments, std::size_t 
                 const std::size_t __self_lidx = __self_item.get_local_id(0);
                 const std::size_t __wgroup_idx = __self_item.get_group(0);
                 const std::size_t __seg_start = __elem_per_segment * __wgroup_idx;
+                sycl::group __group = __self_item.get_group();
 
                 // Subgroup info for SG-strided memory access pattern
                 __dpl_sycl::__sub_group __sub_group = __self_item.get_sub_group();
@@ -338,7 +339,7 @@ __radix_sort_count_submit(sycl::queue& __q, std::size_t __segments, std::size_t 
                         __val_rng2, __proj, __radix_offset, __sg_chunk_start, __sg_chunk_end, __full_end, __sg_size,
                         __sg_local_id, __self_lidx, __slm_buckets, __views);
 
-                __dpl_sycl::__group_barrier(__self_item);
+                sycl::group_barrier(__group);
 
                 // 2. ACCUMULATION PHASE: Read uint8_t columns into _CountT Registers (__count_arr)
                 //    WIs are grouped to prevent uint8_t overflow. Example: __reduction_factor = 4.
@@ -372,7 +373,7 @@ __radix_sort_count_submit(sycl::queue& __q, std::size_t __segments, std::size_t 
                             __slm_buckets[__views.__get_bucket_idx(__radix_base + __r, __col_base + __c)]);
                     }
                 }
-                __dpl_sycl::__group_barrier(__self_item);
+                sycl::group_barrier(__group);
 
                 // 3. REDUCTION PHASE: Write to SLM accessed as _CountT array (__slm_counts)
                 //    The same N bytes of SLM are now viewed as (N / __packing_ratio) _CountT elements.
@@ -395,7 +396,7 @@ __radix_sort_count_submit(sycl::queue& __q, std::size_t __segments, std::size_t 
                     __slm_counts[__views.__get_count_idx(__wg_size, __radix_base + __r, __wi_in_group)] =
                         __count_arr[__r];
                 }
-                __dpl_sycl::__group_barrier(__self_item);
+                sycl::group_barrier(__group);
 
                 // Tree reduction: reduce partial sums down to 1 per radix state
                 std::uint32_t __num_partial_sums = __wis_per_radix_group;
@@ -412,7 +413,7 @@ __radix_sort_count_submit(sycl::queue& __q, std::size_t __segments, std::size_t 
                                                                      __wi_in_group + __stride)];
                         }
                     }
-                    __dpl_sycl::__group_barrier(__self_item);
+                    sycl::group_barrier(__group);
                 }
 
                 // Write final count to global memory (only first 16 WIs, one per radix state)
@@ -562,7 +563,8 @@ __radix_sort_reorder_impl(_InputRange& __input, _OutputRange& __output, _OffsetR
         }
     }
 
-    __dpl_sycl::__group_barrier(__self_item);
+    sycl::group __group = __self_item.get_group();
+    sycl::group_barrier(__group);
 
     // Phase 2: Compute subgroup prefix (subgroups loop through radix states)
     // Reuses the same SLM region: reads totals, computes prefix, writes back in-place
@@ -595,7 +597,7 @@ __radix_sort_reorder_impl(_InputRange& __input, _OutputRange& __output, _OffsetR
         }
     }
 
-    __dpl_sycl::__group_barrier(__self_item);
+    sycl::group_barrier(__group);
 
     // Phase 3: Compute final offsets = global_base + sg_prefix + wi_prefix
     _OffsetT __offsets[__radix_states];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -191,6 +191,7 @@ struct __subgroup_radix_sort
                             _ValT __v[__block_size];
                             __storage() {}
                         } __values;
+                        sycl::group __g = __it.get_group();
                         std::uint16_t __wi = __it.get_local_linear_id();
                         std::uint16_t __begin_bit = 0;
                         constexpr std::uint16_t __end_bit = sizeof(_KeyT) * std::numeric_limits<unsigned char>::digits;
@@ -198,7 +199,7 @@ struct __subgroup_radix_sort
                         //copy(move) values construction
                         __block_load<_ValT>(__wi, __src, __values.__v, __n);
                         // TODO: check if the barrier can be removed
-                        __dpl_sycl::__group_barrier(__it);
+                        sycl::group_barrier(__g);
 
                         while (true)
                         {
@@ -233,7 +234,7 @@ struct __subgroup_radix_sort
                                     __indices[__i] = *__p;
                                     *__p = __indices[__i] + 1;
                                 }
-                                __dpl_sycl::__group_barrier(__it);
+                                sycl::group_barrier(__g);
 
                                 //2. scan phase
                                 {
@@ -246,11 +247,11 @@ struct __subgroup_radix_sort
                                     _ONEDPL_PRAGMA_UNROLL
                                     for (std::uint16_t __i = 1; __i < __bin_count; ++__i)
                                         __bin_sum[__i] = __bin_sum[__i - 1] + __counter_lacc[__wi * __bin_count + __i];
-                                    __dpl_sycl::__group_barrier(__it);
+                                    sycl::group_barrier(__g);
 
                                     //exclusive scan local sum
                                     std::uint16_t __sum_scan = __dpl_sycl::__exclusive_scan_over_group(
-                                        __it.get_group(), __bin_sum[__bin_count - 1],
+                                        __g, __bin_sum[__bin_count - 1],
                                         __dpl_sycl::__plus<std::uint16_t>());
                                     //add to local sum, generate exclusive scan result
                                     _ONEDPL_PRAGMA_UNROLL
@@ -259,7 +260,7 @@ struct __subgroup_radix_sort
 
                                     if (__wi == 0)
                                         __counter_lacc[0] = 0;
-                                    __dpl_sycl::__group_barrier(__it);
+                                    sycl::group_barrier(__g);
                                 }
 
                                 _ONEDPL_PRAGMA_UNROLL
@@ -273,7 +274,7 @@ struct __subgroup_radix_sort
                             __begin_bit += __radix;
 
                             //3. "re-order" phase
-                            __dpl_sycl::__group_barrier(__it);
+                            sycl::group_barrier(__g);
                             if (__begin_bit >= __end_bit)
                             {
                                 // the last iteration - writing out the result
@@ -321,7 +322,7 @@ struct __subgroup_radix_sort
                                         __exchange_lacc[__r] = std::move(__values.__v[__i]);
                                 }
                             }
-                            __dpl_sycl::__group_barrier(__it);
+                            sycl::group_barrier(__g);
 
                             _ONEDPL_PRAGMA_UNROLL
                             for (std::uint16_t __i = 0; __i < __block_size; ++__i)
@@ -330,7 +331,7 @@ struct __subgroup_radix_sort
                                 if (__idx < __n)
                                     __values.__v[__i] = std::move(__exchange_lacc[__idx]);
                             }
-                            __dpl_sycl::__group_barrier(__it);
+                            sycl::group_barrier(__g);
                         }
                     }));
             });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -94,12 +94,6 @@ struct __subgroup_radix_sort
         {
             return __dpl_sycl::__local_accessor<_KeyT>(__buf_size, __cgh);
         }
-
-        inline static constexpr auto
-        get_fence()
-        {
-            return __dpl_sycl::__fence_space_local;
-        }
     };
 
     template <typename _KeyT>
@@ -115,11 +109,6 @@ struct __subgroup_radix_sort
             return sycl::accessor(__buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{});
         }
 
-        inline constexpr static auto
-        get_fence()
-        {
-            return __dpl_sycl::__fence_space_global;
-        }
     };
 
     template <typename _ValueT, typename _Wi, typename _Src, typename _Values>
@@ -209,7 +198,7 @@ struct __subgroup_radix_sort
                         //copy(move) values construction
                         __block_load<_ValT>(__wi, __src, __values.__v, __n);
                         // TODO: check if the barrier can be removed
-                        __dpl_sycl::__group_barrier(__it, decltype(__buf_val)::get_fence());
+                        __dpl_sycl::__group_barrier(__it);
 
                         while (true)
                         {
@@ -244,7 +233,7 @@ struct __subgroup_radix_sort
                                     __indices[__i] = *__p;
                                     *__p = __indices[__i] + 1;
                                 }
-                                __dpl_sycl::__group_barrier(__it, decltype(__buf_count)::get_fence());
+                                __dpl_sycl::__group_barrier(__it);
 
                                 //2. scan phase
                                 {
@@ -257,7 +246,7 @@ struct __subgroup_radix_sort
                                     _ONEDPL_PRAGMA_UNROLL
                                     for (std::uint16_t __i = 1; __i < __bin_count; ++__i)
                                         __bin_sum[__i] = __bin_sum[__i - 1] + __counter_lacc[__wi * __bin_count + __i];
-                                    __dpl_sycl::__group_barrier(__it, decltype(__buf_count)::get_fence());
+                                    __dpl_sycl::__group_barrier(__it);
 
                                     //exclusive scan local sum
                                     std::uint16_t __sum_scan = __dpl_sycl::__exclusive_scan_over_group(
@@ -270,7 +259,7 @@ struct __subgroup_radix_sort
 
                                     if (__wi == 0)
                                         __counter_lacc[0] = 0;
-                                    __dpl_sycl::__group_barrier(__it, decltype(__buf_count)::get_fence());
+                                    __dpl_sycl::__group_barrier(__it);
                                 }
 
                                 _ONEDPL_PRAGMA_UNROLL
@@ -284,7 +273,7 @@ struct __subgroup_radix_sort
                             __begin_bit += __radix;
 
                             //3. "re-order" phase
-                            __dpl_sycl::__group_barrier(__it, decltype(__buf_val)::get_fence());
+                            __dpl_sycl::__group_barrier(__it);
                             if (__begin_bit >= __end_bit)
                             {
                                 // the last iteration - writing out the result
@@ -332,7 +321,7 @@ struct __subgroup_radix_sort
                                         __exchange_lacc[__r] = std::move(__values.__v[__i]);
                                 }
                             }
-                            __dpl_sycl::__group_barrier(__it, decltype(__buf_val)::get_fence());
+                            __dpl_sycl::__group_barrier(__it);
 
                             _ONEDPL_PRAGMA_UNROLL
                             for (std::uint16_t __i = 0; __i < __block_size; ++__i)
@@ -341,7 +330,7 @@ struct __subgroup_radix_sort
                                 if (__idx < __n)
                                     __values.__v[__i] = std::move(__exchange_lacc[__idx]);
                             }
-                            __dpl_sycl::__group_barrier(__it, decltype(__buf_val)::get_fence());
+                            __dpl_sycl::__group_barrier(__it);
                         }
                     }));
             });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -263,7 +263,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
 
                 // __wg_segmented_scan is a derivative work and responsible for the third header copyright
                 __val_type __carry_in = oneapi::dpl::__par_backend_hetero::__wg_segmented_scan(
-                    __item, __loc_acc, __local_id, __local_id - __closest_seg_id, __accumulator, __identity,
+                    __group, __loc_acc, __local_id, __local_id - __closest_seg_id, __accumulator, __identity,
                     __binary_op, __wgroup_size);
 
                 // 2e. Update local partial reductions in first segment and write to global memory.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -160,7 +160,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                                                                               __seg_reduce_count_kernel,
 #endif
                                                                               sycl::nd_item<1> __item) {
-                auto __group = __item.get_group();
+                sycl::group __group = __item.get_group();
                 std::size_t __group_id = __item.get_group(0);
                 std::uint32_t __local_id = __item.get_local_id(0);
                 std::size_t __global_id = __item.get_global_id(0);
@@ -222,7 +222,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
             sycl::nd_range<1>{__n_groups * __wgroup_size, __wgroup_size}, [=](sycl::nd_item<1> __item) {
                 __val_type __loc_partials[__vals_per_item];
 
-                auto __group = __item.get_group();
+                sycl::group __group = __item.get_group();
                 std::size_t __group_id = __item.get_group(0);
                 std::size_t __local_id = __item.get_local_id(0);
                 std::size_t __global_id = __item.get_global_id(0);
@@ -382,7 +382,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                                 }
                             }
                             __loc_partials_acc[__local_id] = __local_collector;
-                            __dpl_sycl::__group_barrier(__item);
+                            sycl::group_barrier(__group);
                             // serial aggregate collection and synchronization
                             if (__local_id == 0)
                             {
@@ -396,8 +396,8 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                                     }
                                 }
                             }
-                            __agg_collector = __dpl_sycl::__group_broadcast(__item.get_group(), __agg_collector);
-                            __last_it = __dpl_sycl::__group_broadcast(__item.get_group(), __last_it);
+                            __agg_collector = __dpl_sycl::__group_broadcast(__group, __agg_collector);
+                            __last_it = __dpl_sycl::__group_broadcast(__group, __last_it);
                         }
 
                         // Check to see if aggregates exist.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1785,7 +1785,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<
                         __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
                     __sub_group_carry.__destroy();
                 }
-                __dpl_sycl::__group_barrier(__ndi);
+                sycl::group_barrier(__ndi.get_group());
 
                 // compute sub-group local prefix sums on (T0..63) carries
                 // and store to scratch space at the end of dst; next
@@ -2112,7 +2112,7 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __max_inputs_per_ite
                     }
                 }
 
-                __dpl_sycl::__group_barrier(__ndi);
+                sycl::group_barrier(__ndi.get_group());
 
                 // Get inter-work group and adjusted for intra-work group prefix
                 bool __sub_group_carry_initialized = true;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan_by_segment.h
@@ -67,15 +67,15 @@ namespace __par_backend_hetero
 // Return Vals : 0 2 5 6 9 0 5 2
 // -----------------------------
 // __wg_segmented_scan is a derivative work and the reason for the additional copyright notice.
-template <typename _NdItem, typename _LocalAcc, typename _IdxType, typename _ValueType, typename _BinaryOp>
+template <typename _Group, typename _LocalAcc, typename _IdxType, typename _ValueType, typename _BinaryOp>
 _ValueType
-__wg_segmented_scan(_NdItem __item, _LocalAcc __local_acc, _IdxType __local_id, _IdxType __delta_local_id,
+__wg_segmented_scan(_Group __group, _LocalAcc __local_acc, _IdxType __local_id, _IdxType __delta_local_id,
                     _ValueType __accumulator, _ValueType __identity, _BinaryOp __binary_op, std::size_t __wgroup_size)
 {
     _IdxType __first = 0;
     __local_acc[__local_id] = __accumulator;
 
-    sycl::group_barrier(__item.get_group());
+    sycl::group_barrier(__group);
 
     for (std::size_t __i = 1; __i < __wgroup_size; __i *= 2)
     {
@@ -84,7 +84,7 @@ __wg_segmented_scan(_NdItem __item, _LocalAcc __local_acc, _IdxType __local_id, 
 
         __first = __wgroup_size - __first;
         __local_acc[__first + __local_id] = __accumulator;
-        sycl::group_barrier(__item.get_group());
+        sycl::group_barrier(__group);
     }
 
     return (__local_id ? __local_acc[__first + __local_id - 1] : __identity);
@@ -219,7 +219,7 @@ struct __sycl_scan_by_segment_impl
                     //get rid of no segment end found flag
                     __closest_seg_id = std::max(std::int32_t(0), __closest_seg_id);
                     __val_type __carry_in =
-                        __wg_segmented_scan(__item, __loc_acc, __local_id, __local_id - __closest_seg_id, __accumulator,
+                        __wg_segmented_scan(__group, __loc_acc, __local_id, __local_id - __closest_seg_id, __accumulator,
                                             __identity, __binary_op, __wgroup_size); // need to use exclusive scan delta
 
                     // 1c. Update local partial reductions and write to global memory.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_scan_by_segment.h
@@ -75,7 +75,7 @@ __wg_segmented_scan(_NdItem __item, _LocalAcc __local_acc, _IdxType __local_id, 
     _IdxType __first = 0;
     __local_acc[__local_id] = __accumulator;
 
-    __dpl_sycl::__group_barrier(__item);
+    sycl::group_barrier(__item.get_group());
 
     for (std::size_t __i = 1; __i < __wgroup_size; __i *= 2)
     {
@@ -84,7 +84,7 @@ __wg_segmented_scan(_NdItem __item, _LocalAcc __local_acc, _IdxType __local_id, 
 
         __first = __wgroup_size - __first;
         __local_acc[__first + __local_id] = __accumulator;
-        __dpl_sycl::__group_barrier(__item);
+        sycl::group_barrier(__item.get_group());
     }
 
     return (__local_id ? __local_acc[__first + __local_id - 1] : __identity);
@@ -269,7 +269,7 @@ struct __sycl_scan_by_segment_impl
                    __seg_scan_prefix_kernel,
 #endif
                    sycl::nd_range<1>{__n_groups * __wgroup_size, __wgroup_size}, [=](sycl::nd_item<1> __item) {
-                       auto __group = __item.get_group();
+                       sycl::group __group = __item.get_group();
                        std::size_t __group_id = __item.get_group(0);
                        std::size_t __global_id = __item.get_global_id(0);
                        std::size_t __local_id = __item.get_local_id(0);
@@ -307,7 +307,7 @@ struct __sycl_scan_by_segment_impl
                                    }
                                }
                                __loc_partials_acc[__local_id] = __local_collector;
-                               __dpl_sycl::__group_barrier(__item);
+                               sycl::group_barrier(__group);
                                // Serial aggregate collection and synchronization
                                if (__local_id == 0)
                                {
@@ -321,8 +321,8 @@ struct __sycl_scan_by_segment_impl
                                        }
                                    }
                                }
-                               __agg_collector = __dpl_sycl::__group_broadcast(__item.get_group(), __agg_collector);
-                               __last_it = __dpl_sycl::__group_broadcast(__item.get_group(), __last_it);
+                               __agg_collector = __dpl_sycl::__group_broadcast(__group, __agg_collector);
+                               __last_it = __dpl_sycl::__group_broadcast(__group, __last_it);
                            }
                            __ag_exists = __dpl_sycl::__any_of_group(__group, __ag_exists);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -69,7 +69,6 @@
 #define _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT               (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
 #define _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT           (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
 #define _ONEDPL_SYCL2020_REQD_SUB_GROUP_SIZE_PRESENT          (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
-#define _ONEDPL_SYCL2020_GROUP_BARRIER_PRESENT                (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
 #define _ONEDPL_SYCL2020_TARGET_PRESENT                       (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50400))
 #define _ONEDPL_SYCL2020_TARGET_DEVICE_PRESENT                (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50400))
 #define _ONEDPL_SYCL2020_ATOMIC_REF_PRESENT                   (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50500))
@@ -225,45 +224,11 @@ __get_accessor_size(const _Accessor& __accessor)
 #endif
 }
 
-// TODO: switch to SYCL 2020 with DPC++ compiler.
-// SYCL 1.2.1 version is used due to having an API with a local memory fence,
-// which gives better performance on Intel GPUs.
-// The performance gap is negligible since
-// https://github.com/intel/intel-graphics-compiler/commit/ed639f68d142bc963a7b626badc207a42fb281cb (Aug 20, 2024)
-// But the fix is not a part of the LTS GPU drivers (Linux) yet.
-//
-// This macro may also serve as a temporary workaround to strengthen the barriers
-// if there are cases where the memory ordering is not strong enough.
-#if !defined(_ONEDPL_SYCL121_GROUP_BARRIER)
-#    if _ONEDPL_LIBSYCL_VERSION
-#        define _ONEDPL_SYCL121_GROUP_BARRIER 1
-#    else
-// For safety, assume that other SYCL implementations comply with SYCL 2020, which is a oneDPL requirement.
-#        define _ONEDPL_SYCL121_GROUP_BARRIER 0
-#    endif
-#endif
-
-#if _ONEDPL_SYCL121_GROUP_BARRIER
-using __fence_space_t = sycl::access::fence_space;
-inline constexpr __fence_space_t __fence_space_local = sycl::access::fence_space::local_space;
-inline constexpr __fence_space_t __fence_space_global = sycl::access::fence_space::global_space;
-#else
-struct __fence_space_t{}; // No-op dummy type since SYCL 2020 does not specify memory fence spaces in group barriers
-inline constexpr __fence_space_t __fence_space_local{};
-inline constexpr __fence_space_t __fence_space_global{};
-#endif // _ONEDPL_SYCL121_GROUP_BARRIER
-
 template <typename _Item>
 void
-__group_barrier(_Item __item, [[maybe_unused]] __dpl_sycl::__fence_space_t __space = __fence_space_local)
+__group_barrier(_Item __item)
 {
-#if _ONEDPL_SYCL121_GROUP_BARRIER
-    __item.barrier(__space);
-#elif _ONEDPL_SYCL2020_GROUP_BARRIER_PRESENT
     sycl::group_barrier(__item.get_group(), sycl::memory_scope::work_group);
-#else
-#    error "sycl::group_barrier is not supported, and no alternative is available"
-#endif
 }
 
 template <typename... _Args>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -224,13 +224,6 @@ __get_accessor_size(const _Accessor& __accessor)
 #endif
 }
 
-template <typename _Item>
-void
-__group_barrier(_Item __item)
-{
-    sycl::group_barrier(__item.get_group(), sycl::memory_scope::work_group);
-}
-
 template <typename... _Args>
 constexpr auto
 __group_broadcast(_Args... __args)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -495,7 +495,7 @@ struct reduce_over_group
         __local_mem[__local_idx] = __val;
         for (std::uint32_t __power_2 = 1; __power_2 < __group_size; __power_2 *= 2)
         {
-            __dpl_sycl::__group_barrier(__item);
+            sycl::group_barrier(__item.get_group());
             if ((__local_idx & (2 * __power_2 - 1)) == 0 && __local_idx + __power_2 < __group_size &&
                 __global_idx + __power_2 < __n)
             {
@@ -865,16 +865,17 @@ struct __scan
     __log_scan_over_group(std::size_t __wgroup_size, sycl::nd_item<1> __item, std::size_t __local_id,
                           _AccLocal& __local_acc, _Tp __adder) const
     {
+        sycl::group __group = __item.get_group();
         _Tp __value = __local_acc[__local_id];
-        __dpl_sycl::__group_barrier(__item);
+        sycl::group_barrier(__group);
         // Hillis-Steele algorithm
         for (std::size_t __shift = 1; __shift < __wgroup_size; __shift *= 2)
         {
             if (__local_id >= __shift)
                 __value = __bin_op(__local_acc[__local_id - __shift], __value);
-            __dpl_sycl::__group_barrier(__item);
+            sycl::group_barrier(__group);
             __local_acc[__local_id] = __value;
-            __dpl_sycl::__group_barrier(__item);
+            sycl::group_barrier(__group);
         }
         return __bin_op(__adder, __value);
     }
@@ -885,7 +886,8 @@ struct __scan
                 _OutAcc& __out_acc, _WGSumsPtr* __wg_sums_ptr, std::size_t __size_per_wg, std::size_t __wgroup_size,
                 std::size_t __iters_per_wg, _InitType __init, std::false_type /*has_known_identity*/) const
     {
-        std::size_t __group_id = __item.get_group(0);
+        sycl::group __group = __item.get_group();
+        std::size_t __group_id = __group.get_group_linear_id();
         std::size_t __global_id = __item.get_global_id(0);
         std::size_t __local_id = __item.get_local_id(0);
         __init_processing<_Tp> __use_init{};
@@ -918,7 +920,7 @@ struct __scan
             // 3:      00000001    10000000
             do
             {
-                __dpl_sycl::__group_barrier(__item);
+                sycl::group_barrier(__group);
 
                 if (__adjusted_global_id < __n && __local_id % (2 * __k) == 2 * __k - 1)
                 {
@@ -926,7 +928,7 @@ struct __scan
                 }
                 __k *= 2;
             } while (__k < __wgroup_size);
-            __dpl_sycl::__group_barrier(__item);
+            sycl::group_barrier(__group);
 
             // 2. scan
             auto __partial_sums = __local_acc[__local_id];
@@ -942,10 +944,10 @@ struct __scan
                 }
                 __k *= 2;
             } while (__k < __wgroup_size);
-            __dpl_sycl::__group_barrier(__item);
+            sycl::group_barrier(__group);
 
             __local_acc[__local_id] = __partial_sums;
-            __dpl_sycl::__group_barrier(__item);
+            sycl::group_barrier(__group);
             __adder = __local_acc[__wgroup_size - 1];
 
             __gl_assigner(__acc, __out_acc, __adjusted_global_id + __shift, __n, __n_out, __local_acc, __local_id);
@@ -964,7 +966,8 @@ struct __scan
                 _OutAcc& __out_acc, _WGSumsPtr* __wg_sums_ptr, std::size_t __size_per_wg, std::size_t __wgroup_size,
                 std::size_t __iters_per_wg, _InitType __init, std::true_type /*has_known_identity*/) const
     {
-        std::size_t __group_id = __item.get_group(0);
+        sycl::group __group = __item.get_group();
+        std::size_t __group_id = __group.get_group_linear_id();
         std::size_t __local_id = __item.get_local_id(0);
         __init_processing<_Tp> __use_init{};
 
@@ -989,10 +992,10 @@ struct __scan
             //       and then decide whether to switch it back on or to keep __log_scan_over_group.
             // _Tp __value = __local_acc[__local_id];
             // __local_acc[__local_id] =
-            //    __dpl_sycl::__inclusive_scan_over_group(__item.get_group(), __value, __bin_op, __adder);
+            //    __dpl_sycl::__inclusive_scan_over_group(__group, __value, __bin_op, __adder);
             __local_acc[__local_id] = __log_scan_over_group(__wgroup_size, __item, __local_id, __local_acc, __adder);
 
-            __dpl_sycl::__group_barrier(__item);
+            sycl::group_barrier(__group);
             __adder = __local_acc[__wgroup_size - 1];
 
             __gl_assigner(__acc, __out_acc, __adjusted_global_id + __shift, __n, __n_out, __local_acc, __local_id);


### PR DESCRIPTION
oneAPI supports SYCL 2020 barriers since 2021.x releases. These are very old compilers, so I suggest removing SYCL 1.2.1 barrier entirely to simplify the code base.

Closes #1679.