### PR TITLE
Push scan operation branch into kernel 

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1401,15 +1401,15 @@ void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
                  _LazyValueType& __init_and_carry, __slm_or_subgroup_tag<_ValueType> __comm_slm)
 {
-    if (__comm_slm.__value_ptr)
-    {
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
-            __sub_group, __value, __binary_op, __init_and_carry, __slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
-    }
-    else
+    if (!__comm_slm.__value_ptr)
     {
         __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __value, __binary_op,
                                                                            __init_and_carry, __subgroup_only_tag{});
+    }
+    else
+    {
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
+            __sub_group, __value, __binary_op, __init_and_carry, __slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
     }
 }
 
@@ -1434,16 +1434,16 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
                          _LazyValueType& __init_and_carry, _SizeType __elements_to_process,
                          __slm_or_subgroup_tag<_ValueType> __comm_slm)
 {
-    if (__comm_slm.__value_ptr)
+    if (!__comm_slm.__value_ptr)
     {
         __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
-            __sub_group, __value, __binary_op, __init_and_carry, __elements_to_process,
-            __slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
+            __sub_group, __value, __binary_op, __init_and_carry, __elements_to_process, __subgroup_only_tag{});
     }
     else
     {
         __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
-            __sub_group, __value, __binary_op, __init_and_carry, __elements_to_process, __subgroup_only_tag{});
+            __sub_group, __value, __binary_op, __init_and_carry, __elements_to_process,
+            __slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -442,11 +442,15 @@ struct __gen_set_mask
             //duplication in __set_b then a mask is 1
 
             const std::size_t __count_a_left =
-                __id - oneapi::dpl::__internal::__pstl_left_bound_idx(__set_a, std::size_t{0}, __id, __set_a, __id, __comp, __proj1, __proj1) + 1;
+                __id -
+                oneapi::dpl::__internal::__pstl_left_bound_idx(__set_a, std::size_t{0}, __id, __set_a, __id, __comp,
+                                                               __proj1, __proj1) +
+                1;
 
-            const std::size_t __count_b = 
-                oneapi::dpl::__internal::__pstl_right_bound_idx(__set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
-                oneapi::dpl::__internal::__pstl_left_bound_idx(__set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
+            const std::size_t __count_b = oneapi::dpl::__internal::__pstl_right_bound_idx(
+                                              __set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
+                                          oneapi::dpl::__internal::__pstl_left_bound_idx(
+                                              __set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -1243,6 +1247,36 @@ struct __slm_or_subgroup_tag
     _ValueType* __value_ptr;
 };
 
+// Layer of abstraction that hoists the runtime "sub-group ops vs SLM fallback" decision to a single branch point.
+// The communication tag passed in encodes which path(s) are available:
+//   - __slm_or_subgroup_tag: both paths are compiled in; the runtime pointer (null => sub-group ops, non-null =>
+//                            SLM) selects the concrete tag, so the body is instantiated once per path and the
+//                            branch happens a single time at each call.
+//   - __slm_only_tag / __subgroup_only_tag: only that single path is compiled; the body is invoked directly.
+template <typename _ValueType, typename _Body>
+void
+__dispatch_comm_tag(__slm_or_subgroup_tag<_ValueType> __comm_slm, _Body&& __body)
+{
+    if (!__comm_slm.__value_ptr)
+        __body(__subgroup_only_tag{});
+    else
+        __body(__slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
+}
+
+template <typename _ValueType, typename _Body>
+void
+__dispatch_comm_tag(__slm_only_tag<_ValueType> __comm_slm, _Body&& __body)
+{
+    __body(__comm_slm);
+}
+
+template <typename _Body>
+void
+__dispatch_comm_tag(__subgroup_only_tag, _Body&& __body)
+{
+    __body(__subgroup_only_tag{});
+}
+
 template <typename _ValueType>
 _ValueType
 __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
@@ -1555,52 +1589,56 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
 
     using _OutRngSize = decltype(oneapi::dpl::__ranges::__size(__out_rng));
 
-    if constexpr (!__capture_output)
-    {
-        auto __noop_write_op = [&](std::size_t, const auto&) {};
-        __scan_through_elements_helper_impl<__sub_group_size, __is_inclusive, __init_present, __capture_output,
-                                            __max_inputs_per_item>(
-            __sub_group, __gen_input_impl, __scan_input_transform, __binary_op, __noop_write_op, __sub_group_carry,
-            __in_rng, __start_id, __n, __iters_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
-            __comm_slm);
-    }
-    else
-    {
-        if constexpr (_Bounded)
+    // Hoist the sub-group-ops vs SLM-fallback decision to here. The element-scan body below is instantiated
+    // once per available communication path; the branch is taken a single time per call to this helper.
+    __dispatch_comm_tag(__comm_slm, [&](auto __comm_slm_concrete) {
+        if constexpr (!__capture_output)
         {
-            _OutRngSize __out_rng_size = oneapi::dpl::__ranges::__size(__out_rng);
-
-            constexpr std::int32_t __write_output_offset = __is_unique_pattern_v ? 1 : 0;
-            const std::size_t __carry_in = __init_present ? __sub_group_carry.__v : 0;
-            if (__carry_in + __max_inputs_per_item * __sub_group_size > __out_rng_size - __write_output_offset)
-            {
-                auto __bounded_write_op = [&](std::size_t __id, const auto& __v) {
-                    if constexpr (__is_temp_data_required)
-                        __write_op(__out_rng, __out_rng_size, __id, __v, __temp_data, __on_oob_reached);
-                    else
-                        __write_op(__out_rng, __out_rng_size, __id, __v, __on_oob_reached);
-                };
-                __scan_through_elements_helper_impl<__sub_group_size, __is_inclusive, __init_present, __capture_output,
-                                                    __max_inputs_per_item>(
-                    __sub_group, __gen_input_impl, __scan_input_transform, __binary_op, __bounded_write_op,
-                    __sub_group_carry, __in_rng, __start_id, __n, __iters_per_item, __subgroup_start_id, __sub_group_id,
-                    __active_subgroups, __comm_slm);
-                return;
-            }
+            auto __noop_write_op = [&](std::size_t, const auto&) {};
+            __scan_through_elements_helper_impl<__sub_group_size, __is_inclusive, __init_present, __capture_output,
+                                                __max_inputs_per_item>(
+                __sub_group, __gen_input_impl, __scan_input_transform, __binary_op, __noop_write_op, __sub_group_carry,
+                __in_rng, __start_id, __n, __iters_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
+                __comm_slm_concrete);
         }
+        else
+        {
+            if constexpr (_Bounded)
+            {
+                _OutRngSize __out_rng_size = oneapi::dpl::__ranges::__size(__out_rng);
 
-        auto __unbounded_write_op = [&](std::size_t __id, const auto& __v) {
-            if constexpr (__is_temp_data_required)
-                __write_op(__out_rng, __id, __v, __temp_data);
-            else
-                __write_op(__out_rng, __id, __v);
-        };
-        __scan_through_elements_helper_impl<__sub_group_size, __is_inclusive, __init_present, __capture_output,
-                                            __max_inputs_per_item>(
-            __sub_group, __gen_input_impl, __scan_input_transform, __binary_op, __unbounded_write_op, __sub_group_carry,
-            __in_rng, __start_id, __n, __iters_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
-            __comm_slm);
-    }
+                constexpr std::int32_t __write_output_offset = __is_unique_pattern_v ? 1 : 0;
+                const std::size_t __carry_in = __init_present ? __sub_group_carry.__v : 0;
+                if (__carry_in + __max_inputs_per_item * __sub_group_size > __out_rng_size - __write_output_offset)
+                {
+                    auto __bounded_write_op = [&](std::size_t __id, const auto& __v) {
+                        if constexpr (__is_temp_data_required)
+                            __write_op(__out_rng, __out_rng_size, __id, __v, __temp_data, __on_oob_reached);
+                        else
+                            __write_op(__out_rng, __out_rng_size, __id, __v, __on_oob_reached);
+                    };
+                    __scan_through_elements_helper_impl<__sub_group_size, __is_inclusive, __init_present,
+                                                        __capture_output, __max_inputs_per_item>(
+                        __sub_group, __gen_input_impl, __scan_input_transform, __binary_op, __bounded_write_op,
+                        __sub_group_carry, __in_rng, __start_id, __n, __iters_per_item, __subgroup_start_id,
+                        __sub_group_id, __active_subgroups, __comm_slm_concrete);
+                    return;
+                }
+            }
+
+            auto __unbounded_write_op = [&](std::size_t __id, const auto& __v) {
+                if constexpr (__is_temp_data_required)
+                    __write_op(__out_rng, __id, __v, __temp_data);
+                else
+                    __write_op(__out_rng, __id, __v);
+            };
+            __scan_through_elements_helper_impl<__sub_group_size, __is_inclusive, __init_present, __capture_output,
+                                                __max_inputs_per_item>(
+                __sub_group, __gen_input_impl, __scan_input_transform, __binary_op, __unbounded_write_op,
+                __sub_group_carry, __in_rng, __start_id, __n, __iters_per_item, __subgroup_start_id, __sub_group_id,
+                __active_subgroups, __comm_slm_concrete);
+        }
+    });
 }
 
 constexpr inline std::uint8_t
@@ -1688,10 +1726,10 @@ struct __comm_slm_handler
 template <typename _InitValueType>
 struct __comm_slm_handler<__subgroup_only_tag, _InitValueType>
 {
-    __comm_slm_handler(bool /*__use_subgroup_ops*/){}
+    __comm_slm_handler(bool /*__use_subgroup_ops*/) {}
 
     __subgroup_only_tag
-    __get_accessor(const std::uint32_t /*__work_group_size*/ ,sycl::handler& /*__cgh*/) const
+    __get_accessor(const std::uint32_t /*__work_group_size*/, sycl::handler& /*__cgh*/) const
     {
         return __subgroup_only_tag{};
     }
@@ -1703,36 +1741,6 @@ struct __comm_slm_handler<__subgroup_only_tag, _InitValueType>
         return __subgroup_only_tag{};
     }
 };
-
-// Layer of abstraction that hoists the runtime "sub-group ops vs SLM fallback" decision to the top of the
-// kernel. The communication tag returned by __comm_slm_handler::__get_data encodes which path(s) are available:
-//   - __slm_or_subgroup_tag: both paths are compiled into the kernel; the runtime pointer (null => sub-group ops,
-//                            non-null => SLM) selects the concrete tag, so the entire kernel body is instantiated
-//                            once per path and the branch happens a single time here.
-//   - __slm_only_tag / __subgroup_only_tag: only that single path is compiled; the body is invoked directly.
-template <typename _ValueType, typename _Body>
-void
-__dispatch_comm_tag(__slm_or_subgroup_tag<_ValueType> __comm_slm, _Body&& __body)
-{
-    if (!__comm_slm.__value_ptr)
-        __body(__subgroup_only_tag{});
-    else
-        __body(__slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
-}
-
-template <typename _ValueType, typename _Body>
-void
-__dispatch_comm_tag(__slm_only_tag<_ValueType> __comm_slm, _Body&& __body)
-{
-    __body(__comm_slm);
-}
-
-template <typename _Body>
-void
-__dispatch_comm_tag(__subgroup_only_tag, _Body&& __body)
-{
-    __body(__subgroup_only_tag{});
-}
 
 template <typename... _Name>
 class __reduce_then_scan_partition_kernel;
@@ -1799,16 +1807,17 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
             auto __temp_acc = __get_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
             auto __oob_pos_acc = __get_oob_pos_accessor_opt<_Bounded>(__cgh, __oob_pos_storage);
             __cgh.parallel_for<_KernelName...>(
-                    __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
+                    __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
 
-                __reduce_then_scan_sub_group_params __sub_group_params(
-                    __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
+                    __reduce_then_scan_sub_group_params __sub_group_params(__work_group_size, __sub_group_size,
+                                                                           __max_num_work_groups, __max_block_size,
+                                                                           __inputs_remaining);
 
-                _InitValueType* __temp_ptr = __temp_acc.__data();
-                // Hoist the sub-group-ops vs SLM-fallback decision to the top of the kernel. The body below is
-                // instantiated once per available communication path; the branch is taken a single time here.
-                __dispatch_comm_tag(__comm_handler.__get_data(__comm_slm), [&](auto __comm_slm_ptr) {
+                    _InitValueType* __temp_ptr = __temp_acc.__data();
+                    // Polymorphic communication tag; the sub-group-ops vs SLM-fallback decision is dispatched at each
+                    // sub-group-scan region (see __scan_through_elements_helper and the carry-computation block below).
+                    auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
                     std::size_t __group_id = __ndi.get_group(0);
                     std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -1859,51 +1868,56 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                         __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
                         std::uint8_t __iters =
                             oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-                        if (__iters == 1)
-                        {
-                            // fill with unused dummy values to avoid overrunning input
-                            std::uint32_t __load_id =
-                                std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
-                            _InitValueType __v = __sub_group_partials[__load_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                     /*__init_present=*/false>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
-                            if (__sub_group_local_id < __active_subgroups)
-                                __temp_ptr[__start_id + __sub_group_local_id] = __v;
-                        }
-                        else
-                        {
-                            std::uint32_t __reduction_scan_id = __sub_group_local_id;
-                            // need to pull out first iteration tp avoid identity
-                            _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
-                            __temp_ptr[__start_id + __reduction_scan_id] = __v;
-                            __reduction_scan_id += __sub_group_size;
-
-                            for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
+                        // Dispatch the sub-group-ops vs SLM-fallback decision once for this carry-computation region.
+                        __dispatch_comm_tag(__comm_slm_ptr, [&](auto __comm_slm_concrete) {
+                            if (__iters == 1)
                             {
-                                __v = __sub_group_partials[__reduction_scan_id];
-                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                                // fill with unused dummy values to avoid overrunning input
+                                std::uint32_t __load_id =
+                                    std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
+                                _InitValueType __v = __sub_group_partials[__load_id];
+                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                         /*__init_present=*/false>(
+                                    __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups,
+                                    __comm_slm_concrete);
+                                if (__sub_group_local_id < __active_subgroups)
+                                    __temp_ptr[__start_id + __sub_group_local_id] = __v;
+                            }
+                            else
+                            {
+                                std::uint32_t __reduction_scan_id = __sub_group_local_id;
+                                // need to pull out first iteration tp avoid identity
+                                _InitValueType __v = __sub_group_partials[__reduction_scan_id];
+                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_concrete);
                                 __temp_ptr[__start_id + __reduction_scan_id] = __v;
                                 __reduction_scan_id += __sub_group_size;
+
+                                for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
+                                {
+                                    __v = __sub_group_partials[__reduction_scan_id];
+                                    __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
+                                                     /*__init_present=*/true>(__sub_group, __v, __reduce_op,
+                                                                              __sub_group_carry, __comm_slm_concrete);
+                                    __temp_ptr[__start_id + __reduction_scan_id] = __v;
+                                    __reduction_scan_id += __sub_group_size;
+                                }
+                                // If we are past the input range, then the previous value of v is passed to the sub-group scan.
+                                // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
+
+                                // fill with unused dummy values to avoid overrunning input
+                                std::uint32_t __load_id =
+                                    std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
+
+                                __v = __sub_group_partials[__load_id];
+                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                         /*__init_present=*/true>(
+                                    __sub_group, __v, __reduce_op, __sub_group_carry,
+                                    __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_concrete);
+                                if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
+                                    __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             }
-                            // If we are past the input range, then the previous value of v is passed to the sub-group scan.
-                            // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
-
-                            // fill with unused dummy values to avoid overrunning input
-                            std::uint32_t __load_id =
-                                std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
-
-                            __v = __sub_group_partials[__load_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                     /*__init_present=*/true>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry,
-                                __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
-                            if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
-                                __temp_ptr[__start_id + __reduction_scan_id] = __v;
-                        }
+                        });
 
                         __sub_group_carry.__destroy();
                     }
@@ -1916,8 +1930,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                             __oob_pos_acc.__data()[0] = __n;
                         }
                     }
-                }); // __dispatch_comm_tag
-            });
+                });
         });
     }
 
@@ -2026,89 +2039,89 @@ struct __parallel_reduce_then_scan_scan_submitter<
             __cgh.parallel_for<_KernelName...>(__nd_range, [=,
                                                             *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(
                                                                __sub_group_size)]] {
-                // Hoist the sub-group-ops vs SLM-fallback decision to the top of the kernel. The body below is
-                // instantiated once per available communication path; the branch is taken a single time here.
-                __dispatch_comm_tag(__comm_handler.__get_data(__comm_slm), [&](auto __comm_slm_ptr) {
-                    __reduce_then_scan_sub_group_params __sub_group_params(__work_group_size, __sub_group_size,
-                                                                           __max_num_work_groups, __max_block_size,
-                                                                           __inputs_remaining);
+                // Polymorphic communication tag; the sub-group-ops vs SLM-fallback decision is dispatched at each
+                // sub-group-scan region (see __scan_through_elements_helper and the carry-computation block below).
+                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
+                __reduce_then_scan_sub_group_params __sub_group_params(
+                    __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
-                    const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                        __inputs_in_block,
-                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+                const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                    __inputs_in_block,
+                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
 
-                    _InitValueType* __tmp_ptr = __temp_acc.__data();
-                    _InitValueType* __res_ptr = __res_acc.__data();
-                    std::uint32_t __group_id = __ndi.get_group(0);
-                    __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-                    std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-                    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+                _InitValueType* __tmp_ptr = __temp_acc.__data();
+                _InitValueType* __res_ptr = __res_acc.__data();
+                std::uint32_t __group_id = __ndi.get_group(0);
+                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+                std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 
-                    std::size_t __group_start_id =
-                        (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
-                                                            __sub_group_params.__num_sub_groups_local);
-                    if constexpr (__is_unique_pattern_v)
+                std::size_t __group_start_id =
+                    (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
+                                                        __sub_group_params.__num_sub_groups_local);
+                if constexpr (__is_unique_pattern_v)
+                {
+                    // for unique patterns, the first element is always copied to the output, so we need to skip it
+                    __group_start_id += 1;
+                }
+
+                std::size_t __max_inputs_in_group =
+                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                    __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
+
+                // propagate carry in from previous block
+                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+
+                // on the first sub-group in a work-group (assuming S subgroups in a work-group):
+                // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
+                // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
+                //    and then compute the prefix sum to generate global carry out
+                //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
+                // 3. on each WG select the adjacent neighboring WG carry in
+                // 4. on each WG add the global carry-in to S sub-group local prefix sums to
+                //    get a T-local global carry in
+                // 5. recompute T-local prefix values, add the T-local global carries,
+                //    and then write back the final values to memory
+                if (__sub_group_id == 0)
+                {
+                    // step 1) load to SLM the WG-local S prefix sums
+                    //         on WG T-local carries
+                    //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
+                    //           S: sum(T0 carry...TS carry)
+                    std::uint8_t __iters =
+                        oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                    std::size_t __subgroups_before_my_group = __group_id * __sub_group_params.__num_sub_groups_local;
+                    std::uint32_t __load_reduction_id = __sub_group_local_id;
+                    std::uint8_t __i = 0;
+                    for (; __i < __iters - 1; __i++)
                     {
-                        // for unique patterns, the first element is always copied to the output, so we need to skip it
-                        __group_start_id += 1;
+                        __sub_group_partials[__load_reduction_id] =
+                            __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
+                        __load_reduction_id += __sub_group_size;
+                    }
+                    if (__load_reduction_id < __active_subgroups)
+                    {
+                        __sub_group_partials[__load_reduction_id] =
+                            __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
                     }
 
-                    std::size_t __max_inputs_in_group =
-                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-                    std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-                    std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                        __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
-
-                    // propagate carry in from previous block
-                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-
-                    // on the first sub-group in a work-group (assuming S subgroups in a work-group):
-                    // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
-                    // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
-                    //    and then compute the prefix sum to generate global carry out
-                    //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
-                    // 3. on each WG select the adjacent neighboring WG carry in
-                    // 4. on each WG add the global carry-in to S sub-group local prefix sums to
-                    //    get a T-local global carry in
-                    // 5. recompute T-local prefix values, add the T-local global carries,
-                    //    and then write back the final values to memory
-                    if (__sub_group_id == 0)
+                    // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
+                    //         compute the prefix in a sub-group to get global work-group carries
+                    //         memory accesses: gather(63, 127, 191, 255, ...)
+                    std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
+                    // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
+                    if (__group_id > 0)
                     {
-                        // step 1) load to SLM the WG-local S prefix sums
-                        //         on WG T-local carries
-                        //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
-                        //           S: sum(T0 carry...TS carry)
-                        std::uint8_t __iters =
-                            oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-                        std::size_t __subgroups_before_my_group =
-                            __group_id * __sub_group_params.__num_sub_groups_local;
-                        std::uint32_t __load_reduction_id = __sub_group_local_id;
-                        std::uint8_t __i = 0;
-                        for (; __i < __iters - 1; __i++)
-                        {
-                            __sub_group_partials[__load_reduction_id] =
-                                __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
-                            __load_reduction_id += __sub_group_size;
-                        }
-                        if (__load_reduction_id < __active_subgroups)
-                        {
-                            __sub_group_partials[__load_reduction_id] =
-                                __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
-                        }
-
-                        // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
-                        //         compute the prefix in a sub-group to get global work-group carries
-                        //         memory accesses: gather(63, 127, 191, 255, ...)
-                        std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
-                        // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
-                        if (__group_id > 0)
-                        {
-                            // only need the last element from each scan of num_sub_groups_local subgroup reductions
-                            const std::size_t __elements_to_process =
-                                __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
-                            const std::size_t __pre_carry_iters =
-                                oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
+                        // only need the last element from each scan of num_sub_groups_local subgroup reductions
+                        const std::size_t __elements_to_process =
+                            __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
+                        const std::size_t __pre_carry_iters =
+                            oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
+                        // Dispatch the sub-group-ops vs SLM-fallback decision once for this carry-computation region.
+                        __dispatch_comm_tag(__comm_slm_ptr, [&](auto __comm_slm_concrete) {
                             if (__pre_carry_iters == 1)
                             {
                                 // single partial scan
@@ -2122,7 +2135,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                 __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                          /*__init_present=*/false>(__sub_group, __value, __reduce_op,
                                                                                    __carry_last, __remaining_elements,
-                                                                                   __comm_slm_ptr);
+                                                                                   __comm_slm_concrete);
                             }
                             else
                             {
@@ -2135,7 +2148,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                 _InitValueType __value = __tmp_ptr[__reduction_id];
                                 __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                                  /*__init_present=*/false>(__sub_group, __value, __reduce_op,
-                                                                           __carry_last, __comm_slm_ptr);
+                                                                           __carry_last, __comm_slm_concrete);
                                 __reduction_id += __reduction_id_increment;
                                 // then some number of full iterations
                                 for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
@@ -2143,7 +2156,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                     __value = __tmp_ptr[__reduction_id];
                                     __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                                      /*__init_present=*/true>(__sub_group, __value, __reduce_op,
-                                                                              __carry_last, __comm_slm_ptr);
+                                                                              __carry_last, __comm_slm_concrete);
                                     __reduction_id += __reduction_id_increment;
                                 }
 
@@ -2158,158 +2171,154 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                 __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                          /*__init_present=*/true>(__sub_group, __value, __reduce_op,
                                                                                   __carry_last, __remaining_elements,
-                                                                                  __comm_slm_ptr);
+                                                                                  __comm_slm_concrete);
                             }
+                        });
 
-                            // steps 3+4) load global carry in from neighbor work-group
-                            //            and apply to local sub-group prefix carries
-                            std::size_t __carry_offset = __sub_group_local_id;
+                        // steps 3+4) load global carry in from neighbor work-group
+                        //            and apply to local sub-group prefix carries
+                        std::size_t __carry_offset = __sub_group_local_id;
 
-                            std::uint8_t __iters =
-                                oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                        std::uint8_t __iters =
+                            oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
 
-                            std::uint8_t __i = 0;
-                            for (; __i < __iters - 1; ++__i)
-                            {
-                                __sub_group_partials[__carry_offset] =
-                                    __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                                __carry_offset += __sub_group_size;
-                            }
-                            if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
-                            {
-                                __sub_group_partials[__carry_offset] =
-                                    __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                                __carry_offset += __sub_group_size;
-                            }
+                        std::uint8_t __i = 0;
+                        for (; __i < __iters - 1; ++__i)
+                        {
+                            __sub_group_partials[__carry_offset] =
+                                __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                            __carry_offset += __sub_group_size;
+                        }
+                        if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
+                        {
+                            __sub_group_partials[__carry_offset] =
+                                __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                            __carry_offset += __sub_group_size;
+                        }
+                        if (__sub_group_local_id == 0)
+                            __sub_group_partials[__active_subgroups] = __carry_last.__v;
+                        __carry_last.__destroy();
+                    }
+                }
+
+                __dpl_sycl::__group_barrier(__ndi);
+
+                // Get inter-work group and adjusted for intra-work group prefix
+                bool __sub_group_carry_initialized = true;
+                if (__block_num == 0)
+                {
+                    if (__sub_group_id > 0)
+                    {
+                        _InitValueType __value =
+                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                        oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
+                        __sub_group_carry.__setup(__value);
+                    }
+                    else if (__group_id > 0)
+                    {
+                        _InitValueType __value = __sub_group_partials[__active_subgroups];
+                        oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
+                        __sub_group_carry.__setup(__value);
+                    }
+                    else // zeroth block, group and subgroup
+                    {
+                        if constexpr (__is_unique_pattern_v)
+                        {
                             if (__sub_group_local_id == 0)
-                                __sub_group_partials[__active_subgroups] = __carry_last.__v;
-                            __carry_last.__destroy();
+                            {
+                                // For unique patterns, always copy the 0th element to the output
+                                __write_op.__assign(__in_rng[0], __out_rng[0]);
+                            }
+                        }
+
+                        if constexpr (std::is_same_v<_InitType,
+                                                     oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
+                        {
+                            // This is the only case where we still don't have a carry in.  No init value, 0th block,
+                            // group, and subgroup. This changes the final scan through elements below.
+                            __sub_group_carry_initialized = false;
+                        }
+                        else
+                        {
+                            __sub_group_carry.__setup(__init.__value);
                         }
                     }
-
-                    __dpl_sycl::__group_barrier(__ndi);
-
-                    // Get inter-work group and adjusted for intra-work group prefix
-                    bool __sub_group_carry_initialized = true;
-                    if (__block_num == 0)
+                }
+                else
+                {
+                    if (__sub_group_id > 0)
                     {
-                        if (__sub_group_id > 0)
-                        {
-                            _InitValueType __value =
-                                __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                            oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value,
-                                                                                            __reduce_op);
-                            __sub_group_carry.__setup(__value);
-                        }
-                        else if (__group_id > 0)
-                        {
-                            _InitValueType __value = __sub_group_partials[__active_subgroups];
-                            oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value,
-                                                                                            __reduce_op);
-                            __sub_group_carry.__setup(__value);
-                        }
-                        else // zeroth block, group and subgroup
-                        {
-                            if constexpr (__is_unique_pattern_v)
-                            {
-                                if (__sub_group_local_id == 0)
-                                {
-                                    // For unique patterns, always copy the 0th element to the output
-                                    __write_op.__assign(__in_rng[0], __out_rng[0]);
-                                }
-                            }
+                        _InitValueType __value =
+                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                        __sub_group_carry.__setup(__reduce_op(
+                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
+                            __value));
+                    }
+                    else if (__group_id > 0)
+                    {
+                        __sub_group_carry.__setup(__reduce_op(
+                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
+                            __sub_group_partials[__active_subgroups]));
+                    }
+                    else
+                    {
+                        __sub_group_carry.__setup(
+                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global));
+                    }
+                }
 
-                            if constexpr (std::is_same_v<_InitType,
-                                                         oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
-                            {
-                                // This is the only case where we still don't have a carry in.  No init value, 0th block,
-                                // group, and subgroup. This changes the final scan through elements below.
-                                __sub_group_carry_initialized = false;
-                            }
-                            else
-                            {
-                                __sub_group_carry.__setup(__init.__value);
-                            }
+                // step 5) apply global carries
+                std::size_t __subgroup_start_id =
+                    __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
+                std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+
+                if (__sub_group_carry_initialized)
+                {
+                    __scan_through_elements_helper<_Bounded, __sub_group_size, __is_inclusive,
+                                                   /*__init_present=*/true,
+                                                   /*__capture_output=*/true, __is_unique_pattern_v,
+                                                   __max_inputs_per_item>(
+                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
+                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr,
+                        __create_on_oob_reached_callback(__oob_pos_acc));
+                }
+                else // first group first block, no subgroup carry
+                {
+                    __scan_through_elements_helper<_Bounded, __sub_group_size, __is_inclusive,
+                                                   /*__init_present=*/false,
+                                                   /*__capture_output=*/true, __is_unique_pattern_v,
+                                                   __max_inputs_per_item>(
+                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
+                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr,
+                        __create_on_oob_reached_callback(__oob_pos_acc));
+                }
+                // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
+                // to write out the last carry out for either the return value or the next block
+                if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
+                    (__active_subgroups == __sub_group_id + 1))
+                {
+                    if (__block_num + 1 == __num_blocks)
+                    {
+                        if constexpr (__is_unique_pattern_v)
+                        {
+                            // unique patterns automatically copy the 0th element and scan starting at index 1
+                            __res_ptr[0] = __transform_result(__sub_group_carry.__v + 1);
+                        }
+                        else
+                        {
+                            __res_ptr[0] = __transform_result(__sub_group_carry.__v);
                         }
                     }
                     else
                     {
-                        if (__sub_group_id > 0)
-                        {
-                            _InitValueType __value =
-                                __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                            __sub_group_carry.__setup(
-                                __reduce_op(__get_block_carry_in(__block_num, __tmp_ptr,
-                                                                 __sub_group_params.__num_sub_groups_global),
-                                            __value));
-                        }
-                        else if (__group_id > 0)
-                        {
-                            __sub_group_carry.__setup(
-                                __reduce_op(__get_block_carry_in(__block_num, __tmp_ptr,
-                                                                 __sub_group_params.__num_sub_groups_global),
-                                            __sub_group_partials[__active_subgroups]));
-                        }
-                        else
-                        {
-                            __sub_group_carry.__setup(__get_block_carry_in(__block_num, __tmp_ptr,
-                                                                           __sub_group_params.__num_sub_groups_global));
-                        }
+                        // capture the last carry out for the next block
+                        __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v,
+                                              __sub_group_params.__num_sub_groups_global);
                     }
-
-                    // step 5) apply global carries
-                    std::size_t __subgroup_start_id =
-                        __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
-                    std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
-
-                    if (__sub_group_carry_initialized)
-                    {
-                        __scan_through_elements_helper<_Bounded, __sub_group_size, __is_inclusive,
-                                                       /*__init_present=*/true,
-                                                       /*__capture_output=*/true, __is_unique_pattern_v,
-                                                       __max_inputs_per_item>(
-                            __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
-                            __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
-                            __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id,
-                            __active_subgroups, __comm_slm_ptr, __create_on_oob_reached_callback(__oob_pos_acc));
-                    }
-                    else // first group first block, no subgroup carry
-                    {
-                        __scan_through_elements_helper<_Bounded, __sub_group_size, __is_inclusive,
-                                                       /*__init_present=*/false,
-                                                       /*__capture_output=*/true, __is_unique_pattern_v,
-                                                       __max_inputs_per_item>(
-                            __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
-                            __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
-                            __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id,
-                            __active_subgroups, __comm_slm_ptr, __create_on_oob_reached_callback(__oob_pos_acc));
-                    }
-                    // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
-                    // to write out the last carry out for either the return value or the next block
-                    if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
-                        (__active_subgroups == __sub_group_id + 1))
-                    {
-                        if (__block_num + 1 == __num_blocks)
-                        {
-                            if constexpr (__is_unique_pattern_v)
-                            {
-                                // unique patterns automatically copy the 0th element and scan starting at index 1
-                                __res_ptr[0] = __transform_result(__sub_group_carry.__v + 1);
-                            }
-                            else
-                            {
-                                __res_ptr[0] = __transform_result(__sub_group_carry.__v);
-                            }
-                        }
-                        else
-                        {
-                            // capture the last carry out for the next block
-                            __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v,
-                                                  __sub_group_params.__num_sub_groups_global);
-                        }
-                    }
-                    __sub_group_carry.__destroy();
-                }); // __dispatch_comm_tag
+                }
+                __sub_group_carry.__destroy();
             });
         });
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1218,25 +1218,22 @@ struct __scan_by_seg_op
 // *** Main reduce then scan infrastructure ***
 
 // Sub-group communication wrappers with SLM fallback.
-// The scan tag dictates what implementation paths are available in the kernel, one or both of the subgroup operation
-// variant and the slm fallback may be available in the kernel, but only one kernel should be compiled per type.
-// For trivially copyable, types, both paths should be available in the kernel, and a runtime parameter
-// will choose between them. This enables CPU trivially copyable types to use the SLM-based path, which is considerably
-// faster. For non-trivially copyable types, only the SLM fallback is available. For some kernel templates, the subgroup
-// operation variant is the only one instantiated.
-// The __comm_slm parameter points to a work-group-sized SLM buffer; each sub-group uses its own
-// slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size].
+// The scan tag dictates what implementation paths are available in the kernel, and holds a slm pointer if applicable.
 
+// For KT kernels, or after the runtime branch where only the subgroup operations are available
 struct __subgroup_only_tag
 {
 };
 
+// For non-trivially copyable types, only the SLM fallback is available.
 template <typename _ValueType>
 struct __slm_only_tag
 {
     _ValueType* __value_ptr;
 };
 
+// For trivially copyable types, both paths are available in the kernel, and a runtime parameter chooses between them.
+// This enables CPU trivially copyable types to use the SLM-based path, which is considerably faster.
 template <typename _ValueType>
 struct __slm_or_subgroup_tag
 {
@@ -1808,9 +1805,9 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
                 _InitValueType* __temp_ptr = __temp_acc.__data();
-                // Polymorphic communication tag; the sub-group-ops vs SLM-fallback decision is dispatched at each
-                // sub-group-scan region (see __scan_through_elements_helper and the carry-computation block below).
-                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
+                // The sub-group-ops vs SLM-fallback decision is dispatched at each sub-group-scan region
+                // (see __scan_through_elements_helper and the carry-computation block below).
+                _ScanOpsTag __comm_scan_tag = __comm_handler.__get_data(__comm_slm);
                 std::size_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -1845,7 +1842,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                         __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
                         __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
                         __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
-                        __comm_slm_ptr);
+                        __comm_scan_tag);
                     if (__sub_group_local_id == 0)
                         __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
                     __sub_group_carry.__destroy();
@@ -1862,7 +1859,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                     std::uint8_t __iters =
                         oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
                     // Dispatch the sub-group-ops vs SLM-fallback decision once for this carry-computation region.
-                    __dispatch_comm_tag(__comm_slm_ptr, [&](auto __comm_slm_concrete) {
+                    __dispatch_comm_tag(__comm_scan_tag, [&](auto __comm_slm_concrete) {
                         if (__iters == 1)
                         {
                             // fill with unused dummy values to avoid overrunning input
@@ -2031,9 +2028,9 @@ struct __parallel_reduce_then_scan_scan_submitter<
             __cgh.parallel_for<_KernelName...>(__nd_range, [=,
                                                             *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(
                                                                __sub_group_size)]] {
-                // Polymorphic communication tag; the sub-group-ops vs SLM-fallback decision is dispatched at each
-                // sub-group-scan region (see __scan_through_elements_helper and the carry-computation block below).
-                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
+                // The sub-group-ops vs SLM-fallback decision is dispatched at each sub-group-scan region
+                // (see __scan_through_elements_helper and the carry-computation block below).
+                _ScanOpsTag __comm_scan_tag = __comm_handler.__get_data(__comm_slm);
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
@@ -2113,7 +2110,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                         const std::size_t __pre_carry_iters =
                             oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
                         // Dispatch the sub-group-ops vs SLM-fallback decision once for this carry-computation region.
-                        __dispatch_comm_tag(__comm_slm_ptr, [&](auto __comm_slm_concrete) {
+                        __dispatch_comm_tag(__comm_scan_tag, [&](auto __comm_slm_concrete) {
                             if (__pre_carry_iters == 1)
                             {
                                 // single partial scan
@@ -2272,7 +2269,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                                    __max_inputs_per_item>(
                         __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
                         __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr,
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_scan_tag,
                         __create_on_oob_reached_callback(__oob_pos_acc));
                 }
                 else // first group first block, no subgroup carry
@@ -2283,7 +2280,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                                    __max_inputs_per_item>(
                         __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
                         __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr,
+                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_scan_tag,
                         __create_on_oob_reached_callback(__oob_pos_acc));
                 }
                 // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1703,7 +1703,7 @@ template <typename _ScanOpsTag, typename _InitValueType>
 struct __comm_slm_handler
 {
     auto
-    __get_accessor(const std::uint32_t __work_group_size, bool __use_subgroup_ops, sycl::handler& __cgh) const
+    __get_accessor(const std::uint32_t __work_group_size, sycl::handler& __cgh) const
     {
         if (!__use_subgroup_ops)
             return __dpl_sycl::__local_accessor<_InitValueType>(__work_group_size, __cgh);
@@ -1713,27 +1713,29 @@ struct __comm_slm_handler
 
     template <typename _Acc>
     _ScanOpsTag
-    __get_data(const _Acc& __comm_slm_acc_opt, bool __use_subgroup_ops) const
+    __get_data(const _Acc& __comm_slm_acc_opt) const
     {
         if (!__use_subgroup_ops)
             return _ScanOpsTag{__dpl_sycl::__get_accessor_ptr(__comm_slm_acc_opt)};
         else
             return _ScanOpsTag{nullptr};
     }
+    bool __use_subgroup_ops;
 };
 
 template <typename _InitValueType>
 struct __comm_slm_handler<__subgroup_only_tag, _InitValueType>
 {
+    __comm_slm_handler(bool /*__use_subgroup_ops*/){}
+
     __subgroup_only_tag
-    __get_accessor(const std::uint32_t /*__work_group_size*/, bool /*__use_subgroup_ops*/,
-                   sycl::handler& /*__cgh*/) const
+    __get_accessor(const std::uint32_t /*__work_group_size*/ ,sycl::handler& /*__cgh*/) const
     {
         return __subgroup_only_tag{};
     }
 
     __subgroup_only_tag
-    __get_data(__subgroup_only_tag, bool /*__use_subgroup_ops*/) const
+    __get_data(__subgroup_only_tag) const
     {
         // Noop, type carries dispatch info for broadcast and shift left subgroup ops
         return __subgroup_only_tag{};
@@ -1798,8 +1800,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            __comm_slm_handler<_ScanOpsTag, _InitValueType> __comm_handler{};
-            auto __comm_slm = __comm_handler.__get_accessor(__work_group_size, __use_subgroup_ops, __cgh);
+            __comm_slm_handler<_ScanOpsTag, _InitValueType> __comm_handler{__use_subgroup_ops};
+            auto __comm_slm = __comm_handler.__get_accessor(__work_group_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __get_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
@@ -1812,7 +1814,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
                 _InitValueType* __temp_ptr = __temp_acc.__data();
-                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm, __use_subgroup_ops);
+                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
                 std::size_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -2013,8 +2015,8 @@ struct __parallel_reduce_then_scan_scan_submitter<
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            __comm_slm_handler<_ScanOpsTag, _InitValueType> __comm_handler{};
-            auto __comm_slm = __comm_handler.__get_accessor(__work_group_size, __use_subgroup_ops, __cgh);
+            __comm_slm_handler<_ScanOpsTag, _InitValueType> __comm_handler{__use_subgroup_ops};
+            auto __comm_slm = __comm_handler.__get_accessor(__work_group_size, __cgh);
 
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
@@ -2025,7 +2027,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
 
             __cgh.parallel_for<_KernelName...>(
                     __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm, __use_subgroup_ops);
+                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
 
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -442,15 +442,11 @@ struct __gen_set_mask
             //duplication in __set_b then a mask is 1
 
             const std::size_t __count_a_left =
-                __id -
-                oneapi::dpl::__internal::__pstl_left_bound_idx(__set_a, std::size_t{0}, __id, __set_a, __id, __comp,
-                                                               __proj1, __proj1) +
-                1;
+                __id - oneapi::dpl::__internal::__pstl_left_bound_idx(__set_a, std::size_t{0}, __id, __set_a, __id, __comp, __proj1, __proj1) + 1;
 
-            const std::size_t __count_b = oneapi::dpl::__internal::__pstl_right_bound_idx(
-                                              __set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
-                                          oneapi::dpl::__internal::__pstl_left_bound_idx(
-                                              __set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
+            const std::size_t __count_b = 
+                oneapi::dpl::__internal::__pstl_right_bound_idx(__set_b, __res, __nb, __set_b, __res, __comp, __proj2, __proj2) -
+                oneapi::dpl::__internal::__pstl_left_bound_idx(__set_b, std::size_t{0}, __res, __set_b, __res, __comp, __proj2, __proj2);
 
             if constexpr (__is_difference)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -1752,9 +1748,7 @@ template <typename... _Name>
 class __reduce_then_scan_scan_kernel;
 
 // Sentinel type used as a stand-in for the OOB-position accessor when _Bounded=false.
-struct __no_oob_pos_acc_tag
-{
-};
+struct __no_oob_pos_acc_tag {};
 
 template <typename _T>
 inline constexpr bool __is_no_oob_pos_acc_v = std::is_same_v<std::remove_cv_t<_T>, __no_oob_pos_acc_tag>;
@@ -1807,130 +1801,128 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
             auto __temp_acc = __get_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
             auto __oob_pos_acc = __get_oob_pos_accessor_opt<_Bounded>(__cgh, __oob_pos_storage);
             __cgh.parallel_for<_KernelName...>(
-                __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                    __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                    __nd_range, [=, *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
+                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
 
-                    __reduce_then_scan_sub_group_params __sub_group_params(__work_group_size, __sub_group_size,
-                                                                           __max_num_work_groups, __max_block_size,
-                                                                           __inputs_remaining);
+                __reduce_then_scan_sub_group_params __sub_group_params(
+                    __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
-                    _InitValueType* __temp_ptr = __temp_acc.__data();
-                    // Polymorphic communication tag; the sub-group-ops vs SLM-fallback decision is dispatched at each
-                    // sub-group-scan region (see __scan_through_elements_helper and the carry-computation block below).
-                    auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
-                    std::size_t __group_id = __ndi.get_group(0);
-                    std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-                    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+                _InitValueType* __temp_ptr = __temp_acc.__data();
+                // Polymorphic communication tag; the sub-group-ops vs SLM-fallback decision is dispatched at each
+                // sub-group-scan region (see __scan_through_elements_helper and the carry-computation block below).
+                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
+                std::size_t __group_id = __ndi.get_group(0);
+                std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+                std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 
-                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-                    std::size_t __group_start_id =
-                        (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
-                                                            __sub_group_params.__num_sub_groups_local);
-                    if constexpr (__is_unique_pattern_v)
-                    {
-                        // for unique patterns, the first element is always copied to the output, so we need to skip it
-                        __group_start_id += 1;
-                    }
-                    std::size_t __max_inputs_in_group =
-                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-                    std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-                    std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                        __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-                    std::size_t __subgroup_start_id =
-                        __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
+                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+                std::size_t __group_start_id =
+                    (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
+                                                        __sub_group_params.__num_sub_groups_local);
+                if constexpr (__is_unique_pattern_v)
+                {
+                    // for unique patterns, the first element is always copied to the output, so we need to skip it
+                    __group_start_id += 1;
+                }
+                std::size_t __max_inputs_in_group =
+                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                    __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+                std::size_t __subgroup_start_id =
+                    __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
 
-                    std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+                std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
 
-                    if (__sub_group_id < __active_subgroups)
-                    {
-                        // adjust for lane-id
-                        // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-                        __scan_through_elements_helper</*_Bounded*/ false, __sub_group_size, __is_inclusive,
-                                                       /*__init_present=*/false,
-                                                       /*__capture_output=*/false, __is_unique_pattern_v,
-                                                       __max_inputs_per_item>(
-                            __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
-                            __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
-                            __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id,
-                            __active_subgroups, __comm_slm_ptr);
-                        if (__sub_group_local_id == 0)
-                            __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
-                        __sub_group_carry.__destroy();
-                    }
-                    __dpl_sycl::__group_barrier(__ndi);
+                if (__sub_group_id < __active_subgroups)
+                {
+                    // adjust for lane-id
+                    // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
+                    __scan_through_elements_helper</*_Bounded*/ false, __sub_group_size, __is_inclusive,
+                                                   /*__init_present=*/false,
+                                                   /*__capture_output=*/false, __is_unique_pattern_v,
+                                                   __max_inputs_per_item>(
+                        __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
+                        __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
+                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
+                        __comm_slm_ptr);
+                    if (__sub_group_local_id == 0)
+                        __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
+                    __sub_group_carry.__destroy();
+                }
+                __dpl_sycl::__group_barrier(__ndi);
 
-                    // compute sub-group local prefix sums on (T0..63) carries
-                    // and store to scratch space at the end of dst; next
-                    // accumulator kernel takes M thread carries from scratch
-                    // to compute a prefix sum on global carries
-                    if (__sub_group_id == 0)
-                    {
-                        __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
-                        std::uint8_t __iters =
-                            oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-                        // Dispatch the sub-group-ops vs SLM-fallback decision once for this carry-computation region.
-                        __dispatch_comm_tag(__comm_slm_ptr, [&](auto __comm_slm_concrete) {
-                            if (__iters == 1)
+                // compute sub-group local prefix sums on (T0..63) carries
+                // and store to scratch space at the end of dst; next
+                // accumulator kernel takes M thread carries from scratch
+                // to compute a prefix sum on global carries
+                if (__sub_group_id == 0)
+                {
+                    __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
+                    std::uint8_t __iters =
+                        oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                    // Dispatch the sub-group-ops vs SLM-fallback decision once for this carry-computation region.
+                    __dispatch_comm_tag(__comm_slm_ptr, [&](auto __comm_slm_concrete) {
+                        if (__iters == 1)
+                        {
+                            // fill with unused dummy values to avoid overrunning input
+                            std::uint32_t __load_id =
+                                std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
+                            _InitValueType __v = __sub_group_partials[__load_id];
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                        /*__init_present=*/false>(
+                                __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups,
+                                __comm_slm_concrete);
+                            if (__sub_group_local_id < __active_subgroups)
+                                __temp_ptr[__start_id + __sub_group_local_id] = __v;
+                        }
+                        else
+                        {
+                            std::uint32_t __reduction_scan_id = __sub_group_local_id;
+                            // need to pull out first iteration tp avoid identity
+                            _InitValueType __v = __sub_group_partials[__reduction_scan_id];
+                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
+                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_concrete);
+                            __temp_ptr[__start_id + __reduction_scan_id] = __v;
+                            __reduction_scan_id += __sub_group_size;
+
+                            for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
                             {
-                                // fill with unused dummy values to avoid overrunning input
-                                std::uint32_t __load_id =
-                                    std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
-                                _InitValueType __v = __sub_group_partials[__load_id];
-                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                         /*__init_present=*/false>(
-                                    __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups,
-                                    __comm_slm_concrete);
-                                if (__sub_group_local_id < __active_subgroups)
-                                    __temp_ptr[__start_id + __sub_group_local_id] = __v;
-                            }
-                            else
-                            {
-                                std::uint32_t __reduction_scan_id = __sub_group_local_id;
-                                // need to pull out first iteration tp avoid identity
-                                _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_concrete);
+                                __v = __sub_group_partials[__reduction_scan_id];
+                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
+                                                    /*__init_present=*/true>(__sub_group, __v, __reduce_op,
+                                                                            __sub_group_carry, __comm_slm_concrete);
                                 __temp_ptr[__start_id + __reduction_scan_id] = __v;
                                 __reduction_scan_id += __sub_group_size;
-
-                                for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
-                                {
-                                    __v = __sub_group_partials[__reduction_scan_id];
-                                    __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
-                                                     /*__init_present=*/true>(__sub_group, __v, __reduce_op,
-                                                                              __sub_group_carry, __comm_slm_concrete);
-                                    __temp_ptr[__start_id + __reduction_scan_id] = __v;
-                                    __reduction_scan_id += __sub_group_size;
-                                }
-                                // If we are past the input range, then the previous value of v is passed to the sub-group scan.
-                                // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
-
-                                // fill with unused dummy values to avoid overrunning input
-                                std::uint32_t __load_id =
-                                    std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
-
-                                __v = __sub_group_partials[__load_id];
-                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                         /*__init_present=*/true>(
-                                    __sub_group, __v, __reduce_op, __sub_group_carry,
-                                    __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_concrete);
-                                if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
-                                    __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             }
-                        });
+                            // If we are past the input range, then the previous value of v is passed to the sub-group scan.
+                            // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
 
-                        __sub_group_carry.__destroy();
-                    }
+                            // fill with unused dummy values to avoid overrunning input
+                            std::uint32_t __load_id =
+                                std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
 
-                    if constexpr (!__is_no_oob_pos_acc_v<decltype(__oob_pos_acc)>)
-                    {
-                        if (__block_num == 0 && __ndi.get_global_linear_id() == 0)
-                        {
-                            // Initialize OOB pos to __n state - means "not yet found"
-                            __oob_pos_acc.__data()[0] = __n;
+                            __v = __sub_group_partials[__load_id];
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                        /*__init_present=*/true>(
+                                __sub_group, __v, __reduce_op, __sub_group_carry,
+                                __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_concrete);
+                            if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
+                                __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         }
+                    });
+                    __sub_group_carry.__destroy();
+                }
+
+                if constexpr (!__is_no_oob_pos_acc_v<decltype(__oob_pos_acc)>)
+                {
+                    if (__block_num == 0 && __ndi.get_global_linear_id() == 0)
+                    {
+                        // Initialize OOB pos to __n state - means "not yet found"
+                        __oob_pos_acc.__data()[0] = __n;
                     }
-                });
+                }
+            });
         });
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1696,7 +1696,7 @@ template <typename _ScanOpsTag, typename _InitValueType>
 struct __comm_slm_handler
 {
     auto
-    __get_accessor(const std::uint32_t __work_group_size, sycl::handler& __cgh) const
+    __get_accessor_or_placeholder(const std::uint32_t __work_group_size, sycl::handler& __cgh) const
     {
         if (!__use_subgroup_ops)
             return __dpl_sycl::__local_accessor<_InitValueType>(__work_group_size, __cgh);
@@ -1706,7 +1706,7 @@ struct __comm_slm_handler
 
     template <typename _Acc>
     _ScanOpsTag
-    __get_data(const _Acc& __comm_slm_acc_opt) const
+    __get_tag_with_workspace(const _Acc& __comm_slm_acc_opt) const
     {
         if (!__use_subgroup_ops)
             return _ScanOpsTag{__dpl_sycl::__get_accessor_ptr(__comm_slm_acc_opt)};
@@ -1722,13 +1722,13 @@ struct __comm_slm_handler<__subgroup_only_tag, _InitValueType>
     __comm_slm_handler(bool /*__use_subgroup_ops*/) {}
 
     __subgroup_only_tag
-    __get_accessor(const std::uint32_t /*__work_group_size*/, sycl::handler& /*__cgh*/) const
+    __get_accessor_or_placeholder(const std::uint32_t /*__work_group_size*/, sycl::handler& /*__cgh*/) const
     {
         return __subgroup_only_tag{};
     }
 
     __subgroup_only_tag
-    __get_data(__subgroup_only_tag) const
+    __get_tag_with_workspace(__subgroup_only_tag) const
     {
         // Noop, type carries dispatch info for broadcast and shift left subgroup ops
         return __subgroup_only_tag{};
@@ -1792,7 +1792,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
             __comm_slm_handler<_ScanOpsTag, _InitValueType> __comm_handler{__use_subgroup_ops};
-            auto __comm_slm = __comm_handler.__get_accessor(__work_group_size, __cgh);
+            auto __comm_acc_or_placeholder = __comm_handler.__get_accessor_or_placeholder(__work_group_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __get_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
@@ -1807,7 +1807,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                 _InitValueType* __temp_ptr = __temp_acc.__data();
                 // The sub-group-ops vs SLM-fallback decision is dispatched at each sub-group-scan region
                 // (see __scan_through_elements_helper and the carry-computation block below).
-                _ScanOpsTag __comm_scan_tag = __comm_handler.__get_data(__comm_slm);
+                _ScanOpsTag __comm_scan_tag = __comm_handler.__get_tag_with_workspace(__comm_acc_or_placeholder);
                 std::size_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -2016,7 +2016,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
             __comm_slm_handler<_ScanOpsTag, _InitValueType> __comm_handler{__use_subgroup_ops};
-            auto __comm_slm = __comm_handler.__get_accessor(__work_group_size, __cgh);
+            auto __comm_acc_or_placeholder = __comm_handler.__get_accessor_or_placeholder(__work_group_size, __cgh);
 
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
@@ -2030,7 +2030,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                     __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                 // The sub-group-ops vs SLM-fallback decision is dispatched at each sub-group-scan region
                 // (see __scan_through_elements_helper and the carry-computation block below).
-                _ScanOpsTag __comm_scan_tag = __comm_handler.__get_data(__comm_slm);
+                _ScanOpsTag __comm_scan_tag = __comm_handler.__get_tag_with_workspace(__comm_acc_or_placeholder);
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2025,9 +2025,9 @@ struct __parallel_reduce_then_scan_scan_submitter<
                 __get_result_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
             auto __oob_pos_acc = __get_oob_pos_accessor_opt<_Bounded>(__cgh, __oob_pos_storage);
 
-            __cgh.parallel_for<_KernelName...>(__nd_range, [=,
-                                                            *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(
-                                                               __sub_group_size)]] {
+
+            __cgh.parallel_for<_KernelName...>(
+                    __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
                 // The sub-group-ops vs SLM-fallback decision is dispatched at each sub-group-scan region
                 // (see __scan_through_elements_helper and the carry-computation block below).
                 _ScanOpsTag __comm_scan_tag = __comm_handler.__get_data(__comm_slm);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1248,19 +1248,19 @@ struct __slm_or_subgroup_tag
 //   - __slm_only_tag / __subgroup_only_tag: only that single path is compiled; the body is invoked directly.
 template <typename _ValueType, typename _Body>
 void
-__dispatch_comm_tag(__slm_or_subgroup_tag<_ValueType> __comm_slm, _Body&& __body)
+__dispatch_comm_tag(__slm_or_subgroup_tag<_ValueType> __comm_tag, _Body&& __body)
 {
-    if (!__comm_slm.__value_ptr)
+    if (!__comm_tag.__value_ptr)
         __body(__subgroup_only_tag{});
     else
-        __body(__slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
+        __body(__slm_only_tag<_ValueType>{__comm_tag.__value_ptr});
 }
 
 template <typename _ValueType, typename _Body>
 void
-__dispatch_comm_tag(__slm_only_tag<_ValueType> __comm_slm, _Body&& __body)
+__dispatch_comm_tag(__slm_only_tag<_ValueType> __comm_tag, _Body&& __body)
 {
-    __body(__comm_slm);
+    __body(__comm_tag);
 }
 
 template <typename _Body>
@@ -1320,17 +1320,17 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value
 }
 
 template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp, typename _InitBroadcastId,
-          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _CommSLMPtr>
+          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _CommTag>
 void
 __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                                  _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm)
+                                  _LazyValueType& __init_and_carry, _CommTag __comm_tag)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_tag);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1342,14 +1342,14 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
         __value = __binary_op(__init_and_carry.__v, __value);
         if (__sub_group_local_id == 0)
             __old_init.__setup(__init_and_carry.__v);
-        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_tag);
     }
     else
     {
-        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_tag));
     }
 
-    __value = __shift_group_right(__sub_group, __value, 1, __comm_slm);
+    __value = __shift_group_right(__sub_group, __value, 1, __comm_tag);
     if constexpr (__init_present)
     {
         if (__sub_group_local_id == 0)
@@ -1362,17 +1362,17 @@ __exclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
 }
 
 template <std::uint8_t __sub_group_size, bool __init_present, typename _MaskOp, typename _InitBroadcastId,
-          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _CommSLMPtr>
+          typename _BinaryOp, typename _ValueType, typename _LazyValueType, typename _CommTag>
 void
 __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                                   _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                                  _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm)
+                                  _LazyValueType& __init_and_carry, _CommTag __comm_tag)
 {
     std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
     _ONEDPL_PRAGMA_UNROLL
     for (std::uint8_t __shift = 1; __shift <= __sub_group_size / 2; __shift <<= 1)
     {
-        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_slm);
+        _ValueType __partial_carry_in = __shift_group_right(__sub_group, __value, __shift, __comm_tag);
         if (__mask_fn(__sub_group_local_id, __shift))
         {
             __value = __binary_op(__partial_carry_in, __value);
@@ -1381,32 +1381,32 @@ __inclusive_sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _M
     if constexpr (__init_present)
     {
         __value = __binary_op(__init_and_carry.__v, __value);
-        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm);
+        __init_and_carry.__v = __group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_tag);
     }
     else
     {
-        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_slm));
+        __init_and_carry.__setup(__group_broadcast(__sub_group, __value, __init_broadcast_id, __comm_tag));
     }
     //return by reference __value and __init_and_carry
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _MaskOp,
           typename _InitBroadcastId, typename _BinaryOp, typename _ValueType, typename _LazyValueType,
-          typename _CommSLMPtr>
+          typename _CommTag>
 void
 __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __mask_fn,
                         _InitBroadcastId __init_broadcast_id, _ValueType& __value, _BinaryOp __binary_op,
-                        _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm)
+                        _LazyValueType& __init_and_carry, _CommTag __comm_tag)
 {
     if constexpr (__is_inclusive)
     {
         __inclusive_sub_group_masked_scan<__sub_group_size, __init_present>(
-            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_tag);
     }
     else
     {
         __exclusive_sub_group_masked_scan<__sub_group_size, __init_present>(
-            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+            __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_tag);
     }
 }
 
@@ -1414,38 +1414,38 @@ template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_presen
           typename _ValueType, typename _LazyValueType, typename _ScanOpsTag = __subgroup_only_tag>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                 _LazyValueType& __init_and_carry, _ScanOpsTag __comm_slm = {})
+                 _LazyValueType& __init_and_carry, _ScanOpsTag __comm_tag = {})
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
     std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
     __sub_group_masked_scan<__sub_group_size, __is_inclusive, __init_present>(
-        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_tag);
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
           typename _ValueType, typename _LazyValueType, typename _SizeType, typename _ScanOpsTag = __subgroup_only_tag>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ScanOpsTag __comm_slm = {})
+                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ScanOpsTag __comm_tag = {})
 {
     auto __mask_fn = [__elements_to_process](auto __sub_group_local_id, auto __offset) {
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
     };
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
     __sub_group_masked_scan<__sub_group_size, __is_inclusive, __init_present>(
-        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+        __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_tag);
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output,
           std::uint16_t __max_inputs_per_item, typename _GenInput, typename _ScanInputTransform, typename _BinaryOp,
-          typename _WriteOp, typename _LazyValueType, typename _InRng, typename _CommSLMPtr>
+          typename _WriteOp, typename _LazyValueType, typename _InRng, typename _CommTag>
 void
 __scan_through_elements_helper_impl(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
                                     _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op,
                                     _WriteOp __write_op, _LazyValueType& __sub_group_carry, const _InRng& __in_rng,
                                     std::size_t __start_id, std::size_t __n, std::uint32_t __iters_per_item,
                                     std::size_t __subgroup_start_id, std::uint32_t __sub_group_id,
-                                    std::uint32_t __active_subgroups, _CommSLMPtr __comm_slm)
+                                    std::uint32_t __active_subgroups, _CommTag __comm_tag)
 {
     using _GenInputType = std::invoke_result_t<_GenInput, _InRng, std::size_t>;
 
@@ -1457,7 +1457,7 @@ __scan_through_elements_helper_impl(const __dpl_sycl::__sub_group& __sub_group, 
 
         _GenInputType __v = __gen_input(__in_rng, __start_id);
         __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_input_transform(__v),
-                                                                           __binary_op, __sub_group_carry, __comm_slm);
+                                                                           __binary_op, __sub_group_carry, __comm_tag);
         __write_op(__start_id, __v);
 
         if (__is_full_block)
@@ -1468,7 +1468,7 @@ __scan_through_elements_helper_impl(const __dpl_sycl::__sub_group& __sub_group, 
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size);
                 __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_tag);
                 __write_op(__start_id + __j * __sub_group_size, __v);
             }
         }
@@ -1480,7 +1480,7 @@ __scan_through_elements_helper_impl(const __dpl_sycl::__sub_group& __sub_group, 
             {
                 __v = __gen_input(__in_rng, __start_id + __j * __sub_group_size);
                 __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_tag);
                 __write_op(__start_id + __j * __sub_group_size, __v);
             }
         }
@@ -1499,7 +1499,7 @@ __scan_through_elements_helper_impl(const __dpl_sycl::__sub_group& __sub_group, 
                 _GenInputType __v = __gen_input(__in_rng, __local_id);
                 __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __n - __subgroup_start_id,
-                    __comm_slm);
+                    __comm_tag);
                 if constexpr (__capture_output)
                 {
                     if (__start_id < __n)
@@ -1510,7 +1510,7 @@ __scan_through_elements_helper_impl(const __dpl_sycl::__sub_group& __sub_group, 
             {
                 _GenInputType __v = __gen_input(__in_rng, __start_id);
                 __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
-                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+                    __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_tag);
 
                 __write_op(__start_id, __v);
 
@@ -1519,7 +1519,7 @@ __scan_through_elements_helper_impl(const __dpl_sycl::__sub_group& __sub_group, 
                     std::size_t __local_id = __start_id + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_id);
                     __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                        __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_slm);
+                        __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry, __comm_tag);
                     __write_op(__local_id, __v);
                 }
 
@@ -1528,7 +1528,7 @@ __scan_through_elements_helper_impl(const __dpl_sycl::__sub_group& __sub_group, 
                 __v = __gen_input(__in_rng, __local_id);
                 __sub_group_scan_partial<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
                     __sub_group, __scan_input_transform(__v), __binary_op, __sub_group_carry,
-                    __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_slm);
+                    __n - (__subgroup_start_id + (__iters - 1) * __sub_group_size), __comm_tag);
                 if constexpr (__capture_output)
                 {
                     if (__offset < __n)
@@ -1557,14 +1557,14 @@ struct __temp_data_required<_T, std::void_t<typename _T::TempData>>
 template <bool _Bounded, std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output,
           bool __is_unique_pattern_v, std::uint16_t __max_inputs_per_item, typename _GenInput,
           typename _ScanInputTransform, typename _BinaryOp, typename _WriteOp, typename _LazyValueType, typename _InRng,
-          typename _OutRng, typename _CommSLMPtr, typename _OnOOBReached = std::nullptr_t>
+          typename _OutRng, typename _CommTag, typename _OnOOBReached = std::nullptr_t>
 void
 __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenInput __gen_input,
                                _ScanInputTransform __scan_input_transform, _BinaryOp __binary_op, _WriteOp __write_op,
                                _LazyValueType& __sub_group_carry, const _InRng& __in_rng, _OutRng& __out_rng,
                                std::size_t __start_id, std::size_t __n, std::uint32_t __iters_per_item,
                                std::size_t __subgroup_start_id, std::uint32_t __sub_group_id,
-                               std::uint32_t __active_subgroups, _CommSLMPtr __comm_slm,
+                               std::uint32_t __active_subgroups, _CommTag __comm_tag,
                                _OnOOBReached __on_oob_reached = {})
 {
     using __temp_data_required_t = __temp_data_required<_GenInput>;
@@ -1584,7 +1584,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
 
     // Hoist the sub-group-ops vs SLM-fallback decision to here. The element-scan body below is instantiated
     // once per available communication path; the branch is taken a single time per call to this helper.
-    __dispatch_comm_tag(__comm_slm, [&](auto __comm_slm_concrete) {
+    __dispatch_comm_tag(__comm_tag, [&](auto __comm_tag_concrete) {
         if constexpr (!__capture_output)
         {
             auto __noop_write_op = [&](std::size_t, const auto&) {};
@@ -1592,7 +1592,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                                                 __max_inputs_per_item>(
                 __sub_group, __gen_input_impl, __scan_input_transform, __binary_op, __noop_write_op, __sub_group_carry,
                 __in_rng, __start_id, __n, __iters_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
-                __comm_slm_concrete);
+                __comm_tag_concrete);
         }
         else
         {
@@ -1614,7 +1614,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                                                         __capture_output, __max_inputs_per_item>(
                         __sub_group, __gen_input_impl, __scan_input_transform, __binary_op, __bounded_write_op,
                         __sub_group_carry, __in_rng, __start_id, __n, __iters_per_item, __subgroup_start_id,
-                        __sub_group_id, __active_subgroups, __comm_slm_concrete);
+                        __sub_group_id, __active_subgroups, __comm_tag_concrete);
                     return;
                 }
             }
@@ -1629,7 +1629,7 @@ __scan_through_elements_helper(const __dpl_sycl::__sub_group& __sub_group, _GenI
                                                 __max_inputs_per_item>(
                 __sub_group, __gen_input_impl, __scan_input_transform, __binary_op, __unbounded_write_op,
                 __sub_group_carry, __in_rng, __start_id, __n, __iters_per_item, __subgroup_start_id, __sub_group_id,
-                __active_subgroups, __comm_slm_concrete);
+                __active_subgroups, __comm_tag_concrete);
         }
     });
 }
@@ -1859,7 +1859,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                     std::uint8_t __iters =
                         oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
                     // Dispatch the sub-group-ops vs SLM-fallback decision once for this carry-computation region.
-                    __dispatch_comm_tag(__comm_scan_tag, [&](auto __comm_slm_concrete) {
+                    __dispatch_comm_tag(__comm_scan_tag, [&](auto __comm_tag_concrete) {
                         if (__iters == 1)
                         {
                             // fill with unused dummy values to avoid overrunning input
@@ -1869,7 +1869,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                             __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                         /*__init_present=*/false>(
                                 __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups,
-                                __comm_slm_concrete);
+                                __comm_tag_concrete);
                             if (__sub_group_local_id < __active_subgroups)
                                 __temp_ptr[__start_id + __sub_group_local_id] = __v;
                         }
@@ -1879,7 +1879,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                             // need to pull out first iteration tp avoid identity
                             _InitValueType __v = __sub_group_partials[__reduction_scan_id];
                             __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_concrete);
+                                __sub_group, __v, __reduce_op, __sub_group_carry, __comm_tag_concrete);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
 
@@ -1888,7 +1888,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                                 __v = __sub_group_partials[__reduction_scan_id];
                                 __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                                     /*__init_present=*/true>(__sub_group, __v, __reduce_op,
-                                                                            __sub_group_carry, __comm_slm_concrete);
+                                                                            __sub_group_carry, __comm_tag_concrete);
                                 __temp_ptr[__start_id + __reduction_scan_id] = __v;
                                 __reduction_scan_id += __sub_group_size;
                             }
@@ -1903,7 +1903,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                             __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                         /*__init_present=*/true>(
                                 __sub_group, __v, __reduce_op, __sub_group_carry,
-                                __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_concrete);
+                                __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_tag_concrete);
                             if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
                                 __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         }
@@ -2110,7 +2110,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                         const std::size_t __pre_carry_iters =
                             oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
                         // Dispatch the sub-group-ops vs SLM-fallback decision once for this carry-computation region.
-                        __dispatch_comm_tag(__comm_scan_tag, [&](auto __comm_slm_concrete) {
+                        __dispatch_comm_tag(__comm_scan_tag, [&](auto __comm_tag_concrete) {
                             if (__pre_carry_iters == 1)
                             {
                                 // single partial scan
@@ -2124,7 +2124,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                 __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                          /*__init_present=*/false>(__sub_group, __value, __reduce_op,
                                                                                    __carry_last, __remaining_elements,
-                                                                                   __comm_slm_concrete);
+                                                                                   __comm_tag_concrete);
                             }
                             else
                             {
@@ -2137,7 +2137,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                 _InitValueType __value = __tmp_ptr[__reduction_id];
                                 __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                                  /*__init_present=*/false>(__sub_group, __value, __reduce_op,
-                                                                           __carry_last, __comm_slm_concrete);
+                                                                           __carry_last, __comm_tag_concrete);
                                 __reduction_id += __reduction_id_increment;
                                 // then some number of full iterations
                                 for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
@@ -2145,7 +2145,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                     __value = __tmp_ptr[__reduction_id];
                                     __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
                                                      /*__init_present=*/true>(__sub_group, __value, __reduce_op,
-                                                                              __carry_last, __comm_slm_concrete);
+                                                                              __carry_last, __comm_tag_concrete);
                                     __reduction_id += __reduction_id_increment;
                                 }
 
@@ -2160,7 +2160,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
                                 __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                          /*__init_present=*/true>(__sub_group, __value, __reduce_op,
                                                                                   __carry_last, __remaining_elements,
-                                                                                  __comm_slm_concrete);
+                                                                                  __comm_tag_concrete);
                             }
                         });
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1396,24 +1396,6 @@ __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType>
-void
-__sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                 _LazyValueType& __init_and_carry, __slm_or_subgroup_tag<_ValueType> __comm_slm)
-{
-    if (!__comm_slm.__value_ptr)
-    {
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __value, __binary_op,
-                                                                           __init_and_carry, __subgroup_only_tag{});
-    }
-    else
-    {
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
-            __sub_group, __value, __binary_op, __init_and_carry, __slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
-    }
-}
-
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
           typename _ValueType, typename _LazyValueType, typename _SizeType, typename _ScanOpsTag = __subgroup_only_tag>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
@@ -1425,26 +1407,6 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
     __sub_group_masked_scan<__sub_group_size, __is_inclusive, __init_present>(
         __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
-}
-
-template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType, typename _SizeType>
-void
-__sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process,
-                         __slm_or_subgroup_tag<_ValueType> __comm_slm)
-{
-    if (!__comm_slm.__value_ptr)
-    {
-        __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
-            __sub_group, __value, __binary_op, __init_and_carry, __elements_to_process, __subgroup_only_tag{});
-    }
-    else
-    {
-        __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
-            __sub_group, __value, __binary_op, __init_and_carry, __elements_to_process,
-            __slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
-    }
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output,
@@ -1742,6 +1704,36 @@ struct __comm_slm_handler<__subgroup_only_tag, _InitValueType>
     }
 };
 
+// Layer of abstraction that hoists the runtime "sub-group ops vs SLM fallback" decision to the top of the
+// kernel. The communication tag returned by __comm_slm_handler::__get_data encodes which path(s) are available:
+//   - __slm_or_subgroup_tag: both paths are compiled into the kernel; the runtime pointer (null => sub-group ops,
+//                            non-null => SLM) selects the concrete tag, so the entire kernel body is instantiated
+//                            once per path and the branch happens a single time here.
+//   - __slm_only_tag / __subgroup_only_tag: only that single path is compiled; the body is invoked directly.
+template <typename _ValueType, typename _Body>
+void
+__dispatch_comm_tag(__slm_or_subgroup_tag<_ValueType> __comm_slm, _Body&& __body)
+{
+    if (!__comm_slm.__value_ptr)
+        __body(__subgroup_only_tag{});
+    else
+        __body(__slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
+}
+
+template <typename _ValueType, typename _Body>
+void
+__dispatch_comm_tag(__slm_only_tag<_ValueType> __comm_slm, _Body&& __body)
+{
+    __body(__comm_slm);
+}
+
+template <typename _Body>
+void
+__dispatch_comm_tag(__subgroup_only_tag, _Body&& __body)
+{
+    __body(__subgroup_only_tag{});
+}
+
 template <typename... _Name>
 class __reduce_then_scan_partition_kernel;
 
@@ -1814,111 +1806,117 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
                 _InitValueType* __temp_ptr = __temp_acc.__data();
-                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
-                std::size_t __group_id = __ndi.get_group(0);
-                std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-                std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
+                // Hoist the sub-group-ops vs SLM-fallback decision to the top of the kernel. The body below is
+                // instantiated once per available communication path; the branch is taken a single time here.
+                __dispatch_comm_tag(__comm_handler.__get_data(__comm_slm), [&](auto __comm_slm_ptr) {
+                    std::size_t __group_id = __ndi.get_group(0);
+                    std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+                    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-                std::size_t __group_start_id =
-                    (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
-                                                        __sub_group_params.__num_sub_groups_local);
-                if constexpr (__is_unique_pattern_v)
-                {
-                    // for unique patterns, the first element is always copied to the output, so we need to skip it
-                    __group_start_id += 1;
-                }
-                std::size_t __max_inputs_in_group =
-                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-                std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                    __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-                std::size_t __subgroup_start_id =
-                    __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
-
-                std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
-
-                if (__sub_group_id < __active_subgroups)
-                {
-                    // adjust for lane-id
-                    // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
-                    __scan_through_elements_helper</*_Bounded*/ false, __sub_group_size, __is_inclusive,
-                                                   /*__init_present=*/false,
-                                                   /*__capture_output=*/false, __is_unique_pattern_v,
-                                                   __max_inputs_per_item>(
-                        __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
-                        __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
-                        __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id, __active_subgroups,
-                        __comm_slm_ptr);
-                    if (__sub_group_local_id == 0)
-                        __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
-                    __sub_group_carry.__destroy();
-                }
-                __dpl_sycl::__group_barrier(__ndi);
-
-                // compute sub-group local prefix sums on (T0..63) carries
-                // and store to scratch space at the end of dst; next
-                // accumulator kernel takes M thread carries from scratch
-                // to compute a prefix sum on global carries
-                if (__sub_group_id == 0)
-                {
-                    __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
-                    std::uint8_t __iters =
-                        oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-                    if (__iters == 1)
+                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+                    std::size_t __group_start_id =
+                        (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
+                                                            __sub_group_params.__num_sub_groups_local);
+                    if constexpr (__is_unique_pattern_v)
                     {
-                        // fill with unused dummy values to avoid overrunning input
-                        std::uint32_t __load_id = std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
-                        _InitValueType __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
-                        if (__sub_group_local_id < __active_subgroups)
-                            __temp_ptr[__start_id + __sub_group_local_id] = __v;
+                        // for unique patterns, the first element is always copied to the output, so we need to skip it
+                        __group_start_id += 1;
                     }
-                    else
-                    {
-                        std::uint32_t __reduction_scan_id = __sub_group_local_id;
-                        // need to pull out first iteration tp avoid identity
-                        _InitValueType __v = __sub_group_partials[__reduction_scan_id];
-                        __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
-                        __temp_ptr[__start_id + __reduction_scan_id] = __v;
-                        __reduction_scan_id += __sub_group_size;
+                    std::size_t __max_inputs_in_group =
+                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+                    std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                    std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                        __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+                    std::size_t __subgroup_start_id =
+                        __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
 
-                        for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
+                    std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+
+                    if (__sub_group_id < __active_subgroups)
+                    {
+                        // adjust for lane-id
+                        // compute sub-group local prefix on T0..63, K samples/T, send to accumulator kernel
+                        __scan_through_elements_helper</*_Bounded*/ false, __sub_group_size, __is_inclusive,
+                                                       /*__init_present=*/false,
+                                                       /*__capture_output=*/false, __is_unique_pattern_v,
+                                                       __max_inputs_per_item>(
+                            __sub_group, __gen_reduce_input, oneapi::dpl::identity{}, __reduce_op, nullptr,
+                            __sub_group_carry, __in_rng, /*unused*/ __in_rng, __start_id, __n,
+                            __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id,
+                            __active_subgroups, __comm_slm_ptr);
+                        if (__sub_group_local_id == 0)
+                            __sub_group_partials[__sub_group_id] = __sub_group_carry.__v;
+                        __sub_group_carry.__destroy();
+                    }
+                    __dpl_sycl::__group_barrier(__ndi);
+
+                    // compute sub-group local prefix sums on (T0..63) carries
+                    // and store to scratch space at the end of dst; next
+                    // accumulator kernel takes M thread carries from scratch
+                    // to compute a prefix sum on global carries
+                    if (__sub_group_id == 0)
+                    {
+                        __start_id = (__group_id * __sub_group_params.__num_sub_groups_local);
+                        std::uint8_t __iters =
+                            oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+                        if (__iters == 1)
                         {
-                            __v = __sub_group_partials[__reduction_scan_id];
-                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                            // fill with unused dummy values to avoid overrunning input
+                            std::uint32_t __load_id =
+                                std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
+                            _InitValueType __v = __sub_group_partials[__load_id];
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                     /*__init_present=*/false>(
+                                __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups, __comm_slm_ptr);
+                            if (__sub_group_local_id < __active_subgroups)
+                                __temp_ptr[__start_id + __sub_group_local_id] = __v;
+                        }
+                        else
+                        {
+                            std::uint32_t __reduction_scan_id = __sub_group_local_id;
+                            // need to pull out first iteration tp avoid identity
+                            _InitValueType __v = __sub_group_partials[__reduction_scan_id];
+                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
                                 __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
                             __temp_ptr[__start_id + __reduction_scan_id] = __v;
                             __reduction_scan_id += __sub_group_size;
+
+                            for (std::uint32_t __i = 1; __i < __iters - 1; __i++)
+                            {
+                                __v = __sub_group_partials[__reduction_scan_id];
+                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
+                                    __sub_group, __v, __reduce_op, __sub_group_carry, __comm_slm_ptr);
+                                __temp_ptr[__start_id + __reduction_scan_id] = __v;
+                                __reduction_scan_id += __sub_group_size;
+                            }
+                            // If we are past the input range, then the previous value of v is passed to the sub-group scan.
+                            // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
+
+                            // fill with unused dummy values to avoid overrunning input
+                            std::uint32_t __load_id =
+                                std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
+
+                            __v = __sub_group_partials[__load_id];
+                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                     /*__init_present=*/true>(
+                                __sub_group, __v, __reduce_op, __sub_group_carry,
+                                __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
+                            if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
+                                __temp_ptr[__start_id + __reduction_scan_id] = __v;
                         }
-                        // If we are past the input range, then the previous value of v is passed to the sub-group scan.
-                        // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
 
-                        // fill with unused dummy values to avoid overrunning input
-                        std::uint32_t __load_id =
-                            std::min(__reduction_scan_id, __sub_group_params.__num_sub_groups_local - 1);
-
-                        __v = __sub_group_partials[__load_id];
-                        __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
-                            __sub_group, __v, __reduce_op, __sub_group_carry,
-                            __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_slm_ptr);
-                        if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
-                            __temp_ptr[__start_id + __reduction_scan_id] = __v;
+                        __sub_group_carry.__destroy();
                     }
 
-                    __sub_group_carry.__destroy();
-                }
-
-                if constexpr (!__is_no_oob_pos_acc_v<decltype(__oob_pos_acc)>)
-                {
-                    if (__block_num == 0 && __ndi.get_global_linear_id() == 0)
+                    if constexpr (!__is_no_oob_pos_acc_v<decltype(__oob_pos_acc)>)
                     {
-                        // Initialize OOB pos to __n state - means "not yet found"
-                        __oob_pos_acc.__data()[0] = __n;
+                        if (__block_num == 0 && __ndi.get_global_linear_id() == 0)
+                        {
+                            // Initialize OOB pos to __n state - means "not yet found"
+                            __oob_pos_acc.__data()[0] = __n;
+                        }
                     }
-                }
+                }); // __dispatch_comm_tag
             });
         });
     }
@@ -2025,282 +2023,293 @@ struct __parallel_reduce_then_scan_scan_submitter<
                 __get_result_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
             auto __oob_pos_acc = __get_oob_pos_accessor_opt<_Bounded>(__cgh, __oob_pos_storage);
 
-            __cgh.parallel_for<_KernelName...>(
-                    __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm);
+            __cgh.parallel_for<_KernelName...>(__nd_range, [=,
+                                                            *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(
+                                                               __sub_group_size)]] {
+                // Hoist the sub-group-ops vs SLM-fallback decision to the top of the kernel. The body below is
+                // instantiated once per available communication path; the branch is taken a single time here.
+                __dispatch_comm_tag(__comm_handler.__get_data(__comm_slm), [&](auto __comm_slm_ptr) {
+                    __reduce_then_scan_sub_group_params __sub_group_params(__work_group_size, __sub_group_size,
+                                                                           __max_num_work_groups, __max_block_size,
+                                                                           __inputs_remaining);
 
-                __reduce_then_scan_sub_group_params __sub_group_params(
-                    __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
+                    const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                        __inputs_in_block,
+                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
 
-                const std::uint32_t __active_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                    __inputs_in_block,
-                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local);
+                    _InitValueType* __tmp_ptr = __temp_acc.__data();
+                    _InitValueType* __res_ptr = __res_acc.__data();
+                    std::uint32_t __group_id = __ndi.get_group(0);
+                    __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
+                    std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
+                    std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
 
-                _InitValueType* __tmp_ptr = __temp_acc.__data();
-                _InitValueType* __res_ptr = __res_acc.__data();
-                std::uint32_t __group_id = __ndi.get_group(0);
-                __dpl_sycl::__sub_group __sub_group = __ndi.get_sub_group();
-                std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-                std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
-
-                std::size_t __group_start_id =
-                    (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
-                                                        __sub_group_params.__num_sub_groups_local);
-                if constexpr (__is_unique_pattern_v)
-                {
-                    // for unique patterns, the first element is always copied to the output, so we need to skip it
-                    __group_start_id += 1;
-                }
-
-                std::size_t __max_inputs_in_group =
-                    __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
-                std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
-                std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                    __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
-
-                // propagate carry in from previous block
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
-
-                // on the first sub-group in a work-group (assuming S subgroups in a work-group):
-                // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
-                // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
-                //    and then compute the prefix sum to generate global carry out
-                //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
-                // 3. on each WG select the adjacent neighboring WG carry in
-                // 4. on each WG add the global carry-in to S sub-group local prefix sums to
-                //    get a T-local global carry in
-                // 5. recompute T-local prefix values, add the T-local global carries,
-                //    and then write back the final values to memory
-                if (__sub_group_id == 0)
-                {
-                    // step 1) load to SLM the WG-local S prefix sums
-                    //         on WG T-local carries
-                    //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
-                    //           S: sum(T0 carry...TS carry)
-                    std::uint8_t __iters =
-                        oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-                    std::size_t __subgroups_before_my_group = __group_id * __sub_group_params.__num_sub_groups_local;
-                    std::uint32_t __load_reduction_id = __sub_group_local_id;
-                    std::uint8_t __i = 0;
-                    for (; __i < __iters - 1; __i++)
+                    std::size_t __group_start_id =
+                        (__block_num * __max_block_size) + (__group_id * __sub_group_params.__inputs_per_sub_group *
+                                                            __sub_group_params.__num_sub_groups_local);
+                    if constexpr (__is_unique_pattern_v)
                     {
-                        __sub_group_partials[__load_reduction_id] =
-                            __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
-                        __load_reduction_id += __sub_group_size;
-                    }
-                    if (__load_reduction_id < __active_subgroups)
-                    {
-                        __sub_group_partials[__load_reduction_id] =
-                            __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
+                        // for unique patterns, the first element is always copied to the output, so we need to skip it
+                        __group_start_id += 1;
                     }
 
-                    // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
-                    //         compute the prefix in a sub-group to get global work-group carries
-                    //         memory accesses: gather(63, 127, 191, 255, ...)
-                    std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
-                    // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
-                    if (__group_id > 0)
+                    std::size_t __max_inputs_in_group =
+                        __sub_group_params.__inputs_per_sub_group * __sub_group_params.__num_sub_groups_local;
+                    std::uint32_t __inputs_in_group = std::min(__n - __group_start_id, __max_inputs_in_group);
+                    std::uint32_t __active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(
+                        __inputs_in_group, __sub_group_params.__inputs_per_sub_group);
+                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __carry_last;
+
+                    // propagate carry in from previous block
+                    oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
+
+                    // on the first sub-group in a work-group (assuming S subgroups in a work-group):
+                    // 1. load S sub-group local carry prefix sums (T0..TS-1) to SLM
+                    // 2. load 32, 64, 96, etc. TS-1 work-group carry-outs (32 for WG num<32, 64 for WG num<64, etc.),
+                    //    and then compute the prefix sum to generate global carry out
+                    //    for each WG, i.e., prefix sum on TS-1 carries over all WG.
+                    // 3. on each WG select the adjacent neighboring WG carry in
+                    // 4. on each WG add the global carry-in to S sub-group local prefix sums to
+                    //    get a T-local global carry in
+                    // 5. recompute T-local prefix values, add the T-local global carries,
+                    //    and then write back the final values to memory
+                    if (__sub_group_id == 0)
                     {
-                        // only need the last element from each scan of num_sub_groups_local subgroup reductions
-                        const std::size_t __elements_to_process =
-                            __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
-                        const std::size_t __pre_carry_iters =
-                            oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
-                        if (__pre_carry_iters == 1)
-                        {
-                            // single partial scan
-                            std::size_t __proposed_id =
-                                __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
-                            std::size_t __remaining_elements = __elements_to_process;
-                            std::size_t __reduction_id = (__proposed_id < __subgroups_before_my_group)
-                                                             ? __proposed_id
-                                                             : __subgroups_before_my_group - 1;
-                            _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                     /*__init_present=*/false>(
-                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
-                        }
-                        else
-                        {
-                            // multiple iterations
-                            // first 1 full
-                            std::uint32_t __reduction_id =
-                                __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
-                            std::uint32_t __reduction_id_increment =
-                                __sub_group_params.__num_sub_groups_local * __sub_group_size;
-                            _InitValueType __value = __tmp_ptr[__reduction_id];
-                            __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
-                                             /*__init_present=*/false>(__sub_group, __value, __reduce_op, __carry_last,
-                                                                       __comm_slm_ptr);
-                            __reduction_id += __reduction_id_increment;
-                            // then some number of full iterations
-                            for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
-                            {
-                                __value = __tmp_ptr[__reduction_id];
-                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
-                                                 /*__init_present=*/true>(__sub_group, __value, __reduce_op,
-                                                                          __carry_last, __comm_slm_ptr);
-                                __reduction_id += __reduction_id_increment;
-                            }
-
-                            // final partial iteration
-
-                            std::size_t __remaining_elements =
-                                __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
-                            // fill with unused dummy values to avoid overrunning input
-                            std::size_t __final_reduction_id =
-                                std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
-                            __value = __tmp_ptr[__final_reduction_id];
-                            __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                     /*__init_present=*/true>(
-                                __sub_group, __value, __reduce_op, __carry_last, __remaining_elements, __comm_slm_ptr);
-                        }
-
-                        // steps 3+4) load global carry in from neighbor work-group
-                        //            and apply to local sub-group prefix carries
-                        std::size_t __carry_offset = __sub_group_local_id;
-
+                        // step 1) load to SLM the WG-local S prefix sums
+                        //         on WG T-local carries
+                        //            0: T0 carry, 1: T0 + T1 carry, 2: T0 + T1 + T2 carry, ...
+                        //           S: sum(T0 carry...TS carry)
                         std::uint8_t __iters =
                             oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
-
+                        std::size_t __subgroups_before_my_group =
+                            __group_id * __sub_group_params.__num_sub_groups_local;
+                        std::uint32_t __load_reduction_id = __sub_group_local_id;
                         std::uint8_t __i = 0;
-                        for (; __i < __iters - 1; ++__i)
+                        for (; __i < __iters - 1; __i++)
                         {
-                            __sub_group_partials[__carry_offset] =
-                                __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                            __carry_offset += __sub_group_size;
+                            __sub_group_partials[__load_reduction_id] =
+                                __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
+                            __load_reduction_id += __sub_group_size;
                         }
-                        if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
+                        if (__load_reduction_id < __active_subgroups)
                         {
-                            __sub_group_partials[__carry_offset] =
-                                __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
-                            __carry_offset += __sub_group_size;
+                            __sub_group_partials[__load_reduction_id] =
+                                __tmp_ptr[__subgroups_before_my_group + __load_reduction_id];
                         }
-                        if (__sub_group_local_id == 0)
-                            __sub_group_partials[__active_subgroups] = __carry_last.__v;
-                        __carry_last.__destroy();
-                    }
-                }
 
-                __dpl_sycl::__group_barrier(__ndi);
-
-                // Get inter-work group and adjusted for intra-work group prefix
-                bool __sub_group_carry_initialized = true;
-                if (__block_num == 0)
-                {
-                    if (__sub_group_id > 0)
-                    {
-                        _InitValueType __value =
-                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                        oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
-                        __sub_group_carry.__setup(__value);
-                    }
-                    else if (__group_id > 0)
-                    {
-                        _InitValueType __value = __sub_group_partials[__active_subgroups];
-                        oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
-                        __sub_group_carry.__setup(__value);
-                    }
-                    else // zeroth block, group and subgroup
-                    {
-                        if constexpr (__is_unique_pattern_v)
+                        // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
+                        //         compute the prefix in a sub-group to get global work-group carries
+                        //         memory accesses: gather(63, 127, 191, 255, ...)
+                        std::uint32_t __offset = __sub_group_params.__num_sub_groups_local - 1;
+                        // only need 32 carries for WGs0..WG32, 64 for WGs32..WGs64, etc.
+                        if (__group_id > 0)
                         {
-                            if (__sub_group_local_id == 0)
+                            // only need the last element from each scan of num_sub_groups_local subgroup reductions
+                            const std::size_t __elements_to_process =
+                                __subgroups_before_my_group / __sub_group_params.__num_sub_groups_local;
+                            const std::size_t __pre_carry_iters =
+                                oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
+                            if (__pre_carry_iters == 1)
                             {
-                                // For unique patterns, always copy the 0th element to the output
-                                __write_op.__assign(__in_rng[0], __out_rng[0]);
+                                // single partial scan
+                                std::size_t __proposed_id =
+                                    __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
+                                std::size_t __remaining_elements = __elements_to_process;
+                                std::size_t __reduction_id = (__proposed_id < __subgroups_before_my_group)
+                                                                 ? __proposed_id
+                                                                 : __subgroups_before_my_group - 1;
+                                _InitValueType __value = __tmp_ptr[__reduction_id];
+                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                         /*__init_present=*/false>(__sub_group, __value, __reduce_op,
+                                                                                   __carry_last, __remaining_elements,
+                                                                                   __comm_slm_ptr);
+                            }
+                            else
+                            {
+                                // multiple iterations
+                                // first 1 full
+                                std::uint32_t __reduction_id =
+                                    __sub_group_params.__num_sub_groups_local * __sub_group_local_id + __offset;
+                                std::uint32_t __reduction_id_increment =
+                                    __sub_group_params.__num_sub_groups_local * __sub_group_size;
+                                _InitValueType __value = __tmp_ptr[__reduction_id];
+                                __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
+                                                 /*__init_present=*/false>(__sub_group, __value, __reduce_op,
+                                                                           __carry_last, __comm_slm_ptr);
+                                __reduction_id += __reduction_id_increment;
+                                // then some number of full iterations
+                                for (std::uint32_t __i = 1; __i < __pre_carry_iters - 1; __i++)
+                                {
+                                    __value = __tmp_ptr[__reduction_id];
+                                    __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
+                                                     /*__init_present=*/true>(__sub_group, __value, __reduce_op,
+                                                                              __carry_last, __comm_slm_ptr);
+                                    __reduction_id += __reduction_id_increment;
+                                }
+
+                                // final partial iteration
+
+                                std::size_t __remaining_elements =
+                                    __elements_to_process - ((__pre_carry_iters - 1) * __sub_group_size);
+                                // fill with unused dummy values to avoid overrunning input
+                                std::size_t __final_reduction_id =
+                                    std::min(std::size_t{__reduction_id}, __subgroups_before_my_group - 1);
+                                __value = __tmp_ptr[__final_reduction_id];
+                                __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
+                                                         /*__init_present=*/true>(__sub_group, __value, __reduce_op,
+                                                                                  __carry_last, __remaining_elements,
+                                                                                  __comm_slm_ptr);
+                            }
+
+                            // steps 3+4) load global carry in from neighbor work-group
+                            //            and apply to local sub-group prefix carries
+                            std::size_t __carry_offset = __sub_group_local_id;
+
+                            std::uint8_t __iters =
+                                oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
+
+                            std::uint8_t __i = 0;
+                            for (; __i < __iters - 1; ++__i)
+                            {
+                                __sub_group_partials[__carry_offset] =
+                                    __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                                __carry_offset += __sub_group_size;
+                            }
+                            if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
+                            {
+                                __sub_group_partials[__carry_offset] =
+                                    __reduce_op(__carry_last.__v, __sub_group_partials[__carry_offset]);
+                                __carry_offset += __sub_group_size;
+                            }
+                            if (__sub_group_local_id == 0)
+                                __sub_group_partials[__active_subgroups] = __carry_last.__v;
+                            __carry_last.__destroy();
+                        }
+                    }
+
+                    __dpl_sycl::__group_barrier(__ndi);
+
+                    // Get inter-work group and adjusted for intra-work group prefix
+                    bool __sub_group_carry_initialized = true;
+                    if (__block_num == 0)
+                    {
+                        if (__sub_group_id > 0)
+                        {
+                            _InitValueType __value =
+                                __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                            oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value,
+                                                                                            __reduce_op);
+                            __sub_group_carry.__setup(__value);
+                        }
+                        else if (__group_id > 0)
+                        {
+                            _InitValueType __value = __sub_group_partials[__active_subgroups];
+                            oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value,
+                                                                                            __reduce_op);
+                            __sub_group_carry.__setup(__value);
+                        }
+                        else // zeroth block, group and subgroup
+                        {
+                            if constexpr (__is_unique_pattern_v)
+                            {
+                                if (__sub_group_local_id == 0)
+                                {
+                                    // For unique patterns, always copy the 0th element to the output
+                                    __write_op.__assign(__in_rng[0], __out_rng[0]);
+                                }
+                            }
+
+                            if constexpr (std::is_same_v<_InitType,
+                                                         oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
+                            {
+                                // This is the only case where we still don't have a carry in.  No init value, 0th block,
+                                // group, and subgroup. This changes the final scan through elements below.
+                                __sub_group_carry_initialized = false;
+                            }
+                            else
+                            {
+                                __sub_group_carry.__setup(__init.__value);
                             }
                         }
-
-                        if constexpr (std::is_same_v<_InitType,
-                                                     oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
-                        {
-                            // This is the only case where we still don't have a carry in.  No init value, 0th block,
-                            // group, and subgroup. This changes the final scan through elements below.
-                            __sub_group_carry_initialized = false;
-                        }
-                        else
-                        {
-                            __sub_group_carry.__setup(__init.__value);
-                        }
-                    }
-                }
-                else
-                {
-                    if (__sub_group_id > 0)
-                    {
-                        _InitValueType __value =
-                            __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
-                        __sub_group_carry.__setup(__reduce_op(
-                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
-                            __value));
-                    }
-                    else if (__group_id > 0)
-                    {
-                        __sub_group_carry.__setup(__reduce_op(
-                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global),
-                            __sub_group_partials[__active_subgroups]));
                     }
                     else
                     {
-                        __sub_group_carry.__setup(
-                            __get_block_carry_in(__block_num, __tmp_ptr, __sub_group_params.__num_sub_groups_global));
-                    }
-                }
-
-                // step 5) apply global carries
-                std::size_t __subgroup_start_id =
-                    __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
-                std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
-
-                if (__sub_group_carry_initialized)
-                {
-                    __scan_through_elements_helper<_Bounded, __sub_group_size, __is_inclusive,
-                                                   /*__init_present=*/true,
-                                                   /*__capture_output=*/true, __is_unique_pattern_v,
-                                                   __max_inputs_per_item>(
-                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
-                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr,
-                        __create_on_oob_reached_callback(__oob_pos_acc));
-                }
-                else // first group first block, no subgroup carry
-                {
-                    __scan_through_elements_helper<_Bounded, __sub_group_size, __is_inclusive,
-                                                   /*__init_present=*/false,
-                                                   /*__capture_output=*/true, __is_unique_pattern_v,
-                                                   __max_inputs_per_item>(
-                        __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
-                        __sub_group_carry, __in_rng, __out_rng, __start_id, __n, __sub_group_params.__inputs_per_item,
-                        __subgroup_start_id, __sub_group_id, __active_subgroups, __comm_slm_ptr,
-                        __create_on_oob_reached_callback(__oob_pos_acc));
-                }
-                // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
-                // to write out the last carry out for either the return value or the next block
-                if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
-                    (__active_subgroups == __sub_group_id + 1))
-                {
-                    if (__block_num + 1 == __num_blocks)
-                    {
-                        if constexpr (__is_unique_pattern_v)
+                        if (__sub_group_id > 0)
                         {
-                            // unique patterns automatically copy the 0th element and scan starting at index 1
-                            __res_ptr[0] = __transform_result(__sub_group_carry.__v + 1);
+                            _InitValueType __value =
+                                __sub_group_partials[std::min(__sub_group_id - 1, __active_subgroups - 1)];
+                            __sub_group_carry.__setup(
+                                __reduce_op(__get_block_carry_in(__block_num, __tmp_ptr,
+                                                                 __sub_group_params.__num_sub_groups_global),
+                                            __value));
+                        }
+                        else if (__group_id > 0)
+                        {
+                            __sub_group_carry.__setup(
+                                __reduce_op(__get_block_carry_in(__block_num, __tmp_ptr,
+                                                                 __sub_group_params.__num_sub_groups_global),
+                                            __sub_group_partials[__active_subgroups]));
                         }
                         else
                         {
-                            __res_ptr[0] = __transform_result(__sub_group_carry.__v);
+                            __sub_group_carry.__setup(__get_block_carry_in(__block_num, __tmp_ptr,
+                                                                           __sub_group_params.__num_sub_groups_global));
                         }
                     }
-                    else
+
+                    // step 5) apply global carries
+                    std::size_t __subgroup_start_id =
+                        __group_start_id + (__sub_group_id * __sub_group_params.__inputs_per_sub_group);
+                    std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
+
+                    if (__sub_group_carry_initialized)
                     {
-                        // capture the last carry out for the next block
-                        __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v,
-                                              __sub_group_params.__num_sub_groups_global);
+                        __scan_through_elements_helper<_Bounded, __sub_group_size, __is_inclusive,
+                                                       /*__init_present=*/true,
+                                                       /*__capture_output=*/true, __is_unique_pattern_v,
+                                                       __max_inputs_per_item>(
+                            __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
+                            __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
+                            __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id,
+                            __active_subgroups, __comm_slm_ptr, __create_on_oob_reached_callback(__oob_pos_acc));
                     }
-                }
-                __sub_group_carry.__destroy();
+                    else // first group first block, no subgroup carry
+                    {
+                        __scan_through_elements_helper<_Bounded, __sub_group_size, __is_inclusive,
+                                                       /*__init_present=*/false,
+                                                       /*__capture_output=*/true, __is_unique_pattern_v,
+                                                       __max_inputs_per_item>(
+                            __sub_group, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op,
+                            __sub_group_carry, __in_rng, __out_rng, __start_id, __n,
+                            __sub_group_params.__inputs_per_item, __subgroup_start_id, __sub_group_id,
+                            __active_subgroups, __comm_slm_ptr, __create_on_oob_reached_callback(__oob_pos_acc));
+                    }
+                    // If within the last active group and sub-group of the block, use the 0th work-item of the sub-group
+                    // to write out the last carry out for either the return value or the next block
+                    if (__sub_group_local_id == 0 && (__active_groups == __group_id + 1) &&
+                        (__active_subgroups == __sub_group_id + 1))
+                    {
+                        if (__block_num + 1 == __num_blocks)
+                        {
+                            if constexpr (__is_unique_pattern_v)
+                            {
+                                // unique patterns automatically copy the 0th element and scan starting at index 1
+                                __res_ptr[0] = __transform_result(__sub_group_carry.__v + 1);
+                            }
+                            else
+                            {
+                                __res_ptr[0] = __transform_result(__sub_group_carry.__v);
+                            }
+                        }
+                        else
+                        {
+                            // capture the last carry out for the next block
+                            __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v,
+                                                  __sub_group_params.__num_sub_groups_global);
+                        }
+                    }
+                    __sub_group_carry.__destroy();
+                }); // __dispatch_comm_tag
             });
         });
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1237,7 +1237,7 @@ struct __slm_only_tag
 template <typename _ValueType>
 struct __slm_or_subgroup_tag
 {
-    _ValueType* __value_ptr;
+    _ValueType* __value_ptr = nullptr;
 };
 
 // Layer of abstraction that hoists the runtime "sub-group ops vs SLM fallback" decision to a single branch point.
@@ -1713,7 +1713,7 @@ struct __comm_slm_handler
         else
             return _ScanOpsTag{nullptr};
     }
-    bool __use_subgroup_ops;
+    bool __use_subgroup_ops = false;
 };
 
 template <typename _InitValueType>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1229,7 +1229,7 @@ struct __subgroup_only_tag
 template <typename _ValueType>
 struct __slm_only_tag
 {
-    _ValueType* __value_ptr;
+    _ValueType* __value_ptr = nullptr;
 };
 
 // For trivially copyable types, both paths are available in the kernel, and a runtime parameter chooses between them.
@@ -1807,7 +1807,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                 _InitValueType* __temp_ptr = __temp_acc.__data();
                 // The sub-group-ops vs SLM-fallback decision is dispatched at each sub-group-scan region
                 // (see __scan_through_elements_helper and the carry-computation block below).
-                _ScanOpsTag __comm_scan_tag = __comm_handler.__get_tag_with_workspace(__comm_acc_or_placeholder);
+                const _ScanOpsTag __comm_scan_tag = __comm_handler.__get_tag_with_workspace(__comm_acc_or_placeholder);
                 std::size_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1887,8 +1887,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                             {
                                 __v = __sub_group_partials[__reduction_scan_id];
                                 __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true,
-                                                    /*__init_present=*/true>(__sub_group, __v, __reduce_op,
-                                                                            __sub_group_carry, __comm_tag_concrete);
+                                                 /*__init_present=*/true>(__sub_group, __v, __reduce_op,
+                                                                          __sub_group_carry, __comm_tag_concrete);
                                 __temp_ptr[__start_id + __reduction_scan_id] = __v;
                                 __reduction_scan_id += __sub_group_size;
                             }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1711,8 +1711,9 @@ struct __comm_slm_handler
             return __dpl_sycl::__local_accessor<_InitValueType>(0, __cgh); // Dummy accessor, won't actually be used
     }
 
+    template <typename _Acc>
     _ScanOpsTag
-    __get_data(const auto& __comm_slm_acc_opt, bool __use_subgroup_ops) const
+    __get_data(const _Acc& __comm_slm_acc_opt, bool __use_subgroup_ops) const
     {
         if (!__use_subgroup_ops)
             return _ScanOpsTag{__dpl_sycl::__get_accessor_ptr(__comm_slm_acc_opt)};

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1867,9 +1867,9 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
                                 std::min(std::uint32_t{__sub_group_local_id}, __active_subgroups - 1);
                             _InitValueType __v = __sub_group_partials[__load_id];
                             __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                        /*__init_present=*/false>(
-                                __sub_group, __v, __reduce_op, __sub_group_carry, __active_subgroups,
-                                __comm_tag_concrete);
+                                                     /*__init_present=*/false>(__sub_group, __v, __reduce_op,
+                                                                               __sub_group_carry, __active_subgroups,
+                                                                               __comm_tag_concrete);
                             if (__sub_group_local_id < __active_subgroups)
                                 __temp_ptr[__start_id + __sub_group_local_id] = __v;
                         }
@@ -1901,7 +1901,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_i
 
                             __v = __sub_group_partials[__load_id];
                             __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
-                                                        /*__init_present=*/true>(
+                                                     /*__init_present=*/true>(
                                 __sub_group, __v, __reduce_op, __sub_group_carry,
                                 __active_subgroups - ((__iters - 1) * __sub_group_size), __comm_tag_concrete);
                             if (__reduction_scan_id < __sub_group_params.__num_sub_groups_local)
@@ -2024,7 +2024,6 @@ struct __parallel_reduce_then_scan_scan_submitter<
             auto __res_acc =
                 __get_result_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
             auto __oob_pos_acc = __get_oob_pos_accessor_opt<_Bounded>(__cgh, __oob_pos_storage);
-
 
             __cgh.parallel_for<_KernelName...>(
                     __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1218,18 +1218,35 @@ struct __scan_by_seg_op
 // *** Main reduce then scan infrastructure ***
 
 // Sub-group communication wrappers with SLM fallback.
-// When __use_subgroup_ops is true, native SYCL sub-group operations are used (trivially copyable types only).
-// When __use_subgroup_ops is false, SLM-based communication is used. This path is required for
-// non-trivially-copyable types and preferred for CPU targets where sub-group ops are slow.
+// The scan tag dictates what implementation paths are available in the kernel, one or both of the subgroup operation
+// variant and the slm fallback may be available in the kernel, but only one kernel should be compiled per type.
+// For trivially copyable, types, both paths should be available in the kernel, and a runtime parameter
+// will choose between them. This enables CPU trivially copyable types to use the SLM-based path, which is considerably
+// faster. For non-trivially copyable types, only the SLM fallback is available. For some kernel templates, the subgroup
+// operation variant is the only one instantiated.
 // The __comm_slm parameter points to a work-group-sized SLM buffer; each sub-group uses its own
 // slice at offset [sub_group_id * sub_group_size, (sub_group_id + 1) * sub_group_size].
 
-// structure to signify no slm has been allocated, and native subgroup ops should be used
-struct __no_slm_tag{};
+struct __subgroup_only_tag
+{
+};
+
+template <typename _ValueType>
+struct __slm_only_tag
+{
+    _ValueType* __value_ptr;
+};
+
+template <typename _ValueType>
+struct __slm_or_subgroup_tag
+{
+    _ValueType* __value_ptr;
+};
 
 template <typename _ValueType>
 _ValueType
-__shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift, __no_slm_tag)
+__shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
+                    __subgroup_only_tag)
 {
     return sycl::shift_group_right(__sub_group, __value, __shift);
 }
@@ -1237,22 +1254,24 @@ __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __val
 template <typename _ValueType>
 _ValueType
 __shift_group_right(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, std::uint32_t __shift,
-                    _ValueType* __comm_slm)
+                    __slm_only_tag<_ValueType> __comm_slm)
 {
     // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
     // preferred (e.g., CPU targets where sub-group ops are slow).
     std::uint32_t __local_id = __sub_group.get_local_linear_id();
     std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
-    __comm_slm[__sg_base + __local_id] = __value;
+    __comm_slm.__value_ptr[__sg_base + __local_id] = __value;
     sycl::group_barrier(__sub_group);
-    _ValueType __result = __comm_slm[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
+    _ValueType __result =
+        __comm_slm.__value_ptr[__sg_base + ((__local_id >= __shift) ? __local_id - __shift : __local_id)];
     sycl::group_barrier(__sub_group);
     return __result;
 }
 
 template <typename _ValueType, typename _IdType>
 _ValueType
-__group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id, __no_slm_tag)
+__group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
+                  __subgroup_only_tag)
 {
     return sycl::group_broadcast(__sub_group, __value, __broadcast_id);
 }
@@ -1260,15 +1279,15 @@ __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value
 template <typename _ValueType, typename _IdType>
 _ValueType
 __group_broadcast(const __dpl_sycl::__sub_group& __sub_group, _ValueType __value, _IdType __broadcast_id,
-                  _ValueType* __comm_slm)
+                  __slm_only_tag<_ValueType> __comm_slm)
 {
     // SLM-based fallback: used for non-trivially-copyable types or when SLM communication is
     // preferred (e.g., CPU targets where sub-group ops are slow).
     std::uint32_t __local_id = __sub_group.get_local_linear_id();
     std::uint32_t __sg_base = __sub_group.get_group_linear_id() * __sub_group.get_max_local_range()[0];
-    __comm_slm[__sg_base + __local_id] = __value;
+    __comm_slm.__value_ptr[__sg_base + __local_id] = __value;
     sycl::group_barrier(__sub_group);
-    _ValueType __result = __comm_slm[__sg_base + __broadcast_id];
+    _ValueType __result = __comm_slm.__value_ptr[__sg_base + __broadcast_id];
     sycl::group_barrier(__sub_group);
     return __result;
 }
@@ -1365,10 +1384,10 @@ __sub_group_masked_scan(const __dpl_sycl::__sub_group& __sub_group, _MaskOp __ma
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType, typename _CommSLMPtr = __no_slm_tag>
+          typename _ValueType, typename _LazyValueType, typename _ScanOpsTag = __subgroup_only_tag>
 void
 __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                 _LazyValueType& __init_and_carry, _CommSLMPtr __comm_slm = {})
+                 _LazyValueType& __init_and_carry, _ScanOpsTag __comm_slm = {})
 {
     auto __mask_fn = [](auto __sub_group_local_id, auto __offset) { return __sub_group_local_id >= __offset; };
     std::uint8_t __init_broadcast_id = __sub_group.get_max_local_range()[0] - 1;
@@ -1377,10 +1396,28 @@ __sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
-          typename _ValueType, typename _LazyValueType, typename _SizeType, typename _CommSLMPtr = __no_slm_tag>
+          typename _ValueType, typename _LazyValueType>
+void
+__sub_group_scan(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
+                 _LazyValueType& __init_and_carry, __slm_or_subgroup_tag<_ValueType> __comm_slm)
+{
+    if (__comm_slm.__value_ptr)
+    {
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(
+            __sub_group, __value, __binary_op, __init_and_carry, __slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
+    }
+    else
+    {
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __value, __binary_op,
+                                                                           __init_and_carry, __subgroup_only_tag{});
+    }
+}
+
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
+          typename _ValueType, typename _LazyValueType, typename _SizeType, typename _ScanOpsTag = __subgroup_only_tag>
 void
 __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
-                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _CommSLMPtr __comm_slm = {})
+                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process, _ScanOpsTag __comm_slm = {})
 {
     auto __mask_fn = [__elements_to_process](auto __sub_group_local_id, auto __offset) {
         return __sub_group_local_id >= __offset && __sub_group_local_id < __elements_to_process;
@@ -1388,6 +1425,26 @@ __sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType&
     std::uint8_t __init_broadcast_id = __elements_to_process - 1;
     __sub_group_masked_scan<__sub_group_size, __is_inclusive, __init_present>(
         __sub_group, __mask_fn, __init_broadcast_id, __value, __binary_op, __init_and_carry, __comm_slm);
+}
+
+template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, typename _BinaryOp,
+          typename _ValueType, typename _LazyValueType, typename _SizeType>
+void
+__sub_group_scan_partial(const __dpl_sycl::__sub_group& __sub_group, _ValueType& __value, _BinaryOp __binary_op,
+                         _LazyValueType& __init_and_carry, _SizeType __elements_to_process,
+                         __slm_or_subgroup_tag<_ValueType> __comm_slm)
+{
+    if (__comm_slm.__value_ptr)
+    {
+        __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
+            __sub_group, __value, __binary_op, __init_and_carry, __elements_to_process,
+            __slm_only_tag<_ValueType>{__comm_slm.__value_ptr});
+    }
+    else
+    {
+        __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
+            __sub_group, __value, __binary_op, __init_and_carry, __elements_to_process, __subgroup_only_tag{});
+    }
 }
 
 template <std::uint8_t __sub_group_size, bool __is_inclusive, bool __init_present, bool __capture_output,
@@ -1642,33 +1699,45 @@ struct __reduce_then_scan_sub_group_params
     std::uint32_t __inputs_per_item;
 };
 
-template <bool __use_subgroup_ops, typename _InitValueType>
-std::enable_if_t<__use_subgroup_ops, __no_slm_tag>
-__create_comm_slm_acc_opt(const std::uint32_t /*__work_group_size*/, sycl::handler& /*__cgh*/)
+template <typename _ScanOpsTag, typename _InitValueType>
+struct __comm_slm_handler
 {
-    return __no_slm_tag{};
-}
+    auto
+    __get_accessor(const std::uint32_t __work_group_size, bool __use_subgroup_ops, sycl::handler& __cgh) const
+    {
+        if (!__use_subgroup_ops)
+            return __dpl_sycl::__local_accessor<_InitValueType>(__work_group_size, __cgh);
+        else
+            return __dpl_sycl::__local_accessor<_InitValueType>(0, __cgh); // Dummy accessor, won't actually be used
+    }
 
-template <bool __use_subgroup_ops, typename _InitValueType>
-std::enable_if_t<!__use_subgroup_ops, __dpl_sycl::__local_accessor<_InitValueType>>
-__create_comm_slm_acc_opt(const std::uint32_t __work_group_size, sycl::handler& __cgh)
-{
-    return __dpl_sycl::__local_accessor<_InitValueType>(__work_group_size, __cgh);
-}
+    _ScanOpsTag
+    __get_data(const auto& __comm_slm_acc_opt, bool __use_subgroup_ops) const
+    {
+        if (!__use_subgroup_ops)
+            return _ScanOpsTag{__dpl_sycl::__get_accessor_ptr(__comm_slm_acc_opt)};
+        else
+            return _ScanOpsTag{nullptr};
+    }
+};
 
-inline __no_slm_tag
-__get_comm_slm_acc_data(__no_slm_tag)
+template <typename _InitValueType>
+struct __comm_slm_handler<__subgroup_only_tag, _InitValueType>
 {
-    // Noop, type carries dispatch info for broadcast and shift left subgroup ops
-    return __no_slm_tag{};
-}
+    __subgroup_only_tag
+    __get_accessor(const std::uint32_t /*__work_group_size*/, bool /*__use_subgroup_ops*/,
+                   sycl::handler& /*__cgh*/) const
+    {
+        return __subgroup_only_tag{};
+    }
 
-template <typename CommSlmAcc>
-auto
-__get_comm_slm_acc_data(const CommSlmAcc& __comm_slm_acc_opt)
-{
-    return __dpl_sycl::__get_accessor_ptr(__comm_slm_acc_opt);
-}
+    __subgroup_only_tag
+    __get_data(__subgroup_only_tag, bool /*__use_subgroup_ops*/) const
+    {
+        // Noop, type carries dispatch info for broadcast and shift left subgroup ops
+        return __subgroup_only_tag{};
+    }
+};
 
 template <typename... _Name>
 class __reduce_then_scan_partition_kernel;
@@ -1679,13 +1748,10 @@ class __reduce_then_scan_reduce_kernel;
 template <typename... _Name>
 class __reduce_then_scan_scan_kernel;
 
-// Type tag used to differentiate kernel name instantiations between the sub-group-ops and SLM-based
-// dispatch paths so the two paths don't collide on a default kernel name.
-template <bool __use_subgroup_ops>
-struct __reduce_then_scan_subgroup_ops_tag;
-
 // Sentinel type used as a stand-in for the OOB-position accessor when _Bounded=false.
-struct __no_oob_pos_acc_tag {};
+struct __no_oob_pos_acc_tag
+{
+};
 
 template <typename _T>
 inline constexpr bool __is_no_oob_pos_acc_v = std::is_same_v<std::remove_cv_t<_T>, __no_oob_pos_acc_tag>;
@@ -1706,16 +1772,15 @@ __get_oob_pos_accessor_opt(sycl::handler& __cgh, _OOBPosStorage& __oob_pos_stora
 }
 
 template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
-          bool __use_subgroup_ops, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
-          typename _KernelName>
+          typename _ScanOpsTag, typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename _KernelName>
 struct __parallel_reduce_then_scan_reduce_submitter;
 
 template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
-          bool __use_subgroup_ops, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
+          typename _ScanOpsTag, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
           typename... _KernelName>
-struct __parallel_reduce_then_scan_reduce_submitter<
-    _Bounded, __max_inputs_per_item, __is_inclusive, __is_unique_pattern_v, __use_subgroup_ops, _GenReduceInput,
-    _ReduceOp, _InitType, __internal::__optional_kernel_name<_KernelName...>>
+struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_item, __is_inclusive,
+                                                    __is_unique_pattern_v, _ScanOpsTag, _GenReduceInput, _ReduceOp,
+                                                    _InitType, __internal::__optional_kernel_name<_KernelName...>>
 {
     static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
     // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
@@ -1732,7 +1797,8 @@ struct __parallel_reduce_then_scan_reduce_submitter<
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            auto __comm_slm = __create_comm_slm_acc_opt<__use_subgroup_ops, _InitValueType>(__work_group_size, __cgh);
+            __comm_slm_handler<_ScanOpsTag, _InitValueType> __comm_handler{};
+            auto __comm_slm = __comm_handler.__get_accessor(__work_group_size, __use_subgroup_ops, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __get_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
@@ -1745,7 +1811,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
 
                 _InitValueType* __temp_ptr = __temp_acc.__data();
-                auto __comm_slm_ptr = __get_comm_slm_acc_data(__comm_slm);
+                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm, __use_subgroup_ops);
                 std::size_t __group_id = __ndi.get_group(0);
                 std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
                 std::uint8_t __sub_group_local_id = __sub_group.get_local_linear_id();
@@ -1864,6 +1930,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<
     const _GenReduceInput __gen_reduce_input;
     const _ReduceOp __reduce_op;
     _InitType __init;
+    const bool __use_subgroup_ops;
 };
 
 template <bool _Bounded, typename _ValueType, typename _Range>
@@ -1874,17 +1941,16 @@ using __transform_reduce_then_scan_result_t =
                        std::tuple<sycl::event, __combined_storage<_ValueType>>>;
 
 template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
-          bool __use_subgroup_ops, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
+          typename _ScanOpsTag, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
           typename _WriteOp, typename _InitType, typename _TransformResult, typename _KernelName>
 struct __parallel_reduce_then_scan_scan_submitter;
 
 template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
-          bool __use_subgroup_ops, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
+          typename _ScanOpsTag, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
           typename _WriteOp, typename _InitType, typename _TransformResult, typename... _KernelName>
-struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __max_inputs_per_item, __is_inclusive,
-                                                  __is_unique_pattern_v, __use_subgroup_ops, _ReduceOp, _GenScanInput,
-                                                  _ScanInputTransform, _WriteOp, _InitType, _TransformResult,
-                                                  __internal::__optional_kernel_name<_KernelName...>>
+struct __parallel_reduce_then_scan_scan_submitter<
+    _Bounded, __max_inputs_per_item, __is_inclusive, __is_unique_pattern_v, _ScanOpsTag, _ReduceOp, _GenScanInput,
+    _ScanInputTransform, _WriteOp, _InitType, _TransformResult, __internal::__optional_kernel_name<_KernelName...>>
 {
     using _InitValueType = typename _InitType::__value_type;
     static constexpr std::uint8_t __sub_group_size = __get_reduce_then_scan_actual_sg_sz_device();
@@ -1946,7 +2012,9 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __max_inputs_per_ite
             __dpl_sycl::__local_accessor<_InitValueType> __sub_group_partials(__max_num_sub_groups_local + 1, __cgh);
             // SLM for sub-group communication (shift_group_right / group_broadcast).
             // Used for non-trivially-copyable types or when SLM communication is preferred (e.g., CPU targets).
-            auto __comm_slm = __create_comm_slm_acc_opt<__use_subgroup_ops, _InitValueType>(__work_group_size, __cgh);
+            __comm_slm_handler<_ScanOpsTag, _InitValueType> __comm_handler{};
+            auto __comm_slm = __comm_handler.__get_accessor(__work_group_size, __use_subgroup_ops, __cgh);
+
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
             auto __temp_acc = __get_accessor(sycl::read_write, __scratch_container, __cgh);
@@ -1956,7 +2024,7 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __max_inputs_per_ite
 
             __cgh.parallel_for<_KernelName...>(
                     __nd_range, [=, *this] (sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(__sub_group_size)]] {
-                auto __comm_slm_ptr = __get_comm_slm_acc_data(__comm_slm);
+                auto __comm_slm_ptr = __comm_handler.__get_data(__comm_slm, __use_subgroup_ops);
 
                 __reduce_then_scan_sub_group_params __sub_group_params(
                     __work_group_size, __sub_group_size, __max_num_work_groups, __max_block_size, __inputs_remaining);
@@ -2247,6 +2315,7 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __max_inputs_per_ite
     const _ScanInputTransform __scan_input_transform;
     const _WriteOp __write_op;
     _InitType __init;
+    const bool __use_subgroup_ops;
     const _TransformResult __transform_result;
 };
 
@@ -2271,9 +2340,9 @@ __create_oob_pos_storage_opt(sycl::queue& __q)
 }
 
 // Helper for __parallel_transform_reduce_then_scan templated on the choice of sub-group communication
-// strategy. When __use_subgroup_ops is true, native SYCL sub-group operations are used; when false,
-// SLM-based fallback is used.
-template <bool _Bounded, bool __use_subgroup_ops, std::uint32_t __bytes_per_work_item_iter, typename _CustomName,
+// strategy via _ScanOpsTag, which selects which communication path(s) are compiled into the kernel. The
+// runtime __use_subgroup_ops flag then chooses between them when both are available.
+template <bool _Bounded, typename _ScanOpsTag, std::uint32_t __bytes_per_work_item_iter, typename _CustomName,
           typename _InRng, typename _OutRng, typename _GenReduceInput, typename _ReduceOp, typename _GenScanInput,
           typename _ScanInputTransform, typename _WriteOp, typename _InitType, typename _Inclusive,
           typename _IsUniquePattern, typename _TransformResult>
@@ -2282,13 +2351,13 @@ __parallel_transform_reduce_then_scan_impl(sycl::queue& __q, const std::size_t _
                                            _OutRng&& __out_rng, _GenReduceInput __gen_reduce_input,
                                            _ReduceOp __reduce_op, _GenScanInput __gen_scan_input,
                                            _ScanInputTransform __scan_input_transform, _WriteOp __write_op,
-                                           _InitType __init, _Inclusive, _IsUniquePattern,
+                                           _InitType __init, _Inclusive, _IsUniquePattern, bool __use_subgroup_ops,
                                            _TransformResult __transform_result, sycl::event __prior_event)
 {
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_then_scan_reduce_kernel<__reduce_then_scan_subgroup_ops_tag<__use_subgroup_ops>, _CustomName>>;
+        __reduce_then_scan_reduce_kernel<_ScanOpsTag, _CustomName>>;
     using _ScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_then_scan_scan_kernel<__reduce_then_scan_subgroup_ops_tag<__use_subgroup_ops>, _CustomName>>;
+        __reduce_then_scan_scan_kernel<_ScanOpsTag, _CustomName>>;
     using _ValueType = typename _InitType::__value_type;
 
     constexpr std::uint8_t __min_sub_group_size = __get_reduce_then_scan_workaround_sg_sz();
@@ -2337,12 +2406,12 @@ __parallel_transform_reduce_then_scan_impl(sycl::queue& __q, const std::size_t _
     // Reduce and scan step implementations
     using _ReduceSubmitter =
         __parallel_reduce_then_scan_reduce_submitter<_Bounded, __max_inputs_per_item, __inclusive,
-                                                     __is_unique_pattern_v, __use_subgroup_ops, _GenReduceInput,
-                                                     _ReduceOp, _InitType, _ReduceKernel>;
+                                                     __is_unique_pattern_v, _ScanOpsTag, _GenReduceInput, _ReduceOp,
+                                                     _InitType, _ReduceKernel>;
     using _ScanSubmitter =
         __parallel_reduce_then_scan_scan_submitter<_Bounded, __max_inputs_per_item, __inclusive, __is_unique_pattern_v,
-                                                   __use_subgroup_ops, _ReduceOp, _GenScanInput, _ScanInputTransform,
-                                                   _WriteOp, _InitType, _TransformResult, _ScanKernel>;
+                                                   _ScanOpsTag, _ReduceOp, _GenScanInput, _ScanInputTransform, _WriteOp,
+                                                   _InitType, _TransformResult, _ScanKernel>;
     _ReduceSubmitter __reduce_submitter{__num_work_groups,
                                         __work_group_size,
                                         __max_inputs_per_block,
@@ -2350,7 +2419,8 @@ __parallel_transform_reduce_then_scan_impl(sycl::queue& __q, const std::size_t _
                                         __n,
                                         __gen_reduce_input,
                                         __reduce_op,
-                                        __init};
+                                        __init,
+                                        __use_subgroup_ops};
     _ScanSubmitter __scan_submitter{__num_work_groups,
                                     __work_group_size,
                                     __max_inputs_per_block,
@@ -2363,6 +2433,7 @@ __parallel_transform_reduce_then_scan_impl(sycl::queue& __q, const std::size_t _
                                     __scan_input_transform,
                                     __write_op,
                                     __init,
+                                    __use_subgroup_ops,
                                     __transform_result};
 
     // Allocate storage for out-of-bounds position if needed
@@ -2428,19 +2499,20 @@ __parallel_transform_reduce_then_scan(sycl::queue& __q, const std::size_t __n, _
     // Native sycl sub-group operations can only be used on trivially copyable types, for other types, use SLM variant
     if constexpr (std::is_trivially_copyable_v<_ValueType>)
     {
-        return __parallel_transform_reduce_then_scan_impl<_Bounded, /*__use_subgroup_ops=*/true,
+        bool __use_subgroup_ops = __q.get_device().is_gpu();
+        return __parallel_transform_reduce_then_scan_impl<_Bounded, __slm_or_subgroup_tag<_ValueType>,
                                                           __bytes_per_work_item_iter, _CustomName>(
             __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
             __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
-            __transform_result, std::move(__prior_event));
+            __use_subgroup_ops, __transform_result, std::move(__prior_event));
     }
     else
     {
-        return __parallel_transform_reduce_then_scan_impl<_Bounded, /*__use_subgroup_ops=*/false,
+        return __parallel_transform_reduce_then_scan_impl<_Bounded, __slm_only_tag<_ValueType>,
                                                           __bytes_per_work_item_iter, _CustomName>(
             __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __gen_reduce_input, __reduce_op,
             __gen_scan_input, __scan_input_transform, __write_op, __init, __inclusive, __is_unique_pattern,
-            __transform_result, std::move(__prior_event));
+            /*__use_subgroup_ops=*/false, __transform_result, std::move(__prior_event));
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -489,12 +489,11 @@ template <typename _SetOpCount, typename _TempData, typename _RetType, typename 
 struct __gen_set_op_from_known_balanced_path;
 
 template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
-          bool __use_subgroup_ops, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
-          typename _KernelName>
+          typename _ScanOpsTag, typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename _KernelName>
 struct __parallel_reduce_then_scan_reduce_submitter;
 
 template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
-          bool __use_subgroup_ops, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
+          typename _ScanOpsTag, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
           typename _WriteOp, typename _InitType, typename _TransformResult, typename _KernelName>
 struct __parallel_reduce_then_scan_scan_submitter;
 
@@ -646,21 +645,21 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
 // Submitters that capture member variables via *this into the kernel lambda must have device copyable specializations
 // if their members may not be trivially copyable.
 template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
-          bool __use_subgroup_ops, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
+          typename _ScanOpsTag, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
           typename... _KernelName>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
     oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_reduce_submitter, _Bounded, __max_inputs_per_item,
-    __is_inclusive, __is_unique_pattern_v, __use_subgroup_ops, _GenReduceInput, _ReduceOp, _InitType, _KernelName...)>
+    __is_inclusive, __is_unique_pattern_v, _ScanOpsTag, _GenReduceInput, _ReduceOp, _InitType, _KernelName...)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_GenReduceInput, _ReduceOp, _InitType>
 {
 };
 
 template <bool _Bounded, std::uint16_t __max_inputs_per_item, bool __is_inclusive, bool __is_unique_pattern_v,
-          bool __use_subgroup_ops, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
+          typename _ScanOpsTag, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
           typename _WriteOp, typename _InitType, typename _TransformResult, typename... _KernelName>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(
     oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_scan_submitter, _Bounded, __max_inputs_per_item,
-    __is_inclusive, __is_unique_pattern_v, __use_subgroup_ops, _ReduceOp, _GenScanInput, _ScanInputTransform, _WriteOp,
+    __is_inclusive, __is_unique_pattern_v, _ScanOpsTag, _ReduceOp, _GenScanInput, _ScanInputTransform, _WriteOp,
     _InitType, _TransformResult, _KernelName...)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_ReduceOp, _GenScanInput, _ScanInputTransform, _WriteOp,
                                                          _InitType, _TransformResult>

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -279,8 +279,8 @@ test_device_copyable()
     //__parallel_reduce_then_scan_reduce_submitter
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_reduce_submitter<
-            /*_Bounded*/ false,
-            16, true, false, false,
+            /*_Bounded*/ false, 16, true, false,
+            oneapi::dpl::__par_backend_hetero::__slm_or_subgroup_tag<int_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_reduce_input<binary_op_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>,
             oneapi::dpl::unseq_backend::__no_init_value<int_device_copyable>,
@@ -290,17 +290,17 @@ test_device_copyable()
     //__parallel_reduce_then_scan_scan_submitter
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_scan_submitter<
-            /*_Bounded*/ false,
-            16, true, false, false, oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>,
+            /*_Bounded*/ false, 16, true, false,
+            oneapi::dpl::__par_backend_hetero::__slm_or_subgroup_tag<int_device_copyable>,
+            oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_scan_input<binary_op_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__get_zeroth_element,
             oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<
                 true, oneapi::dpl::unseq_backend::__init_value<int_device_copyable>, binary_op_device_copyable>,
-            oneapi::dpl::unseq_backend::__no_init_value<int_device_copyable>,
-            oneapi::dpl::identity,
+            oneapi::dpl::unseq_backend::__no_init_value<int_device_copyable>, oneapi::dpl::identity,
             oneapi::dpl::execution::DefaultKernelName>>,
         "__parallel_reduce_then_scan_scan_submitter is not device copyable with device copyable types");
-#endif
+#    endif
 
     //__not_pred
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_device_copyable>>,
@@ -610,8 +610,8 @@ test_non_device_copyable()
     //__parallel_reduce_then_scan_reduce_submitter
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_reduce_submitter<
-            /*_Bounded*/ false,
-            16, true, false, false,
+            /*_Bounded*/ false, 16, true, false,
+            oneapi::dpl::__par_backend_hetero::__slm_only_tag<int_non_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_reduce_input<binary_op_non_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>,
             oneapi::dpl::unseq_backend::__no_init_value<int_non_device_copyable>,
@@ -621,14 +621,14 @@ test_non_device_copyable()
     //__parallel_reduce_then_scan_scan_submitter
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__parallel_reduce_then_scan_scan_submitter<
-            /*_Bounded*/ false,
-            16, true, false, false, oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>,
+            /*_Bounded*/ false, 16, true, false,
+            oneapi::dpl::__par_backend_hetero::__slm_only_tag<int_non_device_copyable>,
+            oneapi::dpl::__par_backend_hetero::__scan_by_seg_op<binary_op_non_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__gen_scan_by_seg_scan_input<binary_op_non_device_copyable>,
             oneapi::dpl::__par_backend_hetero::__get_zeroth_element,
             oneapi::dpl::__par_backend_hetero::__write_scan_by_seg<
                 true, oneapi::dpl::unseq_backend::__init_value<int_non_device_copyable>, binary_op_non_device_copyable>,
-            oneapi::dpl::unseq_backend::__no_init_value<int_non_device_copyable>,
-            oneapi::dpl::identity,
+            oneapi::dpl::unseq_backend::__no_init_value<int_non_device_copyable>, oneapi::dpl::identity,
             oneapi::dpl::execution::DefaultKernelName>>,
         "__parallel_reduce_then_scan_scan_submitter is device copyable with non device copyable types");
 #    endif

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -300,7 +300,7 @@ test_device_copyable()
             oneapi::dpl::unseq_backend::__no_init_value<int_device_copyable>, oneapi::dpl::identity,
             oneapi::dpl::execution::DefaultKernelName>>,
         "__parallel_reduce_then_scan_scan_submitter is not device copyable with device copyable types");
-#    endif
+#endif
 
     //__not_pred
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_device_copyable>>,
@@ -631,7 +631,7 @@ test_non_device_copyable()
             oneapi::dpl::unseq_backend::__no_init_value<int_non_device_copyable>, oneapi::dpl::identity,
             oneapi::dpl::execution::DefaultKernelName>>,
         "__parallel_reduce_then_scan_scan_submitter is device copyable with non device copyable types");
-#    endif
+#endif
 
     //__not_pred
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_pred<noop_non_device_copyable>>,


### PR DESCRIPTION
As mentioned in #2701, we want to avoid multiplying the number of kernels by 2.  

This PR pushes the runtime branch back down into the kernel, but provides tags for selecting the variants to compile, then a runtime bool to select between variants.

The runtime branch is at the level of 1 branch per call to `scan_through_elements_helper`, or equivalent.  This seems acceptable for performance with detriment less than 1% for greater than 256K elements.

I recommend reviewing with whitespace hidden as there are indentation changes from the addition of lambdas for dispatch.