### PR TITLE
Flush `std::cerr` stream before exit on error in tests

### DIFF
--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -86,10 +86,9 @@ const_size(const T (&)[N]) noexcept
 // Issue error message from outstr, adding a newline.
 // Real purpose of this routine is to have a place to hang a breakpoint.
 inline void
-issue_error_message(std::stringstream& outstr)
+issue_error_message(const std::stringstream& outstr)
 {
-    outstr << std::endl;
-    std::cerr << outstr.str();
+    std::cerr << outstr.str() << std::endl;
     std::exit(EXIT_FAILURE);
 }
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -86,11 +86,11 @@ const_size(const T (&)[N]) noexcept
 // Issue error message from outstr, adding a newline.
 // Real purpose of this routine is to have a place to hang a breakpoint.
 inline void
-issue_error_message(::std::stringstream& outstr)
+issue_error_message(std::stringstream& outstr)
 {
-    outstr << ::std::endl;
-    ::std::cerr << outstr.str();
-    ::std::exit(EXIT_FAILURE);
+    outstr << std::endl;
+    std::cerr << outstr.str();
+    std::exit(EXIT_FAILURE);
 }
 
 template <typename TStream>

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -114,8 +114,8 @@ auto async_handler = [](sycl::exception_list ex_list) {
         }
         catch (sycl::exception& ex)
         {
-            ::std::cerr << ex.what() << ::std::endl;
-            ::std::exit(EXIT_FAILURE);
+            std::cerr << ex.what() << std::endl;
+            std::exit(EXIT_FAILURE);
         }
     }
 };


### PR DESCRIPTION
### Motivation
During debugging sometimes is very useful to comment `std::exit` call and re-call algorithm implementation again.
In this case the error message needed on output screen for the future investigation.