### PR TITLE
Improve destroy testing with device policy and non-trivial types

### DIFF
--- a/test/general/sycl_iterator/sycl_iterator_for.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_for.pass.cpp
@@ -245,61 +245,6 @@ DEFINE_TEST(test_uninitialized_value_construct_n)
     }
 };
 
-DEFINE_TEST(test_destroy)
-{
-    DEFINE_TEST_CONSTRUCTOR(test_destroy, 1.0f, 1.0f)
-
-    template <typename Policy, typename Iterator1, typename Size>
-    void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
-    {
-        TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
-
-        using T1 = typename std::iterator_traits<Iterator1>::value_type;
-        auto value = T1{ 2 };
-        ::std::fill(host_keys.get(), host_keys.get() + n, value);
-        host_keys.update_data();
-
-        using _NewKernelName = policy_name_wrapper<new_kernel_name<Policy, 0>, T1>;
-        std::destroy(CLONE_TEST_POLICY_NAME(exec, _NewKernelName), first1 + (n / 3), first1 + (n / 2));
-        if (!::std::is_trivially_destructible_v<T1>)
-            value = T1{-2};
-        wait_and_throw(exec);
-
-        host_keys.retrieve_data();
-        EXPECT_TRUE(check_values(host_keys.get() + (n / 3), host_keys.get() + (n / 2), value),
-                    "wrong effect from destroy");
-    }
-};
-
-DEFINE_TEST(test_destroy_n)
-{
-    DEFINE_TEST_CONSTRUCTOR(test_destroy_n, 1.0f, 1.0f)
-
-    template <typename Policy, typename Iterator1, typename Size>
-    void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
-    {
-        TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
-
-        using T1 = typename std::iterator_traits<Iterator1>::value_type;
-        auto value = T1{ 2 };
-
-        ::std::fill(host_keys.get(), host_keys.get() + n, value);
-        host_keys.update_data();
-
-        using _NewKernelName = policy_name_wrapper<new_kernel_name<Policy, 0>, T1>;
-        std::destroy_n(CLONE_TEST_POLICY_NAME(exec, _NewKernelName), first1, n);
-        if(!::std::is_trivially_destructible_v<T1>)
-            value = T1{-2};
-        wait_and_throw(exec);
-
-        host_keys.retrieve_data();
-        EXPECT_TRUE(check_values(host_keys.get(), host_keys.get() + n, value),
-                    "wrong effect from destroy_n");
-    }
-};
-
 DEFINE_TEST(test_fill)
 {
     DEFINE_TEST_CONSTRUCTOR(test_fill, 1.0f, 1.0f)
@@ -1078,11 +1023,6 @@ test_usm_and_buffer()
     test1buffer<alloc_type, test_uninitialized_value_construct<ValueType>>();
     PRINT_DEBUG("test_uninitialized_value_construct_n");
     test1buffer<alloc_type, test_uninitialized_value_construct_n<ValueType>>();
-    PRINT_DEBUG("test_destroy");
-    test1buffer<alloc_type, test_destroy<SyclTypeWrapper<ValueType>>>();
-    PRINT_DEBUG("test_destroy_n");
-    test1buffer<alloc_type, test_destroy_n<SyclTypeWrapper<ValueType>>>();
-    test1buffer<alloc_type, test_destroy_n<ValueType>>();
 
     //test2buffers
     PRINT_DEBUG("test_replace_copy");

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
@@ -342,7 +342,6 @@ void test_destroy_sycl()
 {
     constexpr std::size_t n = 10;
     sycl::queue q = TestUtils::get_test_queue();
-    auto p = oneapi::dpl::execution::make_device_policy(q);
     auto del_v = [&q](FlaggedValue* ptr) { sycl::free(ptr, q); };
     auto del_f = [&q](int* f) { sycl::free(f, q); };
     using del_v_t = decltype(del_v);
@@ -353,6 +352,7 @@ void test_destroy_sycl()
         for (size_t i = 0; i < n; ++i) new (ptr.get() + i) FlaggedValue(4, flags.get() + i);
         for (size_t i = 0; i < n; ++i) new (flags.get() + i) int(4);
 
+        auto p = TestUtils::make_device_policy<class Destroy>(q);
         oneapi::dpl::destroy(p, ptr.get(), ptr.get() + n);
         bool all_done = std::all_of(flags.get(), flags.get() + n, FlaggedValue::is_destroyed);
         EXPECT_TRUE(all_done, "destroy did not call destructors of all elements in the range");
@@ -363,6 +363,7 @@ void test_destroy_sycl()
         for (size_t i = 0; i < n; ++i) new (ptr.get() + i) FlaggedValue(4, flags.get() + i);
         for (size_t i = 0; i < n; ++i) new (flags.get() + i) int(4);
 
+        auto p = TestUtils::make_device_policy<class DestroyN>(q);
         oneapi::dpl::destroy_n(p, ptr.get(), n);
         bool all_done = std::all_of(flags.get(), flags.get() + n, FlaggedValue::is_destroyed);
         EXPECT_TRUE(all_done, "destroy_n did not call destructors of all elements in the range");

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
@@ -327,6 +327,49 @@ void test_empty_list_initialization_for_uninitialized_fill_n()
 #endif
 }
 
+#if TEST_DPCPP_BACKEND_PRESENT
+struct FlaggedValue
+{
+    int value;
+    int* flag;
+    FlaggedValue(const int& v, int* f) : value(v), flag(f) {}
+    ~FlaggedValue() { *flag = -117; }
+    static bool is_destroyed(int flag) { return flag == -117; }
+    bool operator==(const FlaggedValue& other) const { return value == other.value; }
+};
+
+void test_destroy_sycl()
+{
+    constexpr std::size_t n = 10;
+    sycl::queue q = TestUtils::get_test_queue();
+    auto p = oneapi::dpl::execution::make_device_policy(q);
+    auto del_v = [&q](FlaggedValue* ptr) { sycl::free(ptr, q); };
+    auto del_f = [&q](int* f) { sycl::free(f, q); };
+    using del_v_t = decltype(del_v);
+    using del_f_t = decltype(del_f);
+    {
+        std::unique_ptr<FlaggedValue[], del_v_t> ptr(sycl::malloc_shared<FlaggedValue>(n, q), del_v);
+        std::unique_ptr<int[], del_f_t> flags(sycl::malloc_shared<int>(n, q), del_f);
+        for (size_t i = 0; i < n; ++i) new (ptr.get() + i) FlaggedValue(4, flags.get() + i);
+        for (size_t i = 0; i < n; ++i) new (flags.get() + i) int(4);
+
+        oneapi::dpl::destroy(p, ptr.get(), ptr.get() + n);
+        bool all_done = std::all_of(flags.get(), flags.get() + n, FlaggedValue::is_destroyed);
+        EXPECT_TRUE(all_done, "destroy did not call destructors of all elements in the range");
+    }
+    {
+        std::unique_ptr<FlaggedValue[], del_v_t> ptr(sycl::malloc_shared<FlaggedValue>(n, q), del_v);
+        std::unique_ptr<int[], del_f_t> flags(sycl::malloc_shared<int>(n, q), del_f);
+        for (size_t i = 0; i < n; ++i) new (ptr.get() + i) FlaggedValue(4, flags.get() + i);
+        for (size_t i = 0; i < n; ++i) new (flags.get() + i) int(4);
+
+        oneapi::dpl::destroy_n(p, ptr.get(), n);
+        bool all_done = std::all_of(flags.get(), flags.get() + n, FlaggedValue::is_destroyed);
+        EXPECT_TRUE(all_done, "destroy_n did not call destructors of all elements in the range");
+    }
+}
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
 int
 main()
 {
@@ -334,9 +377,11 @@ main()
     test_uninitialized_fill_destroy_by_type<std::int32_t>();
     test_uninitialized_fill_destroy_by_type<float64_t>();
 
-#if !TEST_DPCPP_BACKEND_PRESENT
     // for user-defined types
-    test_uninitialized_fill_destroy_by_type<Wrapper<::std::string>>();
+#if TEST_DPCPP_BACKEND_PRESENT
+    test_destroy_sycl();
+#else
+    test_uninitialized_fill_destroy_by_type<Wrapper<std::string>>();
     test_uninitialized_fill_destroy_by_type<Wrapper<std::int8_t*>>();
 #endif
 


### PR DESCRIPTION
The original test looked into an uninitialized memory region which is UB. The new test observes another memory region which is changed by the destroy operation.

The new test case was moved into a dedicated file, `uninitialized_fill_destroy.pass.cpp`.