### PR TITLE
Support `sycl::half` in KT sort and correct signed zero handling in radix sort

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -119,12 +119,12 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Int, _N> __src)
     return __src.template bit_cast_view<_UInt>() ^ __mask;
 }
 
-template <bool __is_ascending, typename _Float, int _N, std::enable_if_t<std::is_same_v<_Float, sycl::half>, int> = 0>
+template <bool __is_ascending, int _N>
 __dpl_esimd::__ns::simd<std::uint16_t, _N>
-__order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
+__order_preserving_cast(__dpl_esimd::__ns::simd<sycl::half, _N> __src)
 {
     __dpl_esimd::__ns::simd<std::uint16_t, _N> __uint16_src = __src.template bit_cast_view<std::uint16_t>();
-    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__src == _Float{0});
+    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__src == sycl::half{0});
     __dpl_esimd::__ns::simd<std::uint16_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint16_src >> 15 == 0);
     if constexpr (__is_ascending)
@@ -163,8 +163,8 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
                                      __dpl_esimd::__ns::simd<::std::uint32_t, _N>(::std::uint32_t(0)), __sign_bit_m);
     }
     // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
-    return __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint32_t, _N>(0x80000000u),
-                                    __dpl_esimd::__ns::simd<std::uint32_t, _N>(__uint32_src ^ __mask), __is_zero);
+    return __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint32_t, _N>(0x80000000u), __uint32_src ^ __mask,
+                                    __is_zero);
 }
 
 template <bool __is_ascending, typename _Float, int _N,
@@ -190,7 +190,7 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
     }
     // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     return __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint64_t, _N>(0x8000000000000000u),
-                                    __dpl_esimd::__ns::simd<std::uint64_t, _N>(__uint64_src ^ __mask), __is_zero);
+                                    __uint64_src ^ __mask, __is_zero);
 }
 
 template <typename _T, int _N>

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -136,7 +136,7 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
     else
     {
         __mask = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0x7FFFu),
-                                          __dpl_esimd::__ns::simd<std::uint16_t, _N>(::std::uint16_t(0)), __sign_bit_m);
+                                          __dpl_esimd::__ns::simd<std::uint16_t, _N>(std::uint16_t(0)), __sign_bit_m);
     }
     return __uint16_src ^ __mask;
 }

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -124,7 +124,7 @@ __dpl_esimd::__ns::simd<std::uint16_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<std::uint16_t, _N> __uint16_src = __src.template bit_cast_view<std::uint16_t>();
-    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__uint16_src & 0x7FFFu) == 0;
+    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__src == _Float{0});
     __dpl_esimd::__ns::simd<std::uint16_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint16_src >> 15 == 0);
     if constexpr (__is_ascending)
@@ -147,7 +147,7 @@ __dpl_esimd::__ns::simd<::std::uint32_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<::std::uint32_t, _N> __uint32_src = __src.template bit_cast_view<::std::uint32_t>();
-    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__uint32_src & 0x7FFFFFFFu) == 0;
+    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__src == _Float{0});
     __dpl_esimd::__ns::simd<::std::uint32_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint32_src >> 31 == 0);
     if constexpr (__is_ascending)
@@ -171,7 +171,7 @@ __dpl_esimd::__ns::simd<::std::uint64_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<::std::uint64_t, _N> __uint64_src = __src.template bit_cast_view<::std::uint64_t>();
-    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__uint64_src & 0x7FFFFFFFFFFFFFFFu) == 0;
+    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__src == _Float{0});
     __dpl_esimd::__ns::simd<::std::uint64_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint64_src >> 63 == 0);
     if constexpr (__is_ascending)

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -125,7 +125,6 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<std::uint16_t, _N> __uint16_src = __src.template bit_cast_view<std::uint16_t>();
     __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__uint16_src & 0x7FFFu) == 0;
-    __uint16_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0), __uint16_src, __is_zero);
     __dpl_esimd::__ns::simd<std::uint16_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint16_src >> 15 == 0);
     if constexpr (__is_ascending)
@@ -138,7 +137,8 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
         __mask = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0x7FFFu),
                                           __dpl_esimd::__ns::simd<std::uint16_t, _N>(std::uint16_t(0)), __sign_bit_m);
     }
-    return __uint16_src ^ __mask;
+    return __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0x8000u),
+                                    __dpl_esimd::__ns::simd<std::uint16_t, _N>(__uint16_src ^ __mask), __is_zero);
 }
 
 template <bool __is_ascending, typename _Float, int _N,
@@ -148,7 +148,6 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<::std::uint32_t, _N> __uint32_src = __src.template bit_cast_view<::std::uint32_t>();
     __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__uint32_src & 0x7FFFFFFFu) == 0;
-    __uint32_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint32_t, _N>(0), __uint32_src, __is_zero);
     __dpl_esimd::__ns::simd<::std::uint32_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint32_src >> 31 == 0);
     if constexpr (__is_ascending)
@@ -162,7 +161,8 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
             __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<::std::uint32_t, _N>(0x7FFFFFFFu),
                                      __dpl_esimd::__ns::simd<::std::uint32_t, _N>(::std::uint32_t(0)), __sign_bit_m);
     }
-    return __uint32_src ^ __mask;
+    return __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint32_t, _N>(0x80000000u),
+                                    __dpl_esimd::__ns::simd<std::uint32_t, _N>(__uint32_src ^ __mask), __is_zero);
 }
 
 template <bool __is_ascending, typename _Float, int _N,
@@ -172,7 +172,6 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<::std::uint64_t, _N> __uint64_src = __src.template bit_cast_view<::std::uint64_t>();
     __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__uint64_src & 0x7FFFFFFFFFFFFFFFu) == 0;
-    __uint64_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint64_t, _N>(0), __uint64_src, __is_zero);
     __dpl_esimd::__ns::simd<::std::uint64_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint64_src >> 63 == 0);
     if constexpr (__is_ascending)
@@ -187,7 +186,8 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
             __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<::std::uint64_t, _N>(0x7FFFFFFFFFFFFFFFu),
                                      __dpl_esimd::__ns::simd<::std::uint64_t, _N>(::std::uint64_t(0)), __sign_bit_m);
     }
-    return __uint64_src ^ __mask;
+    return __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint64_t, _N>(0x8000000000000000u),
+                                    __dpl_esimd::__ns::simd<std::uint64_t, _N>(__uint64_src ^ __mask), __is_zero);
 }
 
 template <typename _T, int _N>

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -124,6 +124,8 @@ __dpl_esimd::__ns::simd<::std::uint16_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<::std::uint16_t, _N> __uint16_src = __src.template bit_cast_view<::std::uint16_t>();
+    __dpl_esimd::__ns::simd_mask<_N> __is_neg_zero = (__uint16_src & 0x7FFFu) == 0;
+    __uint16_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0), __uint16_src, __is_neg_zero);
     __dpl_esimd::__ns::simd<::std::uint16_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint16_src >> 15 == 0);
     if constexpr (__is_ascending)
@@ -146,6 +148,8 @@ __dpl_esimd::__ns::simd<::std::uint32_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<::std::uint32_t, _N> __uint32_src = __src.template bit_cast_view<::std::uint32_t>();
+    __dpl_esimd::__ns::simd_mask<_N> __is_neg_zero = (__uint32_src & 0x7FFFFFFFu) == 0;
+    __uint32_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint32_t, _N>(0), __uint32_src, __is_neg_zero);
     __dpl_esimd::__ns::simd<::std::uint32_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint32_src >> 31 == 0);
     if constexpr (__is_ascending)
@@ -168,6 +172,8 @@ __dpl_esimd::__ns::simd<::std::uint64_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<::std::uint64_t, _N> __uint64_src = __src.template bit_cast_view<::std::uint64_t>();
+    __dpl_esimd::__ns::simd_mask<_N> __is_neg_zero = (__uint64_src & 0x7FFFFFFFFFFFFFFFu) == 0;
+    __uint64_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint64_t, _N>(0), __uint64_src, __is_neg_zero);
     __dpl_esimd::__ns::simd<::std::uint64_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint64_src >> 63 == 0);
     if constexpr (__is_ascending)

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -119,6 +119,27 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Int, _N> __src)
     return __src.template bit_cast_view<_UInt>() ^ __mask;
 }
 
+template <bool __is_ascending, typename _Float, int _N, std::enable_if_t<std::is_same_v<_Float, sycl::half>, int> = 0>
+__dpl_esimd::__ns::simd<::std::uint16_t, _N>
+__order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
+{
+    __dpl_esimd::__ns::simd<::std::uint16_t, _N> __uint16_src = __src.template bit_cast_view<::std::uint16_t>();
+    __dpl_esimd::__ns::simd<::std::uint16_t, _N> __mask;
+    __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint16_src >> 15 == 0);
+    if constexpr (__is_ascending)
+    {
+        __mask = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<::std::uint16_t, _N>(0x8000u),
+                                          __dpl_esimd::__ns::simd<::std::uint16_t, _N>(0xFFFFu), __sign_bit_m);
+    }
+    else
+    {
+        __mask =
+            __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<::std::uint16_t, _N>(0x7FFFu),
+                                     __dpl_esimd::__ns::simd<::std::uint16_t, _N>(::std::uint16_t(0)), __sign_bit_m);
+    }
+    return __uint16_src ^ __mask;
+}
+
 template <bool __is_ascending, typename _Float, int _N,
           std::enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint32_t), int> = 0>
 __dpl_esimd::__ns::simd<::std::uint32_t, _N>

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -137,6 +137,7 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
         __mask = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0x7FFFu),
                                           __dpl_esimd::__ns::simd<std::uint16_t, _N>(std::uint16_t(0)), __sign_bit_m);
     }
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     return __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0x8000u),
                                     __dpl_esimd::__ns::simd<std::uint16_t, _N>(__uint16_src ^ __mask), __is_zero);
 }
@@ -161,6 +162,7 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
             __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<::std::uint32_t, _N>(0x7FFFFFFFu),
                                      __dpl_esimd::__ns::simd<::std::uint32_t, _N>(::std::uint32_t(0)), __sign_bit_m);
     }
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     return __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint32_t, _N>(0x80000000u),
                                     __dpl_esimd::__ns::simd<std::uint32_t, _N>(__uint32_src ^ __mask), __is_zero);
 }
@@ -186,6 +188,7 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
             __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<::std::uint64_t, _N>(0x7FFFFFFFFFFFFFFFu),
                                      __dpl_esimd::__ns::simd<::std::uint64_t, _N>(::std::uint64_t(0)), __sign_bit_m);
     }
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     return __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint64_t, _N>(0x8000000000000000u),
                                     __dpl_esimd::__ns::simd<std::uint64_t, _N>(__uint64_src ^ __mask), __is_zero);
 }

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -120,24 +120,23 @@ __order_preserving_cast(__dpl_esimd::__ns::simd<_Int, _N> __src)
 }
 
 template <bool __is_ascending, typename _Float, int _N, std::enable_if_t<std::is_same_v<_Float, sycl::half>, int> = 0>
-__dpl_esimd::__ns::simd<::std::uint16_t, _N>
+__dpl_esimd::__ns::simd<std::uint16_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
-    __dpl_esimd::__ns::simd<::std::uint16_t, _N> __uint16_src = __src.template bit_cast_view<::std::uint16_t>();
+    __dpl_esimd::__ns::simd<std::uint16_t, _N> __uint16_src = __src.template bit_cast_view<std::uint16_t>();
     __dpl_esimd::__ns::simd_mask<_N> __is_neg_zero = (__uint16_src & 0x7FFFu) == 0;
     __uint16_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0), __uint16_src, __is_neg_zero);
-    __dpl_esimd::__ns::simd<::std::uint16_t, _N> __mask;
+    __dpl_esimd::__ns::simd<std::uint16_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint16_src >> 15 == 0);
     if constexpr (__is_ascending)
     {
-        __mask = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<::std::uint16_t, _N>(0x8000u),
-                                          __dpl_esimd::__ns::simd<::std::uint16_t, _N>(0xFFFFu), __sign_bit_m);
+        __mask = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0x8000u),
+                                          __dpl_esimd::__ns::simd<std::uint16_t, _N>(0xFFFFu), __sign_bit_m);
     }
     else
     {
-        __mask =
-            __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<::std::uint16_t, _N>(0x7FFFu),
-                                     __dpl_esimd::__ns::simd<::std::uint16_t, _N>(::std::uint16_t(0)), __sign_bit_m);
+        __mask = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0x7FFFu),
+                                          __dpl_esimd::__ns::simd<std::uint16_t, _N>(::std::uint16_t(0)), __sign_bit_m);
     }
     return __uint16_src ^ __mask;
 }

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -124,8 +124,8 @@ __dpl_esimd::__ns::simd<std::uint16_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<std::uint16_t, _N> __uint16_src = __src.template bit_cast_view<std::uint16_t>();
-    __dpl_esimd::__ns::simd_mask<_N> __is_neg_zero = (__uint16_src & 0x7FFFu) == 0;
-    __uint16_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0), __uint16_src, __is_neg_zero);
+    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__uint16_src & 0x7FFFu) == 0;
+    __uint16_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint16_t, _N>(0), __uint16_src, __is_zero);
     __dpl_esimd::__ns::simd<std::uint16_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint16_src >> 15 == 0);
     if constexpr (__is_ascending)
@@ -147,8 +147,8 @@ __dpl_esimd::__ns::simd<::std::uint32_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<::std::uint32_t, _N> __uint32_src = __src.template bit_cast_view<::std::uint32_t>();
-    __dpl_esimd::__ns::simd_mask<_N> __is_neg_zero = (__uint32_src & 0x7FFFFFFFu) == 0;
-    __uint32_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint32_t, _N>(0), __uint32_src, __is_neg_zero);
+    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__uint32_src & 0x7FFFFFFFu) == 0;
+    __uint32_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint32_t, _N>(0), __uint32_src, __is_zero);
     __dpl_esimd::__ns::simd<::std::uint32_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint32_src >> 31 == 0);
     if constexpr (__is_ascending)
@@ -171,8 +171,8 @@ __dpl_esimd::__ns::simd<::std::uint64_t, _N>
 __order_preserving_cast(__dpl_esimd::__ns::simd<_Float, _N> __src)
 {
     __dpl_esimd::__ns::simd<::std::uint64_t, _N> __uint64_src = __src.template bit_cast_view<::std::uint64_t>();
-    __dpl_esimd::__ns::simd_mask<_N> __is_neg_zero = (__uint64_src & 0x7FFFFFFFFFFFFFFFu) == 0;
-    __uint64_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint64_t, _N>(0), __uint64_src, __is_neg_zero);
+    __dpl_esimd::__ns::simd_mask<_N> __is_zero = (__uint64_src & 0x7FFFFFFFFFFFFFFFu) == 0;
+    __uint64_src = __dpl_esimd::__ns::merge(__dpl_esimd::__ns::simd<std::uint64_t, _N>(0), __uint64_src, __is_zero);
     __dpl_esimd::__ns::simd<::std::uint64_t, _N> __mask;
     __dpl_esimd::__ns::simd_mask<_N> __sign_bit_m = (__uint64_src >> 63 == 0);
     if constexpr (__is_ascending)

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -133,6 +133,8 @@ std::uint16_t
 __order_preserving_cast_scalar(_Float __src)
 {
     std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
+    if ((__uint16_src & 0x7FFFu) == 0)
+        __uint16_src = 0;
     std::uint16_t __mask;
     bool __sign_bit_is_zero = (__uint16_src >> 15 == 0);
     if constexpr (__is_ascending)
@@ -153,6 +155,8 @@ std::uint32_t
 __order_preserving_cast_scalar(_Float __src)
 {
     std::uint32_t __uint32_src = sycl::bit_cast<std::uint32_t>(__src);
+    if ((__uint32_src & 0x7FFFFFFFu) == 0)
+        __uint32_src = 0;
     std::uint32_t __mask;
     bool __sign_bit_is_zero = (__uint32_src >> 31 == 0);
     if constexpr (__is_ascending)
@@ -173,6 +177,8 @@ std::uint64_t
 __order_preserving_cast_scalar(_Float __src)
 {
     std::uint64_t __uint64_src = sycl::bit_cast<std::uint64_t>(__src);
+    if ((__uint64_src & 0x7FFFFFFFFFFFFFFFu) == 0)
+        __uint64_src = 0;
     std::uint64_t __mask;
     bool __sign_bit_is_zero = (__uint64_src >> 63 == 0);
     if constexpr (__is_ascending)

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -127,6 +127,25 @@ __order_preserving_cast_scalar(_Int __src)
     return sycl::bit_cast<_UInt>(__src) ^ __mask;
 }
 
+// Order-preserving cast for 16-bit floats - scalar version
+template <bool __is_ascending, typename _Float, std::enable_if_t<std::is_same_v<_Float, sycl::half>, int> = 0>
+std::uint16_t
+__order_preserving_cast_scalar(_Float __src)
+{
+    std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
+    std::uint16_t __mask;
+    bool __sign_bit_is_zero = (__uint16_src >> 15 == 0);
+    if constexpr (__is_ascending)
+    {
+        __mask = __sign_bit_is_zero ? 0x8000u : 0xFFFFu;
+    }
+    else
+    {
+        __mask = __sign_bit_is_zero ? 0x7FFFu : std::uint16_t(0);
+    }
+    return __uint16_src ^ __mask;
+}
+
 // Order-preserving cast for 32-bit floats - scalar version
 template <bool __is_ascending, typename _Float,
           std::enable_if_t<std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(std::uint32_t), int> = 0>
@@ -185,6 +204,16 @@ __sort_identity()
 // They do not set the smallest exponent bit (i.e. the max is 7F7FFFFF for 32bit float),
 // thus such an identity is not guaranteed to be put at the end of the sorted sequence after each radix sort stage,
 // e.g. 00FF0000 numbers will be pushed out by 7F7FFFFF identities when sorting 16-23 bits.
+template <typename _T, bool __is_ascending, std::enable_if_t<std::is_same_v<_T, sycl::half>, int> = 0>
+constexpr _T
+__sort_identity()
+{
+    if constexpr (__is_ascending)
+        return sycl::bit_cast<_T>(std::uint16_t(0x7FFFu));
+    else
+        return sycl::bit_cast<_T>(std::uint16_t(0xFFFFu));
+}
+
 template <typename _T, bool __is_ascending,
           std::enable_if_t<std::is_floating_point_v<_T> && sizeof(_T) == sizeof(std::uint32_t), int> = 0>
 constexpr _T

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -134,7 +134,7 @@ __order_preserving_cast_scalar(_Float __src)
 {
     std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
     if ((__uint16_src & 0x7FFFu) == 0)
-        __uint16_src = 0;
+        return 0x8000u;
     std::uint16_t __mask;
     bool __sign_bit_is_zero = (__uint16_src >> 15 == 0);
     if constexpr (__is_ascending)
@@ -156,7 +156,7 @@ __order_preserving_cast_scalar(_Float __src)
 {
     std::uint32_t __uint32_src = sycl::bit_cast<std::uint32_t>(__src);
     if ((__uint32_src & 0x7FFFFFFFu) == 0)
-        __uint32_src = 0;
+        return 0x80000000u;
     std::uint32_t __mask;
     bool __sign_bit_is_zero = (__uint32_src >> 31 == 0);
     if constexpr (__is_ascending)
@@ -178,7 +178,7 @@ __order_preserving_cast_scalar(_Float __src)
 {
     std::uint64_t __uint64_src = sycl::bit_cast<std::uint64_t>(__src);
     if ((__uint64_src & 0x7FFFFFFFFFFFFFFFu) == 0)
-        __uint64_src = 0;
+        return 0x8000000000000000u;
     std::uint64_t __mask;
     bool __sign_bit_is_zero = (__uint64_src >> 63 == 0);
     if constexpr (__is_ascending)

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -128,12 +128,12 @@ __order_preserving_cast_scalar(_Int __src)
 }
 
 // Order-preserving cast for 16-bit floats - scalar version
-template <bool __is_ascending, typename _Float, std::enable_if_t<std::is_same_v<_Float, sycl::half>, int> = 0>
+template <bool __is_ascending>
 std::uint16_t
-__order_preserving_cast_scalar(_Float __src)
+__order_preserving_cast_scalar(sycl::half __src)
 {
     // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
-    if (__src == _Float{0})
+    if (__src == sycl::half{0})
         return 0x8000u;
     std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
     std::uint16_t __mask;

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -132,9 +132,9 @@ template <bool __is_ascending, typename _Float, std::enable_if_t<std::is_same_v<
 std::uint16_t
 __order_preserving_cast_scalar(_Float __src)
 {
-    std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
-    if ((__uint16_src & 0x7FFFu) == 0)
+    if (__src == _Float{0})
         return 0x8000u;
+    std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
     std::uint16_t __mask;
     bool __sign_bit_is_zero = (__uint16_src >> 15 == 0);
     if constexpr (__is_ascending)
@@ -154,9 +154,9 @@ template <bool __is_ascending, typename _Float,
 std::uint32_t
 __order_preserving_cast_scalar(_Float __src)
 {
-    std::uint32_t __uint32_src = sycl::bit_cast<std::uint32_t>(__src);
-    if ((__uint32_src & 0x7FFFFFFFu) == 0)
+    if (__src == _Float{0})
         return 0x80000000u;
+    std::uint32_t __uint32_src = sycl::bit_cast<std::uint32_t>(__src);
     std::uint32_t __mask;
     bool __sign_bit_is_zero = (__uint32_src >> 31 == 0);
     if constexpr (__is_ascending)
@@ -176,9 +176,9 @@ template <bool __is_ascending, typename _Float,
 std::uint64_t
 __order_preserving_cast_scalar(_Float __src)
 {
-    std::uint64_t __uint64_src = sycl::bit_cast<std::uint64_t>(__src);
-    if ((__uint64_src & 0x7FFFFFFFFFFFFFFFu) == 0)
+    if (__src == _Float{0})
         return 0x8000000000000000u;
+    std::uint64_t __uint64_src = sycl::bit_cast<std::uint64_t>(__src);
     std::uint64_t __mask;
     bool __sign_bit_is_zero = (__uint64_src >> 63 == 0);
     if constexpr (__is_ascending)

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -132,6 +132,7 @@ template <bool __is_ascending, typename _Float, std::enable_if_t<std::is_same_v<
 std::uint16_t
 __order_preserving_cast_scalar(_Float __src)
 {
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     if (__src == _Float{0})
         return 0x8000u;
     std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
@@ -154,6 +155,7 @@ template <bool __is_ascending, typename _Float,
 std::uint32_t
 __order_preserving_cast_scalar(_Float __src)
 {
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     if (__src == _Float{0})
         return 0x80000000u;
     std::uint32_t __uint32_src = sycl::bit_cast<std::uint32_t>(__src);
@@ -176,6 +178,7 @@ template <bool __is_ascending, typename _Float,
 std::uint64_t
 __order_preserving_cast_scalar(_Float __src)
 {
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     if (__src == _Float{0})
         return 0x8000000000000000u;
     std::uint64_t __uint64_src = sycl::bit_cast<std::uint64_t>(__src);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -76,6 +76,8 @@ template <bool __is_ascending>
 __order_preserving_cast(sycl::half __val)
 {
     ::std::uint16_t __uint16_val = oneapi::dpl::__internal::__dpl_bit_cast<::std::uint16_t>(__val);
+    if ((__uint16_val & 0x7FFFu) == 0)
+        __uint16_val = 0;
     ::std::uint16_t __mask;
     // __uint16_val >> 15 takes the sign bit of the original value
     if constexpr (__is_ascending)
@@ -91,6 +93,8 @@ template <bool __is_ascending, typename _Float,
 __order_preserving_cast(_Float __val)
 {
     ::std::uint32_t __uint32_val = oneapi::dpl::__internal::__dpl_bit_cast<::std::uint32_t>(__val);
+    if ((__uint32_val & 0x7FFFFFFFu) == 0)
+        __uint32_val = 0;
     ::std::uint32_t __mask;
     // __uint32_val >> 31 takes the sign bit of the original value
     if constexpr (__is_ascending)
@@ -106,6 +110,8 @@ template <bool __is_ascending, typename _Float,
 __order_preserving_cast(_Float __val)
 {
     ::std::uint64_t __uint64_val = oneapi::dpl::__internal::__dpl_bit_cast<::std::uint64_t>(__val);
+    if ((__uint64_val & 0x7FFFFFFFFFFFFFFFu) == 0)
+        __uint64_val = 0;
     ::std::uint64_t __mask;
     // __uint64_val >> 63 takes the sign bit of the original value
     if constexpr (__is_ascending)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -75,9 +75,9 @@ template <bool __is_ascending>
 ::std::uint16_t
 __order_preserving_cast(sycl::half __val)
 {
-    ::std::uint16_t __uint16_val = oneapi::dpl::__internal::__dpl_bit_cast<::std::uint16_t>(__val);
-    if ((__uint16_val & 0x7FFFu) == 0)
+    if (__val == sycl::half{0})
         return 0x8000u;
+    std::uint16_t __uint16_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint16_t>(__val);
     ::std::uint16_t __mask;
     // __uint16_val >> 15 takes the sign bit of the original value
     if constexpr (__is_ascending)
@@ -92,9 +92,9 @@ template <bool __is_ascending, typename _Float,
 ::std::uint32_t
 __order_preserving_cast(_Float __val)
 {
-    ::std::uint32_t __uint32_val = oneapi::dpl::__internal::__dpl_bit_cast<::std::uint32_t>(__val);
-    if ((__uint32_val & 0x7FFFFFFFu) == 0)
+    if (__val == _Float{0})
         return 0x80000000u;
+    std::uint32_t __uint32_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint32_t>(__val);
     ::std::uint32_t __mask;
     // __uint32_val >> 31 takes the sign bit of the original value
     if constexpr (__is_ascending)
@@ -109,9 +109,9 @@ template <bool __is_ascending, typename _Float,
 ::std::uint64_t
 __order_preserving_cast(_Float __val)
 {
-    ::std::uint64_t __uint64_val = oneapi::dpl::__internal::__dpl_bit_cast<::std::uint64_t>(__val);
-    if ((__uint64_val & 0x7FFFFFFFFFFFFFFFu) == 0)
+    if (__val == _Float{0})
         return 0x8000000000000000u;
+    std::uint64_t __uint64_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint64_t>(__val);
     ::std::uint64_t __mask;
     // __uint64_val >> 63 takes the sign bit of the original value
     if constexpr (__is_ascending)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -75,6 +75,7 @@ template <bool __is_ascending>
 ::std::uint16_t
 __order_preserving_cast(sycl::half __val)
 {
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     if (__val == sycl::half{0})
         return 0x8000u;
     std::uint16_t __uint16_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint16_t>(__val);
@@ -92,6 +93,7 @@ template <bool __is_ascending, typename _Float,
 ::std::uint32_t
 __order_preserving_cast(_Float __val)
 {
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     if (__val == _Float{0})
         return 0x80000000u;
     std::uint32_t __uint32_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint32_t>(__val);
@@ -109,6 +111,7 @@ template <bool __is_ascending, typename _Float,
 ::std::uint64_t
 __order_preserving_cast(_Float __val)
 {
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
     if (__val == _Float{0})
         return 0x8000000000000000u;
     std::uint64_t __uint64_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint64_t>(__val);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -77,7 +77,7 @@ __order_preserving_cast(sycl::half __val)
 {
     ::std::uint16_t __uint16_val = oneapi::dpl::__internal::__dpl_bit_cast<::std::uint16_t>(__val);
     if ((__uint16_val & 0x7FFFu) == 0)
-        __uint16_val = 0;
+        return 0x8000u;
     ::std::uint16_t __mask;
     // __uint16_val >> 15 takes the sign bit of the original value
     if constexpr (__is_ascending)
@@ -94,7 +94,7 @@ __order_preserving_cast(_Float __val)
 {
     ::std::uint32_t __uint32_val = oneapi::dpl::__internal::__dpl_bit_cast<::std::uint32_t>(__val);
     if ((__uint32_val & 0x7FFFFFFFu) == 0)
-        __uint32_val = 0;
+        return 0x80000000u;
     ::std::uint32_t __mask;
     // __uint32_val >> 31 takes the sign bit of the original value
     if constexpr (__is_ascending)
@@ -111,7 +111,7 @@ __order_preserving_cast(_Float __val)
 {
     ::std::uint64_t __uint64_val = oneapi::dpl::__internal::__dpl_bit_cast<::std::uint64_t>(__val);
     if ((__uint64_val & 0x7FFFFFFFFFFFFFFFu) == 0)
-        __uint64_val = 0;
+        return 0x8000000000000000u;
     ::std::uint64_t __mask;
     // __uint64_val >> 63 takes the sign bit of the original value
     if constexpr (__is_ascending)

--- a/test/kt/CMakeLists.txt
+++ b/test/kt/CMakeLists.txt
@@ -144,6 +144,7 @@ if (ONEDPL_TEST_ENABLE_KT_ESIMD)
 
     # Pin some cases to track them
     _generate_sort_test("kt_esimd" "radix_sort_by_key_out_of_place" "96" "64" "uint32_t" "uint32_t" 1000)
+    _generate_sort_test("kt_esimd" "radix_sort_by_key" "96" "64" "sycl::half" "uint32_t" 1000)
     _generate_sort_test("kt_esimd" "radix_sort" "384" "64" "int32_t" "" 1000)
 endif()
 
@@ -153,6 +154,7 @@ if (ONEDPL_TEST_ENABLE_KT_SYCL)
 
     # Pin some cases to track them
     _generate_sort_test("kt_sycl" "radix_sort_by_key_out_of_place" "3" "1024" "uint32_t" "uint32_t" 1000)
+    _generate_sort_test("kt_sycl" "radix_sort_by_key" "5" "512" "float" "uint32_t" 1000)
     _generate_sort_test("kt_sycl" "radix_sort" "12" "1024" "int32_t" "" 1000)
 endif()
 

--- a/test/kt/CMakeLists.txt
+++ b/test/kt/CMakeLists.txt
@@ -53,8 +53,10 @@ function(_generate_sort_test _variant _base_file _data_per_work_item _work_group
     endif()
 
     string(REPLACE "_t" "" _key_type_short ${_key_type})
+    string(REPLACE "::" "_" _key_type_short ${_key_type_short})
     if (NOT "${_val_type}" STREQUAL "")
         string(REPLACE "_t" "" _val_type_short ${_val_type})
+        string(REPLACE "::" "_" _val_type_short ${_val_type_short})
         set(_target_name "${_variant}_${_base_file}_dpwi${_data_per_work_item}_wgs${_work_group_size}_${_key_type_short}_${_val_type_short}.pass")
     else()
         set(_target_name "${_variant}_${_base_file}_dpwi${_data_per_work_item}_wgs${_work_group_size}_${_key_type_short}.pass")
@@ -113,7 +115,7 @@ function(_generate_sort_tests _variant _key_value_pairs)
         set(_work_group_size_all "64")
     endif()
 
-    set(_type_all "char" "uint16_t" "int" "uint64_t" "float" "double")
+    set(_type_all "char" "uint16_t" "int" "uint64_t" "float" "double" "sycl::half")
 
     foreach (_data_per_work_item ${_data_per_work_item_all})
         foreach (_work_group_size ${_work_group_size_all})

--- a/test/kt/radix_sort.cpp
+++ b/test/kt/radix_sort.cpp
@@ -180,6 +180,36 @@ test_small_sizes(sycl::queue q, KernelParam param)
 
 template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void
+test_negative_zero(sycl::queue q, KernelParam param)
+{
+    // Verify that -0 and +0 are treated as equal by radix sort (both map to the same key).
+    // Input: mix of -0 and +0 with other values to exercise different sort paths.
+    constexpr std::size_t size = 64;
+    std::vector<T> input(size);
+    for (std::size_t i = 0; i < size; ++i)
+    {
+        if (i % 3 == 0)
+            input[i] = -T(0.0);
+        else if (i % 3 == 1)
+            input[i] = T(0.0);
+        else
+            input[i] = T(i) * (i % 2 == 0 ? T(1.0) : T(-1.0));
+    }
+
+    std::vector<T> expected(input);
+    std::stable_sort(expected.begin(), expected.end(), Compare<T, IsAscending>{});
+
+    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> dt_input(q, input.begin(), input.end());
+    kt_ns::radix_sort<IsAscending, RadixBits>(q, dt_input.get_data(), dt_input.get_data() + size, param).wait();
+
+    std::vector<T> actual(size);
+    dt_input.retrieve_data(actual.begin());
+
+    EXPECT_EQ_N(expected.begin(), actual.begin(), size, "wrong results with negative zero test");
+}
+
+template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
+void
 test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
 {
     test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::create_new_kernel_param_idx<0>(param));
@@ -212,6 +242,13 @@ main()
                     q, size, TestUtils::create_new_kernel_param_idx<1>(params));
             }
             test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::create_new_kernel_param_idx<3>(params));
+            if constexpr (std::is_floating_point_v<TEST_KEY_TYPE> || std::is_same_v<TEST_KEY_TYPE, sycl::half>)
+            {
+                test_negative_zero<TEST_KEY_TYPE, Ascending, TestRadixBits>(
+                    q, TestUtils::create_new_kernel_param_idx<4>(params));
+                test_negative_zero<TEST_KEY_TYPE, Descending, TestRadixBits>(
+                    q, TestUtils::create_new_kernel_param_idx<5>(params));
+            }
         }
         catch (const ::std::exception& exc)
         {

--- a/test/kt/radix_sort.cpp
+++ b/test/kt/radix_sort.cpp
@@ -180,36 +180,6 @@ test_small_sizes(sycl::queue q, KernelParam param)
 
 template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void
-test_negative_zero(sycl::queue q, KernelParam param)
-{
-    // Verify that -0 and +0 are treated as equal by radix sort (both map to the same key).
-    // Input: mix of -0 and +0 with other values to exercise different sort paths.
-    constexpr std::size_t size = 64;
-    std::vector<T> input(size);
-    for (std::size_t i = 0; i < size; ++i)
-    {
-        if (i % 3 == 0)
-            input[i] = -T(0.0);
-        else if (i % 3 == 1)
-            input[i] = T(0.0);
-        else
-            input[i] = T(i) * (i % 2 == 0 ? T(1.0) : T(-1.0));
-    }
-
-    std::vector<T> expected(input);
-    std::stable_sort(expected.begin(), expected.end(), Compare<T, IsAscending>{});
-
-    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> dt_input(q, input.begin(), input.end());
-    kt_ns::radix_sort<IsAscending, RadixBits>(q, dt_input.get_data(), dt_input.get_data() + size, param).wait();
-
-    std::vector<T> actual(size);
-    dt_input.retrieve_data(actual.begin());
-
-    EXPECT_EQ_N(expected.begin(), actual.begin(), size, "wrong results with negative zero test");
-}
-
-template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
-void
 test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
 {
     test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::create_new_kernel_param_idx<0>(param));
@@ -241,14 +211,8 @@ main()
                 test_general_cases<TEST_KEY_TYPE, Descending, TestRadixBits>(
                     q, size, TestUtils::create_new_kernel_param_idx<1>(params));
             }
-            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::create_new_kernel_param_idx<3>(params));
-            if constexpr (std::is_floating_point_v<TEST_KEY_TYPE> || std::is_same_v<TEST_KEY_TYPE, sycl::half>)
-            {
-                test_negative_zero<TEST_KEY_TYPE, Ascending, TestRadixBits>(
-                    q, TestUtils::create_new_kernel_param_idx<4>(params));
-                test_negative_zero<TEST_KEY_TYPE, Descending, TestRadixBits>(
-                    q, TestUtils::create_new_kernel_param_idx<5>(params));
-            }
+            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(
+                q, TestUtils::create_new_kernel_param_idx<3>(params));
         }
         catch (const ::std::exception& exc)
         {

--- a/test/kt/radix_sort.cpp
+++ b/test/kt/radix_sort.cpp
@@ -33,6 +33,8 @@
 #include "../support/utils.h"
 #include "../support/sycl_alloc_utils.h"
 
+using namespace TestUtils;
+
 #include "radix_sort_utils.h"
 
 #if _ENABLE_RANGES_TESTING

--- a/test/kt/radix_sort.cpp
+++ b/test/kt/radix_sort.cpp
@@ -33,8 +33,6 @@
 #include "../support/utils.h"
 #include "../support/sycl_alloc_utils.h"
 
-using namespace TestUtils;
-
 #include "radix_sort_utils.h"
 
 #if _ENABLE_RANGES_TESTING

--- a/test/kt/radix_sort_by_key.cpp
+++ b/test/kt/radix_sort_by_key.cpp
@@ -91,6 +91,41 @@ void test_usm(sycl::queue q, std::size_t size, KernelParam param)
     EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, msg.c_str());
 }
 
+// Test that -0 and +0 keys are treated as equal (stability check).
+// All keys are either -0 or +0; values are sequential indices.
+// A stable sort must preserve the original order of values since all keys compare equal.
+// Without the -0 normalization fix, radix sort assigns different sort keys to -0 vs +0,
+// grouping all -0 before +0 and breaking stability.
+template <typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixBits, typename KernelParam>
+void
+test_negative_zero_stability(sycl::queue q, std::size_t size, KernelParam param)
+{
+    std::vector<KeyT> keys(size);
+    std::vector<ValueT> values(size);
+    for (std::size_t i = 0; i < size; ++i)
+    {
+        keys[i] = (i % 2 == 0) ? -KeyT(0.0) : KeyT(0.0);
+        values[i] = static_cast<ValueT>(i);
+    }
+
+    std::vector<KeyT> expected_keys(keys);
+    std::vector<ValueT> expected_values(values);
+    auto expected_first = oneapi::dpl::make_zip_iterator(expected_keys.begin(), expected_values.begin());
+    std::stable_sort(expected_first, expected_first + size, CompareKey<isAscending>{});
+
+    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, KeyT> dt_keys(q, keys.begin(), keys.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, ValueT> dt_values(q, values.begin(), values.end());
+    kt_ns::radix_sort_by_key<isAscending, RadixBits>(q, dt_keys.get_data(), dt_keys.get_data() + size,
+                                                     dt_values.get_data(), param)
+        .wait();
+
+    std::vector<ValueT> actual_values(size);
+    dt_values.retrieve_data(actual_values.begin());
+
+    std::string msg = "negative zero stability broken, n: " + std::to_string(size);
+    EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, msg.c_str());
+}
+
 int main()
 {
     bool run_test = false;
@@ -113,6 +148,15 @@ int main()
                     q, size, TestUtils::create_new_kernel_param_idx<2>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
                     q, size, TestUtils::create_new_kernel_param_idx<3>(params));
+            }
+            if constexpr (std::is_floating_point_v<TEST_KEY_TYPE> || std::is_same_v<TEST_KEY_TYPE, sycl::half>)
+            {
+                test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
+                    q, 64, TestUtils::create_new_kernel_param_idx<4>(params));
+                test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
+                    q, 64, TestUtils::create_new_kernel_param_idx<5>(params));
+                test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
+                    q, 10000, TestUtils::create_new_kernel_param_idx<6>(params));
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/radix_sort_by_key.cpp
+++ b/test/kt/radix_sort_by_key.cpp
@@ -25,8 +25,6 @@
 #include "../support/utils.h"
 #include "../support/sycl_alloc_utils.h"
 
-using namespace TestUtils;
-
 #include "radix_sort_utils.h"
 
 template<typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixBits, typename KernelParam>

--- a/test/kt/radix_sort_by_key.cpp
+++ b/test/kt/radix_sort_by_key.cpp
@@ -91,11 +91,7 @@ void test_usm(sycl::queue q, std::size_t size, KernelParam param)
     EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, msg.c_str());
 }
 
-// Test that -0 and +0 keys are treated as equal (stability check).
-// All keys are either -0 or +0; values are sequential indices.
-// A stable sort must preserve the original order of values since all keys compare equal.
-// Without the -0 normalization fix, radix sort assigns different sort keys to -0 vs +0,
-// grouping all -0 before +0 and breaking stability.
+// Test that -0 and +0 keys are treated as equal.
 template <typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixBits, typename KernelParam>
 void
 test_negative_zero_stability(sycl::queue q, std::size_t size, KernelParam param)

--- a/test/kt/radix_sort_by_key.cpp
+++ b/test/kt/radix_sort_by_key.cpp
@@ -25,6 +25,8 @@
 #include "../support/utils.h"
 #include "../support/sycl_alloc_utils.h"
 
+using namespace TestUtils;
+
 #include "radix_sort_utils.h"
 
 template<typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixBits, typename KernelParam>

--- a/test/kt/radix_sort_by_key.cpp
+++ b/test/kt/radix_sort_by_key.cpp
@@ -96,29 +96,28 @@ template <typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixB
 void
 test_negative_zero_stability(sycl::queue q, std::size_t size, KernelParam param)
 {
-    std::vector<KeyT> keys(size);
-    std::vector<ValueT> values(size);
+    std::vector<KeyT> expected_keys(size);
+    std::vector<ValueT> expected_values(size);
     for (std::size_t i = 0; i < size; ++i)
     {
-        keys[i] = (i % 2 == 0) ? -KeyT(0.0) : KeyT(0.0);
-        values[i] = static_cast<ValueT>(i);
+        expected_keys[i] = (i % 2 == 0) ? -KeyT(0.0) : KeyT(0.0);
+        expected_values[i] = static_cast<ValueT>(i);
     }
 
-    std::vector<KeyT> expected_keys(keys);
-    std::vector<ValueT> expected_values(values);
-    auto expected_first = oneapi::dpl::make_zip_iterator(expected_keys.begin(), expected_values.begin());
-    std::stable_sort(expected_first, expected_first + size, CompareKey<isAscending>{});
-
-    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, KeyT> dt_keys(q, keys.begin(), keys.end());
-    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, ValueT> dt_values(q, values.begin(), values.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, KeyT> dt_keys(q, expected_keys.begin(), expected_keys.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, ValueT> dt_values(q, expected_values.begin(),
+                                                                             expected_values.end());
     kt_ns::radix_sort_by_key<isAscending, RadixBits>(q, dt_keys.get_data(), dt_keys.get_data() + size,
                                                      dt_values.get_data(), param)
         .wait();
 
+    std::vector<KeyT> actual_keys(size);
     std::vector<ValueT> actual_values(size);
+    dt_keys.retrieve_data(actual_keys.begin());
     dt_values.retrieve_data(actual_values.begin());
 
     std::string msg = "negative zero stability broken, n: " + std::to_string(size);
+    EXPECT_EQ_N(expected_keys.begin(), actual_keys.begin(), size, msg.c_str());
     EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, msg.c_str());
 }
 

--- a/test/kt/radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/radix_sort_by_key_out_of_place.cpp
@@ -25,6 +25,8 @@
 #include "../support/utils.h"
 #include "../support/sycl_alloc_utils.h"
 
+using namespace TestUtils;
+
 #include "radix_sort_utils.h"
 
 template <typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixBits, typename KernelParam>

--- a/test/kt/radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/radix_sort_by_key_out_of_place.cpp
@@ -136,36 +136,32 @@ template <typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixB
 void
 test_negative_zero_stability(sycl::queue q, std::size_t size, KernelParam param)
 {
-    std::vector<KeyT> keys(size);
-    std::vector<ValueT> values(size);
+    std::vector<KeyT> expected_keys(size);
+    std::vector<ValueT> expected_values(size);
     for (std::size_t i = 0; i < size; ++i)
     {
-        keys[i] = (i % 2 == 0) ? -KeyT(0.0) : KeyT(0.0);
-        values[i] = static_cast<ValueT>(i);
+        expected_keys[i] = (i % 2 == 0) ? -KeyT(0.0) : KeyT(0.0);
+        expected_values[i] = static_cast<ValueT>(i);
     }
 
-    std::vector<KeyT> expected_keys(keys);
-    std::vector<ValueT> expected_values(values);
-    auto expected_first = oneapi::dpl::make_zip_iterator(expected_keys.begin(), expected_values.begin());
-    std::stable_sort(expected_first, expected_first + size, CompareKey<isAscending>{});
-
-    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, KeyT> dt_keys(q, keys.begin(), keys.end());
-    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, ValueT> dt_values(q, values.begin(), values.end());
-    std::vector<KeyT> keys_out(size);
-    std::vector<ValueT> values_out(size);
-    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, KeyT> dt_keys_out(q, keys_out.begin(), keys_out.end());
-    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, ValueT> dt_values_out(q, values_out.begin(),
-                                                                                 values_out.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, KeyT> dt_keys(q, expected_keys.begin(), expected_keys.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, ValueT> dt_values(q, expected_values.begin(),
+                                                                             expected_values.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, KeyT> dt_keys_out(q, size);
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, ValueT> dt_values_out(q, size);
 
     kt_ns::radix_sort_by_key<isAscending, RadixBits>(q, dt_keys.get_data(), dt_keys.get_data() + size,
                                                      dt_values.get_data(), dt_keys_out.get_data(),
                                                      dt_values_out.get_data(), param)
         .wait();
 
+    std::vector<KeyT> actual_keys(size);
     std::vector<ValueT> actual_values(size);
+    dt_keys_out.retrieve_data(actual_keys.begin());
     dt_values_out.retrieve_data(actual_values.begin());
 
     std::string msg = "negative zero stability broken (out-of-place), n: " + std::to_string(size);
+    EXPECT_EQ_N(expected_keys.begin(), actual_keys.begin(), size, msg.c_str());
     EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, msg.c_str());
 }
 

--- a/test/kt/radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/radix_sort_by_key_out_of_place.cpp
@@ -25,8 +25,6 @@
 #include "../support/utils.h"
 #include "../support/sycl_alloc_utils.h"
 
-using namespace TestUtils;
-
 #include "radix_sort_utils.h"
 
 template <typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixBits, typename KernelParam>

--- a/test/kt/radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/radix_sort_by_key_out_of_place.cpp
@@ -131,6 +131,48 @@ test_usm(sycl::queue q, std::size_t size, KernelParam param)
     EXPECT_EQ_N(expected_values.begin(), actual_values_out.begin(), size, msg_out.c_str());
 }
 
+// Test that -0 and +0 keys are treated as equal (stability check).
+// All keys are either -0 or +0; values are sequential indices.
+// A stable sort must preserve the original order of values since all keys compare equal.
+// Without the -0 normalization fix, radix sort assigns different sort keys to -0 vs +0,
+// grouping all -0 before +0 and breaking stability.
+template <typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixBits, typename KernelParam>
+void
+test_negative_zero_stability(sycl::queue q, std::size_t size, KernelParam param)
+{
+    std::vector<KeyT> keys(size);
+    std::vector<ValueT> values(size);
+    for (std::size_t i = 0; i < size; ++i)
+    {
+        keys[i] = (i % 2 == 0) ? -KeyT(0.0) : KeyT(0.0);
+        values[i] = static_cast<ValueT>(i);
+    }
+
+    std::vector<KeyT> expected_keys(keys);
+    std::vector<ValueT> expected_values(values);
+    auto expected_first = oneapi::dpl::make_zip_iterator(expected_keys.begin(), expected_values.begin());
+    std::stable_sort(expected_first, expected_first + size, CompareKey<isAscending>{});
+
+    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, KeyT> dt_keys(q, keys.begin(), keys.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, ValueT> dt_values(q, values.begin(), values.end());
+    std::vector<KeyT> keys_out(size);
+    std::vector<ValueT> values_out(size);
+    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, KeyT> dt_keys_out(q, keys_out.begin(), keys_out.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::shared, ValueT> dt_values_out(q, values_out.begin(),
+                                                                                 values_out.end());
+
+    kt_ns::radix_sort_by_key<isAscending, RadixBits>(q, dt_keys.get_data(), dt_keys.get_data() + size,
+                                                     dt_values.get_data(), dt_keys_out.get_data(),
+                                                     dt_values_out.get_data(), param)
+        .wait();
+
+    std::vector<ValueT> actual_values(size);
+    dt_values_out.retrieve_data(actual_values.begin());
+
+    std::string msg = "negative zero stability broken (out-of-place), n: " + std::to_string(size);
+    EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, msg.c_str());
+}
+
 int
 main()
 {
@@ -154,6 +196,15 @@ main()
                     q, size, TestUtils::create_new_kernel_param_idx<2>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
                     q, size, TestUtils::create_new_kernel_param_idx<3>(params));
+            }
+            if constexpr (std::is_floating_point_v<TEST_KEY_TYPE> || std::is_same_v<TEST_KEY_TYPE, sycl::half>)
+            {
+                test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
+                    q, 64, TestUtils::create_new_kernel_param_idx<4>(params));
+                test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
+                    q, 64, TestUtils::create_new_kernel_param_idx<5>(params));
+                test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
+                    q, 10000, TestUtils::create_new_kernel_param_idx<6>(params));
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/radix_sort_by_key_out_of_place.cpp
@@ -131,11 +131,7 @@ test_usm(sycl::queue q, std::size_t size, KernelParam param)
     EXPECT_EQ_N(expected_values.begin(), actual_values_out.begin(), size, msg_out.c_str());
 }
 
-// Test that -0 and +0 keys are treated as equal (stability check).
-// All keys are either -0 or +0; values are sequential indices.
-// A stable sort must preserve the original order of values since all keys compare equal.
-// Without the -0 normalization fix, radix sort assigns different sort keys to -0 vs +0,
-// grouping all -0 before +0 and breaking stability.
+// Test that -0 and +0 keys are treated as equal.
 template <typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixBits, typename KernelParam>
 void
 test_negative_zero_stability(sycl::queue q, std::size_t size, KernelParam param)

--- a/test/kt/radix_sort_out_of_place.cpp
+++ b/test/kt/radix_sort_out_of_place.cpp
@@ -33,6 +33,8 @@
 #include "../support/utils.h"
 #include "../support/sycl_alloc_utils.h"
 
+using namespace TestUtils;
+
 #include "radix_sort_utils.h"
 
 #if _ENABLE_RANGES_TESTING

--- a/test/kt/radix_sort_out_of_place.cpp
+++ b/test/kt/radix_sort_out_of_place.cpp
@@ -33,8 +33,6 @@
 #include "../support/utils.h"
 #include "../support/sycl_alloc_utils.h"
 
-using namespace TestUtils;
-
 #include "radix_sort_utils.h"
 
 #if _ENABLE_RANGES_TESTING

--- a/test/parallel_api/algorithm/alg.sorting/alg.sort/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.sort/sort.pass.cpp
@@ -34,19 +34,8 @@ int main()
     test_sort<TestUtils::float32_t>(SortTestConfig{cfg, "float, device"}, sizes, Device<0>{},
                                     Converter<TestUtils::float32_t>{});
 
-    auto sycl_half_convert = [](size_t /*index*/, size_t val) {
-        constexpr std::uint16_t mask = 0xFFFFu;
-        std::uint16_t raw = std::uint16_t(val & mask);
-        // Avoid NaN values, because they need a custom comparator due to: (x < NaN = false) and (NaN < x = false).
-        constexpr std::uint16_t exp_mask = 0x7C00u;
-        constexpr std::uint16_t frac_mask = 0x03FFu;
-        bool is_nan = ((raw & exp_mask) == exp_mask) && ((raw & frac_mask) > 0);
-        if (is_nan)
-        {
-            constexpr std::uint16_t smallest_exp_bit = 0x0400u;
-            raw = raw & (~smallest_exp_bit); // flip the smallest exponent bit
-        }
-        return sycl::bit_cast<sycl::half>(raw);
+    auto half_converter = [](size_t /*index*/, size_t val) {
+        return TestUtils::sycl_half_convert(std::uint16_t(val & 0xFFFFu));
     };
 
     // Test radix-sort bit conversions
@@ -60,7 +49,7 @@ int main()
                             Converter<std::int64_t>{});
     test_sort<TestUtils::float64_t>(SortTestConfig{cfg, "float64_t, device"}, small_sizes, Device<5>{},
                                     Converter<TestUtils::float64_t>{});
-    test_sort<sycl::half>(SortTestConfig{cfg, "sycl::half, device"}, small_sizes, Device<6>{}, sycl_half_convert);
+    test_sort<sycl::half>(SortTestConfig{cfg, "sycl::half, device"}, small_sizes, Device<6>{}, half_converter);
     // TODO: add a test for a MoveConstructible only type
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
@@ -242,6 +242,40 @@ test_with_buffers(Policy&& exec, Size n, StabilityTag stability_tag, Compare... 
     check_sort(keys.begin(), vals.begin(), origin_keys.begin(), origin_vals.begin(), n, n, StableSortTag{}, compare...);
 }
 
+// Test that -0 and +0 keys are treated as equal (stability check).
+// All keys are either -0 or +0; values are sequential indices.
+// A stable sort must preserve the original order of values since all keys compare equal.
+// Without the -0 normalization fix, radix sort assigns different sort keys to -0 vs +0,
+// grouping all -0 before +0 and breaking stability.
+template <typename KeyT, typename ValT, sycl::usm::alloc alloc_type, std::uint32_t KernelNameID, typename Policy>
+void
+test_negative_zero_stability(Policy&& exec, std::size_t n)
+{
+    std::vector<KeyT> keys(n);
+    std::vector<ValT> values(n);
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        keys[i] = (i % 2 == 0) ? -KeyT(0.0) : KeyT(0.0);
+        values[i] = static_cast<ValT>(i);
+    }
+
+    std::vector<KeyT> expected_keys(keys);
+    std::vector<ValT> expected_values(values);
+    call_reference_sort(expected_keys.begin(), expected_values.begin(), n);
+
+    TestUtils::usm_data_transfer<alloc_type, KeyT> keys_device(exec, keys.begin(), keys.end());
+    TestUtils::usm_data_transfer<alloc_type, ValT> vals_device(exec, values.begin(), values.end());
+
+    using _NewKernelName = TestUtils::unique_kernel_name<TagUSM, KernelNameID>;
+    oneapi::dpl::stable_sort_by_key(CLONE_TEST_POLICY_NAME(exec, _NewKernelName), keys_device.get_data(),
+                                    keys_device.get_data() + n, vals_device.get_data());
+
+    std::vector<ValT> actual_values(n);
+    vals_device.retrieve_data(actual_values.begin());
+
+    EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), n, "negative zero stability broken in sort_by_key");
+}
+
 struct CustomGreat
 {
     template <typename T>
@@ -264,6 +298,16 @@ test_device_policy(Policy&& exec, StabilityTag stability_tag)
     test_with_buffers<float, float, 3>(CLONE_TEST_POLICY(exec), small_size, stability_tag, custom_greater);
     test_with_buffers<Particle::energy_type, Particle, 4>(CLONE_TEST_POLICY(exec), large_size, stability_tag, custom_greater);
     test_with_buffers<Particle::energy_type, Particle, 5>(CLONE_TEST_POLICY(exec), small_size, stability_tag);
+
+    if constexpr (std::is_same_v<StabilityTag, StableSortTag>)
+    {
+        test_negative_zero_stability<float, std::uint32_t, sycl::usm::alloc::shared, 6>(CLONE_TEST_POLICY(exec),
+                                                                                        small_size);
+        test_negative_zero_stability<double, std::uint32_t, sycl::usm::alloc::shared, 7>(CLONE_TEST_POLICY(exec),
+                                                                                         small_size);
+        test_negative_zero_stability<sycl::half, std::uint32_t, sycl::usm::alloc::shared, 8>(CLONE_TEST_POLICY(exec),
+                                                                                             small_size);
+    }
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 

--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
@@ -242,11 +242,7 @@ test_with_buffers(Policy&& exec, Size n, StabilityTag stability_tag, Compare... 
     check_sort(keys.begin(), vals.begin(), origin_keys.begin(), origin_vals.begin(), n, n, StableSortTag{}, compare...);
 }
 
-// Test that -0 and +0 keys are treated as equal (stability check).
-// All keys are either -0 or +0; values are sequential indices.
-// A stable sort must preserve the original order of values since all keys compare equal.
-// Without the -0 normalization fix, radix sort assigns different sort keys to -0 vs +0,
-// grouping all -0 before +0 and breaking stability.
+// Test that -0 and +0 keys are treated as equal.
 template <typename KeyT, typename ValT, sycl::usm::alloc alloc_type, std::uint32_t KernelNameID, typename Policy>
 void
 test_negative_zero_stability(Policy&& exec, std::size_t n)

--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
@@ -247,28 +247,27 @@ template <typename KeyT, typename ValT, sycl::usm::alloc alloc_type, std::uint32
 void
 test_negative_zero_stability(Policy&& exec, std::size_t n)
 {
-    std::vector<KeyT> keys(n);
-    std::vector<ValT> values(n);
+    std::vector<KeyT> expected_keys(n);
+    std::vector<ValT> expected_values(n);
     for (std::size_t i = 0; i < n; ++i)
     {
-        keys[i] = (i % 2 == 0) ? -KeyT(0.0) : KeyT(0.0);
-        values[i] = static_cast<ValT>(i);
+        expected_keys[i] = (i % 2 == 0) ? -KeyT(0.0) : KeyT(0.0);
+        expected_values[i] = static_cast<ValT>(i);
     }
 
-    std::vector<KeyT> expected_keys(keys);
-    std::vector<ValT> expected_values(values);
-    call_reference_sort(expected_keys.begin(), expected_values.begin(), n);
-
-    TestUtils::usm_data_transfer<alloc_type, KeyT> keys_device(exec, keys.begin(), keys.end());
-    TestUtils::usm_data_transfer<alloc_type, ValT> vals_device(exec, values.begin(), values.end());
+    TestUtils::usm_data_transfer<alloc_type, KeyT> keys_device(exec, expected_keys.begin(), expected_keys.end());
+    TestUtils::usm_data_transfer<alloc_type, ValT> vals_device(exec, expected_values.begin(), expected_values.end());
 
     using _NewKernelName = TestUtils::unique_kernel_name<TagUSM, KernelNameID>;
     oneapi::dpl::stable_sort_by_key(CLONE_TEST_POLICY_NAME(exec, _NewKernelName), keys_device.get_data(),
                                     keys_device.get_data() + n, vals_device.get_data());
 
+    std::vector<KeyT> actual_keys(n);
     std::vector<ValT> actual_values(n);
+    keys_device.retrieve_data(actual_keys.begin());
     vals_device.retrieve_data(actual_values.begin());
 
+    EXPECT_EQ_N(expected_keys.begin(), actual_keys.begin(), n, "negative zero stability broken in sort_by_key (keys)");
     EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), n, "negative zero stability broken in sort_by_key");
 }
 

--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
@@ -298,10 +298,17 @@ test_device_policy(Policy&& exec, StabilityTag stability_tag)
     {
         test_negative_zero_stability<float, std::uint32_t, sycl::usm::alloc::shared, 6>(CLONE_TEST_POLICY(exec),
                                                                                         small_size);
-        test_negative_zero_stability<double, std::uint32_t, sycl::usm::alloc::shared, 7>(CLONE_TEST_POLICY(exec),
-                                                                                         small_size);
-        test_negative_zero_stability<sycl::half, std::uint32_t, sycl::usm::alloc::shared, 8>(CLONE_TEST_POLICY(exec),
+        sycl::device dev = exec.queue().get_device();
+        if (TestUtils::has_type_support<double>(dev))
+        {
+            test_negative_zero_stability<double, std::uint32_t, sycl::usm::alloc::shared, 7>(CLONE_TEST_POLICY(exec),
                                                                                              small_size);
+        }
+        if (TestUtils::has_type_support<sycl::half>(dev))
+        {
+            test_negative_zero_stability<sycl::half, std::uint32_t, sycl::usm::alloc::shared, 8>(
+                CLONE_TEST_POLICY(exec), small_size);
+        }
     }
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1057,6 +1057,30 @@ generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
     }
 }
 
+#if TEST_DPCPP_BACKEND_PRESENT
+inline void
+generate_arithmetic_data(sycl::half* input, std::size_t size, std::uint32_t seed)
+{
+    std::default_random_engine gen{seed};
+    std::size_t unique_threshold = 75 * size / 100;
+    std::uniform_int_distribution<std::uint16_t> dist(0, 0xFFFFu);
+
+    auto generate_valid_half = [&]() {
+        std::uint16_t raw = dist(gen);
+        constexpr std::uint16_t exp_mask = 0x7C00u;
+        constexpr std::uint16_t frac_mask = 0x03FFu;
+        if (((raw & exp_mask) == exp_mask) && ((raw & frac_mask) != 0))
+            raw &= ~std::uint16_t(0x0400u);
+        return sycl::bit_cast<sycl::half>(raw);
+    };
+
+    std::generate(input, input + unique_threshold, generate_valid_half);
+    assert(unique_threshold >= size / 2 && unique_threshold < size);
+    for (std::uint32_t i = 0, j = unique_threshold; j < size; ++i, ++j)
+        input[j] = input[i];
+}
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
 // Utility that models __estimate_best_start_size in the SYCL backend parallel_for to ensure large enough inputs are
 // used to test the large submitter path. A multiplier to the max size is added to ensure we get a few separate test inputs
 // for this path. For debug testing, only test with a single large size to avoid timeouts. Returns a monotonically increasing

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -60,6 +60,34 @@ namespace TestUtils
 using float64_t = double;
 using float32_t = float;
 
+template <typename T>
+struct is_arithmetic : std::is_arithmetic<T>
+{
+};
+
+template <typename T>
+struct is_floating_point : std::is_floating_point<T>
+{
+};
+
+#if TEST_DPCPP_BACKEND_PRESENT
+template <>
+struct is_arithmetic<sycl::half> : std::true_type
+{
+};
+
+template <>
+struct is_floating_point<sycl::half> : std::true_type
+{
+};
+#endif
+
+template <typename T>
+inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+
+template <typename T>
+inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
+
 template <class T, ::std::size_t N>
 constexpr size_t
 const_size(const T (&)[N]) noexcept
@@ -118,8 +146,10 @@ is_equal_val(const T1& val1, const T2& val2)
 {
     using T = std::common_type_t<T1, T2>;
 
-    if constexpr (std::is_floating_point_v<T>)
+    if constexpr (is_floating_point_v<T>)
     {
+        if (val1 == val2)
+            return true;
         const auto eps = std::numeric_limits<T>::epsilon();
         return std::fabs(T(val1) - T(val2)) < eps;
     }
@@ -1023,7 +1053,7 @@ create_new_kernel_param_idx(KernelParam)
 #endif //TEST_DPCPP_BACKEND_PRESENT
 
 template <typename T>
-typename std::enable_if_t<std::is_arithmetic_v<T>>
+typename std::enable_if_t<is_arithmetic_v<T>>
 generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
 {
     std::default_random_engine gen{seed};
@@ -1038,17 +1068,20 @@ generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
     }
     else
     {
+        using RealT =
+            std::conditional_t<std::is_same_v<T, float> || std::is_same_v<T, double> || std::is_same_v<T, long double>,
+                               T, float>;
         // log2 - exp2 transformation allows generating floating point values,
         // which distribution resembles uniform distribution of their bit representation
         // This is useful for checking different cases of radix sort
-        std::uniform_real_distribution<T> dist_real(std::numeric_limits<T>::min(), log2(std::numeric_limits<T>::max()));
+        std::uniform_real_distribution<RealT> dist_real{RealT(std::numeric_limits<T>::min()),
+                                                        RealT(std::log2(float(std::numeric_limits<T>::max())))};
         std::uniform_int_distribution<int> dist_binary(0, 1);
-        auto randomly_signed_real = [&dist_real, &dist_binary, &gen]()
-        {
-            auto v = exp2(dist_real(gen));
-            return dist_binary(gen) == 0 ? v : -v;
+        auto randomly_signed_real = [&dist_real, &dist_binary, &gen]() {
+            auto v = std::exp2(dist_real(gen));
+            return dist_binary(gen) == 0 ? RealT(v) : RealT(-v);
         };
-        std::generate(input, input + unique_threshold, [&] { return randomly_signed_real(); });
+        std::generate(input, input + unique_threshold, [&] { return T(randomly_signed_real()); });
     }
     assert(unique_threshold >= size/2 && unique_threshold < size);
     for (uint32_t i = 0, j = unique_threshold; j < size; ++i, ++j)

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1058,6 +1058,22 @@ generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
 }
 
 #if TEST_DPCPP_BACKEND_PRESENT
+// Convert raw uint16 bits to a valid sycl::half, avoiding NaN values which
+// need a custom comparator due to: (x < NaN = false) and (NaN < x = false).
+inline sycl::half
+sycl_half_convert(std::uint16_t raw)
+{
+    constexpr std::uint16_t exp_mask = 0x7C00u;
+    constexpr std::uint16_t frac_mask = 0x03FFu;
+    bool is_nan = ((raw & exp_mask) == exp_mask) && ((raw & frac_mask) > 0);
+    if (is_nan)
+    {
+        constexpr std::uint16_t smallest_exp_bit = 0x0400u;
+        raw = raw & (~smallest_exp_bit);
+    }
+    return sycl::bit_cast<sycl::half>(raw);
+}
+
 inline void
 generate_arithmetic_data(sycl::half* input, std::size_t size, std::uint32_t seed)
 {
@@ -1065,19 +1081,7 @@ generate_arithmetic_data(sycl::half* input, std::size_t size, std::uint32_t seed
     std::size_t unique_threshold = 75 * size / 100;
     std::uniform_int_distribution<std::uint16_t> dist(0, 0xFFFFu);
 
-    auto generate_valid_half = [&]() {
-        std::uint16_t raw = dist(gen);
-        constexpr std::uint16_t exp_mask = 0x7C00u;
-        constexpr std::uint16_t frac_mask = 0x03FFu;
-        if (((raw & exp_mask) == exp_mask) && ((raw & frac_mask) != 0))
-            raw &= ~std::uint16_t(0x0400u);
-        // Avoid -0 (0x8000) to avoid comparison issues with 0 (0x0000)
-        if (raw == 0x8000u)
-            raw = 0x0000u;
-        return sycl::bit_cast<sycl::half>(raw);
-    };
-
-    std::generate(input, input + unique_threshold, generate_valid_half);
+    std::generate(input, input + unique_threshold, [&]() { return sycl_half_convert(dist(gen)); });
     assert(unique_threshold >= size / 2 && unique_threshold < size);
     for (std::uint32_t i = 0, j = unique_threshold; j < size; ++i, ++j)
         input[j] = input[i];

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1081,8 +1081,8 @@ generate_arithmetic_data(sycl::half* input, std::size_t size, std::uint32_t seed
     std::size_t unique_threshold = 75 * size / 100;
     std::uniform_int_distribution<std::uint16_t> dist(0, 0xFFFFu);
 
-    std::generate(input, input + unique_threshold, [&]() { return sycl_half_convert(dist(gen)); });
     assert(unique_threshold >= size / 2 && unique_threshold < size);
+    std::generate(input, input + unique_threshold, [&]() { return sycl_half_convert(dist(gen)); });
     for (std::uint32_t i = 0, j = unique_threshold; j < size; ++i, ++j)
         input[j] = input[i];
 }

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1071,6 +1071,9 @@ generate_arithmetic_data(sycl::half* input, std::size_t size, std::uint32_t seed
         constexpr std::uint16_t frac_mask = 0x03FFu;
         if (((raw & exp_mask) == exp_mask) && ((raw & frac_mask) != 0))
             raw &= ~std::uint16_t(0x0400u);
+        // Avoid -0 (0x8000) to avoid comparison issues with 0 (0x0000)
+        if (raw == 0x8000u)
+            raw = 0x0000u;
         return sycl::bit_cast<sycl::half>(raw);
     };
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -60,34 +60,6 @@ namespace TestUtils
 using float64_t = double;
 using float32_t = float;
 
-template <typename T>
-struct is_arithmetic : std::is_arithmetic<T>
-{
-};
-
-template <typename T>
-struct is_floating_point : std::is_floating_point<T>
-{
-};
-
-#if TEST_DPCPP_BACKEND_PRESENT
-template <>
-struct is_arithmetic<sycl::half> : std::true_type
-{
-};
-
-template <>
-struct is_floating_point<sycl::half> : std::true_type
-{
-};
-#endif
-
-template <typename T>
-inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
-
-template <typename T>
-inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
-
 template <class T, ::std::size_t N>
 constexpr size_t
 const_size(const T (&)[N]) noexcept
@@ -146,10 +118,8 @@ is_equal_val(const T1& val1, const T2& val2)
 {
     using T = std::common_type_t<T1, T2>;
 
-    if constexpr (is_floating_point_v<T>)
+    if constexpr (std::is_floating_point_v<T>)
     {
-        if (val1 == val2)
-            return true;
         const auto eps = std::numeric_limits<T>::epsilon();
         return std::fabs(T(val1) - T(val2)) < eps;
     }
@@ -1053,7 +1023,7 @@ create_new_kernel_param_idx(KernelParam)
 #endif //TEST_DPCPP_BACKEND_PRESENT
 
 template <typename T>
-typename std::enable_if_t<is_arithmetic_v<T>>
+typename std::enable_if_t<std::is_arithmetic_v<T>>
 generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
 {
     std::default_random_engine gen{seed};
@@ -1068,20 +1038,17 @@ generate_arithmetic_data(T* input, std::size_t size, std::uint32_t seed)
     }
     else
     {
-        using RealT =
-            std::conditional_t<std::is_same_v<T, float> || std::is_same_v<T, double> || std::is_same_v<T, long double>,
-                               T, float>;
         // log2 - exp2 transformation allows generating floating point values,
         // which distribution resembles uniform distribution of their bit representation
         // This is useful for checking different cases of radix sort
-        std::uniform_real_distribution<RealT> dist_real{RealT(std::numeric_limits<T>::min()),
-                                                        RealT(std::log2(float(std::numeric_limits<T>::max())))};
+        std::uniform_real_distribution<T> dist_real(std::numeric_limits<T>::min(), log2(std::numeric_limits<T>::max()));
         std::uniform_int_distribution<int> dist_binary(0, 1);
-        auto randomly_signed_real = [&dist_real, &dist_binary, &gen]() {
-            auto v = std::exp2(dist_real(gen));
-            return dist_binary(gen) == 0 ? RealT(v) : RealT(-v);
+        auto randomly_signed_real = [&dist_real, &dist_binary, &gen]()
+        {
+            auto v = exp2(dist_real(gen));
+            return dist_binary(gen) == 0 ? v : -v;
         };
-        std::generate(input, input + unique_threshold, [&] { return T(randomly_signed_real()); });
+        std::generate(input, input + unique_threshold, [&] { return randomly_signed_real(); });
     }
     assert(unique_threshold >= size/2 && unique_threshold < size);
     for (uint32_t i = 0, j = unique_threshold; j < size; ++i, ++j)


### PR DESCRIPTION
- Implements support for `sycl::half` in KT SYCL & ESIMD radix sort by adding new conversion operators.
- Corrects signed zero handling across all radix sort implementations. To ensure stability, we must special case the conversion of -0.0 so that all stages map to the same bin as 0.0. Without this, -0 is strictly ordered before 0 in an ascending sort.

Addresses #2664 and #2713 