### PR TITLE
[oneDPL] Avoid reducing inactive work-item values

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -76,13 +76,17 @@ __work_group_reduce_kernel(const _NDItemId __item, const _Size __n, const _Size 
 
     const _Size __n_items = __transform_pattern.output_size(__n, __group_size, __iters_per_work_item);
     // 2. Reduce within work group using local memory
-    __result.__v = __reduce_pattern(__item, __n_items, __result.__v, __local_mem);
-    if (__local_idx == 0)
+    auto __reduced_value = __reduce_pattern(__item, __n_items, __result, __local_mem);
+    if (__item.get_global_id(0) < __n_items)
     {
-        __reduce_pattern.apply_init(__init, __result.__v);
-        __res_ptr[0] = __result.__v;
+        __result.__v = __reduced_value;
+        if (__local_idx == 0)
+        {
+            __reduce_pattern.apply_init(__init, __result.__v);
+            __res_ptr[0] = __result.__v;
+        }
+        __result.__destroy();
     }
-    __result.__destroy();
 }
 
 // Device kernel that transforms and reduces __n elements to the number of work groups preliminary results.
@@ -103,10 +107,14 @@ __device_reduce_kernel(const _NDItemId __item, const _Size __n, const _Size __it
 
     const _Size __n_items = __transform_pattern.output_size(__n, __group_size, __iters_per_work_item);
     // 2. Reduce within work group using local memory
-    __result.__v = __reduce_pattern(__item, __n_items, __result.__v, __local_mem);
-    if (__local_idx == 0)
-        __reduce_result_ptr[__group_idx] = __result.__v;
-    __result.__destroy();
+    auto __reduced_value = __reduce_pattern(__item, __n_items, __result, __local_mem);
+    if (__item.get_global_id(0) < __n_items)
+    {
+        __result.__v = __reduced_value;
+        if (__local_idx == 0)
+            __reduce_result_ptr[__group_idx] = __result.__v;
+        __result.__destroy();
+    }
 }
 
 //------------------------------------------------------------------------
@@ -382,19 +390,23 @@ struct __parallel_transform_reduce_impl
                             __n_items = __transform_pattern2.output_size(__n, __work_group_size, __iters_per_work_item);
                         }
                         // 2. Reduce within work group using local memory
-                        __result.__v = __reduce_pattern(__item, __n_items, __result.__v, __temp_local);
-                        if (__local_idx == 0)
+                        auto __reduced_value = __reduce_pattern(__item, __n_items, __result, __temp_local);
+                        if (__item.get_global_id(0) < __n_items)
                         {
-                            // final reduction
-                            if (__n_groups == 1)
+                            __result.__v = __reduced_value;
+                            if (__local_idx == 0)
                             {
-                                __reduce_pattern.apply_init(__init, __result.__v);
-                                __res_ptr[0] = __result.__v;
-                            }
+                                // final reduction
+                                if (__n_groups == 1)
+                                {
+                                    __reduce_pattern.apply_init(__init, __result.__v);
+                                    __res_ptr[0] = __result.__v;
+                                }
 
-                            __temp_ptr[__offset_1 + __group_idx] = __result.__v;
+                                __temp_ptr[__offset_1 + __group_idx] = __result.__v;
+                            }
+                            __result.__destroy();
                         }
-                        __result.__destroy();
                     });
             });
             __is_first = false;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -466,7 +466,8 @@ struct transform_reduce
 
 // Reduce local reductions of each work item to a single reduced element per work group. The local reductions are held
 // in local memory. sycl::reduce_over_group is used for supported data types and operations. All other operations are
-// processed in order and without a known identity.
+// processed in order and without a known identity. For the local-memory path, only work-item 0 returns the reduced
+// value.
 template <typename _BinaryOperation1, typename _Tp>
 struct reduce_over_group
 {
@@ -475,39 +476,46 @@ struct reduce_over_group
     // Reduce on local memory with subgroups
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    reduce_impl(const _NDItemId __item, const _Size __n, const _Tp& __val, const _AccLocal& /*__local_mem*/,
-                std::true_type /*has_known_identity*/) const
+    reduce_impl(const _NDItemId __item, const _Size __n, oneapi::dpl::__internal::__lazy_ctor_storage<_Tp>& __val,
+                const _AccLocal& /*__local_mem*/, std::true_type /*has_known_identity*/) const
     {
         const _Size __global_idx = __item.get_global_id(0);
         return __dpl_sycl::__reduce_over_group(
-            __item.get_group(), __global_idx >= __n ? __known_identity<_BinaryOperation1, _Tp> : __val, __bin_op1);
+            __item.get_group(), __global_idx >= __n ? __known_identity<_BinaryOperation1, _Tp> : __val.__v, __bin_op1);
     }
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    reduce_impl(const _NDItemId __item, const _Size __n, const _Tp& __val, const _AccLocal& __local_mem,
-                std::false_type /*has_known_identity*/) const
+    reduce_impl(const _NDItemId __item, const _Size __n, oneapi::dpl::__internal::__lazy_ctor_storage<_Tp>& __val,
+                const _AccLocal& __local_mem, std::false_type /*has_known_identity*/) const
     {
         auto __local_idx = __item.get_local_id(0);
-        const _Size __global_idx = __item.get_global_id(0);
         auto __group_size = __item.get_local_range().size();
 
-        __local_mem[__local_idx] = __val;
+        const _Size __global_idx = __item.get_global_id(0);
+        if (__global_idx < __n)
+            __local_mem[__local_idx] = __val.__v;
+
+        const _Size __group_start = __item.get_group(0) * __group_size;
+        _Size __active_count = __n > __group_start ? __n - __group_start : 0;
+        if (__active_count > __group_size)
+            __active_count = __group_size;
+
         for (std::uint32_t __power_2 = 1; __power_2 < __group_size; __power_2 *= 2)
         {
             sycl::group_barrier(__item.get_group());
-            if ((__local_idx & (2 * __power_2 - 1)) == 0 && __local_idx + __power_2 < __group_size &&
-                __global_idx + __power_2 < __n)
+            if ((__local_idx & (2 * __power_2 - 1)) == 0 && __local_idx + __power_2 < __active_count)
             {
                 __local_mem[__local_idx] = __bin_op1(__local_mem[__local_idx], __local_mem[__local_idx + __power_2]);
             }
         }
-        return __local_mem[__local_idx];
+        return __local_mem[0];
     }
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    operator()(const _NDItemId __item, const _Size __n, const _Tp& __val, const _AccLocal& __local_mem) const
+    operator()(const _NDItemId __item, const _Size __n, oneapi::dpl::__internal::__lazy_ctor_storage<_Tp>& __val,
+               const _AccLocal& __local_mem) const
     {
         return reduce_impl(__item, __n, __val, __local_mem, __has_known_identity<_BinaryOperation1, _Tp>{});
     }


### PR DESCRIPTION
When a work group contains inactive work-items and the binary operation has no known identity, the SYCL reduce path may access values from inactive lanes or lazy storage that was not constructed.

This fixes a oneDPL undefined-behavior issue exposed while investigating uxlfoundation/oneDPL#2716. The remaining software-emulated FP64 wrong result is tracked separately by intel/intel-graphics-compiler#413.

### Changes

- Restrict the no-known-identity local-memory reduction to active work-items in the current work group.
- Handle `__lazy_ctor_storage` without reading, assigning, or destroying `__v` for inactive work-items before it is constructed.
- Keep the no-known-identity path as a bounded parallel tree reduction.