### PR TITLE
Rename __local to avoid issues in ACPP/HIP

### DIFF
--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -268,14 +268,14 @@ struct __enumerable_thread_local_storage_base
     get_for_current_thread()
     {
         const std::size_t __i = _Derived::get_thread_num();
-        std::optional<_ValueType>& __current = __thread_specific_storage[__i];
-        if (!__current)
+        std::optional<_ValueType>& __local_value = __thread_specific_storage[__i];
+        if (!__local_value)
         {
             // create temporary storage on first usage to avoid extra parallel region and unnecessary instantiation
-            std::apply([&__current](_Args... __arg_pack) { __current.emplace(__arg_pack...); }, __args);
+            std::apply([&__local_value](_Args... __arg_pack) { __local_value.emplace(__arg_pack...); }, __args);
             __num_elements.fetch_add(1, std::memory_order_relaxed);
         }
-        return *__current;
+        return *__local_value;
     }
 
     std::vector<std::optional<_ValueType>> __thread_specific_storage;

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -268,14 +268,14 @@ struct __enumerable_thread_local_storage_base
     get_for_current_thread()
     {
         const std::size_t __i = _Derived::get_thread_num();
-        std::optional<_ValueType>& __local = __thread_specific_storage[__i];
-        if (!__local)
+        std::optional<_ValueType>& __current = __thread_specific_storage[__i];
+        if (!__current)
         {
             // create temporary storage on first usage to avoid extra parallel region and unnecessary instantiation
-            std::apply([&__local](_Args... __arg_pack) { __local.emplace(__arg_pack...); }, __args);
+            std::apply([&__current](_Args... __arg_pack) { __current.emplace(__arg_pack...); }, __args);
             __num_elements.fetch_add(1, std::memory_order_relaxed);
         }
-        return *__local;
+        return *__current;
     }
 
     std::vector<std::optional<_ValueType>> __thread_specific_storage;


### PR DESCRIPTION
`__local` variable may cause compilation issues in AdaptiveCPP/HIP according to https://github.com/acts-project/traccc/commit/8b98b830febd2457957e393f048c1a41a6d6cf3b.

I have not verified the fix, but it should be fine as is - this is just a replacement of a variable name.