### PR TITLE
Improve performance of rotate

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1622,11 +1622,6 @@ __pattern_reverse_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bi
 //------------------------------------------------------------------------
 // rotate
 //------------------------------------------------------------------------
-//Advantages over "3x reverse" version of algorithm:
-//1:Not sensitive to size of shift
-//  (With 3x reverse was large variance)
-//2:The average time is better until ~10e8 elements
-//Wrapper needed to avoid kernel problems
 template <typename Name>
 struct __rotate_wrapper;
 
@@ -1635,38 +1630,26 @@ _Iterator
 __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __new_first,
                  _Iterator __last)
 {
-    auto __n = __last - __first;
-    if (__n <= 0)
+    const std::size_t __n = __last - __first;
+    if (__n == 0)
         return __first;
-
-    using _Tp = typename ::std::iterator_traits<_Iterator>::value_type;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write>();
     auto __buf = __keep(__first, __last);
-    auto __temp_buf = oneapi::dpl::__par_backend_hetero::__buffer<_Tp>(__n);
+    const std::size_t __shift = __new_first - __first;
 
-    auto __temp_rng_w =
-        oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::write>(__temp_buf.get_buffer());
-
-    const auto __shift = __new_first - __first;
+    // 1. In-place reverse of the ranges before and after the shift point, done in one kernel
+    auto __dbrick = oneapi::dpl::__par_backend_hetero::__dual_brick{
+        unseq_backend::__reverse_functor{__shift}, unseq_backend::__reverse_functor{__n - __shift, __shift}, __shift};
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec),
-        unseq_backend::__rotate_copy<typename std::iterator_traits<_Iterator>::difference_type>{__n, __shift}, __n,
-        __buf.all_view(), __temp_rng_w);
+        _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec), __dbrick,
+        __n / 2, __buf.all_view())
+        .wait(); // TODO: need a non-blocking dependency between the kernels
 
-    //An explicit wait isn't required here because we are working with a temporary sycl::buffer and sycl accessors and
-    //SYCL runtime makes a dependency graph to prevent the races between two __parallel_for patterns.
-
-    using _Function = __brick_move<__hetero_tag<_BackendTag>>;
-    auto __temp_rng_rw =
-        oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::read_write>(__temp_buf.get_buffer());
-    auto __brick = unseq_backend::walk_n_vectors_or_scalars<_Function>{_Function{}, static_cast<std::size_t>(__n)};
-    oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __brick,
-                                                      __n, __temp_rng_rw, __buf.all_view())
+    // 2. In-place reverse of the whole range
+    oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                                                      unseq_backend::__reverse_functor{__n}, __n / 2, __buf.all_view())
         .__checked_deferrable_wait();
-
-    // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
-    // we must call __parallel_for with wait() to provide the blocking synchronization for this pattern.
 
     return __first + (__last - __new_first);
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1640,16 +1640,28 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
 
     if (__shift > 0 && __shift < __n)
     {
-        // 1. In-place reverse of the ranges before and after the shift point, done in one kernel
-        auto __dbrick = oneapi::dpl::__par_backend_hetero::__dual_brick{
-            unseq_backend::__reverse_functor{__shift}, unseq_backend::__reverse_functor{__n - __shift, __shift},
-            __shift / 2};
-        oneapi::dpl::__par_backend_hetero::__parallel_for(
-            _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec), __dbrick,
-            __n / 2, __buf.all_view())
-            .wait(); // TODO: need a non-blocking dependency between the kernels
+        if (__shift > 1 && __shift < __n - 1)
+        {
+            // Reverse the ranges before and after the shift point, in one kernel
+            auto __dbrick = oneapi::dpl::__par_backend_hetero::__dual_brick{
+                unseq_backend::__reverse_functor{__shift}, unseq_backend::__reverse_functor{__n - __shift, __shift},
+                __shift / 2 /*iterations in the first reverse*/};
+            oneapi::dpl::__par_backend_hetero::__parallel_for(
+                _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec),
+                __dbrick, __n / 2, __buf.all_view())
+                .wait();
+        }
+        else if (__n > 2)
+        {
+            // For a non-trivial single-position shift, reverse only the bigger part
+            oneapi::dpl::__par_backend_hetero::__parallel_for(
+                _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                unseq_backend::__reverse_functor{__n - 1, __shift == 1 ? 1u : 0u}, (__n - 1) / 2, __buf.all_view())
+                .wait();
+        }
+        // TODO: need a non-blocking dependency between the kernels
 
-        // 2. In-place reverse of the whole range
+        // Now reverse the whole range
         oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                                                           unseq_backend::__reverse_functor{__n}, __n / 2,
                                                           __buf.all_view())

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1643,7 +1643,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
         // 1. In-place reverse of the ranges before and after the shift point, done in one kernel
         auto __dbrick = oneapi::dpl::__par_backend_hetero::__dual_brick{
             unseq_backend::__reverse_functor{__shift}, unseq_backend::__reverse_functor{__n - __shift, __shift},
-            __shift};
+            __shift / 2};
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec), __dbrick,
             __n / 2, __buf.all_view())

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1638,19 +1638,23 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     auto __buf = __keep(__first, __last);
     const std::size_t __shift = __new_first - __first;
 
-    // 1. In-place reverse of the ranges before and after the shift point, done in one kernel
-    auto __dbrick = oneapi::dpl::__par_backend_hetero::__dual_brick{
-        unseq_backend::__reverse_functor{__shift}, unseq_backend::__reverse_functor{__n - __shift, __shift}, __shift};
-    oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec), __dbrick,
-        __n / 2, __buf.all_view())
-        .wait(); // TODO: need a non-blocking dependency between the kernels
+    if (__shift > 0 && __shift < __n)
+    {
+        // 1. In-place reverse of the ranges before and after the shift point, done in one kernel
+        auto __dbrick = oneapi::dpl::__par_backend_hetero::__dual_brick{
+            unseq_backend::__reverse_functor{__shift}, unseq_backend::__reverse_functor{__n - __shift, __shift},
+            __shift};
+        oneapi::dpl::__par_backend_hetero::__parallel_for(
+            _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec), __dbrick,
+            __n / 2, __buf.all_view())
+            .wait(); // TODO: need a non-blocking dependency between the kernels
 
-    // 2. In-place reverse of the whole range
-    oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                                                      unseq_backend::__reverse_functor{__n}, __n / 2, __buf.all_view())
-        .__checked_deferrable_wait();
-
+        // 2. In-place reverse of the whole range
+        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                                                          unseq_backend::__reverse_functor{__n}, __n / 2,
+                                                          __buf.all_view())
+            .__checked_deferrable_wait();
+    }
     return __first + (__last - __new_first);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1648,7 +1648,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
                 __shift / 2 /*iterations in the first reverse*/};
             oneapi::dpl::__par_backend_hetero::__parallel_for(
                 _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec),
-                __dbrick, __n / 2, __buf.all_view())
+                __dbrick, __shift / 2 + (__n - __shift) / 2, __buf.all_view())
                 .wait();
         }
         else if (__n > 2)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1623,7 +1623,7 @@ __pattern_reverse_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bi
 // rotate
 //------------------------------------------------------------------------
 template <typename Name>
-struct __rotate_wrapper;
+struct __rotate_dual_reverse;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator>
 _Iterator
@@ -1647,7 +1647,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
                 unseq_backend::__reverse_functor{__shift}, unseq_backend::__reverse_functor{__n - __shift, __shift},
                 __shift / 2 /*iterations in the first reverse*/};
             oneapi::dpl::__par_backend_hetero::__parallel_for(
-                _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_wrapper>(__exec),
+                _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_dual_reverse>(__exec),
                 __dbrick, __shift / 2 + (__n - __shift) / 2, __buf.all_view())
                 .wait();
         }
@@ -1655,8 +1655,8 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
         {
             // For a non-trivial single-position shift, reverse only the bigger part
             oneapi::dpl::__par_backend_hetero::__parallel_for(
-                _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                unseq_backend::__reverse_functor{__n - 1, __shift == 1 ? 1u : 0u}, (__n - 1) / 2, __buf.all_view())
+                _BackendTag{}, __exec, unseq_backend::__reverse_functor{__n - 1, __shift == 1 ? 1u : 0u},
+                (__n - 1) / 2, __buf.all_view())
                 .wait();
         }
         // TODO: need a non-blocking dependency between the kernels

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -176,22 +176,27 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     }
 
     template <typename _Fp>
-    static std::tuple<std::size_t, std::size_t, bool>
-    __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t, std::size_t, const _Fp&)
+    static std::tuple<std::size_t, std::size_t, bool, bool>
+    __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t __work_group_size,
+                   std::size_t __data_per_work_item, const _Fp&)
     {
-        return {__count, __item.get_global_linear_id(), true};
+        const bool __is_full_group =
+            (__item.get_group_linear_id() + 1) * __work_group_size * __data_per_work_item <= __count;
+        return {__count, __item.get_global_linear_id(), __is_full_group, true};
     }
 
     template <typename _Brick1, typename _Brick2>
-    static std::tuple<std::size_t, std::size_t, bool>
+    static std::tuple<std::size_t, std::size_t, bool, bool>
     __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t __work_group_size,
                    std::size_t __data_per_work_item, const __dual_brick<_Brick1, _Brick2>& __dbrick)
     {
+        std::size_t __group_id = __item.get_group_linear_id();
+        std::size_t __item_global_id = __item.get_global_linear_id();
         const std::size_t __groups_before_pivot =
             oneapi::dpl::__internal::__dpl_ceiling_div(__dbrick.__pivot, __work_group_size * __data_per_work_item);
-        const bool __use_first_brick = __item.get_group_linear_id() < __groups_before_pivot;
-        std::size_t __item_global_id = __item.get_global_linear_id();
-        if (__use_first_brick)
+
+        const bool __before_pivot = __group_id < __groups_before_pivot;
+        if (__before_pivot)
         {
             __count = __dbrick.__pivot;
         }
@@ -200,8 +205,10 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
             // Adjust the global ID so that the second brick also works with zero-based indexes
             __item_global_id -= __work_group_size * __groups_before_pivot;
             __count -= __dbrick.__pivot;
+            __group_id -= __groups_before_pivot;
         }
-        return {__count, __item_global_id, __use_first_brick};
+        const bool __is_full_group = (__group_id + 1) * __work_group_size * __data_per_work_item <= __count;
+        return {__count, __item_global_id, __is_full_group, __before_pivot};
     }
 
     // SPIR-V compilation targets show best performance with a stride of the sub-group size.
@@ -276,12 +283,11 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range(sycl::range<1>(__num_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item</*dim=*/1> __item) {
-                    const auto /*size_t, size_t, bool*/ [__bound, __adjusted_global_id, __brick_hint] =
+                    const auto /*size_t, size_t, bool, bool*/[__bound, __adjusted_global_id, __is_full, __brick_hint] =
                         __global_space(__item, __count, __work_group_size, __data_per_work_item, __brick);
                     const auto /*size_t*/ [__number_of_peers, __local_id] = __local_space(__item, __work_group_size);
 
                     const std::size_t __group_start_idx = __data_per_work_item * (__adjusted_global_id - __local_id);
-                    const bool __is_full = __group_start_idx + __data_per_work_item * __number_of_peers <= __bound;
                     const std::size_t __idx = __group_start_idx + __vector_size * __local_id;
                     const std::uint16_t __stride = __vector_size * __number_of_peers;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -176,21 +176,22 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     }
 
     template <typename _Fp>
-    static std::tuple<std::size_t, std::size_t>
+    static std::tuple<std::size_t, std::size_t, bool>
     __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t, std::size_t, const _Fp&)
     {
-        return {__count, __item.get_global_linear_id()};
+        return {__count, __item.get_global_linear_id(), true};
     }
 
     template <typename _Brick1, typename _Brick2>
-    static std::tuple<std::size_t, std::size_t>
+    static std::tuple<std::size_t, std::size_t, bool>
     __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t __work_group_size,
                    std::size_t __data_per_work_item, const __dual_brick<_Brick1, _Brick2>& __dbrick)
     {
         const std::size_t __groups_before_pivot =
             oneapi::dpl::__internal::__dpl_ceiling_div(__dbrick.__pivot, __work_group_size * __data_per_work_item);
+        const bool __use_first_brick = __item.get_group_linear_id() < __groups_before_pivot;
         std::size_t __item_global_id = __item.get_global_linear_id();
-        if (__item.get_group_linear_id() < __groups_before_pivot)
+        if (__use_first_brick)
         {
             __count = __dbrick.__pivot;
         }
@@ -198,8 +199,9 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
         {
             // Adjust the global ID so that the second brick also works with zero-based indexes
             __item_global_id -= __work_group_size * __groups_before_pivot;
+            __count -= __dbrick.__pivot;
         }
-        return {__count, __item_global_id};
+        return {__count, __item_global_id, __use_first_brick};
     }
 
     // SPIR-V compilation targets show best performance with a stride of the sub-group size.
@@ -224,7 +226,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     template <std::uint8_t __num_strides, typename _Fp, typename... _Args>
     static void
     __execute(std::size_t __bound, bool __is_full, std::size_t __idx, std::uint16_t __stride, const _Fp& __brick,
-              _Args&&... __args)
+              bool /*hint*/, _Args&&... __args)
     {
         __strided_loop<__num_strides> __loop{__bound};
         if (__is_full)
@@ -236,12 +238,12 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     template <std::uint8_t __num_strides, typename _Brick1, typename _Brick2, typename... _Args>
     static void
     __execute(std::size_t __bound, bool __is_full, std::size_t __idx, std::uint16_t __stride,
-              const __dual_brick<_Brick1, _Brick2>& __dbrick, _Args&&... __args)
+             const __dual_brick<_Brick1, _Brick2>& __dbrick, bool __use_first_brick, _Args&&... __args)
     {
-        if (__bound <= __dbrick.__pivot)
-            __execute<__num_strides>(__bound, __is_full, __idx, __stride, __dbrick.__brick1, __args...);
+        if (__use_first_brick)
+            __execute<__num_strides>(__bound, __is_full, __idx, __stride, __dbrick.__brick1, true, __args...);
         else
-            __execute<__num_strides>(__bound, __is_full, __idx, __stride, __dbrick.__brick2, __args...);
+            __execute<__num_strides>(__bound, __is_full, __idx, __stride, __dbrick.__brick2, true, __args...);
     }
 
     // Once there is enough work to launch a group on each compute unit with our chosen __iters_per_item,
@@ -274,7 +276,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range(sycl::range<1>(__num_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item</*dim=*/1> __item) {
-                    const auto /*size_t*/ [__bound, __adjusted_global_id] =
+                    const auto /*size_t, size_t, bool*/ [__bound, __adjusted_global_id, __brick_hint] =
                         __global_space(__item, __count, __work_group_size, __data_per_work_item, __brick);
                     const auto /*size_t*/ [__number_of_peers, __local_id] = __local_space(__item, __work_group_size);
 
@@ -283,8 +285,8 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
                     const std::size_t __idx = __group_start_idx + __vector_size * __local_id;
                     const std::uint16_t __stride = __vector_size * __number_of_peers;
 
-                    __execute<__iters_per_work_item>(__bound, __is_full, __idx, __stride, __brick, __params_t{},
-                                                     __rngs...);
+                    __execute<__iters_per_work_item>(__bound, __is_full, __idx, __stride, __brick, __brick_hint,
+                                                     __params_t{}, __rngs...);
                 });
         });
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -71,18 +71,18 @@ struct __dual_brick
 {
     _Brick1 __brick1;
     _Brick2 __brick2;
-    std::size_t __pivot;  // the number of iterations for the first brick
-    std::size_t __offset; // the starting data index for the second brick
+    std::size_t __pivot; // the number of iterations for the first brick
 
     // When called by __parallel_for_small_submitter, dispatch to the proper brick based on __idx
     template <typename... _Ranges>
     void
-    operator()(std::true_type __full, const std::size_t __global_id, __pfor_params_simple __params, _Ranges&&... __rngs) const
+    operator()(std::true_type __full, const std::size_t __idx, __pfor_params_simple __params, _Ranges&&... __rngs) const
     {
+        // Adjust the index so that bricks work with zero-based indexes
         if (__idx < __pivot)
-            __brick1(__full, __global_id, __params, std::forward<_Ranges>(__rngs)...);
+            __brick1(__full, __idx, __params, std::forward<_Ranges>(__rngs)...);
         else
-            __brick2(__full, __global_id - __pivot + __offset, __params, std::forward<_Ranges>(__rngs)...);
+            __brick2(__full, __idx - __pivot, __params, std::forward<_Ranges>(__rngs)...);
     }
 };
 
@@ -172,31 +172,30 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     }
 
     template <typename _Fp>
-    static std::tuple<std::size_t, std::size_t, std::size_t>
+    static std::tuple<std::size_t, std::size_t>
     __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t, std::uint16_t, const _Fp&)
     {
-        return {0, __count, __item.get_global_linear_id()};
+        return {__count, __item.get_global_linear_id()};
     }
 
     template <typename _Brick1, typename _Brick2>
-    static std::tuple<std::size_t, std::size_t, std::size_t>
+    static std::tuple<std::size_t, std::size_t>
     __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t __work_group_size,
                    std::uint16_t __data_per_work_item, const __dual_brick<_Brick1, _Brick2>& __dbrick)
     {
         const std::size_t __groups_before_pivot =
             oneapi::dpl::__internal::__dpl_ceiling_div(__dbrick.__pivot, __work_group_size * __data_per_work_item);
         std::size_t __item_global_id = __item.get_global_linear_id();
-        std::size_t __offset = 0;
         if (__item.get_group_linear_id() < __groups_before_pivot)
         {
             __count = __dbrick.__pivot;
         }
         else
         {
-            __offset = __dbrick.__offset;
+            // Adjust the global ID so that the second brick also works with zero-based indexes
             __item_global_id -= __work_group_size * __groups_before_pivot;
         }
-        return {__offset, __count, __item_global_id};
+        return {__count, __item_global_id};
     }
 
     // SPIR-V compilation targets show best performance with a stride of the sub-group size.
@@ -218,26 +217,27 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
         return {__group_size, __item_local_id};
     }
 
-    template <typename _Executor, typename _Fp, typename... _Args>
+    template <std::uint8_t __num_strides, typename _Fp, typename... _Args>
     static void
-    __execute(_Executor&& __loop, bool __is_full, std::size_t __idx, std::uint16_t __stride, const _Fp& __brick,
+    __execute(std::size_t __bound, bool __is_full, std::size_t __idx, std::uint16_t __stride, const _Fp& __brick,
               _Args&&... __args)
     {
+        __strided_loop<__num_strides> __loop{__bound};
         if (__is_full)
             __loop(std::true_type{}, __idx, __stride, __brick, __args...);
         else
             __loop(std::false_type{}, __idx, __stride, __brick, __args...);
     }
 
-    template <typename _Executor, typename _Brick1, typename _Brick2, typename... _Args>
+    template <std::uint8_t __num_strides, typename _Brick1, typename _Brick2, typename... _Args>
     static void
-    __execute(_Executor&& __loop, bool __is_full, std::size_t __idx, std::uint16_t __stride,
+    __execute(std::size_t __bound, bool __is_full, std::size_t __idx, std::uint16_t __stride,
               const __dual_brick<_Brick1, _Brick2>& __dbrick, _Args&&... __args)
     {
-        if (__idx < __dbrick.__offset)
-            __execute(__loop, __is_full, __idx, __stride, __dbrick.__brick1, __args...);
+        if (__bound <= __dbrick.__pivot)
+            __execute<__num_strides>(__bound, __is_full, __idx, __stride, __dbrick.__brick1, __args...);
         else
-            __execute(__loop, __is_full, __idx, __stride, __dbrick.__brick2, __args...);
+            __execute<__num_strides>(__bound, __is_full, __idx, __stride, __dbrick.__brick2, __args...);
     }
 
     // Once there is enough work to launch a group on each compute unit with our chosen __iters_per_item,
@@ -270,18 +270,17 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range(sycl::range<1>(__num_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item</*dim=*/1> __item) {
-                    const auto /*size_t*/ [__offset, __bound, __adjusted_global_id] =
+                    const auto /*size_t*/ [__bound, __adjusted_global_id] =
                         __global_space(__item, __count, __work_group_size, __data_per_work_item, __brick);
                     const auto /*uint16_t*/ [__number_of_peers, __local_id] = __local_space(__item, __work_group_size);
 
-                    const std::size_t __group_start_idx =
-                        __offset + __data_per_work_item * (__adjusted_global_id - __local_id);
+                    const std::size_t __group_start_idx = __data_per_work_item * (__adjusted_global_id - __local_id);
                     const bool __is_full = __group_start_idx + __data_per_work_item * __number_of_peers <= __bound;
                     const std::size_t __idx = __group_start_idx + __vector_size * __local_id;
                     const std::uint16_t __stride = __vector_size * __number_of_peers;
 
-                    __execute(__strided_loop<__iters_per_work_item>{__bound}, __is_full, __idx, __stride, __brick,
-                              __params_t{}, __rngs...);
+                    __execute<__iters_per_work_item>(__bound, __is_full, __idx, __stride, __brick, __params_t{},
+                                                     __rngs...);
                 });
         });
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -85,6 +85,9 @@ struct __dual_brick
             __brick2(__full, __idx - __pivot, __params, std::forward<_Ranges>(__rngs)...);
     }
 };
+// C++17 needs an explicit deduction guide for structured initialization
+template <typename _Brick1, typename _Brick2>
+__dual_brick(_Brick1, _Brick2, std::size_t) -> __dual_brick<_Brick1, _Brick2>;
 
 template <typename _Brick, typename... _Ranges>
 class __iterations_per_item

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -73,7 +73,7 @@ struct __dual_brick
     _Brick2 __brick2;
     std::size_t __pivot; // the number of iterations for the first brick
 
-    // When called by __parallel_for_small_submitter, dispatch to the proper brick based on __idx
+    // When called by __parallel_for_small_submitter, dispatch to the proper brick based on the pivot
     template <typename... _Ranges>
     void
     operator()(std::true_type __full, const std::size_t __idx, __pfor_params_simple __params, _Ranges&&... __rngs) const
@@ -129,9 +129,6 @@ struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name..
     __future<sycl::event>
     operator()(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
-        assert(oneapi::dpl::__ranges::__min_size_calc{}(__rngs...) > 0);
-        assert(__count > 0);
-
         _PRINT_INFO_IN_DEBUG_MODE(__q);
         auto __event = __q.submit([__rngs..., __brick, __count](sycl::handler& __cgh) {
 
@@ -141,7 +138,6 @@ struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name..
             __cgh.parallel_for<_Name...>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item) {
                 // Simple loop and no vectorization within the brick, to evenly spread work across compute units.
                 const std::size_t __idx = __item.get_linear_id();
-                assert(__idx < __count);
                 __brick(std::true_type{}, __idx, __pfor_params_simple{}, __rngs...);
             });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -245,9 +245,9 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     template <std::uint8_t __num_strides, typename _Brick1, typename _Brick2, typename... _Args>
     static void
     __execute(std::size_t __bound, bool __is_full, std::size_t __idx, std::uint16_t __stride,
-             const __dual_brick<_Brick1, _Brick2>& __dbrick, bool __use_first_brick, _Args&&... __args)
+              const __dual_brick<_Brick1, _Brick2>& __dbrick, bool __before_pivot, _Args&&... __args)
     {
-        if (__use_first_brick)
+        if (__before_pivot)
             __execute<__num_strides>(__bound, __is_full, __idx, __stride, __dbrick.__brick1, true, __args...);
         else
             __execute<__num_strides>(__bound, __is_full, __idx, __stride, __dbrick.__brick2, true, __args...);
@@ -283,7 +283,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range(sycl::range<1>(__num_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item</*dim=*/1> __item) {
-                    const auto /*size_t, size_t, bool, bool*/[__bound, __adjusted_global_id, __is_full, __brick_hint] =
+                    const auto /*size_t, size_t, bool, bool*/ [__bound, __adjusted_global_id, __is_full, __brick_hint] =
                         __global_space(__item, __count, __work_group_size, __data_per_work_item, __brick);
                     const auto /*size_t*/ [__number_of_peers, __local_id] = __local_space(__item, __work_group_size);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -141,6 +141,7 @@ struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name..
             __cgh.parallel_for<_Name...>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item) {
                 // Simple loop and no vectorization within the brick, to evenly spread work across compute units.
                 const std::size_t __idx = __item.get_linear_id();
+                assert(__idx < __count);
                 __brick(std::true_type{}, __idx, __pfor_params_simple{}, __rngs...);
             });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -66,6 +66,26 @@ struct __pfor_params_simple
     constexpr static std::uint8_t __iters_per_item = 1;
 };
 
+template <typename _Brick1, typename _Brick2>
+struct __dual_brick
+{
+    _Brick1 __brick1;
+    _Brick2 __brick2;
+    std::size_t __pivot;  // the number of iterations for the first brick
+    std::size_t __offset; // the starting data index for the second brick
+
+    // When called by __parallel_for_small_submitter, dispatch to the proper brick based on __idx
+    template <typename... _Ranges>
+    void
+    operator()(std::true_type __full, const std::size_t __global_id, __pfor_params_simple __params, _Ranges&&... __rngs) const
+    {
+        if (__idx < __pivot)
+            __brick1(__full, __global_id, __params, std::forward<_Ranges>(__rngs)...);
+        else
+            __brick2(__full, __global_id - __pivot + __offset, __params, std::forward<_Ranges>(__rngs)...);
+    }
+};
+
 template <typename _Brick, typename... _Ranges>
 class __iterations_per_item
 {
@@ -135,14 +155,56 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     // Limit the work-group size to 512 which has empirically yielded the best results across different architectures.
     static constexpr std::uint16_t __work_group_size_limit = 512;
 
-    // SPIR-V compilation targets show best performance with a stride of the sub-group size.
-    // Other compilation targets perform best with a work-group size stride. This utility can only be called from the
-    // device.
-    static inline std::tuple<std::size_t, std::size_t, bool>
-    __stride_recommender(const sycl::nd_item<1>& __item, std::size_t __count, std::size_t __iters_per_work_item,
-                         std::size_t __adj_elements_per_work_item, std::size_t __group_size)
+    template <typename _Fp>
+    static std::size_t
+    __number_of_groups(std::size_t __count, std::size_t __data_per_work_group, const _Fp& __brick)
     {
-        std::uint32_t __item_local_id;
+        return oneapi::dpl::__internal::__dpl_ceiling_div(__count, __data_per_work_group);
+    }
+
+    template <typename _Brick1, typename _Brick2>
+    static std::size_t
+    __number_of_groups(std::size_t __count, std::size_t __data_per_work_group,
+                       const __dual_brick<_Brick1, _Brick2>& __dbrick)
+    {
+        return oneapi::dpl::__internal::__dpl_ceiling_div(__dbrick.__pivot, __data_per_work_group) +
+               oneapi::dpl::__internal::__dpl_ceiling_div(__count - __dbrick.__pivot, __data_per_work_group);
+    }
+
+    template <typename _Fp>
+    static std::tuple<std::size_t, std::size_t, std::size_t>
+    __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t, std::uint16_t, const _Fp&)
+    {
+        return {0, __count, __item.get_global_linear_id()};
+    }
+
+    template <typename _Brick1, typename _Brick2>
+    static std::tuple<std::size_t, std::size_t, std::size_t>
+    __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t __work_group_size,
+                   std::uint16_t __data_per_work_item, const __dual_brick<_Brick1, _Brick2>& __dbrick)
+    {
+        const std::size_t __groups_before_pivot =
+            oneapi::dpl::__internal::__dpl_ceiling_div(__dbrick.__pivot, __work_group_size * __data_per_work_item);
+        std::size_t __item_global_id = __item.get_global_linear_id();
+        std::size_t __offset = 0;
+        if (__item.get_group_linear_id() < __groups_before_pivot)
+        {
+            __count = __dbrick.__pivot;
+        }
+        else
+        {
+            __offset = __dbrick.__offset;
+            __item_global_id -= __work_group_size * __groups_before_pivot;
+        }
+        return {__offset, __count, __item_global_id};
+    }
+
+    // SPIR-V compilation targets show best performance with a stride of the sub-group size.
+    // Other compilation targets perform best with a work-group size stride.
+    static inline std::tuple<std::uint16_t, std::uint16_t>
+    __local_space(const sycl::nd_item<1>& __item, std::uint16_t __group_size)
+    {
+        std::uint16_t __item_local_id;
         if constexpr (oneapi::dpl::__internal::__is_spirv_target_v)
         {
             const __dpl_sycl::__sub_group __sub_group = __item.get_sub_group();
@@ -153,12 +215,29 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
         {
             __item_local_id = __item.get_local_linear_id();
         }
-        const std::size_t __group_start_idx =
-            __iters_per_work_item * __adj_elements_per_work_item * (__item.get_global_linear_id() - __item_local_id);
-        const bool __is_full_group =
-            __group_start_idx + __iters_per_work_item * __adj_elements_per_work_item * __group_size <= __count;
-        const std::size_t __work_item_start_idx = __group_start_idx + __adj_elements_per_work_item * __item_local_id;
-        return std::tuple(__work_item_start_idx, __adj_elements_per_work_item * __group_size, __is_full_group);
+        return {__group_size, __item_local_id};
+    }
+
+    template <typename _Executor, typename _Fp, typename... _Args>
+    static void
+    __execute(_Executor&& __loop, bool __is_full, std::size_t __idx, std::uint16_t __stride, const _Fp& __brick,
+              _Args&&... __args)
+    {
+        if (__is_full)
+            __loop(std::true_type{}, __idx, __stride, __brick, __args...);
+        else
+            __loop(std::false_type{}, __idx, __stride, __brick, __args...);
+    }
+
+    template <typename _Executor, typename _Brick1, typename _Brick2, typename... _Args>
+    static void
+    __execute(_Executor&& __loop, bool __is_full, std::size_t __idx, std::uint16_t __stride,
+              const __dual_brick<_Brick1, _Brick2>& __dbrick, _Args&&... __args)
+    {
+        if (__idx < __dbrick.__offset)
+            __execute(__loop, __is_full, __idx, __stride, __dbrick.__brick1, __args...);
+        else
+            __execute(__loop, __is_full, __idx, __stride, __dbrick.__brick2, __args...);
     }
 
     // Once there is enough work to launch a group on each compute unit with our chosen __iters_per_item,
@@ -166,7 +245,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     static inline std::size_t
     __minimal_useful_size(const sycl::queue& __q, std::size_t __iters_per_work_item)
     {
-        const std::size_t __work_group_size =
+        const std::uint16_t __work_group_size =
             oneapi::dpl::__internal::__max_work_group_size(__q, __work_group_size_limit);
         const std::uint32_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__q);
         return __work_group_size * __iters_per_work_item * __max_cu;
@@ -177,7 +256,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     operator()(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
         using __params_t = __pfor_params<_Ranges...>;
-        const std::size_t __work_group_size =
+        const std::uint16_t __work_group_size =
             oneapi::dpl::__internal::__max_work_group_size(__q, __work_group_size_limit);
         _PRINT_INFO_IN_DEBUG_MODE(__q);
         auto __event = __q.submit([__rngs..., __brick, __work_group_size, __count](sycl::handler& __cgh) {
@@ -185,23 +264,24 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
             constexpr std::uint8_t __iters_per_work_item = __iterations_per_item_v<_Fp, _Ranges...>;
             constexpr std::uint8_t __vector_size = __params_t::__vector_size;
-            const std::size_t __num_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
-                __count, (__work_group_size * __vector_size * __iters_per_work_item));
+            const std::uint16_t __data_per_work_item = __iters_per_work_item * __vector_size;
+            const std::size_t __num_groups =
+                __number_of_groups(__count, __work_group_size * __data_per_work_item, __brick);
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range(sycl::range<1>(__num_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item</*dim=*/1> __item) {
-                    __params_t __params;
-                    const auto [__idx, __stride, __is_full] =
-                        __stride_recommender(__item, __count, __iters_per_work_item, __vector_size, __work_group_size);
-                    __strided_loop<__iters_per_work_item> __execute_loop{static_cast<std::size_t>(__count)};
-                    if (__is_full)
-                    {
-                        __execute_loop(std::true_type{}, __idx, __stride, __brick, __params, __rngs...);
-                    }
-                    else
-                    {
-                        __execute_loop(std::false_type{}, __idx, __stride, __brick, __params, __rngs...);
-                    }
+                    const auto /*size_t*/ [__offset, __bound, __adjusted_global_id] =
+                        __global_space(__item, __count, __work_group_size, __data_per_work_item, __brick);
+                    const auto /*uint16_t*/ [__number_of_peers, __local_id] = __local_space(__item, __work_group_size);
+
+                    const std::size_t __group_start_idx =
+                        __offset + __data_per_work_item * (__adjusted_global_id - __local_id);
+                    const bool __is_full = __group_start_idx + __data_per_work_item * __number_of_peers <= __bound;
+                    const std::size_t __idx = __group_start_idx + __vector_size * __local_id;
+                    const std::uint16_t __stride = __vector_size * __number_of_peers;
+
+                    __execute(__strided_loop<__iters_per_work_item>{__bound}, __is_full, __idx, __stride, __brick,
+                              __params_t{}, __rngs...);
                 });
         });
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -176,7 +176,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
 
     template <typename _Fp>
     static std::tuple<std::size_t, std::size_t>
-    __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t, std::uint16_t, const _Fp&)
+    __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t, std::size_t, const _Fp&)
     {
         return {__count, __item.get_global_linear_id()};
     }
@@ -184,7 +184,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     template <typename _Brick1, typename _Brick2>
     static std::tuple<std::size_t, std::size_t>
     __global_space(const sycl::nd_item<1>& __item, std::size_t __count, std::uint16_t __work_group_size,
-                   std::uint16_t __data_per_work_item, const __dual_brick<_Brick1, _Brick2>& __dbrick)
+                   std::size_t __data_per_work_item, const __dual_brick<_Brick1, _Brick2>& __dbrick)
     {
         const std::size_t __groups_before_pivot =
             oneapi::dpl::__internal::__dpl_ceiling_div(__dbrick.__pivot, __work_group_size * __data_per_work_item);
@@ -203,10 +203,10 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
 
     // SPIR-V compilation targets show best performance with a stride of the sub-group size.
     // Other compilation targets perform best with a work-group size stride.
-    static inline std::tuple<std::uint16_t, std::uint16_t>
+    static inline std::tuple<std::size_t, std::size_t>
     __local_space(const sycl::nd_item<1>& __item, std::uint16_t __group_size)
     {
-        std::uint16_t __item_local_id;
+        std::size_t __item_local_id;
         if constexpr (oneapi::dpl::__internal::__is_spirv_target_v)
         {
             const __dpl_sycl::__sub_group __sub_group = __item.get_sub_group();
@@ -267,7 +267,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
             constexpr std::uint8_t __iters_per_work_item = __iterations_per_item_v<_Fp, _Ranges...>;
             constexpr std::uint8_t __vector_size = __params_t::__vector_size;
-            const std::uint16_t __data_per_work_item = __iters_per_work_item * __vector_size;
+            const std::size_t __data_per_work_item = __iters_per_work_item * __vector_size;
             const std::size_t __num_groups =
                 __number_of_groups(__count, __work_group_size * __data_per_work_item, __brick);
             __cgh.parallel_for<_Name...>(
@@ -275,7 +275,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
                 [=](sycl::nd_item</*dim=*/1> __item) {
                     const auto /*size_t*/ [__bound, __adjusted_global_id] =
                         __global_space(__item, __count, __work_group_size, __data_per_work_item, __brick);
-                    const auto /*uint16_t*/ [__number_of_peers, __local_id] = __local_space(__item, __work_group_size);
+                    const auto /*size_t*/ [__number_of_peers, __local_id] = __local_space(__item, __work_group_size);
 
                     const std::size_t __group_start_idx = __data_per_work_item * (__adjusted_global_id - __local_id);
                     const bool __is_full = __group_start_idx + __data_per_work_item * __number_of_peers <= __bound;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -1215,7 +1215,6 @@ struct __strided_loop
     operator()(/*__is_full*/ std::true_type, std::size_t __idx, std::uint16_t __stride, _LoopBodyOp __loop_body_op,
                _Args&&... __args) const
     {
-        assert(__idx + (__num_strides - 1) * __stride < __full_range_size);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint8_t __i = 0; __i < __num_strides; ++__i)
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -1215,6 +1215,7 @@ struct __strided_loop
     operator()(/*__is_full*/ std::true_type, std::size_t __idx, std::uint16_t __stride, _LoopBodyOp __loop_body_op,
                _Args&&... __args) const
     {
+        assert(__idx + (__num_strides - 1) * __stride < __full_range_size);
         _ONEDPL_PRAGMA_UNROLL
         for (std::uint8_t __i = 0; __i < __num_strides; ++__i)
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -1228,7 +1228,8 @@ struct __strided_loop
     operator()(/*__is_full*/ std::false_type, std::size_t __idx, std::uint16_t __stride, _LoopBodyOp __loop_body_op,
                _Args&&... __args) const
     {
-        for (; __idx < __full_range_size; __idx += __stride)
+        std::size_t __limit = std::min(__full_range_size, __idx + __num_strides * __stride);
+        for (; __idx < __limit; __idx += __stride)
         {
             __loop_body_op(std::false_type{}, __idx, __args...);
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -704,8 +704,6 @@ struct __reverse_functor
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
-        assert(__idx < (__end - __begin) / 2);
-
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
         _ValueType __rng_left_vector[_Params::__vector_size];
         _ValueType __rng_right_vector[_Params::__vector_size];
@@ -754,7 +752,6 @@ struct __reverse_functor
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
-        assert(__idx < (__end - __begin) / 2);
         using std::swap;
         swap(__rng[__begin + __idx], __rng[__end - __idx - 1]);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -693,35 +693,38 @@ struct __brick_includes
 struct __reverse_functor
 {
   private:
-    const std::size_t __size;
+    const std::size_t __end;
+    const std::size_t __begin;
 
   public:
-    __reverse_functor(std::size_t __size) : __size(__size) {}
+    // Construction parameters: the number of elements to reverse, the index of the first element (0 by default)
+    __reverse_functor(std::size_t __n, std::size_t __shift = 0) : __end(__n + __shift), __begin(__shift) {}
 
     template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
-    operator()(_IsFull, const std::size_t __left_start_idx, _Params, _Range&& __rng) const
+    operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
 
         _ValueType __rng_left_vector[_Params::__vector_size];
         _ValueType __rng_right_vector[_Params::__vector_size];
 
-        oneapi::dpl::__par_backend_hetero::__vector_load<_Params::__vector_size> __vec_load{__size};
+        oneapi::dpl::__par_backend_hetero::__vector_load<_Params::__vector_size> __vec_load{__end};
         oneapi::dpl::__par_backend_hetero::__vector_reverse<_Params::__vector_size> __vec_reverse;
-        oneapi::dpl::__par_backend_hetero::__vector_store<_Params::__vector_size>
-            __vec_store{__size - __left_start_idx};
+        oneapi::dpl::__par_backend_hetero::__vector_store<_Params::__vector_size> __vec_store{__end - __idx};
         oneapi::dpl::__par_backend_hetero::__scalar_load_op __load_op;
         oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<oneapi::dpl::__internal::__pstl_assign>
             __store_op;
 
+        const std::size_t __left_start_idx = __begin + __idx;
+
         if constexpr (_IsFull::value == false)
         {
-            if (__left_start_idx + _Params::__vector_size >= __size - __left_start_idx)
+            if (__left_start_idx + _Params::__vector_size >= __end - __idx)
             {
                 // The remaining data to reverse fits into a single vector
                 __vec_load(std::false_type{}, __left_start_idx, __load_op, __rng, __rng_left_vector);
-                __vec_reverse(std::false_type{}, __size - 2 * __left_start_idx, __rng_left_vector);
+                __vec_reverse(std::false_type{}, __end - __idx - __left_start_idx, __rng_left_vector);
                 __vec_store(std::false_type{}, __left_start_idx, __store_op, __rng_left_vector, __rng);
                 return;
             }
@@ -733,7 +736,7 @@ struct __reverse_functor
         // There may exist a single point of double processing between left and right vectors in the last work-item
         // which reverses middle elements.
 
-        const std::size_t __right_start_idx = __size - __left_start_idx - _Params::__vector_size;
+        const std::size_t __right_start_idx = __end - __idx - _Params::__vector_size;
 
         // 1. Load two vectors that we want to swap: one from the left half of the buffer and one from the right.
         // Note that due to indices we have chosen, there will always be a full vector of elements to load.
@@ -751,7 +754,7 @@ struct __reverse_functor
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
         using std::swap;
-        swap(__rng[__idx], __rng[__size - __idx - 1]);
+        swap(__rng[__begin + __idx], __rng[__end - __idx - 1]);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -704,7 +704,7 @@ struct __reverse_functor
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
-        assert(__idx < (__end - __begin)/ 2);
+        assert(__idx < (__end - __begin) / 2);
 
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
         _ValueType __rng_left_vector[_Params::__vector_size];
@@ -754,7 +754,7 @@ struct __reverse_functor
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
-        assert(__idx < (__end - __begin)/ 2);
+        assert(__idx < (__end - __begin) / 2);
         using std::swap;
         swap(__rng[__begin + __idx], __rng[__end - __idx - 1]);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -693,19 +693,20 @@ struct __brick_includes
 struct __reverse_functor
 {
   private:
-    const std::size_t __end;
     const std::size_t __begin;
+    const std::size_t __end;
 
   public:
     // Construction parameters: the number of elements to reverse, the index of the first element (0 by default)
-    __reverse_functor(std::size_t __n, std::size_t __shift = 0) : __end(__n + __shift), __begin(__shift) {}
+    __reverse_functor(std::size_t __n, std::size_t __shift = 0) : __begin(__shift), __end(__n + __shift) {}
 
     template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
-        using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
+        assert(__idx < (__end - __begin)/ 2);
 
+        using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
         _ValueType __rng_left_vector[_Params::__vector_size];
         _ValueType __rng_right_vector[_Params::__vector_size];
 
@@ -753,6 +754,7 @@ struct __reverse_functor
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
+        assert(__idx < (__end - __begin)/ 2);
         using std::swap;
         swap(__rng[__begin + __idx], __rng[__end - __idx - 1]);
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -70,9 +70,11 @@ void
 test()
 {
     std::vector<std::size_t> test_sizes = TestUtils::get_pattern_for_test_sizes();
-    const std::size_t max_len = test_sizes.back();
+    std::size_t max_len = test_sizes.back();
     // Add a value to cover the case of len modulo 8 == 3
-    test_sizes.push_back((max_len / 8) * 8 - 5);
+    max_len = (max_len / 8) * 8 + 11;
+    test_sizes.push_back(max_len);
+    test_sizes.push_back(max_len - 16);
 
     Sequence<T> actual(max_len);
     Sequence<T> data(max_len, [](std::size_t i) { return T(i); });

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -53,9 +53,9 @@ struct test_one_policy
 
         reverse(std::forward<ExecutionPolicy>(exec), actual_b, actual_e);
 
-        bool check = equal(data_b, data_e, reverse_iterator<Iterator2>(actual_e));
-
-        EXPECT_TRUE(check, "wrong result of reverse");
+        auto mismatch =
+            std::distance(actual_b, std::mismatch(actual_b, actual_e, reverse_iterator<Iterator1>(data_e)).first);
+        EXPECT_EQ(std::distance(actual_b, actual_e), mismatch, "wrong effect of reverse: mismatch at position");
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -53,9 +53,8 @@ struct test_one_policy
 
         reverse(std::forward<ExecutionPolicy>(exec), actual_b, actual_e);
 
-        auto mismatch =
-            std::distance(actual_b, std::mismatch(actual_b, actual_e, reverse_iterator<Iterator1>(data_e)).first);
-        EXPECT_EQ(std::distance(actual_b, actual_e), mismatch, "wrong effect of reverse: mismatch at position");
+        EXPECT_EQ_N(std::reverse_iterator<Iterator1>(data_e), actual_b, std::distance(actual_b, actual_e),
+                    "wrong effect of reverse");
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -86,25 +86,28 @@ struct test_one_policy
     {
         using namespace std;
         using T = typename iterator_traits<Iterator>::value_type;
-        Iterator actual_m = ::std::next(actual_b, shift);
+        Iterator actual_m = std::next(actual_b, shift);
 
         copy(data_b, data_e, actual_b);
         Iterator actual_return = rotate(CLONE_TEST_POLICY(exec), actual_b, actual_m, actual_e);
 
-        EXPECT_TRUE(actual_return == ::std::next(actual_b, ::std::distance(actual_m, actual_e)), "wrong result of rotate");
+        EXPECT_TRUE(actual_return == std::next(actual_b, std::distance(actual_m, actual_e)), "wrong result of rotate");
         auto comparator = compare<T>();
-        bool check = ::std::equal(actual_return, actual_e, data_b, comparator);
-        check = check && ::std::equal(actual_b, actual_return, ::std::next(data_b, shift), comparator);
 
-        EXPECT_TRUE(check, "wrong effect of rotate");
+        auto mismatch = std::distance(actual_b, std::mismatch(actual_return, actual_e, data_b, comparator).first);
+        EXPECT_EQ(std::distance(actual_b, actual_e), mismatch, "wrong effect of rotate: mismatch at position");
+        mismatch = std::distance(actual_b,
+                                 std::mismatch(actual_b, actual_return, std::next(data_b, shift), comparator).first);
+        EXPECT_EQ(std::distance(actual_b, actual_return), mismatch, "wrong effect of rotate: mismatch at position");
+
         EXPECT_TRUE(check_move(CLONE_TEST_POLICY(exec), actual_b, actual_e, shift), "wrong move test of rotate");
     }
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
-    ::std::enable_if_t<
-        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator> &&
-        !::std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
-        ::std::is_same_v<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>,
+    std::enable_if_t<
+        is_base_of_iterator_category_v<std::random_access_iterator_tag, Iterator> &&
+        !std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
+        std::is_same_v<typename std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>,
         bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator b, Iterator e, Size shift)
     {
@@ -117,10 +120,10 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
-    ::std::enable_if_t<
-        !(is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator> &&
-        !::std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
-        ::std::is_same_v<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>),
+    std::enable_if_t<
+        !(is_base_of_iterator_category_v<std::random_access_iterator_tag, Iterator> &&
+          !std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
+          std::is_same_v<typename std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>),
         bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator /* b */, Iterator /* e */, Size /* shift */)
     {
@@ -135,15 +138,19 @@ test()
     const auto test_sizes = TestUtils::get_pattern_for_test_sizes();
     const std::int32_t max_len = test_sizes.back();
 
-    Sequence<T> actual(max_len, [](::std::size_t i) { return T(i); });
-    Sequence<T> data(max_len, [](::std::size_t i) { return T(i); });
+    Sequence<T> actual(max_len, [](std::size_t i) { return T(i); });
+    Sequence<T> data(max_len, [](std::size_t i) { return T(i); });
 
     for (std::int32_t len : test_sizes)
     {
-        std::int32_t shifts[] = {0, 1, 2, len / 3, (2 * len) / 3, len - 1};
+        std::int32_t shifts[] = {0, 1, 2, -1, -1, -1, -1};
+        if (len > 2) shifts[6] = len;
+        if (len > 3) shifts[5] = len - 1;
+        if (len > 4) shifts[4] = (2 * len) / 3;
+        if (len > 8) shifts[3] = len / 3;
         for (auto shift : shifts)
         {
-            if (shift >= 0 && shift < len)
+            if (shift >= 0 && shift <= len)
             {
                 invoke_on_all_policies<>()(test_one_policy<T>(), data.begin(), data.begin() + len, actual.begin(),
                                            actual.begin() + len, shift);
@@ -155,9 +162,9 @@ test()
 int
 main()
 {
+    test<std::int32_t>();
     test<std::int8_t>();
     test<std::int16_t>();
-    test<std::int32_t>();
 #if !TEST_DPCPP_BACKEND_PRESENT
     test<wrapper<float64_t>>();
     test<MemoryChecker>();


### PR DESCRIPTION
The patch improves performance of the `rotate` algorithm with device policies by using in-place triple-reverse rotation instead of a temporary buffer.

Changes:
- A new `__dual_brick` class for `__parallel_for`, which combines two bricks and a pivot point in the iteration space where the execution shifts from the first brick to the second one.
- Modifications in `__parallel_for_large_submitter` to customize certain parts for `__dual_brick` vs regular ones.
- Make `__is_full` a property of a work group. even when strides are based on subgroups. That fixes sporadic test failures on some platforms.
- Add a "shift" to `__reverse_functor`, for reversing any subrange in the input data.
- Modify `__pattern_rotate` to implement the triple reverse using two kernels and the dual brick.