### PR TITLE
Add missed include guards in tests

### DIFF
--- a/test/parallel_api/ranges/std_ranges_memory_test.h
+++ b/test/parallel_api/ranges/std_ranges_memory_test.h
@@ -13,6 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef _STD_RANGES_MEMORY_TEST_H
+#define _STD_RANGES_MEMORY_TEST_H
+
 #if _ENABLE_STD_RANGES_TESTING
 
 #include <oneapi/dpl/memory>
@@ -144,4 +147,5 @@ private:
 
 } //namespace test_std_ranges
 
-#endif //_ENABLE_STD_RANGES_TESTING
+#endif // _ENABLE_STD_RANGES_TESTING
+#endif // _STD_RANGES_MEMORY_TEST_H

--- a/test/support/binary_search_utils.h
+++ b/test/support/binary_search_utils.h
@@ -13,6 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef _BINARY_SEARCH_UTILS_H
+#define _BINARY_SEARCH_UTILS_H
+
 using namespace TestUtils;
 
 // TODO: replace data generation with random data and update check to compare result to
@@ -38,3 +41,5 @@ initialize_data(Accessor1 data, Accessor2 value, Accessor3 result, Size n)
         result[i / 2] = 0;
     }
 }
+
+#endif // _BINARY_SEARCH_UTILS_H

--- a/test/xpu_api/random/statistics_tests/statistics_common.h
+++ b/test/xpu_api/random/statistics_tests/statistics_common.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------===//
 
+#ifndef _STATISTICS_COMMON_H
+#define _STATISTICS_COMMON_H
+
 #include <iostream>
 #include <vector>
 
@@ -42,3 +45,5 @@ compare_moments(int nsamples, const std::vector<ScalarIntType>& samples, double 
 
     return 0;
 }
+
+#endif // _STATISTICS_COMMON_H

--- a/test/xpu_api/ranges/xpu_std_ranges_test.h
+++ b/test/xpu_api/ranges/xpu_std_ranges_test.h
@@ -13,6 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef _XPU_STD_RANGES_TEST_H
+#define _XPU_STD_RANGES_TEST_H
+
 #include "support/utils_sycl.h"
 
 template<typename KernelName, typename Test>
@@ -32,3 +35,5 @@ kernel_test(Test test)
 
     return buffer1.get_host_access(sycl::read_only)[0];
 }
+
+#endif // _XPU_STD_RANGES_TEST_H


### PR DESCRIPTION
## Summary

Added missing include guards to 4 test header files to prevent multiple inclusion issues.

### Changes
•	`test/parallel_api/ranges/std_ranges_memory_test.h` — added #ifndef _STD_RANGES_MEMORY_TEST_H guard; also fixed #endif comment style
•	`test/xpu_api/ranges/xpu_std_ranges_test.h` — added #ifndef _XPU_STD_RANGES_TEST_H guard
•	`test/xpu_api/random/statistics_tests/statistics_common.h` — added #ifndef _STATISTICS_COMMON_H guard; also added missing newline at end of file
•	`test/support/binary_search_utils.h` — added #ifndef _BINARY_SEARCH_UTILS_H guard

### Motivation
Test header files included in multiple translation units were missing include guards, which could cause redefinition errors or unexpected behavior in such configurations.