### PR TITLE
Improve tests for `std::ranges::is_heap` and `std::ranges::is_heap_until` -  V1

### DIFF
--- a/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
@@ -43,6 +43,10 @@ main()
         return late_violation_test_sz - val > 41 ? late_violation_test_sz - val : -val;
     };
 
+    // Valid min-heap w.r.t. greater but not sorted: element i has value i, except every 17th element
+    // (i % 17 == 1) drops to its parent's value (i - 1) / 2, adding parent == child ties along heap paths.
+    auto non_desc_heap_gen = [](auto i) { return (i % 17 == 1) ? (i - 1) / 2 : i; };
+
     // --- returns true ---
 
     // big_sz: exercises the multi-work-group device path on the true (full-scan) case
@@ -55,6 +59,11 @@ main()
 
     // ascending default data is a valid min-heap w.r.t. greater; member-function projection
     test_range_algo<2, P2>{}(dpl_ranges::is_heap, is_heap_checker, std::ranges::greater{}, &P2::proj);
+
+    // valid min-heap w.r.t. greater, not just sorted data: every 17th element (i % 17 == 1) drops to its
+    // parent's value (i - 1) / 2, creating parent == child ties that is_heap must accept (returns true)
+    test_range_algo<21, int, data_in, decltype(non_desc_heap_gen)>{}(dpl_ranges::is_heap, is_heap_checker,
+                                                                     std::ranges::greater{});
 
     // --- returns false ---
 

--- a/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
@@ -35,9 +35,9 @@ main()
     auto desc_gen = [](auto i) { return -static_cast<int>(i); };
 
     constexpr int late_violation_test_sz = 63 * 1024 + 347;
-    // Most elements get -i (descending, forming a valid max-heap prefix), but the final 41
-    // elements switch to (late_violation_test_sz - i), inserting small positive values
-    // whose parents hold large-negative values, breaking the max-heap property near the leaves.
+    // Element i gets -i (valid max-heap w.r.t. less), except the last 41 elements switch to
+    // (late_violation_test_sz - i), giving small positive values [1..41] while their parents
+    // hold large-negative values near -late_violation_test_sz/2, breaking the heap property.
     auto late_violation_gen = [](auto i) {
         int val = static_cast<int>(i);
         return late_violation_test_sz - val > 41 ? -val : late_violation_test_sz - val;

--- a/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
@@ -62,21 +62,21 @@ main()
 
     // valid min-heap w.r.t. greater, not just sorted data: every 17th element (i % 17 == 1) drops to its
     // parent's value (i - 1) / 2, creating parent == child ties that is_heap must accept (returns true)
-    test_range_algo<21, int, data_in, decltype(non_desc_heap_gen)>{}(dpl_ranges::is_heap, is_heap_checker,
+    test_range_algo<3, int, data_in, decltype(non_desc_heap_gen)>{}(dpl_ranges::is_heap, is_heap_checker,
                                                                      std::ranges::greater{});
 
     // --- returns false ---
 
     // large valid max-heap: data stays descending to the very end, so is_heap scans the whole range and returns true
-    test_range_algo<3, int, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
+    test_range_algo<4, int, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap, is_heap_checker, std::ranges::less{}, proj);
 
     // same full-range valid max-heap with custom comp and P2::x projection
-    test_range_algo<4, P2, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
+    test_range_algo<5, P2, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap, is_heap_checker, CustomLess{}, &P2::x);
 
     // default overload (comp = less, proj = identity): ascending data violates max-heap property
-    test_range_algo<5>{}(dpl_ranges::is_heap, is_heap_checker);
+    test_range_algo<6>{}(dpl_ranges::is_heap, is_heap_checker);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
@@ -35,12 +35,12 @@ main()
     auto desc_gen = [](auto i) { return -static_cast<int>(i); };
 
     constexpr int late_violation_test_sz = 63 * 1024 + 347;
-    // Strictly descending data (a valid max-heap w.r.t. less): element i gets
-    // late_violation_test_sz - i until that would fall to 41 or below, then the
-    // final 41 elements switch to -i, pushing the smallest values to the tail.
+    // Most elements get -i (descending, forming a valid max-heap prefix), but the final 41
+    // elements switch to (late_violation_test_sz - i), inserting small positive values
+    // whose parents hold large-negative values, breaking the max-heap property near the leaves.
     auto late_violation_gen = [](auto i) {
         int val = static_cast<int>(i);
-        return late_violation_test_sz - val > 41 ? late_violation_test_sz - val : -val;
+        return late_violation_test_sz - val > 41 ? -val : late_violation_test_sz - val;
     };
 
     // Valid min-heap w.r.t. greater but not sorted: element i has value i, except every 17th element
@@ -67,11 +67,11 @@ main()
 
     // --- returns false ---
 
-    // large valid max-heap: data stays descending to the very end, so is_heap scans the whole range and returns true
+    // large range with heap violation near the end: is_heap scans and returns false
     test_range_algo<4, int, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap, is_heap_checker, std::ranges::less{}, proj);
 
-    // same full-range valid max-heap with custom comp and P2::x projection
+    // same late-violation data with custom comp and P2::x projection; is_heap returns false
     test_range_algo<5, P2, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap, is_heap_checker, CustomLess{}, &P2::x);
 

--- a/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
@@ -9,6 +9,18 @@
 
 #include "std_ranges_test.h"
 
+#if _ENABLE_STD_RANGES_TESTING
+struct CustomLess
+{
+    template <typename T>
+    bool
+    operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs < rhs;
+    }
+};
+#endif // _ENABLE_STD_RANGES_TESTING
+
 std::int32_t
 main()
 {
@@ -18,21 +30,39 @@ main()
 
     auto is_heap_checker = TEST_PREPARE_CALLABLE(std::ranges::is_heap);
 
-    // A descending sequence is a max-heap with respect to std::ranges::less, so is_heap is expected
-    // to return true; this exercises a full scan of the large device-sized range.
-    auto generator = [](auto i) { return -i; };
-    test_range_algo<0, int, data_in, decltype(generator)>{big_sz}(
+    // Descending values form a max-heap w.r.t. less: element i has value -i,
+    // so parent >= child for all nodes.
+    auto desc_gen = [](auto i) { return -static_cast<int>(i); };
+    // Nearly a valid max-heap, but element at index 2000 is corrupted (value 0 > its parent -999).
+    // The violation is only detectable near the end of small_size (2025), forcing nearly the full
+    // range to be scanned before reporting false.
+    auto late_violation_gen = [](auto i) -> int { return i == 2000 ? 0 : -static_cast<int>(i); };
+
+    // --- returns true ---
+
+    // big_sz: exercises the multi-work-group device path on the true (full-scan) case
+    test_range_algo<0, int, data_in, decltype(desc_gen)>{big_sz}(
         dpl_ranges::is_heap, is_heap_checker, std::ranges::less{});
 
-    test_range_algo<1>{}(dpl_ranges::is_heap, is_heap_checker, std::ranges::less{}, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::is_heap, is_heap_checker, std::ranges::less{}, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::is_heap, is_heap_checker, std::ranges::less{}, &P2::proj);
+    // custom comp + P2::x (member-data projection); descending x values form a max-heap
+    test_range_algo<1, P2, data_in, decltype(desc_gen)>{}(
+        dpl_ranges::is_heap, is_heap_checker, CustomLess{}, &P2::x);
 
-    test_range_algo<4>{}(dpl_ranges::is_heap, is_heap_checker, std::ranges::greater{}, proj);
-    test_range_algo<5, P2>{}(dpl_ranges::is_heap, is_heap_checker, std::ranges::greater{}, &P2::x);
-    test_range_algo<6, P2>{}(dpl_ranges::is_heap, is_heap_checker, std::ranges::greater{}, &P2::proj);
+    // ascending default data is a valid min-heap w.r.t. greater; member-function projection
+    test_range_algo<2, P2>{}(dpl_ranges::is_heap, is_heap_checker, std::ranges::greater{}, &P2::proj);
 
-    test_range_algo<7>{}(dpl_ranges::is_heap, is_heap_checker);
+    // --- returns false ---
+
+    // heap violation at index 2000 (near the end); forces nearly the full range to be checked
+    test_range_algo<3, int, data_in, decltype(late_violation_gen)>{}(
+        dpl_ranges::is_heap, is_heap_checker, std::ranges::less{}, proj);
+
+    // same late violation with custom comp and P2::x projection
+    test_range_algo<4, P2, data_in, decltype(late_violation_gen)>{}(
+        dpl_ranges::is_heap, is_heap_checker, CustomLess{}, &P2::x);
+
+    // default overload (comp = less, proj = identity): ascending data violates max-heap property
+    test_range_algo<5>{}(dpl_ranges::is_heap, is_heap_checker);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
@@ -33,10 +33,15 @@ main()
     // Descending values form a max-heap w.r.t. less: element i has value -i,
     // so parent >= child for all nodes.
     auto desc_gen = [](auto i) { return -static_cast<int>(i); };
-    // Nearly a valid max-heap, but element at index 2000 is corrupted (value 0 > its parent -999).
-    // The violation is only detectable near the end of small_size (2025), forcing nearly the full
-    // range to be scanned before reporting false.
-    auto late_violation_gen = [](auto i) -> int { return i == 2000 ? 0 : -static_cast<int>(i); };
+
+    constexpr int late_violation_test_sz = 63 * 1024 + 347;
+    // Strictly descending data (a valid max-heap w.r.t. less): element i gets
+    // late_violation_test_sz - i until that would fall to 41 or below, then the
+    // final 41 elements switch to -i, pushing the smallest values to the tail.
+    auto late_violation_gen = [](auto i) {
+        int val = static_cast<int>(i);
+        return late_violation_test_sz - val > 41 ? late_violation_test_sz - val : -val;
+    };
 
     // --- returns true ---
 
@@ -53,12 +58,12 @@ main()
 
     // --- returns false ---
 
-    // heap violation at index 2000 (near the end); forces nearly the full range to be checked
-    test_range_algo<3, int, data_in, decltype(late_violation_gen)>{}(
+    // large valid max-heap: data stays descending to the very end, so is_heap scans the whole range and returns true
+    test_range_algo<3, int, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap, is_heap_checker, std::ranges::less{}, proj);
 
-    // same late violation with custom comp and P2::x projection
-    test_range_algo<4, P2, data_in, decltype(late_violation_gen)>{}(
+    // same full-range valid max-heap with custom comp and P2::x projection
+    test_range_algo<4, P2, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap, is_heap_checker, CustomLess{}, &P2::x);
 
     // default overload (comp = less, proj = identity): ascending data violates max-heap property

--- a/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap.pass.cpp
@@ -60,8 +60,7 @@ main()
     // ascending default data is a valid min-heap w.r.t. greater; member-function projection
     test_range_algo<2, P2>{}(dpl_ranges::is_heap, is_heap_checker, std::ranges::greater{}, &P2::proj);
 
-    // valid min-heap w.r.t. greater, not just sorted data: every 17th element (i % 17 == 1) drops to its
-    // parent's value (i - 1) / 2, creating parent == child ties that is_heap must accept (returns true)
+    // non_desc_heap_gen: valid min-heap w.r.t. greater with parent == child ties; is_heap returns true
     test_range_algo<3, int, data_in, decltype(non_desc_heap_gen)>{}(dpl_ranges::is_heap, is_heap_checker,
                                                                      std::ranges::greater{});
 

--- a/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
@@ -30,31 +30,55 @@ main()
 
     auto is_heap_until_checker = TEST_PREPARE_CALLABLE(std::ranges::is_heap_until);
 
+    // Descending values form a max-heap w.r.t. less: element i has value -i,
+    // so parent >= child for all nodes.
+    auto desc_gen = [](auto i) { return -static_cast<int>(i); };
+
     // Spike at index 42 breaks the max-heap property; is_heap_until stops at that position.
     // big_sz tests the case where the violation is found at a fixed position within a large range.
     auto spike_gen = [](auto i) { return i == 42 ? 1 : -static_cast<int>(i); };
-    // Nearly a valid max-heap, but element at index 2000 is corrupted (value 0 > its parent -999).
-    // The violation is only detectable near the end of small_size (2025); is_heap_until stops
-    // near the end of the range.
-    auto late_violation_gen = [](auto i) -> int { return i == 2000 ? 0 : -static_cast<int>(i); };
+
+    constexpr int late_violation_test_sz = 63 * 1024 + 347;
+    // Strictly descending data (a valid max-heap w.r.t. less): element i gets
+    // late_violation_test_sz - i until that would fall to 41 or below, then the
+    // final 41 elements switch to -i, pushing the smallest values to the tail.
+    auto late_violation_gen = [](auto i) {
+        int val = static_cast<int>(i);
+        return late_violation_test_sz - val > 41 ? late_violation_test_sz - val : -val;
+    };
+
+    // Valid min-heap w.r.t. greater but not sorted: element i has value i, except every 17th element
+    // (i % 17 == 1) drops to its parent's value (i - 1) / 2, adding parent == child ties along heap paths.
+    auto non_desc_heap_gen = [](auto i) { return (i % 17 == 1) ? (i - 1) / 2 : i; };
 
     // big_sz: stop at a mid-range position (index 42) within a large range (multi-WG device path)
     test_range_algo<0, int, data_in, decltype(spike_gen)>{big_sz}(
         dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{});
 
-    // late violation (index 2000): is_heap_until stops near the end of the range
-    test_range_algo<1, int, data_in, decltype(late_violation_gen)>{}(
+    // big_sz: full scan over a large valid max-heap (no violation) exercises the multi-WG device
+    // path returning end()
+    test_range_algo<1, int, data_in, decltype(desc_gen)>{big_sz}(
+        dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{});
+
+    // large valid max-heap: data stays descending to the very end, so is_heap_until scans the whole
+    // range and returns end()
+    test_range_algo<2, int, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{}, proj);
 
-    // same late violation with custom comp and P2::x projection
-    test_range_algo<2, P2, data_in, decltype(late_violation_gen)>{}(
+    // same full-range valid max-heap with custom comp and P2::x projection
+    test_range_algo<3, P2, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap_until, is_heap_until_checker, CustomLess{}, &P2::x);
 
     // ascending default data is a valid min-heap w.r.t. greater; is_heap_until returns end()
-    test_range_algo<3, P2>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::greater{}, &P2::proj);
+    test_range_algo<4, P2>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::greater{}, &P2::proj);
+
+    // valid min-heap w.r.t. greater, not just sorted data: every 17th element (i % 17 == 1) drops to its
+    // parent's value (i - 1) / 2, creating parent == child ties that is_heap_until accepts (returns end())
+    test_range_algo<5, int, data_in, decltype(non_desc_heap_gen)>{}(
+        dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::greater{});
 
     // default overload (comp = less, proj = identity): ascending data, stops at begin()+1
-    test_range_algo<4>{}(dpl_ranges::is_heap_until, is_heap_until_checker);
+    test_range_algo<6>{}(dpl_ranges::is_heap_until, is_heap_until_checker);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
@@ -9,6 +9,18 @@
 
 #include "std_ranges_test.h"
 
+#if _ENABLE_STD_RANGES_TESTING
+struct CustomLess
+{
+    template <typename T>
+    bool
+    operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs < rhs;
+    }
+};
+#endif // _ENABLE_STD_RANGES_TESTING
+
 std::int32_t
 main()
 {
@@ -18,20 +30,31 @@ main()
 
     auto is_heap_until_checker = TEST_PREPARE_CALLABLE(std::ranges::is_heap_until);
 
-    // A descending sequence is a max-heap (std::ranges::less); the spike at index 42 breaks the
-    // heap property there, so is_heap_until is expected to stop at a non-trivial position.
-    auto generator = [](auto i) { return i == 42 ? 1 : -i; };
-    test_range_algo<0, int, data_in, decltype(generator)>{big_sz}(
+    // Spike at index 42 breaks the max-heap property; is_heap_until stops at that position.
+    // big_sz tests the case where the violation is found at a fixed position within a large range.
+    auto spike_gen = [](auto i) { return i == 42 ? 1 : -static_cast<int>(i); };
+    // Nearly a valid max-heap, but element at index 2000 is corrupted (value 0 > its parent -999).
+    // The violation is only detectable near the end of small_size (2025); is_heap_until stops
+    // near the end of the range.
+    auto late_violation_gen = [](auto i) -> int { return i == 2000 ? 0 : -static_cast<int>(i); };
+
+    // big_sz: stop at a mid-range position (index 42) within a large range (multi-WG device path)
+    test_range_algo<0, int, data_in, decltype(spike_gen)>{big_sz}(
         dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{});
-    test_range_algo<1>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{}, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{}, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{}, &P2::proj);
 
-    test_range_algo<4>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::greater{}, proj);
-    test_range_algo<5, P2>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::greater{}, &P2::x);
-    test_range_algo<6, P2>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::greater{}, &P2::proj);
+    // late violation (index 2000): is_heap_until stops near the end of the range
+    test_range_algo<1, int, data_in, decltype(late_violation_gen)>{}(
+        dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{}, proj);
 
-    test_range_algo<7>{}(dpl_ranges::is_heap_until, is_heap_until_checker);
+    // same late violation with custom comp and P2::x projection
+    test_range_algo<2, P2, data_in, decltype(late_violation_gen)>{}(
+        dpl_ranges::is_heap_until, is_heap_until_checker, CustomLess{}, &P2::x);
+
+    // ascending default data is a valid min-heap w.r.t. greater; is_heap_until returns end()
+    test_range_algo<3, P2>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::greater{}, &P2::proj);
+
+    // default overload (comp = less, proj = identity): ascending data, stops at begin()+1
+    test_range_algo<4>{}(dpl_ranges::is_heap_until, is_heap_until_checker);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
@@ -71,8 +71,7 @@ main()
     // ascending default data is a valid min-heap w.r.t. greater; is_heap_until returns end()
     test_range_algo<4, P2>{}(dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::greater{}, &P2::proj);
 
-    // valid min-heap w.r.t. greater, not just sorted data: every 17th element (i % 17 == 1) drops to its
-    // parent's value (i - 1) / 2, creating parent == child ties that is_heap_until accepts (returns end())
+    // non_desc_heap_gen: valid min-heap w.r.t. greater with parent == child ties; is_heap_until returns end()
     test_range_algo<5, int, data_in, decltype(non_desc_heap_gen)>{}(
         dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::greater{});
 

--- a/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
@@ -39,12 +39,12 @@ main()
     auto spike_gen = [](auto i) { return i == 42 ? 1 : -static_cast<int>(i); };
 
     constexpr int late_violation_test_sz = 63 * 1024 + 347;
-    // Strictly descending data (a valid max-heap w.r.t. less): element i gets
-    // late_violation_test_sz - i until that would fall to 41 or below, then the
-    // final 41 elements switch to -i, pushing the smallest values to the tail.
+    // Most elements get -i (descending, forming a valid max-heap prefix), but the final 41
+    // elements switch to (late_violation_test_sz - i), inserting small positive values
+    // whose parents hold large-negative values, breaking the max-heap property near the leaves.
     auto late_violation_gen = [](auto i) {
         int val = static_cast<int>(i);
-        return late_violation_test_sz - val > 41 ? late_violation_test_sz - val : -val;
+        return late_violation_test_sz - val > 41 ? -val : late_violation_test_sz - val;
     };
 
     // Valid min-heap w.r.t. greater but not sorted: element i has value i, except every 17th element
@@ -60,12 +60,11 @@ main()
     test_range_algo<1, int, data_in, decltype(desc_gen)>{big_sz}(
         dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{});
 
-    // large valid max-heap: data stays descending to the very end, so is_heap_until scans the whole
-    // range and returns end()
+    // large range with heap violation near the end: is_heap_until stops before end()
     test_range_algo<2, int, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap_until, is_heap_until_checker, std::ranges::less{}, proj);
 
-    // same full-range valid max-heap with custom comp and P2::x projection
+    // same late-violation data with custom comp and P2::x projection; is_heap_until stops before end()
     test_range_algo<3, P2, data_in, decltype(late_violation_gen)>{late_violation_test_sz}(
         dpl_ranges::is_heap_until, is_heap_until_checker, CustomLess{}, &P2::x);
 

--- a/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_heap_until.pass.cpp
@@ -39,9 +39,9 @@ main()
     auto spike_gen = [](auto i) { return i == 42 ? 1 : -static_cast<int>(i); };
 
     constexpr int late_violation_test_sz = 63 * 1024 + 347;
-    // Most elements get -i (descending, forming a valid max-heap prefix), but the final 41
-    // elements switch to (late_violation_test_sz - i), inserting small positive values
-    // whose parents hold large-negative values, breaking the max-heap property near the leaves.
+    // Element i gets -i (valid max-heap w.r.t. less), except the last 41 elements switch to
+    // (late_violation_test_sz - i), giving small positive values [1..41] while their parents
+    // hold large-negative values near -late_violation_test_sz/2, breaking the heap property.
     auto late_violation_gen = [](auto i) {
         int val = static_cast<int>(i);
         return late_violation_test_sz - val > 41 ? -val : late_violation_test_sz - val;


### PR DESCRIPTION
## Description
Test-only improvements for the range-based `oneapi::dpl::ranges::is_heap` and `oneapi::dpl::ranges::is_heap_until` algorithms (V1, stacked on dev/skopienko/std_ranges_is_heap). No production code is changed.

## Motivation
The original suite was thin: it mainly scanned a single large descending range, used only std::ranges::less/greater, and every "not a heap" case was detected at the very first element. Neither the comparator/projection variety nor the non-trivial result positions of these algorithms were covered.

## What this PR does
•	Adds a user-defined CustomLess comparator next to `std::ranges::less` / `std::ranges::greater`, and broadens the comparator × projection matrix to also use identity, the `proj` (×2) free function, `&P2::x` (member data) and `&P2::proj` (member function).
•	Introduces data generators for distinct heap shapes:
•	`desc_gen` — element `i` has value `-i`, a valid max-heap w.r.t. less.
•	`non_desc_heap_gen` — a valid min-heap w.r.t. greater that is not merely sorted: every 17th element drops to its parent's value, adding `parent == child` ties.
•	`late_violation_gen` — element `i` gets `-i` (valid max-heap w.r.t. less) except the last `41` elements switch to `late_violation_test_sz - i` (values [1..41]); their parents hold large-negative values near `-late_violation_test_sz/2`, so `parent < child` near the leaves, breaking the heap property. Sized by an explicit `constexpr int late_violation_test_sz = 63 * 1024 + 347`.
•	`spike_gen` (`is_heap_until` only) — descending with a single spike at index 42 that breaks the max-heap property mid-range.
•	Drives the multi-work-group device path via `big_sz` for both the "valid heap" and the "violation found" outcomes.

## Coverage
•	`oneapi::dpl::ranges::is_heap` — both results:
•	true: `desc_gen` max-heap incl. large `big_sz` scan; ascending min-heap w.r.t. `greater`; heap-with-ties via `non_desc_heap_gen`.
•	false: `late_violation_gen` with `less+proj` and with `CustomLess`+`&P2::x` (violation near end of large range); default ascending data (violation at `begin+1`).
•	`oneapi::dpl::ranges::is_heap_until` — both `end()` and a stop before `end()`:
•	Returns `end()`: `desc_gen` large valid max-heap (`big_sz`); ascending min-heap w.r.t. `greater`; heap-with-ties via `non_desc_heap_gen`.
•	Stops before `end()`: `spike_gen` at index `42` (`big_sz`); `late_violation_gen` with `less`+`proj` and with `CustomLess`+`&P2::x` (violation near end of large range); default ascending data (stops at `begin+1`).