### PR TITLE
Improve SYCL implementation of __parallel_for

### DIFF
--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -78,6 +78,8 @@ struct __custom_brick
     void
     operator()(_IsFull, const std::size_t idx, _Params, _Acc acc) const
     {
+        static_assert(_Params::__vector_size == 1,
+                      "The brick operates with tuples which must be excluded from vectorizable types");
         if (use_32bit_indexing)
             search_impl<std::uint32_t>(idx, acc);
         else

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -41,9 +41,6 @@ enum class search_algorithm
 template <typename Comp, typename T, search_algorithm func>
 struct __custom_brick
 {
-    constexpr static bool __can_vectorize = false;
-    constexpr static bool __can_process_multiple_iters = true;
-
     Comp comp;
     T size;
     bool use_32bit_indexing;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -39,10 +39,9 @@ namespace dpl
 namespace __par_backend_hetero
 {
 
-template <bool __enable_tuning, typename _Brick, typename... _Ranges>
-struct __pfor_params
+template <typename... _Ranges>
+class __pfor_params
 {
-  private:
     using _ValueTypes = std::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
     constexpr static std::uint8_t __min_type_size = oneapi::dpl::__internal::__min_nested_type_size<_ValueTypes>::value;
     // Empirically determined 'bytes-in-flight' to maximize bandwidth utilization
@@ -51,16 +50,37 @@ struct __pfor_params
     constexpr static std::uint8_t __max_vector_size = 4;
 
   public:
-    constexpr static bool __b_vectorize = __enable_tuning && _Brick::__can_vectorize &&
-                                          (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) &&
-                                          __min_type_size < 4;
+    constexpr static bool __can_vectorize =
+        (std::is_fundamental_v<oneapi::dpl::__internal::__value_t<_Ranges>> && ...) && __min_type_size < 4;
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
     constexpr static std::uint8_t __vector_size =
-        __b_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
-    constexpr static std::uint8_t __iters_per_item = (__enable_tuning && _Brick::__can_process_multiple_iters)
-                                                         ? __bytes_per_item / (__min_type_size * __vector_size)
-                                                         : 1;
+        __can_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
+    constexpr static std::uint8_t __iters_per_item = __bytes_per_item / (__min_type_size * __vector_size);
 };
+
+struct __pfor_params_simple
+{
+    constexpr static bool __can_vectorize = false;
+    constexpr static std::uint8_t __vector_size = 1;
+    constexpr static std::uint8_t __iters_per_item = 1;
+};
+
+template <typename _Brick, typename... _Ranges>
+class __iterations_per_item
+{
+    template <typename _F>
+    static std::integral_constant<std::uint8_t, _F::__iters_per_item>
+    test(int);
+
+    template <typename>
+    static std::integral_constant<std::uint8_t, __pfor_params<_Ranges...>::__iters_per_item>
+    test(...);
+
+  public:
+    constexpr static std::uint8_t value = decltype(test<_Brick>(0))::value;
+};
+template <typename _Brick, typename... _Ranges>
+inline constexpr std::uint8_t __iterations_per_item_v = __iterations_per_item<_Brick, _Ranges...>::value;
 
 template <typename... Name>
 class __parallel_for_small_kernel;
@@ -95,11 +115,9 @@ struct __parallel_for_small_submitter<__internal::__optional_kernel_name<_Name..
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
             __cgh.parallel_for<_Name...>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item) {
-                // Disable vectorization and multiple iterations per item within the brick to evenly spread work across
-                // compute units.
-                __pfor_params<false /*__enable_tuning*/, _Fp, _Ranges...> __params;
+                // Simple loop and no vectorization within the brick, to evenly spread work across compute units.
                 const std::size_t __idx = __item.get_linear_id();
-                __brick(std::true_type{}, __idx, __params, __rngs...);
+                __brick(std::true_type{}, __idx, __pfor_params_simple{}, __rngs...);
             });
         });
 
@@ -156,22 +174,20 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
 
     // Once there is enough work to launch a group on each compute unit with our chosen __iters_per_item,
     // then we should start using this code path.
-    template <typename _Fp, typename... _Ranges>
-    static std::size_t
-    __estimate_best_start_size(const sycl::queue& __q)
+    static inline std::size_t
+    __minimal_useful_size(const sycl::queue& __q, std::size_t __iters_per_work_item)
     {
-        using __params_t = __pfor_params<true /*__enable_tuning*/, _Fp, _Ranges...>;
         const std::size_t __work_group_size =
             oneapi::dpl::__internal::__max_work_group_size(__q, __max_work_group_size);
         const std::uint32_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__q);
-        return __work_group_size * __params_t::__iters_per_item * __max_cu;
+        return __work_group_size * __iters_per_work_item * __max_cu;
     }
 
     template <typename _Fp, typename _Index, typename... _Ranges>
     __future<sycl::event>
     operator()(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
-        using __params_t = __pfor_params<true /*__enable_tuning*/, _Fp, _Ranges...>;
+        using __params_t = __pfor_params<_Ranges...>;
         assert(oneapi::dpl::__ranges::__first_size_calc{}(__rngs...) > 0);
         const std::size_t __work_group_size =
             oneapi::dpl::__internal::__max_work_group_size(__q, __max_work_group_size);
@@ -179,7 +195,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
         auto __event = __q.submit([__rngs..., __brick, __work_group_size, __count](sycl::handler& __cgh) {
             //get an access to data under SYCL buffer:
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
-            constexpr std::uint8_t __iters_per_work_item = __params_t::__iters_per_item;
+            constexpr std::uint8_t __iters_per_work_item = __iterations_per_item_v<_Fp, _Ranges...>;
             constexpr std::uint8_t __vector_size = __params_t::__vector_size;
             const std::size_t __num_groups = oneapi::dpl::__internal::__dpl_ceiling_div(
                 __count, (__work_group_size * __vector_size * __iters_per_work_item));
@@ -205,36 +221,12 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     }
 };
 
-template <typename _Brick>
-struct __has_pfor_brick_members
-{
-  private:
-    template <typename _F>
-    static auto
-    test(int) -> decltype(std::bool_constant<_F::__can_vectorize>{},
-                          std::bool_constant<_F::__can_process_multiple_iters>{}, std::true_type{});
-
-    template <typename>
-    static std::false_type
-    test(...);
-
-  public:
-    constexpr static bool value = decltype(test<_Brick>(0))::value;
-};
-
-template <typename Brick>
-inline constexpr bool __has_pfor_brick_members_v = __has_pfor_brick_members<Brick>::value;
-
 //General version of parallel_for, one additional parameter - __count of iterations of loop __cgh.parallel_for,
 //for some algorithms happens that size of processing range is n, but amount of iterations is n/2.
 template <typename _CustomName, typename _Fp, typename _Index, typename... _Ranges>
 __future<sycl::event>
 __parallel_for_impl(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs)
 {
-    static_assert(
-        __has_pfor_brick_members_v<_Fp>,
-        "The brick provided to __parallel_for must define const / constexpr static bool members __can_vectorize and "
-        "__can_process_multiple_iters which must be evaluated at compile time.");
     assert(oneapi::dpl::__ranges::__min_size_calc{}(__rngs...) > 0);
     assert(__count > 0);
 
@@ -245,13 +237,13 @@ __parallel_for_impl(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... 
 
     using __small_submitter = __parallel_for_small_submitter<_ForKernelSmall>;
     using __large_submitter = __parallel_for_large_submitter<_ForKernelLarge>;
-    using __params_t = __pfor_params<true /*__enable_tuning*/, _Fp, _Ranges...>;
+    constexpr std::uint8_t __iters_per_work_item = __iterations_per_item_v<_Fp, _Ranges...>;
     // Compile two kernels: one for small-to-medium inputs and a second for large. This avoids runtime checks within a
     // single kernel that worsen performance for small cases. If the number of iterations of the large submitter is 1,
     // then only compile the basic kernel as the two versions are effectively the same.
-    if constexpr (__params_t::__iters_per_item > 1 || __params_t::__vector_size > 1)
+    if constexpr (__iters_per_work_item > 1 || __pfor_params<_Ranges...>::__vector_size > 1)
     {
-        if (__count >= __large_submitter::template __estimate_best_start_size<_Fp, _Ranges...>(__q))
+        if (__count >= __large_submitter::__minimal_useful_size(__q, __iters_per_work_item))
         {
             return __large_submitter{}(__q, __brick, __count, std::forward<_Ranges>(__rngs)...);
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -132,44 +132,32 @@ template <typename... _Name>
 struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name...>>
 {
     // Limit the work-group size to 512 which has empirically yielded the best results across different architectures.
-    static constexpr std::uint16_t __max_work_group_size = 512;
+    static constexpr std::uint16_t __work_group_size_limit = 512;
 
     // SPIR-V compilation targets show best performance with a stride of the sub-group size.
     // Other compilation targets perform best with a work-group size stride. This utility can only be called from the
     // device.
     static inline std::tuple<std::size_t, std::size_t, bool>
     __stride_recommender(const sycl::nd_item<1>& __item, std::size_t __count, std::size_t __iters_per_work_item,
-                         std::size_t __adj_elements_per_work_item, std::size_t __work_group_size)
+                         std::size_t __adj_elements_per_work_item, std::size_t __group_size)
     {
-        const std::size_t __work_group_id = __item.get_group().get_group_linear_id();
+        std::uint32_t __item_local_id;
         if constexpr (oneapi::dpl::__internal::__is_spirv_target_v)
         {
             const __dpl_sycl::__sub_group __sub_group = __item.get_sub_group();
-            const std::uint32_t __sub_group_size = __sub_group.get_local_linear_range();
-            const std::uint32_t __sub_group_id = __sub_group.get_group_linear_id();
-            const std::uint32_t __sub_group_local_id = __sub_group.get_local_linear_id();
-
-            const std::size_t __sub_group_start_idx =
-                __iters_per_work_item * __adj_elements_per_work_item *
-                (__work_group_id * __work_group_size + __sub_group_size * __sub_group_id);
-            const bool __is_full_sub_group =
-                __sub_group_start_idx + __iters_per_work_item * __adj_elements_per_work_item * __sub_group_size <=
-                __count;
-            const std::size_t __work_item_idx =
-                __sub_group_start_idx + __adj_elements_per_work_item * __sub_group_local_id;
-            return std::tuple(__work_item_idx, __adj_elements_per_work_item * __sub_group_size, __is_full_sub_group);
+            __group_size = __sub_group.get_local_linear_range();
+            __item_local_id = __sub_group.get_local_linear_id();
         }
         else
         {
-            const std::size_t __work_group_start_idx =
-                __work_group_id * __work_group_size * __iters_per_work_item * __adj_elements_per_work_item;
-            const std::size_t __work_item_idx =
-                __work_group_start_idx + __item.get_local_linear_id() * __adj_elements_per_work_item;
-            const bool __is_full_work_group =
-                __work_group_start_idx + __iters_per_work_item * __work_group_size * __adj_elements_per_work_item <=
-                __count;
-            return std::tuple(__work_item_idx, __work_group_size * __adj_elements_per_work_item, __is_full_work_group);
+            __item_local_id = __item.get_local_linear_id();
         }
+        const std::size_t __group_start_idx =
+            __iters_per_work_item * __adj_elements_per_work_item * (__item.get_global_linear_id() - __item_local_id);
+        const bool __is_full_group =
+            __group_start_idx + __iters_per_work_item * __adj_elements_per_work_item * __group_size <= __count;
+        const std::size_t __work_item_start_idx = __group_start_idx + __adj_elements_per_work_item * __item_local_id;
+        return std::tuple(__work_item_start_idx, __adj_elements_per_work_item * __group_size, __is_full_group);
     }
 
     // Once there is enough work to launch a group on each compute unit with our chosen __iters_per_item,
@@ -178,7 +166,7 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     __minimal_useful_size(const sycl::queue& __q, std::size_t __iters_per_work_item)
     {
         const std::size_t __work_group_size =
-            oneapi::dpl::__internal::__max_work_group_size(__q, __max_work_group_size);
+            oneapi::dpl::__internal::__max_work_group_size(__q, __work_group_size_limit);
         const std::uint32_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__q);
         return __work_group_size * __iters_per_work_item * __max_cu;
     }
@@ -188,9 +176,8 @@ struct __parallel_for_large_submitter<__internal::__optional_kernel_name<_Name..
     operator()(sycl::queue& __q, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
         using __params_t = __pfor_params<_Ranges...>;
-        assert(oneapi::dpl::__ranges::__first_size_calc{}(__rngs...) > 0);
         const std::size_t __work_group_size =
-            oneapi::dpl::__internal::__max_work_group_size(__q, __max_work_group_size);
+            oneapi::dpl::__internal::__max_work_group_size(__q, __work_group_size_limit);
         _PRINT_INFO_IN_DEBUG_MODE(__q);
         auto __event = __q.submit([__rngs..., __brick, __work_group_size, __count](sycl::handler& __cgh) {
             //get an access to data under SYCL buffer:

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_for.h
@@ -55,7 +55,8 @@ class __pfor_params
     // Vectorize for small types, so we generate 128-byte load / stores in a sub-group
     constexpr static std::uint8_t __vector_size =
         __can_vectorize ? oneapi::dpl::__internal::__dpl_ceiling_div(__max_vector_size, __min_type_size) : 1;
-    constexpr static std::uint8_t __iters_per_item = __bytes_per_item / (__min_type_size * __vector_size);
+    constexpr static std::uint8_t __iters_per_item =
+        std::max<std::uint8_t>(1, __bytes_per_item / (__min_type_size * __vector_size));
 };
 
 struct __pfor_params_simple

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -73,12 +73,11 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
             __cgh.single_task<_Name...>([=]() {
-                // Disable vectorization and multiple iterations per item.
-                __pfor_params<false /*__enable_tuning*/, _Fp, _Ranges...> __params;
 #pragma unroll(unroll_factor)
                 for (auto __idx = 0; __idx < __count; ++__idx)
                 {
-                    __brick(std::true_type{}, __idx, __params, __rngs...);
+                    // No vectorization within the brick
+                    __brick(std::true_type{}, __idx, __pfor_params_simple{}, __rngs...);
                 }
             });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -1209,7 +1209,7 @@ struct __vector_reverse
 template <std::uint8_t __num_strides>
 struct __strided_loop
 {
-    std::size_t __full_range_size;
+    std::size_t __full_range_size = 0;
     template <typename _LoopBodyOp, typename... _Args>
     void
     operator()(/*__is_full*/ std::true_type, std::size_t __idx, std::uint16_t __stride, _LoopBodyOp __loop_body_op,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -1204,15 +1204,15 @@ struct __vector_reverse
     }
 };
 
-// Processes a loop with a given stride. Intended to be used with sub-group / work-group strides for good memory access patterns
-// (potentially with vectorization)
+// Processes a loop with a given stride. Intended to be used with sub-group / work-group strides
+// for good memory access patterns (potentially with vectorization)
 template <std::uint8_t __num_strides>
 struct __strided_loop
 {
     std::size_t __full_range_size;
-    template <typename _IdxType, typename _LoopBodyOp, typename... _Args>
+    template <typename _LoopBodyOp, typename... _Args>
     void
-    operator()(/*__is_full*/ std::true_type, _IdxType __idx, std::uint16_t __stride, _LoopBodyOp __loop_body_op,
+    operator()(/*__is_full*/ std::true_type, std::size_t __idx, std::uint16_t __stride, _LoopBodyOp __loop_body_op,
                _Args&&... __args) const
     {
         _ONEDPL_PRAGMA_UNROLL
@@ -1222,9 +1222,9 @@ struct __strided_loop
             __idx += __stride;
         }
     }
-    template <typename _IdxType, typename _LoopBodyOp, typename... _Args>
+    template <typename _LoopBodyOp, typename... _Args>
     void
-    operator()(/*__is_full*/ std::false_type, _IdxType __idx, std::uint16_t __stride, _LoopBodyOp __loop_body_op,
+    operator()(/*__is_full*/ std::false_type, std::size_t __idx, std::uint16_t __stride, _LoopBodyOp __loop_body_op,
                _Args&&... __args) const
     {
         for (; __idx < __full_range_size; __idx += __stride)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -1227,16 +1227,9 @@ struct __strided_loop
     operator()(/*__is_full*/ std::false_type, _IdxType __idx, std::uint16_t __stride, _LoopBodyOp __loop_body_op,
                _Args&&... __args) const
     {
-        // This operation improves safety by preventing underflow for unsigned types which would otherwise require a
-        // check outside of the __strided_loop body.
-        __idx = std::min<std::size_t>(__idx, __full_range_size);
-        // Constrain the number of iterations as much as possible and then pass the knowledge that we are not a full loop to the body operation
-        const std::uint8_t __adjusted_iters_per_work_item =
-            oneapi::dpl::__internal::__dpl_ceiling_div(__full_range_size - __idx, __stride);
-        for (std::uint8_t __i = 0; __i < __adjusted_iters_per_work_item; ++__i)
+        for (; __idx < __full_range_size; __idx += __stride)
         {
             __loop_body_op(std::false_type{}, __idx, __args...);
-            __idx += __stride;
         }
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -142,7 +142,7 @@ struct walk_n_vectors_or_scalars
     mutable _F __f;
     std::size_t __n;
     template <typename _IsFull, typename _Params, typename _InRng, typename _OutRng,
-              std::enable_if_t<_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     __vector_impl(_IsFull __is_full, const std::size_t __idx, _Params, _InRng&& __in_rng, _OutRng&& __out_rng) const
     {
@@ -158,7 +158,7 @@ struct walk_n_vectors_or_scalars
         __vec_store(__is_full, __idx, __store_op, __in_rng_vector, __out_rng);
     }
     template <typename _IsFull, typename _Params, typename _InRng1, typename _InRng2, typename _OutRng,
-              std::enable_if_t<_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     __vector_impl(_IsFull __is_full, const std::size_t __idx, _Params, _InRng1&& __in_rng1, _InRng2&& __in_rng2,
                   _OutRng&& __out_rng) const
@@ -182,12 +182,10 @@ struct walk_n_vectors_or_scalars
     }
 
   public:
-    constexpr static bool __can_vectorize = true;
-    constexpr static bool __can_process_multiple_iters = true;
     walk_n_vectors_or_scalars(_F __f, std::size_t __n) : __f(std::move(__f)), __n(__n) {}
 
     template <typename _IsFull, typename _Params, typename... _Ranges,
-              std::enable_if_t<_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Ranges&&... __rngs) const
     {
@@ -207,7 +205,7 @@ struct walk_n_vectors_or_scalars
 
     // _IsFull is ignored here. We assume that boundary checking has been already performed for this index.
     template <typename _IsFull, typename _Params, typename... _Ranges,
-              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<!_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Ranges&&... __rngs) const
     {
@@ -228,13 +226,10 @@ struct walk_adjacent_difference
     oneapi::dpl::__internal::__pstl_assign __assigner;
 
   public:
-    constexpr static bool __can_vectorize = true;
-    constexpr static bool __can_process_multiple_iters = true;
-
     walk_adjacent_difference(_F __f, std::size_t __n) : __f(std::move(__f)), __n(__n) {}
 
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
-              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<!_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
@@ -245,7 +240,7 @@ struct walk_adjacent_difference
             __f(__rng1[__idx + (-1)], __rng1[__idx], __rng2[__idx]);
     }
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
-              std::enable_if_t<_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
@@ -1087,11 +1082,9 @@ struct __reverse_functor
     _Size __size;
 
   public:
-    constexpr static bool __can_vectorize = true;
-    constexpr static bool __can_process_multiple_iters = true;
     __reverse_functor(_Size __size) : __size(__size) {}
 
-    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__b_vectorize, int> = 0>
+    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __left_start_idx, _Params, _Range&& __rng) const
     {
@@ -1128,7 +1121,7 @@ struct __reverse_functor
         __vec_store(std::true_type{}, __right_start_idx, __store_op, __rng_left_vector, __rng);
         __vec_store(std::true_type{}, __left_start_idx, __store_op, __rng_right_vector, __rng);
     }
-    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<!_Params::__b_vectorize, int> = 0>
+    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<!_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
@@ -1148,19 +1141,17 @@ struct __reverse_copy
     oneapi::dpl::__internal::__pstl_assign __assigner;
 
   public:
-    constexpr static bool __can_vectorize = true;
-    constexpr static bool __can_process_multiple_iters = true;
     __reverse_copy(_Size __size) : __size(__size) {}
 
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
-              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<!_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
         __rng2[__idx] = __rng1[__size - __idx - 1];
     }
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
-              std::enable_if_t<_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
@@ -1210,12 +1201,10 @@ struct __rotate_copy
     oneapi::dpl::__internal::__pstl_assign __assigner;
 
   public:
-    constexpr static bool __can_vectorize = true;
-    constexpr static bool __can_process_multiple_iters = true;
     __rotate_copy(_Size __size, _Size __shift) : __size(__size), __shift(__shift) {}
 
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
-              std::enable_if_t<_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
@@ -1255,7 +1244,7 @@ struct __rotate_copy
         __vec_store(__is_full, __idx, __store_op, __rng1_vector, __rng2);
     }
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
-              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<!_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
@@ -1354,13 +1343,12 @@ template <typename _DiffType>
 struct __brick_shift_left
 {
     // Multiple iterations per item are manually processed in the brick with a nd-range strided approach.
-    constexpr static bool __can_vectorize = true;
-    constexpr static bool __can_process_multiple_iters = false;
+    constexpr static std::uint8_t __iters_per_item = 1;
 
     _DiffType __size;
     _DiffType __n;
 
-    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__b_vectorize, int> = 0>
+    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
@@ -1405,7 +1393,7 @@ struct __brick_shift_left
         }
     }
 
-    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<!_Params::__b_vectorize, int> = 0>
+    template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<!_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
@@ -1435,8 +1423,6 @@ struct __brick_assign_key_position
 template <typename _BinaryOperator, typename _Size>
 struct __brick_reduce_idx
 {
-    constexpr static bool __can_vectorize = false;
-    constexpr static bool __can_process_multiple_iters = true;
     __brick_reduce_idx(const _BinaryOperator& __b, const _Size __n_) : __binary_op(__b), __n(__n_) {}
 
     template <typename _Values>
@@ -1476,12 +1462,10 @@ struct __brick_swap
     std::size_t __n;
 
   public:
-    constexpr static bool __can_vectorize = true;
-    constexpr static bool __can_process_multiple_iters = true;
     __brick_swap(_F __f, std::size_t __n) : __f(std::move(__f)), __n(__n) {}
 
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
-              std::enable_if_t<_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull __is_full, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {
@@ -1504,7 +1488,7 @@ struct __brick_swap
     }
 
     template <typename _IsFull, typename _Params, typename _Range1, typename _Range2,
-              std::enable_if_t<!_Params::__b_vectorize, int> = 0>
+              std::enable_if_t<!_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range1&& __rng1, _Range2&& __rng2) const
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1450,7 +1450,7 @@ struct __brick_reduce_idx
         {
             // repeat for adjacent elements
             std::size_t __rest = std::min<std::size_t>(_Params::__vector_size, __end - __idx) - 1;
-            for(++__idx; __rest > 0; ++__idx, --__rest)
+            for (++__idx; __rest > 0; ++__idx, --__rest)
             {
                 __segment_end = (__idx == __end - 1) ? __value_type(__n) : __segment_starts[__idx + 1];
                 __out_values[__idx] = reduce(__segment_starts[__idx], __segment_end, __values);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1438,13 +1438,24 @@ struct __brick_reduce_idx
     }
     template <typename _IsFull, typename _Params, typename _ReduceIdx, typename _Values, typename _OutValues>
     void
-    operator()(_IsFull, const std::size_t __idx, _Params, const _ReduceIdx& __segment_starts, const _Values& __values,
+    operator()(_IsFull, std::size_t __idx, _Params, const _ReduceIdx& __segment_starts, const _Values& __values,
                _OutValues& __out_values) const
     {
         using __value_type = decltype(__segment_starts[__idx]);
-        __value_type __segment_end =
-            (__idx == __segment_starts.size() - 1) ? __value_type(__n) : __segment_starts[__idx + 1];
+        const std::size_t __end = __segment_starts.size();
+        __value_type __segment_end = (__idx == __end - 1) ? __value_type(__n) : __segment_starts[__idx + 1];
         __out_values[__idx] = reduce(__segment_starts[__idx], __segment_end, __values);
+
+        if constexpr (_Params::__vector_size > 1)
+        {
+            // repeat for adjacent elements
+            std::size_t __rest = std::min<std::size_t>(_Params::__vector_size, __end - __idx) - 1;
+            for(++__idx; __rest > 0; ++__idx, --__rest)
+            {
+                __segment_end = (__idx == __end - 1) ? __value_type(__n) : __segment_starts[__idx + 1];
+                __out_values[__idx] = reduce(__segment_starts[__idx], __segment_end, __values);
+            }
+        }
     }
 
   private:

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -386,14 +386,15 @@ main()
     run_test</*use_device_alloc=*/true, MatrixPoint<float>, UserBinaryPredicate<MatrixPoint<float>>, MaxFunctor<MatrixPoint<float>>>();
 #endif
 
-    run_test</*use_device_alloc=*/false, int, ::std::equal_to<int>, ::std::plus<int>>();
-    run_test</*use_device_alloc=*/true, float, ::std::equal_to<float>, ::std::plus<float>>();
-    run_test</*use_device_alloc=*/false, double, ::std::equal_to<double>, ::std::plus<double>>();
+    run_test</*use_device_alloc=*/true, std::uint16_t, std::equal_to<std::uint16_t>, std::plus<std::uint16_t>>();
+    run_test</*use_device_alloc=*/false, int, std::equal_to<int>, std::plus<int>>();
+    run_test</*use_device_alloc=*/true, float, std::equal_to<float>, std::plus<float>>();
+    run_test</*use_device_alloc=*/false, double, std::equal_to<double>, std::plus<double>>();
 
     // TODO investigate possible overflow: see issue #1416
-    run_test_on_device</*use_device_alloc=*/true, int, ::std::equal_to<int>, ::std::multiplies<int>>();
-    run_test_on_device</*use_device_alloc=*/false, float, ::std::equal_to<float>, ::std::multiplies<float>>();
-    run_test_on_device</*use_device_alloc=*/true, double, ::std::equal_to<double>, ::std::multiplies<double>>();
+    run_test_on_device</*use_device_alloc=*/true, int, std::equal_to<int>, std::multiplies<int>>();
+    run_test_on_device</*use_device_alloc=*/false, float, std::equal_to<float>, std::multiplies<float>>();
+    run_test_on_device</*use_device_alloc=*/true, double, std::equal_to<double>, std::multiplies<double>>();
 
     return TestUtils::done();
 }


### PR DESCRIPTION
The patch improves `__par_backend_hetero::__parallel_for`:
- For `__can_vectorize`, instead of reporting whether "vector" operations are supported bricks simply react (or not) to `__pfor_params` value that indicates vector operations might be useful.
- Instead of `__can_process_multiple_iters` which was only set to false by one brick, that brick now sets `__iters_per_item = 1`, and the new `__iterations_per_item_v` trait detects it for a brick, defaulting to `__pfor_params::__iters_per_item`.
- As a result, `__pfor_params` become brick-independent and now simply provide recommended parameters, while most bricks do not have any custom "traits".
- For further clarity, the "not for tuning" parameters are split into a separate `__pfor_params_simple` class.
- `__stride_recommender` is reworked in order to a) fix the computation for sub-groups, which size is not guaranteed to be uniform and so cannot be used in global data indexing calculations, and b) unify the two code paths, leaving only the necessary minimum conditioned.
- Unnecessary complexity in the "partial" implementation of `__strided_loop` is removed.
- Some renaming for improved code clarity.
