### PR TITLE
Limit compilation of permutations in per-commit std_ranges CI

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -239,6 +239,12 @@ jobs:
 
           # TODO: fix or justify the excluded warnings
           EXTRA_CXX_FLAGS="-Wall -Wextra-semi -Werror -Wno-error=sign-compare"
+          if [[ "${{ matrix.backend }}" == "dpcpp" ]]; then
+            # Reduce std_ranges view-type permutations in per-commit CI to keep
+            # build time under the job limit. A couple of representative tests
+            # force full coverage back on regardless of this flag.
+            EXTRA_CXX_FLAGS="${EXTRA_CXX_FLAGS} -DONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS=0"
+          fi
           if [[ "${{ matrix.cxx_compiler }}" != "g++" ]]; then
             EXTRA_CXX_FLAGS="${EXTRA_CXX_FLAGS} -Wno-error=pass-failed"
           fi
@@ -404,6 +410,13 @@ jobs:
             set warning_flags=/W4 /WX /wd4018 /wd4100 /wd4146 /wd4244 /wd4245 /wd4267 /wd4310 /wd4389 /wd4805 /wd4996
           ) else (
             set warning_flags=-Wall -Werror -Wno-error=sign-compare -Wno-error=pass-failed
+          )
+
+          :: Reduce std_ranges view-type permutations in per-commit CI to keep
+          :: build time under the job limit. A couple of representative tests
+          :: force full coverage back on regardless of this flag.
+          if "${{ matrix.backend }}" == "dpcpp" (
+            set warning_flags=!warning_flags! -DONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS=0
           )
 
           cmake -G "Ninja" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DCMAKE_CXX_FLAGS="%warning_flags%" ..

--- a/test/parallel_api/ranges/std_ranges_find.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find.pass.cpp
@@ -13,6 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Force the full set of range/view permutations regardless of any external
+// build-time reduction (e.g. per-commit CI). This test is kept as a
+// full-coverage representative of the read/search-style std_ranges algorithms.
+#ifdef ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
+#    undef ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
+#endif
+#define ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS 1
+
 #include "std_ranges_test.h"
 
 std::int32_t

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -44,8 +44,9 @@ static_assert(ONEDPL_HAS_RANGE_ALGORITHMS >= 202605L);
 // (the default), every view-type permutation is built and run, giving full
 // coverage. When set to 0, only a single representative permutation is built
 // per call, which substantially reduces compile time. Per-commit CI defines
-// this to 0 for the bulk of the std_ranges tests; a couple of representative
-// tests force it back to 1 so full permutation coverage is retained there.
+// this to 0 for the bulk of the std_ranges tests when building with the dpcpp
+// backend; a couple of representative tests force it back to 1 so full
+// permutation coverage is still exercised in that CI.
 #    ifndef ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
 #        define ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS 1
 #    endif

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -40,6 +40,16 @@ static_assert(ONEDPL_HAS_RANGE_ALGORITHMS >= 202605L);
 #include <memory>
 #include <array>
 
+// Controls how many range/view permutations each test builds. When set to 1
+// (the default), every view-type permutation is built and run, giving full
+// coverage. When set to 0, only a single representative permutation is built
+// per call, which substantially reduces compile time. Per-commit CI defines
+// this to 0 for the bulk of the std_ranges tests; a couple of representative
+// tests force it back to 1 so full permutation coverage is retained there.
+#    ifndef ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
+#        define ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS 1
+#    endif
+
 namespace test_std_ranges
 {
 
@@ -1024,18 +1034,21 @@ struct test_range_algo
     test_range_algo_impl_host(auto algo, auto& checker, auto... args)
     {
         auto subrange_view = subrange_view_fo{};
-#if TEST_CPP20_SPAN_PRESENT
+#    if TEST_CPP20_SPAN_PRESENT && ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
         auto span_view = span_view_fo{};
 #endif
 
-        test<T, host_vector<T>,   mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, std::identity{},  std::identity{}, args...);
         test<T, host_vector<T>,   mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, subrange_view,    std::identity{}, args...);
+#    if ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
+        test<T, host_vector<T>, mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker,
+                                                                          std::identity{}, std::identity{}, args...);
         test<T, host_vector<T>,   mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, std::views::all,  std::identity{}, args...);
         test<T, host_subrange<T>, mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, std::views::all,  std::identity{}, args...);
 #if TEST_CPP20_SPAN_PRESENT
         test<T, host_vector<T>,   mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, span_view,        std::identity{}, args...);
         test<T, host_span<T>,     mode, DataGen1, DataGen2>{}.host_policies(n_serial, n_parallel, algo, checker, std::views::all,  std::identity{}, args...);
 #endif
+#    endif // ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
     }
 
 #if TEST_DPCPP_BACKEND_PRESENT
@@ -1043,7 +1056,7 @@ struct test_range_algo
     void test_range_algo_impl_hetero(Policy&& exec, auto algo, auto& checker, auto... args)
     {
         auto subrange_view = subrange_view_fo{};
-#if TEST_CPP20_SPAN_PRESENT
+#        if TEST_CPP20_SPAN_PRESENT && ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
         auto span_view = span_view_fo{};
 #endif
 
@@ -1058,11 +1071,13 @@ struct test_range_algo
                 constexpr TestDataMode resHeteroMode = ResolveTestDataModeForHeteroPolicy<mode>::res_mode;
 
                 test<T, usm_vector<T>,   resHeteroMode, DataGen1, DataGen2>{}(n_device, CLONE_TEST_POLICY_IDX(exec, call_id + 10), algo, checker, subrange_view,   subrange_view,   args...);
+#        if ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
                 test<T, usm_subrange<T>, resHeteroMode, DataGen1, DataGen2>{}(n_device, CLONE_TEST_POLICY_IDX(exec, call_id + 30), algo, checker, std::identity{}, std::identity{}, args...);
 #if TEST_CPP20_SPAN_PRESENT
                 test<T, usm_vector<T>,   resHeteroMode, DataGen1, DataGen2>{}(n_device, CLONE_TEST_POLICY_IDX(exec, call_id + 20), algo, checker, span_view,       subrange_view,   args...);
                 test<T, usm_span<T>,     resHeteroMode, DataGen1, DataGen2>{}(n_device, CLONE_TEST_POLICY_IDX(exec, call_id + 40), algo, checker, std::identity{}, std::identity{}, args...);
 #endif
+#        endif // ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
             }
         }
     }

--- a/test/parallel_api/ranges/std_ranges_transform.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_transform.pass.cpp
@@ -13,6 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Force the full set of range/view permutations regardless of any external
+// build-time reduction (e.g. per-commit CI). This test is kept as a
+// full-coverage representative of the write/output-style std_ranges algorithms.
+#ifdef ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
+#    undef ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
+#endif
+#define ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS 1
+
 #include "std_ranges_test.h"
 
 std::int32_t


### PR DESCRIPTION
Limit compilation of std_ranges for per-commit CI.  The idea is that we don't need to compile all variants of all std_ranges tests.  We can cover the full set of permutations in a few tests.  We still cover these in nightly CI, and by default, just not in per commit CI.

Closes https://github.com/uxlfoundation/oneDPL/issues/2727