### PR TITLE
Add early-exit condition to the radix sort onesweep kernel

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
@@ -691,13 +691,15 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
                                         std::uint32_t __sub_group_id, std::uint32_t __tile_id,
                                         _GlobOffsetT __global_base) const
     {
-        _LocOffsetT __sub_group_offset = __sub_group_id * __data_per_sub_group;
+        const _LocOffsetT __sub_group_offset = __sub_group_id * __data_per_sub_group;
 
-        const _GlobOffsetT __tile_start =
-            static_cast<_GlobOffsetT>(__tile_id) * __work_group_size * __data_per_work_item;
-        bool __is_full_tile = (__tile_start + __work_group_size * __data_per_work_item) <= __n;
+        // Determine fullness per sub-group (mirroring __load) rather than per work-group: only the
+        // boundary sub-group needs the masked store path.
+        const _GlobOffsetT __sg_input_offset =
+            __data_per_sub_group * (__tile_id * __num_sub_groups_per_work_group + __sub_group_id);
+        bool __is_full_block = (__sg_input_offset + __data_per_sub_group) <= __n;
 
-        if (__is_full_tile)
+        if (__is_full_block)
         {
             _ONEDPL_PRAGMA_UNROLL
             for (std::uint32_t __i = 0; __i < __data_per_work_item; ++__i)

--- a/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
@@ -185,6 +185,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
     static constexpr std::uint32_t __sub_group_size = 32;
     static constexpr std::uint32_t __num_sub_groups_per_work_group = __work_group_size / __sub_group_size;
     static constexpr std::uint32_t __data_per_sub_group = __data_per_work_item * __sub_group_size;
+    static constexpr std::uint32_t __data_per_work_group = __data_per_sub_group * __num_sub_groups_per_work_group;
 
     static constexpr std::uint32_t __bit_count = sizeof(_KeyT) * 8;
     static constexpr _LocOffsetT __mask = __bin_count - 1;
@@ -421,10 +422,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
         }
 
         // Detect single-bin tiles: if all elements land in one bin, we can skip SLM reorder.
-        // any_of_group provides the same synchronization as group_barrier (SYCL 2020 spec 4.17.3).
-        constexpr _LocOffsetT __total_tile_elements = __work_group_size * __data_per_work_item;
-        bool __my_bin_is_full =
-            (__sub_group_id < __bin_summary_sub_group_size) && (__item_bin_count == __total_tile_elements);
+        bool __my_bin_is_full = (__item_bin_count == __data_per_work_group);
         bool __is_single_bin = sycl::any_of_group(__group, __my_bin_is_full);
 
         // 1.4. Finalize the partial scans from step 1.3 by connecting the independent sub-group segments
@@ -691,15 +689,9 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
     template <typename _KVPack>
     void inline __direct_copy_to_output(const _KVPack& __pack, const _LocOffsetT (&__ranks)[__data_per_work_item],
                                         std::uint32_t __sub_group_id, std::uint32_t __tile_id,
-                                        _LocOffsetT* __slm_subgroup_hists, _GlobOffsetT* __slm_global_incoming,
-                                        _LocOffsetT __single_bin_id) const
+                                        _GlobOffsetT __global_base) const
     {
-        // Sub-group offset from the inclusive scan of this bin's count up to (sub_group_id - 1)
-        _LocOffsetT __sub_group_offset =
-            (__sub_group_id == 0) ? _LocOffsetT(0)
-                                  : __slm_subgroup_hists[(__sub_group_id - 1) * __bin_count + __single_bin_id];
-
-        _GlobOffsetT __global_base = __slm_global_incoming[__single_bin_id];
+        _LocOffsetT __sub_group_offset = __sub_group_id * __data_per_sub_group;
 
         const _GlobOffsetT __tile_start =
             static_cast<_GlobOffsetT>(__tile_id) * __work_group_size * __data_per_work_item;
@@ -784,8 +776,10 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
 
             if (__is_single_bin)
             {
-                __direct_copy_to_output(__values_pack, __ranks, __sg_id, __tile_id, __slm_subgroup_hists,
-                                        __slm_global_incoming, __bins[0]);
+                _GlobOffsetT __global_base =
+                    __idx.get_local_linear_id() == 0 ? __slm_global_incoming[__bins[0]] : _GlobOffsetT(0);
+                __global_base = sycl::group_broadcast(__group, __global_base, 0);
+                __direct_copy_to_output(__values_pack, __ranks, __sg_id, __tile_id, __global_base);
             }
             else
             {

--- a/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
@@ -424,6 +424,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
         // Detect single-bin tiles: if all elements land in one bin, we can skip SLM reorder.
         bool __my_bin_is_full = (__item_bin_count == __data_per_work_group);
         bool __is_single_bin = sycl::any_of_group(__group, __my_bin_is_full);
+        sycl::group_barrier(__group);
 
         // 1.4. Finalize the partial scans from step 1.3 by connecting the independent sub-group segments
         // together, propagating prefixes across the "__bin_process_width"-sized segments and converting

--- a/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
@@ -377,7 +377,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
         sycl::group_barrier(__idx.get_group());
     }
 
-    inline void
+    inline bool
     __rank_global(const sycl::nd_item<1>& __idx, sycl::sub_group __sub_group, std::uint32_t __tile_id,
                   std::uint32_t __sub_group_id, std::uint32_t __sub_group_local_id, _LocOffsetT* __slm_subgroup_hists,
                   _LocOffsetT* __slm_group_hist, _GlobOffsetT* __slm_global_incoming) const
@@ -419,7 +419,13 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
             __inter_bin_scan_bin_width_totals<__bin_process_width>(__sub_group, __sub_group_id, __sub_group_local_id,
                                                                    __item_grf_hist_summary_arr, __slm_group_hist);
         }
-        sycl::group_barrier(__group);
+
+        // Detect single-bin tiles: if all elements land in one bin, we can skip SLM reorder.
+        // any_of_group provides the same synchronization as group_barrier (SYCL 2020 spec 4.17.3).
+        constexpr _LocOffsetT __total_tile_elements = __work_group_size * __data_per_work_item;
+        bool __my_bin_is_full =
+            (__sub_group_id < __bin_summary_sub_group_size) && (__item_bin_count == __total_tile_elements);
+        bool __is_single_bin = sycl::any_of_group(__group, __my_bin_is_full);
 
         // 1.4. Finalize the partial scans from step 1.3 by connecting the independent sub-group segments
         // together, propagating prefixes across the "__bin_process_width"-sized segments and converting
@@ -441,6 +447,7 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
         }
 
         sycl::group_barrier(__group);
+        return __is_single_bin;
     }
 
     template <std::uint32_t __bin_process_width>
@@ -681,6 +688,54 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
         }
     }
 
+    template <typename _KVPack>
+    void inline __direct_copy_to_output(const _KVPack& __pack, const _LocOffsetT (&__ranks)[__data_per_work_item],
+                                        std::uint32_t __sub_group_id, std::uint32_t __tile_id,
+                                        _LocOffsetT* __slm_subgroup_hists, _GlobOffsetT* __slm_global_incoming,
+                                        _LocOffsetT __single_bin_id) const
+    {
+        // Sub-group offset from the inclusive scan of this bin's count up to (sub_group_id - 1)
+        _LocOffsetT __sub_group_offset =
+            (__sub_group_id == 0) ? _LocOffsetT(0)
+                                  : __slm_subgroup_hists[(__sub_group_id - 1) * __bin_count + __single_bin_id];
+
+        _GlobOffsetT __global_base = __slm_global_incoming[__single_bin_id];
+
+        const _GlobOffsetT __tile_start =
+            static_cast<_GlobOffsetT>(__tile_id) * __work_group_size * __data_per_work_item;
+        bool __is_full_tile = (__tile_start + __work_group_size * __data_per_work_item) <= __n;
+
+        if (__is_full_tile)
+        {
+            _ONEDPL_PRAGMA_UNROLL
+            for (std::uint32_t __i = 0; __i < __data_per_work_item; ++__i)
+            {
+                _GlobOffsetT __global_pos = __global_base + __ranks[__i] + __sub_group_offset;
+                __out_pack.__keys_rng()[__global_pos] = __pack.__keys[__i];
+                if constexpr (__has_values)
+                {
+                    __out_pack.__vals_rng()[__global_pos] = __pack.__vals[__i];
+                }
+            }
+        }
+        else
+        {
+            _ONEDPL_PRAGMA_UNROLL
+            for (std::uint32_t __i = 0; __i < __data_per_work_item; ++__i)
+            {
+                _GlobOffsetT __global_pos = __global_base + __ranks[__i] + __sub_group_offset;
+                if (__global_pos < __n)
+                {
+                    __out_pack.__keys_rng()[__global_pos] = __pack.__keys[__i];
+                    if constexpr (__has_values)
+                    {
+                        __out_pack.__vals_rng()[__global_pos] = __pack.__vals[__i];
+                    }
+                }
+            }
+        }
+    }
+
     auto
     get(syclex::properties_tag) const
     {
@@ -724,24 +779,31 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
 
             __rank_local(__idx, __sub_group, __ranks, __bins, __slm_subgroup_hists, __sub_group_slm_offset,
                          __sg_local_id);
-            __rank_global(__idx, __sub_group, __tile_id, __sg_id, __sg_local_id, __slm_subgroup_hists, __slm_group_hist,
-                          __slm_global_incoming);
+            bool __is_single_bin = __rank_global(__idx, __sub_group, __tile_id, __sg_id, __sg_local_id,
+                                                 __slm_subgroup_hists, __slm_group_hist, __slm_global_incoming);
 
-            // For reorder phase, reinterpret the sub-group histogram space as key/value storage
-            // The reorder space overlaps with the sub-group histogram region (reinterpret_cast)
-            _KeyT* __slm_keys = reinterpret_cast<_KeyT*>(__slm_raw);
-            _ValT* __slm_vals = nullptr;
-            if constexpr (__has_values)
+            if (__is_single_bin)
             {
-                __slm_vals =
-                    reinterpret_cast<_ValT*>(__slm_raw + __work_group_size * __data_per_work_item * sizeof(_KeyT));
+                __direct_copy_to_output(__values_pack, __ranks, __sg_id, __tile_id, __slm_subgroup_hists,
+                                        __slm_global_incoming, __bins[0]);
             }
+            else
+            {
+                // Standard SLM reorder path
+                _KeyT* __slm_keys = reinterpret_cast<_KeyT*>(__slm_raw);
+                _ValT* __slm_vals = nullptr;
+                if constexpr (__has_values)
+                {
+                    __slm_vals =
+                        reinterpret_cast<_ValT*>(__slm_raw + __work_group_size * __data_per_work_item * sizeof(_KeyT));
+                }
 
-            __reorder_reg_to_slm(__idx, __values_pack, __ranks, __bins, __sg_id, __slm_subgroup_hists, __slm_group_hist,
-                                 __slm_global_incoming, __slm_keys, __slm_vals);
+                __reorder_reg_to_slm(__idx, __values_pack, __ranks, __bins, __sg_id, __slm_subgroup_hists,
+                                     __slm_group_hist, __slm_global_incoming, __slm_keys, __slm_vals);
 
-            __reorder_slm_to_glob(__idx, __values_pack, __sg_id, __sg_local_id, __slm_global_incoming, __slm_keys,
-                                  __slm_vals);
+                __reorder_slm_to_glob(__idx, __values_pack, __sg_id, __sg_local_id, __slm_global_incoming, __slm_keys,
+                                      __slm_vals);
+            }
 
             sycl::group_barrier(__group);
             // Make sure our atomic updates are pushed to other groups

--- a/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
@@ -693,8 +693,6 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
     {
         const _LocOffsetT __sub_group_offset = __sub_group_id * __data_per_sub_group;
 
-        // Determine fullness per sub-group (mirroring __load) rather than per work-group: only the
-        // boundary sub-group needs the masked store path.
         const _GlobOffsetT __sg_input_offset =
             __data_per_sub_group * (__tile_id * __num_sub_groups_per_work_group + __sub_group_id);
         bool __is_full_block = (__sg_input_offset + __data_per_sub_group) <= __n;
@@ -781,11 +779,11 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
                 _GlobOffsetT __global_base =
                     __idx.get_local_linear_id() == 0 ? __slm_global_incoming[__bins[0]] : _GlobOffsetT(0);
                 __global_base = sycl::group_broadcast(__group, __global_base, 0);
+                // All work-items execute a coalesced store of key / values as all keys map to the same bin.
                 __direct_copy_to_output(__values_pack, __ranks, __sg_id, __tile_id, __global_base);
             }
             else
             {
-                // Standard SLM reorder path
                 _KeyT* __slm_keys = reinterpret_cast<_KeyT*>(__slm_raw);
                 _ValT* __slm_vals = nullptr;
                 if constexpr (__has_values)

--- a/test/kt/radix_sort.cpp
+++ b/test/kt/radix_sort.cpp
@@ -192,8 +192,8 @@ test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
 #endif // _ENABLE_RANGES_TESTING
 }
 
-// Test with constrained-range data to exercise single-bin direct copy optimization.
-// Keys in [0, 1000] guarantee that upper radix stages (bits 16+) produce single-bin tiles.
+// Test with constrained-range data to exercise the single-bin direct-copy optimization on the upper
+// radix stages while the lower stages still reorder. See generate_constrained_range_data for details.
 template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void
 test_constrained_range(sycl::queue q, std::size_t size, KernelParam param)
@@ -203,9 +203,7 @@ test_constrained_range(sycl::queue q, std::size_t size, KernelParam param)
               << std::endl;
 #endif
     std::vector<T> expected(size);
-    std::default_random_engine gen{73};
-    std::uniform_int_distribution<std::uint32_t> dist(0, 1000);
-    std::generate(expected.begin(), expected.end(), [&] { return static_cast<T>(dist(gen)); });
+    generate_constrained_range_data(expected.data(), size, 73);
 
     TestUtils::usm_data_transfer<sycl::usm::alloc::device, T> dt_input(q, expected.begin(), expected.end());
     std::stable_sort(expected.begin(), expected.end(), Compare<T, IsAscending>{});
@@ -215,7 +213,7 @@ test_constrained_range(sycl::queue q, std::size_t size, KernelParam param)
     std::vector<T> actual(size);
     dt_input.retrieve_data(actual.begin());
 
-    std::string msg = "wrong results with constrained range [0,1000], n: " + std::to_string(size);
+    std::string msg = "wrong results with constrained range, n: " + std::to_string(size);
     EXPECT_EQ_N(expected.begin(), actual.begin(), size, msg.c_str());
 }
 
@@ -241,16 +239,13 @@ main()
             test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(
                 q, TestUtils::create_new_kernel_param_idx<3>(params));
 
-            // Constrained-range tests to exercise single-bin optimization (only for types >= 32 bits)
-            if constexpr (std::is_integral_v<TEST_KEY_TYPE> && sizeof(TEST_KEY_TYPE) >= 4)
+            // Constrained-range tests to exercise the single-bin direct-copy optimization, for all key types.
+            for (auto size : {std::size_t(1000), std::size_t(67543), std::size_t(100'000)})
             {
-                for (auto size : {std::size_t(1000), std::size_t(67543), std::size_t(100'000)})
-                {
-                    test_constrained_range<TEST_KEY_TYPE, Ascending, TestRadixBits>(
-                        q, size, TestUtils::create_new_kernel_param_idx<4>(params));
-                    test_constrained_range<TEST_KEY_TYPE, Descending, TestRadixBits>(
-                        q, size, TestUtils::create_new_kernel_param_idx<5>(params));
-                }
+                test_constrained_range<TEST_KEY_TYPE, Ascending, TestRadixBits>(
+                    q, size, TestUtils::create_new_kernel_param_idx<4>(params));
+                test_constrained_range<TEST_KEY_TYPE, Descending, TestRadixBits>(
+                    q, size, TestUtils::create_new_kernel_param_idx<5>(params));
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/radix_sort.cpp
+++ b/test/kt/radix_sort.cpp
@@ -192,6 +192,33 @@ test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
 #endif // _ENABLE_RANGES_TESTING
 }
 
+// Test with constrained-range data to exercise single-bin direct copy optimization.
+// Keys in [0, 1000] guarantee that upper radix stages (bits 16+) produce single-bin tiles.
+template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
+void
+test_constrained_range(sycl::queue q, std::size_t size, KernelParam param)
+{
+#if LOG_TEST_INFO
+    std::cout << "\t\ttest_constrained_range<" << TypeInfo().name<T>() << ", " << IsAscending << ">(" << size << ");"
+              << std::endl;
+#endif
+    std::vector<T> expected(size);
+    std::default_random_engine gen{73};
+    std::uniform_int_distribution<std::uint32_t> dist(0, 1000);
+    std::generate(expected.begin(), expected.end(), [&] { return static_cast<T>(dist(gen)); });
+
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, T> dt_input(q, expected.begin(), expected.end());
+    std::stable_sort(expected.begin(), expected.end(), Compare<T, IsAscending>{});
+
+    kt_ns::radix_sort<IsAscending, RadixBits>(q, dt_input.get_data(), dt_input.get_data() + size, param).wait();
+
+    std::vector<T> actual(size);
+    dt_input.retrieve_data(actual.begin());
+
+    std::string msg = "wrong results with constrained range [0,1000], n: " + std::to_string(size);
+    EXPECT_EQ_N(expected.begin(), actual.begin(), size, msg.c_str());
+}
+
 int
 main()
 {
@@ -213,6 +240,18 @@ main()
             }
             test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(
                 q, TestUtils::create_new_kernel_param_idx<3>(params));
+
+            // Constrained-range tests to exercise single-bin optimization (only for types >= 32 bits)
+            if constexpr (std::is_integral_v<TEST_KEY_TYPE> && sizeof(TEST_KEY_TYPE) >= 4)
+            {
+                for (auto size : {std::size_t(1000), std::size_t(67543), std::size_t(100'000)})
+                {
+                    test_constrained_range<TEST_KEY_TYPE, Ascending, TestRadixBits>(
+                        q, size, TestUtils::create_new_kernel_param_idx<4>(params));
+                    test_constrained_range<TEST_KEY_TYPE, Descending, TestRadixBits>(
+                        q, size, TestUtils::create_new_kernel_param_idx<5>(params));
+                }
+            }
         }
         catch (const ::std::exception& exc)
         {

--- a/test/kt/radix_sort_by_key.cpp
+++ b/test/kt/radix_sort_by_key.cpp
@@ -121,16 +121,15 @@ test_negative_zero_stability(sycl::queue q, std::size_t size, KernelParam param)
     EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, msg.c_str());
 }
 
-// Test with constrained-range keys to exercise single-bin direct copy optimization.
+// Test with constrained-range keys to exercise the single-bin direct-copy optimization on the upper
+// radix stages while the lower stages still reorder. See generate_constrained_range_data for details.
 template <typename KeyT, typename ValueT, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void
 test_constrained_range_by_key(sycl::queue q, std::size_t size, KernelParam param)
 {
     std::vector<KeyT> expected_keys(size);
     std::vector<ValueT> expected_values(size);
-    std::default_random_engine gen{73};
-    std::uniform_int_distribution<std::uint32_t> dist(0, 1000);
-    std::generate(expected_keys.begin(), expected_keys.end(), [&] { return static_cast<KeyT>(dist(gen)); });
+    generate_constrained_range_data(expected_keys.data(), size, 73);
     TestUtils::generate_arithmetic_data(expected_values.data(), size, 7);
 
     TestUtils::usm_data_transfer<sycl::usm::alloc::device, KeyT> keys(q, expected_keys.begin(), expected_keys.end());
@@ -149,7 +148,7 @@ test_constrained_range_by_key(sycl::queue q, std::size_t size, KernelParam param
     keys.retrieve_data(actual_keys.begin());
     values.retrieve_data(actual_values.begin());
 
-    std::string msg = "wrong results with constrained range [0,1000] by key, n: " + std::to_string(size);
+    std::string msg = "wrong results with constrained range by key, n: " + std::to_string(size);
     EXPECT_EQ_N(expected_keys.begin(), actual_keys.begin(), size, (msg + " (keys)").c_str());
     EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, (msg + " (values)").c_str());
 }
@@ -187,16 +186,13 @@ int main()
                     q, 10000, TestUtils::create_new_kernel_param_idx<6>(params));
             }
 
-            // Constrained-range tests to exercise single-bin optimization (only for key types >= 32 bits)
-            if constexpr (std::is_integral_v<TEST_KEY_TYPE> && sizeof(TEST_KEY_TYPE) >= 4)
+            // Constrained-range tests to exercise the single-bin direct-copy optimization, for all key types.
+            for (auto size : {std::size_t(1000), std::size_t(67543), std::size_t(100'000)})
             {
-                for (auto size : {std::size_t(1000), std::size_t(67543), std::size_t(100'000)})
-                {
-                    test_constrained_range_by_key<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
-                        q, size, TestUtils::create_new_kernel_param_idx<4>(params));
-                    test_constrained_range_by_key<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
-                        q, size, TestUtils::create_new_kernel_param_idx<5>(params));
-                }
+                test_constrained_range_by_key<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
+                    q, size, TestUtils::create_new_kernel_param_idx<7>(params));
+                test_constrained_range_by_key<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
+                    q, size, TestUtils::create_new_kernel_param_idx<8>(params));
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/radix_sort_by_key.cpp
+++ b/test/kt/radix_sort_by_key.cpp
@@ -121,6 +121,39 @@ test_negative_zero_stability(sycl::queue q, std::size_t size, KernelParam param)
     EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, msg.c_str());
 }
 
+// Test with constrained-range keys to exercise single-bin direct copy optimization.
+template <typename KeyT, typename ValueT, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
+void
+test_constrained_range_by_key(sycl::queue q, std::size_t size, KernelParam param)
+{
+    std::vector<KeyT> expected_keys(size);
+    std::vector<ValueT> expected_values(size);
+    std::default_random_engine gen{73};
+    std::uniform_int_distribution<std::uint32_t> dist(0, 1000);
+    std::generate(expected_keys.begin(), expected_keys.end(), [&] { return static_cast<KeyT>(dist(gen)); });
+    TestUtils::generate_arithmetic_data(expected_values.data(), size, 7);
+
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, KeyT> keys(q, expected_keys.begin(), expected_keys.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, ValueT> values(q, expected_values.begin(),
+                                                                          expected_values.end());
+
+    auto expected_first = oneapi::dpl::make_zip_iterator(std::begin(expected_keys), std::begin(expected_values));
+    std::stable_sort(expected_first, expected_first + size, CompareKey<IsAscending>{});
+
+    kt_ns::radix_sort_by_key<IsAscending, RadixBits>(q, keys.get_data(), keys.get_data() + size, values.get_data(),
+                                                     param)
+        .wait();
+
+    std::vector<KeyT> actual_keys(size);
+    std::vector<ValueT> actual_values(size);
+    keys.retrieve_data(actual_keys.begin());
+    values.retrieve_data(actual_values.begin());
+
+    std::string msg = "wrong results with constrained range [0,1000] by key, n: " + std::to_string(size);
+    EXPECT_EQ_N(expected_keys.begin(), actual_keys.begin(), size, (msg + " (keys)").c_str());
+    EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, (msg + " (values)").c_str());
+}
+
 int main()
 {
     bool run_test = false;
@@ -152,6 +185,18 @@ int main()
                     q, 64, TestUtils::create_new_kernel_param_idx<5>(params));
                 test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
                     q, 10000, TestUtils::create_new_kernel_param_idx<6>(params));
+            }
+
+            // Constrained-range tests to exercise single-bin optimization (only for key types >= 32 bits)
+            if constexpr (std::is_integral_v<TEST_KEY_TYPE> && sizeof(TEST_KEY_TYPE) >= 4)
+            {
+                for (auto size : {std::size_t(1000), std::size_t(67543), std::size_t(100'000)})
+                {
+                    test_constrained_range_by_key<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
+                        q, size, TestUtils::create_new_kernel_param_idx<4>(params));
+                    test_constrained_range_by_key<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
+                        q, size, TestUtils::create_new_kernel_param_idx<5>(params));
+                }
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/radix_sort_by_key_out_of_place.cpp
@@ -165,6 +165,41 @@ test_negative_zero_stability(sycl::queue q, std::size_t size, KernelParam param)
     EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, msg.c_str());
 }
 
+// Test with constrained-range keys to exercise the single-bin direct-copy optimization on the upper
+// radix stages while the lower stages still reorder. See generate_constrained_range_data for details.
+template <typename KeyT, typename ValueT, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
+void
+test_constrained_range_by_key(sycl::queue q, std::size_t size, KernelParam param)
+{
+    std::vector<KeyT> input_keys(size);
+    std::vector<ValueT> input_values(size);
+    generate_constrained_range_data(input_keys.data(), size, 73);
+    TestUtils::generate_arithmetic_data(input_values.data(), size, 7);
+
+    std::vector<KeyT> expected_keys(input_keys);
+    std::vector<ValueT> expected_values(input_values);
+    auto expected_first = oneapi::dpl::make_zip_iterator(std::begin(expected_keys), std::begin(expected_values));
+    std::stable_sort(expected_first, expected_first + size, CompareKey<IsAscending>{});
+
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, KeyT> keys(q, input_keys.begin(), input_keys.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, ValueT> values(q, input_values.begin(), input_values.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, KeyT> keys_out(q, size);
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, ValueT> values_out(q, size);
+
+    kt_ns::radix_sort_by_key<IsAscending, RadixBits>(q, keys.get_data(), keys.get_data() + size, values.get_data(),
+                                                     keys_out.get_data(), values_out.get_data(), param)
+        .wait();
+
+    std::vector<KeyT> actual_keys(size);
+    std::vector<ValueT> actual_values(size);
+    keys_out.retrieve_data(actual_keys.begin());
+    values_out.retrieve_data(actual_values.begin());
+
+    std::string msg = "wrong results with constrained range by key (out-of-place), n: " + std::to_string(size);
+    EXPECT_EQ_N(expected_keys.begin(), actual_keys.begin(), size, (msg + " (keys)").c_str());
+    EXPECT_EQ_N(expected_values.begin(), actual_values.begin(), size, (msg + " (values)").c_str());
+}
+
 int
 main()
 {
@@ -197,6 +232,15 @@ main()
                     q, 64, TestUtils::create_new_kernel_param_idx<5>(params));
                 test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
                     q, 10000, TestUtils::create_new_kernel_param_idx<6>(params));
+            }
+
+            // Constrained-range tests to exercise the single-bin direct-copy optimization, for all key types.
+            for (auto size : {std::size_t(1000), std::size_t(67543), std::size_t(100'000)})
+            {
+                test_constrained_range_by_key<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
+                    q, size, TestUtils::create_new_kernel_param_idx<7>(params));
+                test_constrained_range_by_key<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
+                    q, size, TestUtils::create_new_kernel_param_idx<8>(params));
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/radix_sort_out_of_place.cpp
+++ b/test/kt/radix_sort_out_of_place.cpp
@@ -205,6 +205,40 @@ test_small_sizes(sycl::queue q, KernelParam param)
     EXPECT_EQ_RANGES(output_ref, output, "output data modified when size == 0");
 }
 
+// Test with constrained-range data to exercise the single-bin direct-copy optimization on the upper
+// radix stages while the lower stages still reorder. See generate_constrained_range_data for details.
+template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
+void
+test_constrained_range(sycl::queue q, std::size_t size, KernelParam param)
+{
+#if LOG_TEST_INFO
+    std::cout << "\t\ttest_constrained_range<" << TypeInfo().name<T>() << ", " << IsAscending << ">(" << size << ");"
+              << std::endl;
+#endif
+    std::vector<T> input(size);
+    generate_constrained_range_data(input.data(), size, 73);
+    std::vector<T> input_ref(input);
+    std::vector<T> output_ref(input);
+    std::vector<T> output(size, T{9});
+    std::stable_sort(output_ref.begin(), output_ref.end(), Compare<T, IsAscending>{});
+
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, T> dt_input(q, input.begin(), input.end());
+    TestUtils::usm_data_transfer<sycl::usm::alloc::device, T> dt_output(q, output.begin(), output.end());
+
+    kt_ns::radix_sort<IsAscending, RadixBits>(q, dt_input.get_data(), dt_input.get_data() + size, dt_output.get_data(),
+                                              param)
+        .wait();
+
+    std::vector<T> input_actual(size);
+    std::vector<T> output_actual(size);
+    dt_input.retrieve_data(input_actual.begin());
+    dt_output.retrieve_data(output_actual.begin());
+
+    std::string msg = "constrained range, n: " + std::to_string(size);
+    EXPECT_EQ_N(input_ref.begin(), input_actual.begin(), size, ("input modified, " + msg).c_str());
+    EXPECT_EQ_N(output_ref.begin(), output_actual.begin(), size, ("wrong results, " + msg).c_str());
+}
+
 template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void
 test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
@@ -239,6 +273,15 @@ main()
                     q, size, TestUtils::create_new_kernel_param_idx<1>(params));
             }
             test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::create_new_kernel_param_idx<3>(params));
+
+            // Constrained-range tests to exercise the single-bin direct-copy optimization, for all key types.
+            for (auto size : {std::size_t(1000), std::size_t(67543), std::size_t(100'000)})
+            {
+                test_constrained_range<TEST_KEY_TYPE, Ascending, TestRadixBits>(
+                    q, size, TestUtils::create_new_kernel_param_idx<4>(params));
+                test_constrained_range<TEST_KEY_TYPE, Descending, TestRadixBits>(
+                    q, size, TestUtils::create_new_kernel_param_idx<5>(params));
+            }
         }
         catch (const ::std::exception& exc)
         {

--- a/test/kt/radix_sort_utils.h
+++ b/test/kt/radix_sort_utils.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <vector>
 #include <type_traits>
+#include <algorithm>
 
 #if __has_include(<sycl/sycl.hpp>)
 #    include <sycl/sycl.hpp>
@@ -132,6 +133,54 @@ struct CompareKey<false>
 constexpr bool Ascending = true;
 constexpr bool Descending = false;
 constexpr std::uint8_t TestRadixBits = 8;
+
+// Fill `data` with distinct values from a narrow range so that the upper radix stages observe a single
+// bin and exercise the single-bin direct-copy optimization, while the lower stages still reorder (forcing
+// the optimization to scatter distinct keys to distinct output positions). Integral types use [0, 1000].
+//
+// Floating-point types use [1.0, 1.2). The IEEE-754 layout is [sign | exponent | mantissa]:
+//   - sign     = 0           (all values positive)
+//   - exponent = bias        (encodes 2^0, since 1.0 <= x < 2.0)
+//   - mantissa: 1.0 <= x < 1.2 means the fraction is in [0, 0.2), so the top two mantissa bits are 00
+//               and only the lower mantissa bits vary.
+// This fixes the sign, the entire exponent, and the top two mantissa bits, so the most-significant byte is
+// constant across all three IEEE formats:
+//   - float64: 1 sign + 11 exp bits -> MSB holds sign + 7 exp bits (all fixed); next byte holds 4 exp + top
+//              4 mantissa bits (top 2 fixed as 00). Top stage (top byte) is single-bin.
+//   - float32: 1 sign + 8 exp bits  -> MSB holds sign + 7 exp bits (all fixed). Top stage is single-bin.
+//   - sycl::half (float16): 1 sign + 5 exp bits + 10 mantissa bits -> MSB holds sign + 5 exp + top 2
+//              mantissa bits (top 2 fixed as 00). Top stage is single-bin.
+// The upper bound is 1.2 rather than 1.25 because values are generated in float and narrowed to T: with
+// sycl::half's 10-bit mantissa, floats just under 1.25 round up to exactly 1.25, whose top two mantissa
+// bits are 01, spilling into a second top-stage bin. 1.2 stays below that rounding cliff for all three types.
+// All generated values are finite (no NaN/inf).
+template <typename T>
+void
+generate_constrained_range_data(T* data, std::size_t size, std::uint32_t seed)
+{
+    std::default_random_engine gen{seed};
+    if constexpr (std::is_integral_v<T>)
+    {
+        // For single byte type, just use a constant value and only vart first stage bits for other
+        // types.
+        std::uniform_int_distribution<std::uint32_t> dist;
+        if constexpr (sizeof(T) == 8)
+        {
+            dist = std::uniform_int_distribution<std::uint32_t>{0, 42};
+        }
+        else
+        {
+            dist = std::uniform_int_distribution<std::uint32_t>{0, 256};
+        }
+        std::generate(data, data + size, [&] { return static_cast<T>(dist(gen)); });
+    }
+    else
+    {
+        // sycl::half is not directly usable with std::uniform_real_distribution; generate in float and cast.
+        std::uniform_real_distribution<float> dist(1.0f, 1.2f);
+        std::generate(data, data + size, [&] { return static_cast<T>(dist(gen)); });
+    }
+}
 
 #if LOG_TEST_INFO
 struct TypeInfo

--- a/test/kt/radix_sort_utils.h
+++ b/test/kt/radix_sort_utils.h
@@ -147,25 +147,25 @@ generate_constrained_range_data(T* data, std::size_t size, std::uint32_t seed)
     std::default_random_engine gen{seed};
     if constexpr (std::is_integral_v<T>)
     {
-        std::uniform_int_distribution<std::uint32_t> dist;
+        std::uniform_int_distribution<T> dist;
         if constexpr (sizeof(T) <= TestRadixBits / 8)
         {
-            dist = std::uniform_int_distribution<std::uint32_t>{42, 42};
+            dist = std::uniform_int_distribution<T>{42, 42};
         }
         else
         {
-            dist = std::uniform_int_distribution<std::uint32_t>{0, (1 << TestRadixBits) - 1};
+            dist = std::uniform_int_distribution<T>{0, (1 << TestRadixBits) - 1};
         }
-        std::generate(data, data + size, [&] { return static_cast<T>(dist(gen)); });
+        std::generate(data, data + size, [&] { return dist(gen); });
     }
     else
     {
         using UIntT = std::conditional_t<sizeof(T) == 2, std::uint16_t,
                                          std::conditional_t<sizeof(T) == 4, std::uint32_t, std::uint64_t>>;
         static_assert(sizeof(UIntT) == sizeof(T));
-        std::uniform_int_distribution<std::uint32_t> dist{0, (1 << TestRadixBits) - 1};
+        std::uniform_int_distribution<UIntT> dist{0, (1 << TestRadixBits) - 1};
         std::generate(data, data + size, [&] {
-            UIntT bits = static_cast<UIntT>(dist(gen));
+            UIntT bits = dist(gen);
             T value;
             std::memcpy(&value, &bits, sizeof(T));
             return value;

--- a/test/kt/radix_sort_utils.h
+++ b/test/kt/radix_sort_utils.h
@@ -147,25 +147,25 @@ generate_constrained_range_data(T* data, std::size_t size, std::uint32_t seed)
     std::default_random_engine gen{seed};
     if constexpr (std::is_integral_v<T>)
     {
-        std::uniform_int_distribution<T> dist;
+        std::uniform_int_distribution<std::uint32_t> dist;
         if constexpr (sizeof(T) <= TestRadixBits / 8)
         {
-            dist = std::uniform_int_distribution<T>{42, 42};
+            dist = std::uniform_int_distribution<std::uint32_t>{42, 42};
         }
         else
         {
-            dist = std::uniform_int_distribution<T>{0, (1 << TestRadixBits) - 1};
+            dist = std::uniform_int_distribution<std::uint32_t>{0, (1 << TestRadixBits) - 1};
         }
-        std::generate(data, data + size, [&] { return dist(gen); });
+        std::generate(data, data + size, [&] { return static_cast<T>(dist(gen)); });
     }
     else
     {
         using UIntT = std::conditional_t<sizeof(T) == 2, std::uint16_t,
                                          std::conditional_t<sizeof(T) == 4, std::uint32_t, std::uint64_t>>;
         static_assert(sizeof(UIntT) == sizeof(T));
-        std::uniform_int_distribution<UIntT> dist{0, (1 << TestRadixBits) - 1};
+        std::uniform_int_distribution<std::uint32_t> dist{0, (1 << TestRadixBits) - 1};
         std::generate(data, data + size, [&] {
-            UIntT bits = dist(gen);
+            UIntT bits = static_cast<UIntT>(dist(gen));
             T value;
             std::memcpy(&value, &bits, sizeof(T));
             return value;

--- a/test/kt/radix_sort_utils.h
+++ b/test/kt/radix_sort_utils.h
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <random>
 #include <cmath>
+#include <cstring>
 #include <limits>
 #include <iostream>
 #include <cstdint>
@@ -134,51 +135,41 @@ constexpr bool Ascending = true;
 constexpr bool Descending = false;
 constexpr std::uint8_t TestRadixBits = 8;
 
-// Fill `data` with distinct values from a narrow range so that the upper radix stages observe a single
-// bin and exercise the single-bin direct-copy optimization, while the lower stages still reorder (forcing
-// the optimization to scatter distinct keys to distinct output positions). Integral types use [0, 1000].
-//
-// Floating-point types use [1.0, 1.2). The IEEE-754 layout is [sign | exponent | mantissa]:
-//   - sign     = 0           (all values positive)
-//   - exponent = bias        (encodes 2^0, since 1.0 <= x < 2.0)
-//   - mantissa: 1.0 <= x < 1.2 means the fraction is in [0, 0.2), so the top two mantissa bits are 00
-//               and only the lower mantissa bits vary.
-// This fixes the sign, the entire exponent, and the top two mantissa bits, so the most-significant byte is
-// constant across all three IEEE formats:
-//   - float64: 1 sign + 11 exp bits -> MSB holds sign + 7 exp bits (all fixed); next byte holds 4 exp + top
-//              4 mantissa bits (top 2 fixed as 00). Top stage (top byte) is single-bin.
-//   - float32: 1 sign + 8 exp bits  -> MSB holds sign + 7 exp bits (all fixed). Top stage is single-bin.
-//   - sycl::half (float16): 1 sign + 5 exp bits + 10 mantissa bits -> MSB holds sign + 5 exp + top 2
-//              mantissa bits (top 2 fixed as 00). Top stage is single-bin.
-// The upper bound is 1.2 rather than 1.25 because values are generated in float and narrowed to T: with
-// sycl::half's 10-bit mantissa, floats just under 1.25 round up to exactly 1.25, whose top two mantissa
-// bits are 01, spilling into a second top-stage bin. 1.2 stays below that rounding cliff for all three types.
-// All generated values are finite (no NaN/inf).
+// Generate data to test optimizations for when a tile's input falls into a single bin.
+// Only generate random data for the first stage and zero out the bits for the upper stages
+// where the optimization is applied. For a single stage radix sort, generate a constant range
+// of a non-zero value.
 template <typename T>
 void
 generate_constrained_range_data(T* data, std::size_t size, std::uint32_t seed)
 {
+    static_assert(std::is_arithmetic_v<T> || std::is_same_v<sycl::half, T>);
     std::default_random_engine gen{seed};
     if constexpr (std::is_integral_v<T>)
     {
-        // For single byte type, just use a constant value and only vart first stage bits for other
-        // types.
         std::uniform_int_distribution<std::uint32_t> dist;
-        if constexpr (sizeof(T) == 8)
+        if constexpr (sizeof(T) <= TestRadixBits / 8)
         {
-            dist = std::uniform_int_distribution<std::uint32_t>{0, 42};
+            dist = std::uniform_int_distribution<std::uint32_t>{42, 42};
         }
         else
         {
-            dist = std::uniform_int_distribution<std::uint32_t>{0, 256};
+            dist = std::uniform_int_distribution<std::uint32_t>{0, (1 << TestRadixBits) - 1};
         }
         std::generate(data, data + size, [&] { return static_cast<T>(dist(gen)); });
     }
     else
     {
-        // sycl::half is not directly usable with std::uniform_real_distribution; generate in float and cast.
-        std::uniform_real_distribution<float> dist(1.0f, 1.2f);
-        std::generate(data, data + size, [&] { return static_cast<T>(dist(gen)); });
+        using UIntT = std::conditional_t<sizeof(T) == 2, std::uint16_t,
+                                         std::conditional_t<sizeof(T) == 4, std::uint32_t, std::uint64_t>>;
+        static_assert(sizeof(UIntT) == sizeof(T));
+        std::uniform_int_distribution<std::uint32_t> dist{0, (1 << TestRadixBits) - 1};
+        std::generate(data, data + size, [&] {
+            UIntT bits = static_cast<UIntT>(dist(gen));
+            T value;
+            std::memcpy(&value, &bits, sizeof(T));
+            return value;
+        });
     }
 }
 


### PR DESCRIPTION
In the SYCL radix sort KT, keys are reordered into SLM before being scattered into memory. In the case where all keys 
collapse to the same bin in a work-group, each work-group is able to copy its already loaded keys and values into global memory in sequential order.

When scanning over keys prior to lookback, we can detect this case and entirely skip SLM reorder after the lookback.