### PR TITLE
Fix warning: `comparison of integer expressions of different signedness`

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -785,7 +785,7 @@ __find_subrange(_RandomAccessIterator __first, _RandomAccessIterator __last, _Ra
         __first = __internal::__brick_find_if(__first, __last, __unary_pred, __is_vector);
 
         // check that all of elements in [first+1, first+count) equal to value
-        if (__first != __last && (__global_last - __first >= __count) &&
+        if (__first != __last && oneapi::dpl::__internal::__cmp_less_equal(__count, __global_last - __first) &&
             !__internal::__brick_any_of(__first + 1, __first + __count,
                                         __not_pred<decltype(__unary_pred)&>(__unary_pred), __is_vector))
         {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -38,6 +38,7 @@
 #include "iterator_impl.h"
 #include "functional_impl.h"      // for oneapi::dpl::identity, std::invoke
 #include "set_algorithms_utils.h" // for __set_iterator_mask and etc.
+#include "utils.h"
 
 #if _ONEDPL_HETERO_BACKEND
 #    include "hetero/algorithm_impl_hetero.h" // for __pattern_fill_n, __pattern_generate_n

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -773,7 +773,7 @@ __find_subrange(_RandomAccessIterator __first, _RandomAccessIterator __last, _Ra
         return __first; // According to the standard std::search_n shall return first when count < 1
     }
 
-    if (static_cast<_Size>(__global_last - __first) < __count)
+    if (oneapi::dpl::__internal::__cmp_less(__global_last - __first, __count))
     {
         return __last;
     }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -780,7 +780,7 @@ __find_subrange(_RandomAccessIterator __first, _RandomAccessIterator __last, _Ra
 
     auto __unary_pred =
         [__pred, &__value](auto&& __val) mutable { return __pred(std::forward<decltype(__val)>(__val), __value); };
-    while (__first != __last && (static_cast<_Size>(__global_last - __first) >= __count))
+    while (__first != __last && oneapi::dpl::__internal::__cmp_less_equal(__count, __global_last - __first))
     {
         __first = __internal::__brick_find_if(__first, __last, __unary_pred, __is_vector);
 

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -110,7 +110,7 @@ void
 __parallel_strict_scan(oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,
                        _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
 {
-    if (__n <= __default_chunk_size)
+    if (oneapi::dpl::__internal::__cmp_less_equal(__n, __default_chunk_size))
     {
         _Tp __sum = __initial;
         if (__n)

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -17,6 +17,7 @@
 #define _ONEDPL_INTERNAL_OMP_PARALLEL_SCAN_H
 
 #include "parallel_invoke.h"
+#include "../utils.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -762,7 +762,7 @@ class __merge_func
         Iterator2
         operator()(Iterator1 __first1, Iterator1 __last1, Iterator2 __first2)
         {
-            if (__last1 - __first1 < __merge_cut_off)
+            if (oneapi::dpl::__internal::__cmp_less(__last1 - __first1, __merge_cut_off))
                 return ::std::move(__first1, __last1, __first2);
 
             auto __n = __last1 - __first1;
@@ -781,7 +781,7 @@ class __merge_func
         Iterator2
         operator()(Iterator1 __first1, Iterator1 __last1, Iterator2 __first2)
         {
-            if (__last1 - __first1 < __merge_cut_off)
+            if (oneapi::dpl::__internal::__cmp_less(__last1 - __first1, __merge_cut_off))
             {
                 for (; __first1 != __last1; ++__first1, (void)++__first2)
                     __move_value_construct()(__first1, __first2);
@@ -804,7 +804,7 @@ class __merge_func
         void
         operator()(Iterator __first, Iterator __last)
         {
-            if (__last - __first < __merge_cut_off)
+            if (oneapi::dpl::__internal::__cmp_less(__last - __first, __merge_cut_off))
                 _Cleanup()(__first, __last);
             else
             {
@@ -923,7 +923,7 @@ class __merge_func
         const auto __n = __nx + __ny;
 
         // need to merge {x} and {y}
-        if (__n > __merge_cut_off)
+        if (oneapi::dpl::__internal::__cmp_less(__n, __merge_cut_off))
             return split_merging(__self);
 
         //merge to buffer

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -923,7 +923,7 @@ class __merge_func
         const auto __n = __nx + __ny;
 
         // need to merge {x} and {y}
-        if (oneapi::dpl::__internal::__cmp_less(__n, __merge_cut_off))
+        if (oneapi::dpl::__internal::__cmp_less(__merge_cut_off, __n))
             return split_merging(__self);
 
         //merge to buffer

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1259,6 +1259,7 @@ __parallel_merge(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&,
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _SizeType = typename std::common_type_t<_DifferenceType1, _DifferenceType2>;
     const _SizeType __n = (__xe - __xs) + (__ye - __ys);
+    assert(__n > 0);
     if (oneapi::dpl::__internal::__cmp_less_equal(__n, __merge_cut_off))
     {
         // Fall back on serial merge

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1219,7 +1219,7 @@ operator()(__task* __self)
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _SizeType = typename std::common_type_t<_DifferenceType1, _DifferenceType2>;
     const _SizeType __n = (_M_xe - _M_xs) + (_M_ye - _M_ys);
-    if (__n <= __merge_cut_off)
+    if (oneapi::dpl::__internal::__cmp_less_equal(__n, __merge_cut_off))
     {
         _M_leaf_merge(_M_xs, _M_xe, _M_ys, _M_ye, _M_zs, _M_comp);
         return nullptr;

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1259,7 +1259,7 @@ __parallel_merge(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&,
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _SizeType = typename std::common_type_t<_DifferenceType1, _DifferenceType2>;
     const _SizeType __n = (__xe - __xs) + (__ye - __ys);
-    if (__n <= __merge_cut_off)
+    if (oneapi::dpl::__internal::__cmp_less_equal(__n, __merge_cut_off))
     {
         // Fall back on serial merge
         __leaf_merge(__xs, __xe, __ys, __ye, __zs, __comp);

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1259,7 +1259,6 @@ __parallel_merge(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&,
     using _DifferenceType2 = typename std::iterator_traits<_RandomAccessIterator2>::difference_type;
     using _SizeType = typename std::common_type_t<_DifferenceType1, _DifferenceType2>;
     const _SizeType __n = (__xe - __xs) + (__ye - __ys);
-    assert(__n > 0);
     if (oneapi::dpl::__internal::__cmp_less_equal(__n, __merge_cut_off))
     {
         // Fall back on serial merge

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -669,28 +669,28 @@ __dpl_signbit(const _T& __x)
 }
 
 // This prevents warning about comparison of integer expressions of different signedness
-template <typename T, typename U>
-constexpr std::enable_if_t<std::is_integral_v<T> && std::is_integral_v<U>, bool>
-__cmp_less(T __t, U __u)
+template <typename _T, typename _U>
+constexpr std::enable_if_t<std::is_integral_v<_T> && std::is_integral_v<_U>, bool>
+__cmp_less(_T __t, _U __u)
 {
-    if constexpr (std::is_signed_v<T> == std::is_signed_v<U>)
+    if constexpr (std::is_signed_v<_T> == std::is_signed_v<_U>)
         return __t < __u;
-    else if constexpr (std::is_signed_v<T>)
-        return __t < 0 || static_cast<std::make_unsigned_t<T>>(__t) < __u;
+    else if constexpr (std::is_signed_v<_T>)
+        return __t < 0 || static_cast<std::make_unsigned_t<_T>>(__t) < __u;
     else
-        return __u >= 0 && __t < static_cast<std::make_unsigned_t<U>>(__u);
+        return __u >= 0 && __t < static_cast<std::make_unsigned_t<_U>>(__u);
 }
 
-template <typename T, typename U>
-constexpr std::enable_if_t<std::is_integral_v<T> && std::is_integral_v<U>, bool>
-__cmp_less_equal(T __t, U __u)
+template <typename _T, typename _U>
+constexpr std::enable_if_t<std::is_integral_v<_T> && std::is_integral_v<_U>, bool>
+__cmp_less_equal(_T __t, _U __u)
 {
-    if constexpr (std::is_signed_v<T> == std::is_signed_v<U>)
+    if constexpr (std::is_signed_v<_T> == std::is_signed_v<_U>)
         return __t <= __u;
-    else if constexpr (std::is_signed_v<T>)
-        return __t < 0 || static_cast<std::make_unsigned_t<T>>(__t) <= __u;
+    else if constexpr (std::is_signed_v<_T>)
+        return __t < 0 || static_cast<std::make_unsigned_t<_T>>(__t) <= __u;
     else
-        return __u >= 0 && __t <= static_cast<std::make_unsigned_t<U>>(__u);
+        return __u >= 0 && __t <= static_cast<std::make_unsigned_t<_U>>(__u);
 }
 
 template <typename _Size, typename _Comparator>

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -668,6 +668,19 @@ __dpl_signbit(const _T& __x)
     return (__x & __mask) != 0;
 }
 
+// This prevents warning about comparison of integer expressions of different signedness
+template <typename T, typename U>
+constexpr std::enable_if_t<std::is_integral_v<T> && std::is_integral_v<U>, bool>
+__cmp_less(T __t, U __u)
+{
+    if constexpr (std::is_signed_v<T> == std::is_signed_v<U>)
+        return __t < __u;
+    else if constexpr (std::is_signed_v<T>)
+        return __t < 0 || static_cast<std::make_unsigned_t<T>>(__t) < __u;
+    else
+        return __u >= 0 && __t < static_cast<std::make_unsigned_t<U>>(__u);
+}
+
 template <typename _Size, typename _Comparator>
 _Size
 __pstl_lower_bound_impl(_Size __first, _Size __last, _Comparator&& __comp)

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -681,6 +681,18 @@ __cmp_less(T __t, U __u)
         return __u >= 0 && __t < static_cast<std::make_unsigned_t<U>>(__u);
 }
 
+template <typename T, typename U>
+constexpr std::enable_if_t<std::is_integral_v<T> && std::is_integral_v<U>, bool>
+__cmp_less_equal(T __t, U __u)
+{
+    if constexpr (std::is_signed_v<T> == std::is_signed_v<U>)
+        return __t <= __u;
+    else if constexpr (std::is_signed_v<T>)
+        return __t < 0 || static_cast<std::make_unsigned_t<T>>(__t) <= __u;
+    else
+        return __u >= 0 && __t <= static_cast<std::make_unsigned_t<U>>(__u);
+}
+
 template <typename _Size, typename _Comparator>
 _Size
 __pstl_lower_bound_impl(_Size __first, _Size __last, _Comparator&& __comp)


### PR DESCRIPTION
/oneDPL/include/oneapi/dpl/pstl/./omp/parallel_scan.h:113:13: warning: comparison of integer expressions of different signedness: ‘long int’ and ‘const std::size_t’ {aka ‘const long unsigned int’} [-Wsign-compare]

This warning has been detected at https://github.com/uxlfoundation/oneDPL/actions/runs/28441982213?pr=2736

## Description
Several internal call sites compared integer expressions of different signedness by force-casting one operand (e.g. `static_cast<_Size>(__last - __first))`. Besides triggering `-Wsign-compare` warnings, this pattern is unsafe: when a signed difference is negative, casting it to an unsigned type produces a large positive value and yields an incorrect comparison result.
This PR introduces `C++17`-compatible helpers that replicate the semantics of `C++20`'s `std::cmp_less` / `std::cmp_less_equal`, and uses them at the affected call sites. This removes the warnings and fixes the latent incorrect-comparison behavior for negative signed values.

## Changes
include/oneapi/dpl/pstl/utils.h — add two helpers in oneapi::dpl::__internal:
•	`__cmp_less(T, U)`
•	`__cmp_less_equal(T, U)`
Both are `constexpr`, constrained to integral types via `std::enable_if_t`, and perform sign-aware comparisons without any narrowing/lossy casts.
Replace unsafe casted comparisons with the new helpers:
•	pstl/algorithm_impl.h (`__find_subrange`): two comparisons of `__global_last - __first` against `__count`.
•	pstl/omp/parallel_scan.h (`__parallel_strict_scan`): `__n` vs `__default_chunk_size`.
•	pstl/parallel_backend_tbb.h (`__parallel_merge`): `__n` vs `__merge_cut_off`.

## Notes
•	`C++17` baseline is preserved; no `C++20` library features (`std::cmp_*`) are required.
•	All replacements are semantically equivalent to the original intended comparisons (with argument order adjusted where needed, e.g. `count <= size` for the `>=` case).
•	Behavior of serial/parallel/device code paths is unchanged aside from correcting the negative-value edge case.

## Testing
•	Existing tests continue to pass.