### PR TITLE
Add support of `oneapi::dpl::ranges::nth_element` algorithm

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1522,6 +1522,35 @@ __pattern_mismatch(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// __pattern_nth_element
+//---------------------------------------------------------------------------------------------------------------------
+
+template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
+std::ranges::borrowed_iterator_t<_R>
+__pattern_nth_element(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __nth, _Comp __comp,
+                      _Proj __proj)
+{
+    static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
+
+    auto __beg = std::ranges::begin(__r);
+    auto __end = __beg + std::ranges::size(__r);
+
+    oneapi::dpl::__internal::__pattern_nth_element(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __beg, __nth, __end,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
+
+    return __end;
+}
+
+template <typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
+std::ranges::borrowed_iterator_t<_R>
+__pattern_nth_element(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&&, _R&& __r,
+                      std::ranges::iterator_t<_R> __nth, _Comp __comp, _Proj __proj)
+{
+    return std::ranges::nth_element(std::forward<_R>(__r), __nth, __comp, __proj);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // __pattern_remove_if
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1532,9 +1532,7 @@ __pattern_nth_element(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, std::rang
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
-    auto __beg = std::ranges::begin(__r);
-    auto __end = __beg + std::ranges::size(__r);
-
+    auto [__beg, __end] = oneapi::dpl::__ranges::__bounds(__r);
     oneapi::dpl::__internal::__pattern_nth_element(
         __tag, std::forward<_ExecutionPolicy>(__exec), __beg, __nth, __end,
         oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -52,6 +52,7 @@ struct __equal_fn;
 struct __lex_compare_fn;
 struct __is_sorted_fn;
 struct __is_sorted_until_fn;
+struct __nth_element_fn;
 struct __stable_sort_leaf;
 struct __stable_sort_fn;
 struct __sort_leaf;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1419,6 +1419,26 @@ struct __internal::__unique_copy_fn
 }; //__unique_copy_fn
 inline constexpr __internal::__unique_copy_fn unique_copy;
 
+// [alg.nth.element]
+
+struct __internal::__nth_element_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
+                _Comp = std::ranges::less>
+    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
+             && std::ranges::sized_range<_R>
+    std::ranges::borrowed_iterator_t<_R>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __nth, _Comp __comp = {},
+               _Proj __proj = {}) const
+    {
+        const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        return oneapi::dpl::__internal::__ranges::__pattern_nth_element(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __nth, __comp, __proj);
+    }
+}; //__nth_element_fn
+inline constexpr __internal::__nth_element_fn nth_element;
+
 } //ranges
 
 #endif //_ONEDPL_CPP20_RANGES_PRESENT

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1428,6 +1428,7 @@ struct __internal::__nth_element_fn
                 _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
+
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __nth, _Comp __comp = {},
                _Proj __proj = {}) const

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1426,8 +1426,8 @@ struct __internal::__nth_element_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
                 _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __nth, _Comp __comp = {},
                _Proj __proj = {}) const

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1423,9 +1423,8 @@ inline constexpr __internal::__unique_copy_fn unique_copy;
 
 struct __internal::__nth_element_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
-                _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,
+              typename _Proj = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -733,6 +733,31 @@ __pattern_copy_if_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
 #endif //_ONEDPL_CPP20_RANGES_PRESENT
 
 //------------------------------------------------------------------------
+// __pattern_nth_element
+//------------------------------------------------------------------------
+
+#if _ONEDPL_CPP20_RANGES_PRESENT
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Comp, typename _Proj>
+std::ranges::borrowed_iterator_t<_Range>
+__pattern_nth_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Range&& __r,
+                      std::ranges::iterator_t<_Range> __nth, _Comp __comp, _Proj __proj)
+{
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+
+    if (__first != __last && __nth != __last)
+    {
+        // TODO: check partition-based implementation
+        // - try to avoid host dereference issue
+        // - measure performance of the issue-free implementation
+        __pattern_partial_sort(__tag, std::forward<_ExecutionPolicy>(__exec), __first, __nth + 1, __last,
+                               oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
+    }
+
+    return __last;
+}
+#endif // #if _ONEDPL_CPP20_RANGES_PRESENT
+
+//------------------------------------------------------------------------
 // remove_if
 //------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -744,14 +744,9 @@ __pattern_nth_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 {
     auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
 
-    if (__first != __last && __nth != __last)
-    {
-        // TODO: check partition-based implementation
-        // - try to avoid host dereference issue
-        // - measure performance of the issue-free implementation
-        __pattern_partial_sort(__tag, std::forward<_ExecutionPolicy>(__exec), __first, __nth + 1, __last,
-                               oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
-    }
+    oneapi::dpl::__internal::__pattern_nth_element(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __nth, __last,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
 
     return __last;
 }

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -179,6 +179,9 @@ main()
     // Member-function projection (P2::proj): host only (skipped inside device kernels).
     test_nth_element<6, P2>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{}, &P2::proj);
 
+    // External projection proj_apm: exercised on host and device.
+    test_nth_element<7, A_PM>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{}, proj_apm);
+
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -1,0 +1,145 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+#if _ENABLE_STD_RANGES_TESTING
+
+#include <functional>
+#include <vector>
+
+using namespace test_std_ranges;
+namespace dpl_ranges = oneapi::dpl::ranges;
+
+// nth_element does not produce a fully deterministic order: only the element at 'nth' is placed
+// in its final sorted position, and the range is partitioned around it. The parallel and device
+// specializations rearrange the rest of the elements differently from std::ranges::nth_element,
+// so we verify the algorithm post-conditions instead of comparing the whole range element-wise.
+//   1) the projected key at 'nth' is equivalent (under comp) to the reference one produced by
+//      std::ranges::nth_element for the same input;
+//   2) nothing before 'nth' is ordered after it and nothing after 'nth' is ordered before it.
+template <typename Range, typename Reference, typename Comp, typename Proj>
+void
+check_nth_element_effect(Range&& r, const Reference& reference, int n, int nth, Comp comp, Proj proj, const char* msg)
+{
+    if (n == 0 || nth == n) // no element is selected: nothing to check
+        return;
+
+    auto ordered = [&](auto&& a, auto&& b) { return std::invoke(comp, std::invoke(proj, a), std::invoke(proj, b)); };
+
+    EXPECT_TRUE(!ordered(r[nth], reference[nth]) && !ordered(reference[nth], r[nth]),
+                (std::string("wrong nth element value: ") + msg).c_str());
+
+    for (int i = 0; i < nth; ++i)
+        EXPECT_TRUE(!ordered(r[nth], r[i]), (std::string("wrong left partition: ") + msg).c_str());
+    for (int i = nth + 1; i < n; ++i)
+        EXPECT_TRUE(!ordered(r[i], r[nth]), (std::string("wrong right partition: ") + msg).c_str());
+}
+
+// The set of 'nth' positions to exercise for a range of size n, including the end position (no-op).
+std::vector<int>
+nth_positions(int n)
+{
+    std::vector<int> res;
+    for (int p : {0, n / 4, n / 2, 3 * n / 4, n > 0 ? n - 1 : 0, n})
+        if (p >= 0 && p <= n && std::find(res.begin(), res.end(), p) == res.end())
+            res.push_back(p);
+    return res;
+}
+
+template <typename T, typename Checker, typename Comp, typename Proj, typename Gen>
+void
+test_nth_element_host(int n, Checker checker, Comp comp, Proj proj, Gen gen, const char* msg)
+{
+    for (int nth : nth_positions(n))
+    {
+        std::vector<T> reference(n);
+        for (int i = 0; i < n; ++i)
+            reference[i] = gen(i);
+        checker(reference, reference.begin() + nth, comp, proj);
+
+        auto run = [&](auto&& policy)
+        {
+            std::vector<T> data(n);
+            for (int i = 0; i < n; ++i)
+                data[i] = gen(i);
+
+            auto res = dpl_ranges::nth_element(policy, data, data.begin() + nth, comp, proj);
+            EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
+            check_nth_element_effect(data, reference, n, nth, comp, proj, msg);
+        };
+
+        run(oneapi::dpl::execution::seq);
+        run(oneapi::dpl::execution::unseq);
+        run(oneapi::dpl::execution::par);
+        run(oneapi::dpl::execution::par_unseq);
+    }
+}
+
+#if TEST_DPCPP_BACKEND_PRESENT
+template <int CallId, typename T, typename Checker, typename Comp, typename Proj, typename Gen>
+void
+test_nth_element_device(int n, Checker checker, Comp comp, Proj proj, Gen gen, const char* msg)
+{
+    auto policy = TestUtils::get_dpcpp_test_policy();
+    for (int nth : nth_positions(n))
+    {
+        std::vector<T> reference(n);
+        for (int i = 0; i < n; ++i)
+            reference[i] = gen(i);
+        checker(reference, reference.begin() + nth, comp, proj);
+
+        std::vector<T> host(n);
+        for (int i = 0; i < n; ++i)
+            host[i] = gen(i);
+
+        usm_vector<T> usm(policy, host.data(), n);
+        auto& vec = usm();
+
+        auto res =
+            dpl_ranges::nth_element(CLONE_TEST_POLICY_IDX(policy, CallId), vec, vec.begin() + nth, comp, proj);
+        EXPECT_TRUE(res == vec.end(), (std::string("wrong return value: ") + msg).c_str());
+        check_nth_element_effect(vec, reference, n, nth, comp, proj, msg);
+    }
+}
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+#endif // _ENABLE_STD_RANGES_TESTING
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    auto nth_element_checker = TEST_PREPARE_CALLABLE(std::ranges::nth_element);
+
+    auto gen_int = [](int i) { return (i * 7 + 3) % 97 - 48; };
+    auto gen_p2 = [](int i) { return P2((i * 7 + 3) % 97 - 48); };
+
+    for (int n : {0, 1, 2, 3, 7, 20, small_size})
+    {
+        test_nth_element_host<int>(n, nth_element_checker, std::ranges::less{},    std::identity{}, gen_int, "host, less");
+        test_nth_element_host<int>(n, nth_element_checker, std::ranges::greater{}, std::identity{}, gen_int, "host, greater");
+        test_nth_element_host<int>(n, nth_element_checker, std::ranges::less{},    proj,            gen_int, "host, less, proj");
+        test_nth_element_host<P2> (n, nth_element_checker, std::ranges::less{},    &P2::x,           gen_p2, "host, less, &P2::x");
+        test_nth_element_host<P2> (n, nth_element_checker, std::ranges::greater{}, &P2::proj,        gen_p2, "host, greater, &P2::proj");
+    }
+
+#if TEST_DPCPP_BACKEND_PRESENT
+    for (int n : {0, 1, small_size, medium_size})
+    {
+        test_nth_element_device<0, int>(n, nth_element_checker, std::ranges::less{},    std::identity{}, gen_int, "device, less");
+        test_nth_element_device<1, int>(n, nth_element_checker, std::ranges::greater{}, std::identity{}, gen_int, "device, greater");
+        test_nth_element_device<2, int>(n, nth_element_checker, std::ranges::less{},    proj,            gen_int, "device, less, proj");
+    }
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -17,6 +17,17 @@
 using namespace test_std_ranges;
 namespace dpl_ranges = oneapi::dpl::ranges;
 
+// Custom comparator to exercise a user-defined function object in addition to std::ranges::less/greater.
+struct CustomLess
+{
+    template <typename T>
+    bool
+    operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs < rhs;
+    }
+};
+
 // nth_element does not produce a fully deterministic order: only the element at 'nth' is placed
 // in its final sorted position, and the range is partitioned around it. The parallel and device
 // specializations rearrange the rest of the elements differently from std::ranges::nth_element,
@@ -53,62 +64,97 @@ nth_positions(int n)
     return res;
 }
 
-template <typename T, typename Checker, typename Comp, typename Proj, typename Gen>
-void
-test_nth_element_host(int n, Checker checker, Comp comp, Proj proj, Gen gen, const char* msg)
+// Default data generator: values in [-48, 48] with duplicates to exercise partition ties.
+inline auto nth_element_gen = [](int i) { return (i * 7 + 3) % 97 - 48; };
+
+// A single declarative test case, in the spirit of test_range_algo: one instantiation runs the
+// tested algorithm against std::ranges::nth_element for every policy (serial/parallel and, when
+// available, device), across a set of sizes and 'nth' positions, for a fixed comparator/projection.
+template <int CallId, typename T, typename Gen = decltype(nth_element_gen)>
+struct test_nth_element
 {
-    for (int nth : nth_positions(n))
+    template <typename Algo, typename Checker, typename Comp, typename Proj = std::identity>
+    void
+    operator()(Algo algo, Checker checker, Comp comp, Proj proj = {}) const
     {
-        std::vector<T> reference(n);
-        for (int i = 0; i < n; ++i)
-            reference[i] = gen(i);
-        checker(reference, reference.begin() + nth, comp, proj);
-
-        auto run = [&](auto&& policy)
-        {
-            std::vector<T> data(n);
-            for (int i = 0; i < n; ++i)
-                data[i] = gen(i);
-
-            auto res = dpl_ranges::nth_element(policy, data, data.begin() + nth, comp, proj);
-            EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
-            check_nth_element_effect(data, reference, n, nth, comp, proj, msg);
-        };
-
-        run(oneapi::dpl::execution::seq);
-        run(oneapi::dpl::execution::unseq);
-        run(oneapi::dpl::execution::par);
-        run(oneapi::dpl::execution::par_unseq);
-    }
-}
+        for (int n : {0, 1, 2, 3, 7, 20, small_size})
+            host_case(algo, checker, n, comp, proj);
 
 #if TEST_DPCPP_BACKEND_PRESENT
-template <int CallId, typename T, typename Checker, typename Comp, typename Proj, typename Gen>
-void
-test_nth_element_device(int n, Checker checker, Comp comp, Proj proj, Gen gen, const char* msg)
-{
-    auto policy = TestUtils::get_dpcpp_test_policy();
-    for (int nth : nth_positions(n))
-    {
-        std::vector<T> reference(n);
-        for (int i = 0; i < n; ++i)
-            reference[i] = gen(i);
-        checker(reference, reference.begin() + nth, comp, proj);
-
-        std::vector<T> host(n);
-        for (int i = 0; i < n; ++i)
-            host[i] = gen(i);
-
-        usm_vector<T> usm(policy, host.data(), n);
-        auto& vec = usm();
-
-        auto res =
-            dpl_ranges::nth_element(CLONE_TEST_POLICY_IDX(policy, CallId), vec, vec.begin() + nth, comp, proj);
-        EXPECT_TRUE(res == vec.end(), (std::string("wrong return value: ") + msg).c_str());
-        check_nth_element_effect(vec, reference, n, nth, comp, proj, msg);
-    }
-}
+        // Pointer-to-member-function comparators/projections are not supported inside device kernels.
+        if constexpr (!std::disjunction_v<std::is_member_function_pointer<Comp>,
+                                          std::is_member_function_pointer<Proj>>)
+        {
+#if _PSTL_LAMBDA_PTR_TO_MEMBER_WINDOWS_BROKEN
+            if constexpr (!std::disjunction_v<std::is_member_pointer<Comp>, std::is_member_pointer<Proj>>)
+#endif
+            {
+                for (int n : {0, 1, small_size, medium_size})
+                    device_case(algo, checker, n, comp, proj);
+            }
+        }
 #endif // TEST_DPCPP_BACKEND_PRESENT
+    }
+
+  private:
+    static std::vector<T>
+    make_data(int n)
+    {
+        Gen gen{};
+        std::vector<T> data(n);
+        for (int i = 0; i < n; ++i)
+            data[i] = T(gen(i));
+        return data;
+    }
+
+    template <typename Algo, typename Checker, typename Comp, typename Proj>
+    void
+    host_case(Algo algo, Checker checker, int n, Comp comp, Proj proj) const
+    {
+        const std::string msg = "host, nth_element<" + std::to_string(CallId) + ">";
+        for (int nth : nth_positions(n))
+        {
+            std::vector<T> reference = make_data(n);
+            checker(reference, reference.begin() + nth, comp, proj);
+
+            auto run = [&](auto&& policy)
+            {
+                std::vector<T> data = make_data(n);
+                auto res = algo(policy, data, data.begin() + nth, comp, proj);
+                EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
+                check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+            };
+
+            run(oneapi::dpl::execution::seq);
+            run(oneapi::dpl::execution::unseq);
+            run(oneapi::dpl::execution::par);
+            run(oneapi::dpl::execution::par_unseq);
+        }
+    }
+
+#if TEST_DPCPP_BACKEND_PRESENT
+    template <typename Algo, typename Checker, typename Comp, typename Proj>
+    void
+    device_case(Algo algo, Checker checker, int n, Comp comp, Proj proj) const
+    {
+        const std::string msg = "device, nth_element<" + std::to_string(CallId) + ">";
+        auto policy = TestUtils::get_dpcpp_test_policy();
+        for (int nth : nth_positions(n))
+        {
+            std::vector<T> reference = make_data(n);
+            checker(reference, reference.begin() + nth, comp, proj);
+
+            std::vector<T> host = make_data(n);
+            usm_vector<T> usm(policy, host.data(), n);
+            auto& vec = usm();
+
+            auto res = algo(CLONE_TEST_POLICY_IDX(policy, CallId), vec, vec.begin() + nth, comp, proj);
+            EXPECT_TRUE(res == vec.end(), (std::string("wrong return value: ") + msg).c_str());
+            check_nth_element_effect(vec, reference, n, nth, comp, proj, msg.c_str());
+        }
+    }
+#endif // TEST_DPCPP_BACKEND_PRESENT
+};
 
 #endif // _ENABLE_STD_RANGES_TESTING
 
@@ -118,26 +164,20 @@ main()
 #if _ENABLE_STD_RANGES_TESTING
     auto nth_element_checker = TEST_PREPARE_CALLABLE(std::ranges::nth_element);
 
-    auto gen_int = [](int i) { return (i * 7 + 3) % 97 - 48; };
-    auto gen_p2 = [](int i) { return P2((i * 7 + 3) % 97 - 48); };
+    // comp = less/greater/CustomLess, proj = identity: plain integer keys.
+    test_nth_element<0, int>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
+    test_nth_element<1, int>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{});
+    test_nth_element<2, int>{}(dpl_ranges::nth_element, nth_element_checker, CustomLess{});
 
-    for (int n : {0, 1, 2, 3, 7, 20, small_size})
-    {
-        test_nth_element_host<int>(n, nth_element_checker, std::ranges::less{},    std::identity{}, gen_int, "host, less");
-        test_nth_element_host<int>(n, nth_element_checker, std::ranges::greater{}, std::identity{}, gen_int, "host, greater");
-        test_nth_element_host<int>(n, nth_element_checker, std::ranges::less{},    proj,            gen_int, "host, less, proj");
-        test_nth_element_host<P2> (n, nth_element_checker, std::ranges::less{},    &P2::x,           gen_p2, "host, less, &P2::x");
-        test_nth_element_host<P2> (n, nth_element_checker, std::ranges::greater{}, &P2::proj,        gen_p2, "host, greater, &P2::proj");
-    }
+    // Projection applied to integer keys.
+    test_nth_element<3, int>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{}, proj);
 
-#if TEST_DPCPP_BACKEND_PRESENT
-    for (int n : {0, 1, small_size, medium_size})
-    {
-        test_nth_element_device<0, int>(n, nth_element_checker, std::ranges::less{},    std::identity{}, gen_int, "device, less");
-        test_nth_element_device<1, int>(n, nth_element_checker, std::ranges::greater{}, std::identity{}, gen_int, "device, greater");
-        test_nth_element_device<2, int>(n, nth_element_checker, std::ranges::less{},    proj,            gen_int, "device, less, proj");
-    }
-#endif // TEST_DPCPP_BACKEND_PRESENT
+    // Member-data projection (P2::x): exercised on host and device.
+    test_nth_element<4, P2>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{}, &P2::x);
+    test_nth_element<5, P2>{}(dpl_ranges::nth_element, nth_element_checker, CustomLess{}, &P2::x);
+
+    // Member-function projection (P2::proj): host only (skipped inside device kernels).
+    test_nth_element<6, P2>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{}, &P2::proj);
 
 #endif //_ENABLE_STD_RANGES_TESTING
 

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -81,9 +81,9 @@ inline auto nth_element_reverse_gen = [](int i) { return -i; };
 template <int CallId, typename T, typename Gen = decltype(nth_element_gen)>
 struct test_nth_element
 {
-    template <typename Algo, typename Checker, typename Comp, typename Proj = std::identity>
+    template <typename Algo, typename Checker, typename Comp = std::ranges::less, typename Proj = std::identity>
     void
-    operator()(Algo algo, Checker checker, Comp comp, Proj proj = {}) const
+    operator()(Algo algo, Checker checker, Comp comp = {}, Proj proj = {}) const
     {
         for (int n : {0, 1, 2, 3, 7, 20, small_size})
             host_case(algo, checker, n, comp, proj);
@@ -147,9 +147,24 @@ struct test_nth_element
             auto run = [&](auto&& policy)
             {
                 std::vector<T> data = make_data(n);
-                auto res = algo(policy, data, data.begin() + nth, comp, proj);
-                EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
-                check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                if constexpr (!std::is_same_v<Proj, std::identity>)
+                {
+                    auto res = algo(policy, data, data.begin() + nth, comp, proj);
+                    EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
+                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                }
+                else if constexpr (!std::is_same_v<Comp, std::ranges::less>)
+                {
+                    auto res = algo(policy, data, data.begin() + nth, comp);
+                    EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
+                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                }
+                else
+                {
+                    auto res = algo(policy, data, data.begin() + nth);
+                    EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
+                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                }
             };
 
             run(oneapi::dpl::execution::seq);
@@ -174,9 +189,24 @@ struct test_nth_element
             {
                 std::vector<T> data = make_data(n);
                 auto view = std::ranges::subrange(data.begin(), data.end());
-                auto res = algo(policy, view, view.begin() + nth, comp, proj);
-                EXPECT_TRUE(res == data.end(), (std::string("wrong return value (subrange): ") + msg).c_str());
-                check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                if constexpr (!std::is_same_v<Proj, std::identity>)
+                {
+                    auto res = algo(policy, view, view.begin() + nth, comp, proj);
+                    EXPECT_TRUE(res == data.end(), (std::string("wrong return value (subrange): ") + msg).c_str());
+                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                }
+                else if constexpr (!std::is_same_v<Comp, std::ranges::less>)
+                {
+                    auto res = algo(policy, view, view.begin() + nth, comp);
+                    EXPECT_TRUE(res == data.end(), (std::string("wrong return value (subrange): ") + msg).c_str());
+                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                }
+                else
+                {
+                    auto res = algo(policy, view, view.begin() + nth);
+                    EXPECT_TRUE(res == data.end(), (std::string("wrong return value (subrange): ") + msg).c_str());
+                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                }
             };
             run_subrange(oneapi::dpl::execution::seq);
             run_subrange(oneapi::dpl::execution::par);
@@ -187,9 +217,24 @@ struct test_nth_element
             {
                 std::vector<T> data = make_data(n);
                 std::span<T> view(data.data(), data.size());
-                auto res = algo(policy, view, view.begin() + nth, comp, proj);
-                EXPECT_TRUE(res == view.end(), (std::string("wrong return value (span): ") + msg).c_str());
-                check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                if constexpr (!std::is_same_v<Proj, std::identity>)
+                {
+                    auto res = algo(policy, view, view.begin() + nth, comp, proj);
+                    EXPECT_TRUE(res == view.end(), (std::string("wrong return value (span): ") + msg).c_str());
+                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                }
+                else if constexpr (!std::is_same_v<Comp, std::ranges::less>)
+                {
+                    auto res = algo(policy, view, view.begin() + nth, comp);
+                    EXPECT_TRUE(res == view.end(), (std::string("wrong return value (span): ") + msg).c_str());
+                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                }
+                else
+                {
+                    auto res = algo(policy, view, view.begin() + nth);
+                    EXPECT_TRUE(res == view.end(), (std::string("wrong return value (span): ") + msg).c_str());
+                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                }
             };
             run_span(oneapi::dpl::execution::seq);
             run_span(oneapi::dpl::execution::par);
@@ -247,7 +292,7 @@ main()
     auto nth_element_checker = TEST_PREPARE_CALLABLE(std::ranges::nth_element);
 
     // comp = less/greater/CustomLess, proj = identity: plain integer keys.
-    test_nth_element<0, int>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
+    test_nth_element<0, int>{}(dpl_ranges::nth_element, nth_element_checker);
     test_nth_element<1, int>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{});
     test_nth_element<2, int>{}(dpl_ranges::nth_element, nth_element_checker, CustomLess{});
 

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -67,6 +67,14 @@ nth_positions(int n)
 // Default data generator: values in [-48, 48] with duplicates to exercise partition ties.
 inline auto nth_element_gen = [](int i) { return (i * 7 + 3) % 97 - 48; };
 
+// Degenerate distributions that stress the partition/selection paths differently from random data:
+//  - all elements equal (every pivot choice ties),
+//  - already sorted ascending,
+//  - sorted descending.
+inline auto nth_element_equal_gen = [](int) { return 42; };
+inline auto nth_element_sorted_gen = [](int i) { return i; };
+inline auto nth_element_reverse_gen = [](int i) { return -i; };
+
 // A single declarative test case, in the spirit of test_range_algo: one instantiation runs the
 // tested algorithm against std::ranges::nth_element for every policy (serial/parallel and, when
 // available, device), across a set of sizes and 'nth' positions, for a fixed comparator/projection.
@@ -79,6 +87,18 @@ struct test_nth_element
     {
         for (int n : {0, 1, 2, 3, 7, 20, small_size})
             host_case(algo, checker, n, comp, proj);
+
+        // Borrowed views (std::ranges::subrange, std::span): exercise the algorithm on non-container
+        // random-access sized ranges, not only on std::vector.
+        for (int n : {0, 1, 2, 3, 7, 20, small_size})
+            host_view_case(algo, checker, n, comp, proj);
+
+        // A non-borrowed rvalue range must yield std::ranges::dangling as the return type.
+        using dangling_ret_t = decltype(algo(oneapi::dpl::execution::seq, std::declval<std::vector<T>>(),
+                                             std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
+                                             std::declval<Proj>()));
+        static_assert(std::is_same_v<dangling_ret_t, std::ranges::dangling>,
+                      "nth_element over an rvalue non-borrowed range must return std::ranges::dangling");
 
 #if TEST_DPCPP_BACKEND_PRESENT
         // Pointer-to-member-function comparators/projections are not supported inside device kernels.
@@ -132,6 +152,44 @@ struct test_nth_element
         }
     }
 
+    template <typename Algo, typename Checker, typename Comp, typename Proj>
+    void
+    host_view_case(Algo algo, Checker checker, int n, Comp comp, Proj proj) const
+    {
+        const std::string msg = "host view, nth_element<" + std::to_string(CallId) + ">";
+        for (int nth : nth_positions(n))
+        {
+            std::vector<T> reference = make_data(n);
+            checker(reference, reference.begin() + nth, comp, proj);
+
+            // std::ranges::subrange over an lvalue vector: a borrowed, random-access, sized view.
+            auto run_subrange = [&](auto&& policy)
+            {
+                std::vector<T> data = make_data(n);
+                auto view = std::ranges::subrange(data.begin(), data.end());
+                auto res = algo(policy, view, view.begin() + nth, comp, proj);
+                EXPECT_TRUE(res == data.end(), (std::string("wrong return value (subrange): ") + msg).c_str());
+                check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+            };
+            run_subrange(oneapi::dpl::execution::seq);
+            run_subrange(oneapi::dpl::execution::par);
+
+#if TEST_CPP20_SPAN_PRESENT
+            // std::span: a borrowed, non-owning view without an owning container interface.
+            auto run_span = [&](auto&& policy)
+            {
+                std::vector<T> data = make_data(n);
+                std::span<T> view(data.data(), data.size());
+                auto res = algo(policy, view, view.begin() + nth, comp, proj);
+                EXPECT_TRUE(res == view.end(), (std::string("wrong return value (span): ") + msg).c_str());
+                check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+            };
+            run_span(oneapi::dpl::execution::seq);
+            run_span(oneapi::dpl::execution::par);
+#endif // TEST_CPP20_SPAN_PRESENT
+        }
+    }
+
 #if TEST_DPCPP_BACKEND_PRESENT
     template <typename Algo, typename Checker, typename Comp, typename Proj>
     void
@@ -181,6 +239,14 @@ main()
 
     // External projection proj_apm: exercised on host and device.
     test_nth_element<7, A_PM>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{}, proj_apm);
+
+    // Degenerate data distributions: all-equal, ascending, descending.
+    test_nth_element<8, int, decltype(nth_element_equal_gen)>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
+    test_nth_element<9, int, decltype(nth_element_sorted_gen)>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
+    test_nth_element<10, int, decltype(nth_element_reverse_gen)>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
+
+    // Floating-point keys.
+    test_nth_element<11, double>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
 
 #endif //_ENABLE_STD_RANGES_TESTING
 

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -32,20 +32,14 @@ struct CustomLess
 // in its final sorted position, and the range is partitioned around it. The parallel and device
 // specializations rearrange the rest of the elements differently from std::ranges::nth_element,
 // so we verify the algorithm post-conditions instead of comparing the whole range element-wise.
-//   1) the projected key at 'nth' is equivalent (under comp) to the reference one produced by
-//      std::ranges::nth_element for the same input;
-//   2) nothing before 'nth' is ordered after it and nothing after 'nth' is ordered before it.
-template <typename Range, typename Reference, typename Comp, typename Proj>
+template <typename Range, typename Comp, typename Proj>
 void
-check_nth_element_effect(Range&& r, const Reference& reference, int n, int nth, Comp comp, Proj proj, const char* msg)
+check_nth_element_effect(Range&& r, int n, int nth, Comp comp, Proj proj, const char* msg)
 {
     if (n == 0 || nth == n) // no element is selected: nothing to check
         return;
 
     auto ordered = [&](auto&& a, auto&& b) { return std::invoke(comp, std::invoke(proj, a), std::invoke(proj, b)); };
-
-    EXPECT_TRUE(!ordered(r[nth], reference[nth]) && !ordered(reference[nth], r[nth]),
-                (std::string("wrong nth element value: ") + msg).c_str());
 
     for (int i = 0; i < nth; ++i)
         EXPECT_TRUE(!ordered(r[nth], r[i]), (std::string("wrong left partition: ") + msg).c_str());
@@ -151,19 +145,19 @@ struct test_nth_element
                 {
                     auto res = algo(policy, data, data.begin() + nth, comp, proj);
                     EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
-                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                    check_nth_element_effect(data, n, nth, comp, proj, msg.c_str());
                 }
                 else if constexpr (!std::is_same_v<Comp, std::ranges::less>)
                 {
                     auto res = algo(policy, data, data.begin() + nth, comp);
                     EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
-                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                    check_nth_element_effect(data, n, nth, comp, proj, msg.c_str());
                 }
                 else
                 {
                     auto res = algo(policy, data, data.begin() + nth);
                     EXPECT_TRUE(res == data.end(), (std::string("wrong return value: ") + msg).c_str());
-                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                    check_nth_element_effect(data, n, nth, comp, proj, msg.c_str());
                 }
             };
 
@@ -193,19 +187,19 @@ struct test_nth_element
                 {
                     auto res = algo(policy, view, view.begin() + nth, comp, proj);
                     EXPECT_TRUE(res == data.end(), (std::string("wrong return value (subrange): ") + msg).c_str());
-                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                    check_nth_element_effect(data, n, nth, comp, proj, msg.c_str());
                 }
                 else if constexpr (!std::is_same_v<Comp, std::ranges::less>)
                 {
                     auto res = algo(policy, view, view.begin() + nth, comp);
                     EXPECT_TRUE(res == data.end(), (std::string("wrong return value (subrange): ") + msg).c_str());
-                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                    check_nth_element_effect(data, n, nth, comp, proj, msg.c_str());
                 }
                 else
                 {
                     auto res = algo(policy, view, view.begin() + nth);
                     EXPECT_TRUE(res == data.end(), (std::string("wrong return value (subrange): ") + msg).c_str());
-                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                    check_nth_element_effect(data, n, nth, comp, proj, msg.c_str());
                 }
             };
             run_subrange(oneapi::dpl::execution::seq);
@@ -221,19 +215,19 @@ struct test_nth_element
                 {
                     auto res = algo(policy, view, view.begin() + nth, comp, proj);
                     EXPECT_TRUE(res == view.end(), (std::string("wrong return value (span): ") + msg).c_str());
-                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                    check_nth_element_effect(data, n, nth, comp, proj, msg.c_str());
                 }
                 else if constexpr (!std::is_same_v<Comp, std::ranges::less>)
                 {
                     auto res = algo(policy, view, view.begin() + nth, comp);
                     EXPECT_TRUE(res == view.end(), (std::string("wrong return value (span): ") + msg).c_str());
-                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                    check_nth_element_effect(data, n, nth, comp, proj, msg.c_str());
                 }
                 else
                 {
                     auto res = algo(policy, view, view.begin() + nth);
                     EXPECT_TRUE(res == view.end(), (std::string("wrong return value (span): ") + msg).c_str());
-                    check_nth_element_effect(data, reference, n, nth, comp, proj, msg.c_str());
+                    check_nth_element_effect(data, n, nth, comp, proj, msg.c_str());
                 }
             };
             run_span(oneapi::dpl::execution::seq);
@@ -260,7 +254,7 @@ struct test_nth_element
 
             auto res = algo(CLONE_TEST_POLICY_IDX(policy, CallId), vec, vec.begin() + nth, comp, proj);
             EXPECT_TRUE(res == vec.end(), (std::string("wrong return value: ") + msg).c_str());
-            check_nth_element_effect(vec, reference, n, nth, comp, proj, msg.c_str());
+            check_nth_element_effect(vec, n, nth, comp, proj, msg.c_str());
         }
     }
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -304,12 +304,12 @@ main()
     test_nth_element<7, A_PM>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{}, proj_apm);
 
     // Degenerate data distributions: all-equal, ascending, descending.
-    test_nth_element<8, int, decltype(nth_element_equal_gen)>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
-    test_nth_element<9, int, decltype(nth_element_sorted_gen)>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
-    test_nth_element<10, int, decltype(nth_element_reverse_gen)>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
+    test_nth_element<8, int, decltype(nth_element_equal_gen)>{}(dpl_ranges::nth_element, nth_element_checker);
+    test_nth_element<9, int, decltype(nth_element_sorted_gen)>{}(dpl_ranges::nth_element, nth_element_checker);
+    test_nth_element<10, int, decltype(nth_element_reverse_gen)>{}(dpl_ranges::nth_element, nth_element_checker);
 
     // Floating-point keys.
-    test_nth_element<11, double>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{});
+    test_nth_element<11, double>{}(dpl_ranges::nth_element, nth_element_checker);
 
 #endif //_ENABLE_STD_RANGES_TESTING
 

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -196,6 +196,11 @@ struct test_nth_element
     {
         const std::string msg = "device, nth_element<" + std::to_string(CallId) + ">";
         auto policy = TestUtils::get_dpcpp_test_policy();
+
+        // Skip device tests for double if the device does not support double precision floating point.
+        if (std::is_same_v<T, double> && !policy.queue().get_device().has(sycl::aspect::fp64))
+            return;
+
         for (int nth : nth_positions(n))
         {
             std::vector<T> reference = make_data(n);

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -221,6 +221,41 @@ struct test_nth_element
 #endif // TEST_DPCPP_BACKEND_PRESENT
 };
 
+class A_PM
+{
+  protected:
+    int a = {};
+
+  public:
+    A_PM() = default;
+    A_PM(int v) : a(v) {}
+
+    int
+    get() const
+    {
+        return a;
+    }
+};
+
+class B_PM
+{
+  protected:
+    int b = {};
+
+  public:
+    B_PM() = default;
+    B_PM(int v) : b(v) {}
+
+    int
+    get() const
+    {
+        return b;
+    }
+};
+
+auto proj_apm = [](const A_PM& a) { return a.get(); };
+auto proj_bpm = [](const B_PM& b) { return b.get(); };
+
 #endif // _ENABLE_STD_RANGES_TESTING
 
 std::int32_t

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -93,24 +93,12 @@ struct test_nth_element
         for (int n : {0, 1, 2, 3, 7, 20, small_size})
             host_view_case(algo, checker, n, comp, proj);
 
-        // A non-borrowed rvalue range must yield std::ranges::dangling as the return type.
-        using dangling_ret_seq_t = decltype(algo(oneapi::dpl::execution::seq, std::declval<std::vector<T>>(),
-                                                 std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
-                                                 std::declval<Proj>()));
-        using dangling_ret_unseq_t = decltype(algo(oneapi::dpl::execution::unseq, std::declval<std::vector<T>>(),
-                                                   std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
-                                                   std::declval<Proj>()));
-        using dangling_ret_par_t = decltype(algo(oneapi::dpl::execution::par, std::declval<std::vector<T>>(),
-                                                  std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
-                                                  std::declval<Proj>()));
-        using dangling_ret_par_unseq_t = decltype(algo(oneapi::dpl::execution::par_unseq, std::declval<std::vector<T>>(),
-                                                       std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
-                                                       std::declval<Proj>()));
-
-        static_assert(std::is_same_v<dangling_ret_seq_t, std::ranges::dangling>);
-        static_assert(std::is_same_v<dangling_ret_unseq_t, std::ranges::dangling>);
-        static_assert(std::is_same_v<dangling_ret_par_t, std::ranges::dangling>);
-        static_assert(std::is_same_v<dangling_ret_par_unseq_t, std::ranges::dangling>);
+        // A non-borrowed rvalue range must yield std::ranges::dangling as the return type. The niebloid's
+        // return type does not depend on the policy, so a single check is sufficient; reuse the harness trait.
+        using rvalue_ret_t = decltype(algo(oneapi::dpl::execution::par, std::declval<std::vector<T>>(),
+                                           std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
+                                           std::declval<Proj>()));
+        static_assert(all_dangling_in_result_v<rvalue_ret_t>);
 #if TEST_DPCPP_BACKEND_PRESENT
         // Pointer-to-member-function comparators/projections are not supported inside device kernels.
         if constexpr (!std::disjunction_v<std::is_member_function_pointer<Comp>,

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -94,12 +94,23 @@ struct test_nth_element
             host_view_case(algo, checker, n, comp, proj);
 
         // A non-borrowed rvalue range must yield std::ranges::dangling as the return type.
-        using dangling_ret_t = decltype(algo(oneapi::dpl::execution::seq, std::declval<std::vector<T>>(),
-                                             std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
-                                             std::declval<Proj>()));
-        static_assert(std::is_same_v<dangling_ret_t, std::ranges::dangling>,
-                      "nth_element over an rvalue non-borrowed range must return std::ranges::dangling");
+        using dangling_ret_seq_t = decltype(algo(oneapi::dpl::execution::seq, std::declval<std::vector<T>>(),
+                                                 std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
+                                                 std::declval<Proj>()));
+        using dangling_ret_unseq_t = decltype(algo(oneapi::dpl::execution::unseq, std::declval<std::vector<T>>(),
+                                                   std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
+                                                   std::declval<Proj>()));
+        using dangling_ret_par_t = decltype(algo(oneapi::dpl::execution::par, std::declval<std::vector<T>>(),
+                                                  std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
+                                                  std::declval<Proj>()));
+        using dangling_ret_par_unseq_t = decltype(algo(oneapi::dpl::execution::par_unseq, std::declval<std::vector<T>>(),
+                                                       std::declval<std::vector<T>>().begin(), std::declval<Comp>(),
+                                                       std::declval<Proj>()));
 
+        static_assert(std::is_same_v<dangling_ret_seq_t, std::ranges::dangling>);
+        static_assert(std::is_same_v<dangling_ret_unseq_t, std::ranges::dangling>);
+        static_assert(std::is_same_v<dangling_ret_par_t, std::ranges::dangling>);
+        static_assert(std::is_same_v<dangling_ret_par_unseq_t, std::ranges::dangling>);
 #if TEST_DPCPP_BACKEND_PRESENT
         // Pointer-to-member-function comparators/projections are not supported inside device kernels.
         if constexpr (!std::disjunction_v<std::is_member_function_pointer<Comp>,

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -236,25 +236,7 @@ class A_PM
         return a;
     }
 };
-
-class B_PM
-{
-  protected:
-    int b = {};
-
-  public:
-    B_PM() = default;
-    B_PM(int v) : b(v) {}
-
-    int
-    get() const
-    {
-        return b;
-    }
-};
-
 auto proj_apm = [](const A_PM& a) { return a.get(); };
-auto proj_bpm = [](const B_PM& b) { return b.get(); };
 
 #endif // _ENABLE_STD_RANGES_TESTING
 

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -75,17 +75,17 @@ inline auto nth_element_reverse_gen = [](int i) { return -i; };
 template <int CallId, typename T, typename Gen = decltype(nth_element_gen)>
 struct test_nth_element
 {
-    template <typename Algo, typename Checker, typename Comp = std::ranges::less, typename Proj = std::identity>
+    template <typename Algo, typename Comp = std::ranges::less, typename Proj = std::identity>
     void
-    operator()(Algo algo, Checker checker, Comp comp = {}, Proj proj = {}) const
+    operator()(Algo algo, Comp comp = {}, Proj proj = {}) const
     {
         for (int n : {0, 1, 2, 3, 7, 20, small_size})
-            host_case(algo, checker, n, comp, proj);
+            host_case(algo, n, comp, proj);
 
         // Borrowed views (std::ranges::subrange, std::span): exercise the algorithm on non-container
         // random-access sized ranges, not only on std::vector.
         for (int n : {0, 1, 2, 3, 7, 20, small_size})
-            host_view_case(algo, checker, n, comp, proj);
+            host_view_case(algo, n, comp, proj);
 
         // A non-borrowed rvalue range must yield std::ranges::dangling as the return type. The niebloid's
         // return type does not depend on the policy, so a single check is sufficient; reuse the harness trait.
@@ -110,7 +110,7 @@ struct test_nth_element
                 if (!std::is_same_v<T, double> || policy.queue().get_device().has(sycl::aspect::fp64))
                 {
                     for (int n : {0, 1, small_size, medium_size})
-                        device_case(policy, algo, checker, n, comp, proj);
+                        device_case(policy, algo, n, comp, proj);
                 }
             }
         }
@@ -128,16 +128,13 @@ struct test_nth_element
         return data;
     }
 
-    template <typename Algo, typename Checker, typename Comp, typename Proj>
+    template <typename Algo, typename Comp, typename Proj>
     void
-    host_case(Algo algo, Checker checker, int n, Comp comp, Proj proj) const
+    host_case(Algo algo, int n, Comp comp, Proj proj) const
     {
         const std::string msg = "host, nth_element<" + std::to_string(CallId) + ">";
         for (int nth : nth_positions(n))
         {
-            std::vector<T> reference = make_data(n);
-            checker(reference, reference.begin() + nth, comp, proj);
-
             auto run = [&](auto&& policy)
             {
                 std::vector<T> data = make_data(n);
@@ -168,16 +165,13 @@ struct test_nth_element
         }
     }
 
-    template <typename Algo, typename Checker, typename Comp, typename Proj>
+    template <typename Algo, typename Comp, typename Proj>
     void
-    host_view_case(Algo algo, Checker checker, int n, Comp comp, Proj proj) const
+    host_view_case(Algo algo, int n, Comp comp, Proj proj) const
     {
         const std::string msg = "host view, nth_element<" + std::to_string(CallId) + ">";
         for (int nth : nth_positions(n))
         {
-            std::vector<T> reference = make_data(n);
-            checker(reference, reference.begin() + nth, comp, proj);
-
             // std::ranges::subrange over an lvalue vector: a borrowed, random-access, sized view.
             auto run_subrange = [&](auto&& policy)
             {
@@ -237,17 +231,14 @@ struct test_nth_element
     }
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    template <typename ExecutionPolicy, typename Algo, typename Checker, typename Comp, typename Proj>
+    template <typename ExecutionPolicy, typename Algo, typename Comp, typename Proj>
     void
-    device_case(ExecutionPolicy&& policy, Algo algo, Checker checker, int n, Comp comp, Proj proj) const
+    device_case(ExecutionPolicy&& policy, Algo algo, int n, Comp comp, Proj proj) const
     {
         const std::string msg = "device, nth_element<" + std::to_string(CallId) + ">";
 
         for (int nth : nth_positions(n))
         {
-            std::vector<T> reference = make_data(n);
-            checker(reference, reference.begin() + nth, comp, proj);
-
             std::vector<T> host = make_data(n);
             usm_vector<T> usm(policy, host.data(), n);
             auto& vec = usm();
@@ -283,34 +274,31 @@ std::int32_t
 main()
 {
 #if _ENABLE_STD_RANGES_TESTING
-    auto nth_element_checker = TEST_PREPARE_CALLABLE(std::ranges::nth_element);
-
     // comp = less/greater/CustomLess, proj = identity: plain integer keys.
-    test_nth_element<0, int>{}(dpl_ranges::nth_element, nth_element_checker);
-    test_nth_element<1, int>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{});
-    test_nth_element<2, int>{}(dpl_ranges::nth_element, nth_element_checker, CustomLess{});
+    test_nth_element<0, int>{}(dpl_ranges::nth_element);
+    test_nth_element<1, int>{}(dpl_ranges::nth_element, std::ranges::greater{});
+    test_nth_element<2, int>{}(dpl_ranges::nth_element, CustomLess{});
 
     // Projection applied to integer keys.
-    test_nth_element<3, int>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{}, proj);
+    test_nth_element<3, int>{}(dpl_ranges::nth_element, std::ranges::less{}, proj);
 
     // Member-data projection (P2::x): exercised on host and device.
-    test_nth_element<4, P2>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::less{}, &P2::x);
-    test_nth_element<5, P2>{}(dpl_ranges::nth_element, nth_element_checker, CustomLess{}, &P2::x);
+    test_nth_element<4, P2>{}(dpl_ranges::nth_element, std::ranges::less{}, &P2::x);
+    test_nth_element<5, P2>{}(dpl_ranges::nth_element, CustomLess{}, &P2::x);
 
     // Member-function projection (P2::proj): host only (skipped inside device kernels).
-    test_nth_element<6, P2>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{}, &P2::proj);
+    test_nth_element<6, P2>{}(dpl_ranges::nth_element, std::ranges::greater{}, &P2::proj);
 
     // External projection proj_apm: exercised on host and device.
-    test_nth_element<7, A_PM>{}(dpl_ranges::nth_element, nth_element_checker, std::ranges::greater{}, proj_apm);
+    test_nth_element<7, A_PM>{}(dpl_ranges::nth_element, std::ranges::greater{}, proj_apm);
 
     // Degenerate data distributions: all-equal, ascending, descending.
-    test_nth_element<8, int, decltype(nth_element_equal_gen)>{}(dpl_ranges::nth_element, nth_element_checker);
-    test_nth_element<9, int, decltype(nth_element_sorted_gen)>{}(dpl_ranges::nth_element, nth_element_checker);
-    test_nth_element<10, int, decltype(nth_element_reverse_gen)>{}(dpl_ranges::nth_element, nth_element_checker);
+    test_nth_element<8, int, decltype(nth_element_equal_gen)>{}(dpl_ranges::nth_element);
+    test_nth_element<9, int, decltype(nth_element_sorted_gen)>{}(dpl_ranges::nth_element);
+    test_nth_element<10, int, decltype(nth_element_reverse_gen)>{}(dpl_ranges::nth_element);
 
     // Floating-point keys.
-    test_nth_element<11, double>{}(dpl_ranges::nth_element, nth_element_checker);
-
+    test_nth_element<11, double>{}(dpl_ranges::nth_element);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_nth_element.pass.cpp
@@ -100,6 +100,8 @@ struct test_nth_element
                                            std::declval<Proj>()));
         static_assert(all_dangling_in_result_v<rvalue_ret_t>);
 #if TEST_DPCPP_BACKEND_PRESENT
+
+
         // Pointer-to-member-function comparators/projections are not supported inside device kernels.
         if constexpr (!std::disjunction_v<std::is_member_function_pointer<Comp>,
                                           std::is_member_function_pointer<Proj>>)
@@ -108,8 +110,14 @@ struct test_nth_element
             if constexpr (!std::disjunction_v<std::is_member_pointer<Comp>, std::is_member_pointer<Proj>>)
 #endif
             {
-                for (int n : {0, 1, small_size, medium_size})
-                    device_case(algo, checker, n, comp, proj);
+                auto policy = TestUtils::get_dpcpp_test_policy();
+
+                // Skip device tests for double if the device does not support double precision floating point.
+                if (!std::is_same_v<T, double> || policy.queue().get_device().has(sycl::aspect::fp64))
+                {
+                    for (int n : {0, 1, small_size, medium_size})
+                        device_case(policy, algo, checker, n, comp, proj);
+                }
             }
         }
 #endif // TEST_DPCPP_BACKEND_PRESENT
@@ -190,16 +198,11 @@ struct test_nth_element
     }
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    template <typename Algo, typename Checker, typename Comp, typename Proj>
+    template <typename ExecutionPolicy, typename Algo, typename Checker, typename Comp, typename Proj>
     void
-    device_case(Algo algo, Checker checker, int n, Comp comp, Proj proj) const
+    device_case(ExecutionPolicy&& policy, Algo algo, Checker checker, int n, Comp comp, Proj proj) const
     {
         const std::string msg = "device, nth_element<" + std::to_string(CallId) + ">";
-        auto policy = TestUtils::get_dpcpp_test_policy();
-
-        // Skip device tests for double if the device does not support double precision floating point.
-        if (std::is_same_v<T, double> && !policy.queue().get_device().has(sycl::aspect::fp64))
-            return;
 
         for (int nth : nth_positions(n))
         {

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -164,6 +164,41 @@ struct B
 auto proj_a = [](const A& a) { return a.a; };
 auto proj_b = [](const B& b) { return b.b; };
 
+class A_PM
+{
+  protected:
+    int a = {};
+
+  public:
+    A_PM() = default;
+    A_PM(int v): a(v) {}
+
+    int
+    get() const
+    {
+        return a;
+    }
+};
+
+class B_PM
+{
+  protected:
+    int b = {};
+
+  public:
+    B_PM() = default;
+    B_PM(int v): b(v) {}
+
+    int
+    get() const
+    {
+        return b;
+    }
+};
+
+auto proj_apm = [](const A_PM& a) { return a.get(); };
+auto proj_bpm = [](const B_PM& b) { return b.get(); };
+
 // These are copies of __range_size and __range_size_t utilities from oneDPL
 // to get a size type of a range be it sized or not
 template <typename R>

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -164,41 +164,6 @@ struct B
 auto proj_a = [](const A& a) { return a.a; };
 auto proj_b = [](const B& b) { return b.b; };
 
-class A_PM
-{
-  protected:
-    int a = {};
-
-  public:
-    A_PM() = default;
-    A_PM(int v): a(v) {}
-
-    int
-    get() const
-    {
-        return a;
-    }
-};
-
-class B_PM
-{
-  protected:
-    int b = {};
-
-  public:
-    B_PM() = default;
-    B_PM(int v): b(v) {}
-
-    int
-    get() const
-    {
-        return b;
-    }
-};
-
-auto proj_apm = [](const A_PM& a) { return a.get(); };
-auto proj_bpm = [](const B_PM& b) { return b.get(); };
-
 // These are copies of __range_size and __range_size_t utilities from oneDPL
 // to get a size type of a range be it sized or not
 template <typename R>


### PR DESCRIPTION
## Pull request overview

This PR adds a new C++20 ranges algorithm entry point, `oneapi::dpl::ranges::nth_element` (described at https://eel.is/c++draft/alg.nth.element), wiring it through the ranges glue layer to the existing host/device backends and introducing a dedicated correctness test that checks `nth_element` postconditions rather than full-order equality.

**Changes:**
- Add `oneapi::dpl::ranges::nth_element` callable object and its dispatch to backend-specific `__pattern_nth_element` implementations.
- Implement `__pattern_nth_element` for host ranges dispatch and add a hetero (device) ranges pattern.
- Add a new test validating the algorithm’s postconditions across policies, sizes, comparators, and projections (including member projections).