### PR TITLE
Fix a bug in the "vectorized" SYCL reverse brick

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1581,16 +1581,14 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator>
 void
 __pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last)
 {
-    auto __n = __last - __first;
+    std::size_t __n = __last - __first;
     if (__n <= 1)
         return;
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write>();
     auto __buf = __keep(__first, __last);
-    oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-        unseq_backend::__reverse_functor<typename std::iterator_traits<_Iterator>::difference_type>{__n}, __n / 2,
-        __buf.all_view())
+    oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                                                      unseq_backend::__reverse_functor{__n}, __n / 2, __buf.all_view())
         .__checked_deferrable_wait();
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1581,7 +1581,7 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator>
 void
 __pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last)
 {
-    std::size_t __n = __last - __first;
+    const std::size_t __n = __last - __first;
     if (__n <= 1)
         return;
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -805,8 +805,8 @@ __pattern_reverse(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R&& __r
         return;
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), unseq_backend::__reverse_functor<decltype(__n)>{__n},
-        __n / 2, oneapi::dpl::__ranges::__get_subscription_view(std::forward<_R>(__r)))
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), unseq_backend::__reverse_functor{__n}, __n / 2,
+        oneapi::dpl::__ranges::__get_subscription_view(std::forward<_R>(__r)))
         .__checked_deferrable_wait();
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1074,21 +1074,19 @@ struct __brick_includes
 //------------------------------------------------------------------------
 // reverse
 //------------------------------------------------------------------------
-template <typename _Size>
 struct __reverse_functor
 {
   private:
-    _Size __size;
+    const std::size_t __size;
 
   public:
-    __reverse_functor(_Size __size) : __size(__size) {}
+    __reverse_functor(std::size_t __size) : __size(__size) {}
 
     template <typename _IsFull, typename _Params, typename _Range, std::enable_if_t<_Params::__can_vectorize, int> = 0>
     void
     operator()(_IsFull, const std::size_t __left_start_idx, _Params, _Range&& __rng) const
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
-        const std::size_t __n = __size;
 
         // In the below implementation, we see that _IsFull is ignored in favor of std::true_type{} in all cases.
         // This relaxation is due to the fact that in-place reverse launches work only over the first half of the
@@ -1102,9 +1100,9 @@ struct __reverse_functor
         _ValueType __rng_left_vector[_Params::__vector_size];
         _ValueType __rng_right_vector[_Params::__vector_size];
 
-        oneapi::dpl::__par_backend_hetero::__vector_load<_Params::__vector_size> __vec_load{__n};
+        oneapi::dpl::__par_backend_hetero::__vector_load<_Params::__vector_size> __vec_load{__size};
         oneapi::dpl::__par_backend_hetero::__vector_reverse<_Params::__vector_size> __vec_reverse;
-        oneapi::dpl::__par_backend_hetero::__vector_store<_Params::__vector_size> __vec_store{__n};
+        oneapi::dpl::__par_backend_hetero::__vector_store<_Params::__vector_size> __vec_store{__size};
         oneapi::dpl::__par_backend_hetero::__scalar_load_op __load_op;
         oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<oneapi::dpl::__internal::__pstl_assign>
             __store_op;
@@ -1124,7 +1122,7 @@ struct __reverse_functor
     void
     operator()(_IsFull, const std::size_t __idx, _Params, _Range&& __rng) const
     {
-        using ::std::swap;
+        using std::swap;
         swap(__rng[__idx], __rng[__size - __idx - 1]);
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1112,7 +1112,7 @@ struct __reverse_functor
         }
 
         // In the below implementation, _IsFull is ignored in favor of std::true_type{} in all cases.
-        // This relaxation is due to the fact that in-place reverse iterates only over the first half of the buffer,
+        // This relaxation is due to the fact that in-place reverse iterates only over the first half of the buffer.
         // Since there is more than a single vector of data to reverse, there is no OOB accesses or race condition.
         // There may exist a single point of double processing between left and right vectors in the last work-item
         // which reverses middle elements.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1088,32 +1088,43 @@ struct __reverse_functor
     {
         using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
 
-        // In the below implementation, we see that _IsFull is ignored in favor of std::true_type{} in all cases.
-        // This relaxation is due to the fact that in-place reverse launches work only over the first half of the
-        // buffer. As long as __size >= __vec_size there is no risk of an OOB accesses or a race condition. There may
-        // exist a  single point of double processing between left and right vectors in the last work-item which
-        // reverses middle elements. This extra processing of elements <= __vec_size is more performant than applying
-        // additional branching (such as in reverse_copy).
-
-        const std::size_t __right_start_idx = __size - __left_start_idx - _Params::__vector_size;
-
         _ValueType __rng_left_vector[_Params::__vector_size];
         _ValueType __rng_right_vector[_Params::__vector_size];
 
         oneapi::dpl::__par_backend_hetero::__vector_load<_Params::__vector_size> __vec_load{__size};
         oneapi::dpl::__par_backend_hetero::__vector_reverse<_Params::__vector_size> __vec_reverse;
-        oneapi::dpl::__par_backend_hetero::__vector_store<_Params::__vector_size> __vec_store{__size};
+        oneapi::dpl::__par_backend_hetero::__vector_store<_Params::__vector_size> __vec_store{__size / 2};
         oneapi::dpl::__par_backend_hetero::__scalar_load_op __load_op;
         oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<oneapi::dpl::__internal::__pstl_assign>
             __store_op;
 
-        // 1. Load two vectors that we want to swap: one from the left half of the buffer and one from the right
+        if constexpr (_IsFull::value == false)
+        {
+            if (__left_start_idx + _Params::__vector_size >= __size - __left_start_idx)
+            {
+                // The remaining data to reverse fits into a single vector
+                __vec_load(std::false_type{}, __left_start_idx, __load_op, __rng, __rng_left_vector);
+                __vec_reverse(std::false_type{}, __size - __left_start_idx, __rng_left_vector);
+                __vec_store(std::false_type{}, __left_start_idx, __store_op, __rng_left_vector, __rng);
+                return;
+            }
+        }
+
+        // In the below implementation, _IsFull is ignored in favor of std::true_type{} in all cases.
+        // This relaxation is due to the fact that in-place reverse iterates only over the first half of the buffer,
+        // Since there is more than a single vector of data to reverse, there is no OOB accesses or race condition.
+        // There may exist a single point of double processing between left and right vectors in the last work-item
+        // which reverses middle elements.
+
+        const std::size_t __right_start_idx = __size - __left_start_idx - _Params::__vector_size;
+
+        // 1. Load two vectors that we want to swap: one from the left half of the buffer and one from the right.
+        // Note that due to indices we have chosen, there will always be a full vector of elements to load.
         __vec_load(std::true_type{}, __left_start_idx, __load_op, __rng, __rng_left_vector);
         __vec_load(std::true_type{}, __right_start_idx, __load_op, __rng, __rng_right_vector);
-        // 2. Reverse vectors in registers. Note that due to indices we have chosen, there will always be a full
-        // vector of elements to load
-        __vec_reverse(std::true_type{}, __left_start_idx, __rng_left_vector);
-        __vec_reverse(std::true_type{}, __right_start_idx, __rng_right_vector);
+        // 2. Reverse vectors in registers.
+        __vec_reverse(std::true_type{}, _Params::__vector_size, __rng_left_vector);
+        __vec_reverse(std::true_type{}, _Params::__vector_size, __rng_right_vector);
         // 3. Store the left-half vector to the corresponding right-half indices and vice versa
         __vec_store(std::true_type{}, __right_start_idx, __store_op, __rng_left_vector, __rng);
         __vec_store(std::true_type{}, __left_start_idx, __store_op, __rng_right_vector, __rng);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -1093,7 +1093,8 @@ struct __reverse_functor
 
         oneapi::dpl::__par_backend_hetero::__vector_load<_Params::__vector_size> __vec_load{__size};
         oneapi::dpl::__par_backend_hetero::__vector_reverse<_Params::__vector_size> __vec_reverse;
-        oneapi::dpl::__par_backend_hetero::__vector_store<_Params::__vector_size> __vec_store{__size / 2};
+        oneapi::dpl::__par_backend_hetero::__vector_store<_Params::__vector_size>
+            __vec_store{__size - __left_start_idx};
         oneapi::dpl::__par_backend_hetero::__scalar_load_op __load_op;
         oneapi::dpl::__par_backend_hetero::__scalar_store_transform_op<oneapi::dpl::__internal::__pstl_assign>
             __store_op;
@@ -1104,7 +1105,7 @@ struct __reverse_functor
             {
                 // The remaining data to reverse fits into a single vector
                 __vec_load(std::false_type{}, __left_start_idx, __load_op, __rng, __rng_left_vector);
-                __vec_reverse(std::false_type{}, __size - __left_start_idx, __rng_left_vector);
+                __vec_reverse(std::false_type{}, __size - 2 * __left_start_idx, __rng_left_vector);
                 __vec_store(std::false_type{}, __left_start_idx, __store_op, __rng_left_vector, __rng);
                 return;
             }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -72,7 +72,7 @@ test()
     std::vector<std::size_t> test_sizes = TestUtils::get_pattern_for_test_sizes();
     const std::size_t max_len = test_sizes.back();
     // Add a value to cover the case of len modulo 8 == 3
-    test_sizes.insert(test_sizes.end(), (max_len / 8) * 8 - 5);
+    test_sizes.push_back((max_len / 8) * 8 - 5);
 
     Sequence<T> actual(max_len);
     Sequence<T> data(max_len, [](std::size_t i) { return T(i); });

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -69,11 +69,12 @@ template <typename T>
 void
 test()
 {
-    const auto test_sizes = TestUtils::get_pattern_for_test_sizes();
+    std::vector<std::size_t> test_sizes = TestUtils::get_pattern_for_test_sizes();
     const std::size_t max_len = test_sizes.back();
+    // Add a value to cover the case of len modulo 8 == 3
+    test_sizes.insert(test_sizes.end(), (max_len / 8) * 8 - 5);
 
     Sequence<T> actual(max_len);
-
     Sequence<T> data(max_len, [](::std::size_t i) { return T(i); });
 
     for (std::size_t len : test_sizes)

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -29,14 +29,14 @@ struct test_one_policy
 {
 #if _PSTL_ICC_18_VC141_TEST_SIMD_LAMBDA_RELEASE_BROKEN // dummy specialization by policy type, in case of broken configuration
     template <typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
+    std::enable_if_t<is_base_of_iterator_category_v<std::random_access_iterator_tag, Iterator1>>
     operator()(oneapi::dpl::execution::unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
     }
 
     template <typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
+    std::enable_if_t<is_base_of_iterator_category_v<std::random_access_iterator_tag, Iterator1>>
     operator()(oneapi::dpl::execution::parallel_unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
@@ -44,7 +44,7 @@ struct test_one_policy
 #endif
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, Iterator1>>
+    std::enable_if_t<is_base_of_iterator_category_v<std::bidirectional_iterator_tag, Iterator1>>
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, Iterator1>>
+    std::enable_if_t<!is_base_of_iterator_category_v<std::bidirectional_iterator_tag, Iterator1>>
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e */)
     {
     }
@@ -75,7 +75,7 @@ test()
     test_sizes.insert(test_sizes.end(), (max_len / 8) * 8 - 5);
 
     Sequence<T> actual(max_len);
-    Sequence<T> data(max_len, [](::std::size_t i) { return T(i); });
+    Sequence<T> data(max_len, [](std::size_t i) { return T(i); });
 
     for (std::size_t len : test_sizes)
     {


### PR DESCRIPTION
The problematic scenario is shown by the modified test: when the number of remaining elements in the middle of the data to reverse is less than 4 (the `__vector_size` for byte-sized types). processing it with two vector loads and stores touches elements outside the valid range of the given work item, causing a data race..

The solution is to check `_IsFull` and then, in case there is enough data for only one vector load/store, limit the operations correspondingly.

In addition, the excessive template parameter of `__reverse_functor` is removed.