### PR TITLE
Dev/skopienko/bounded set op hetero renames

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -764,7 +764,7 @@ __parallel_set_write_a_b_op(_SetTag __set_tag, sycl::queue& __q, _Range1&& __rng
 {
     constexpr std::uint16_t __diagonal_spacing = 32;
 
-    using _SetOperation = __set_generic_operation<_SetTag>;
+    using _SetOperation = __set_operation<_SetTag>;
     using _In1ValueT = oneapi::dpl::__internal::__value_t<_Range1>;
     using _In2ValueT = oneapi::dpl::__internal::__value_t<_Range2>;
     using _OutValueT = oneapi::dpl::__internal::__value_t<_Range3>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -764,7 +764,7 @@ __parallel_set_write_a_b_op(_SetTag __set_tag, sycl::queue& __q, _Range1&& __rng
 {
     constexpr std::uint16_t __diagonal_spacing = 32;
 
-    using _SetOperation = __get_set_operation<_SetTag>;
+    using _SetOperation = __set_generic_operation<_SetTag>;
     using _In1ValueT = oneapi::dpl::__internal::__value_t<_Range1>;
     using _In2ValueT = oneapi::dpl::__internal::__value_t<_Range2>;
     using _OutValueT = oneapi::dpl::__internal::__value_t<_Range3>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -452,7 +452,7 @@ struct __gen_unique_mask
 // Set operation generic implementation, used for serial set operation of intersection, difference, union, and
 // symmetric difference.
 template <typename _SetTag>
-struct __set_generic_operation
+struct __set_operation
 {
     template <typename _InRng1, typename _InRng2, typename _SizeType, typename _TempOutput, typename _Compare,
               typename _Proj1, typename _Proj2, typename _FinalPosSaver>
@@ -472,9 +472,9 @@ struct __set_generic_operation
         while (__idx < __num_eles_min)
         {
             // Bounds checks are enabled only when this diagonal can reach the end of either range.
-            __set_generic_operation_iteration(__in_rng1, __size1, __in_rng2, __size2, __idx1, __idx2, __num_eles_min,
-                                              __temp_out, __idx, __count, __comp, __proj1, __proj2, __check_bounds,
-                                              __final_pos_saver);
+            __set_operation_iteration(__in_rng1, __size1, __in_rng2, __size2, __idx1, __idx2, __num_eles_min,
+                                      __temp_out, __idx, __count, __comp, __proj1, __proj2, __check_bounds,
+                                      __final_pos_saver);
         }
 
         return __count;
@@ -485,11 +485,11 @@ struct __set_generic_operation
     template <typename _InRng1, typename _Size1, typename _InRng2, typename _Size2, typename _SizeType,
               typename _TempOutput, typename _Compare, typename _Proj1, typename _Proj2, typename _FinalPosSaver>
     void
-    __set_generic_operation_iteration(const _InRng1& __in_rng1, const _Size1 __size1, const _InRng2& __in_rng2,
-                                      const _Size2 __size2, std::size_t& __idx1, std::size_t& __idx2,
-                                      const _SizeType __num_eles_min, _TempOutput& __temp_out, _SizeType& __idx,
-                                      _SizeType& __count, const _Compare __comp, _Proj1 __proj1, _Proj2 __proj2,
-                                      bool __check_bounds, _FinalPosSaver __final_pos_saver) const
+    __set_operation_iteration(const _InRng1& __in_rng1, const _Size1 __size1, const _InRng2& __in_rng2,
+                              const _Size2 __size2, std::size_t& __idx1, std::size_t& __idx2,
+                              const _SizeType __num_eles_min, _TempOutput& __temp_out, _SizeType& __idx,
+                              _SizeType& __count, const _Compare __comp, _Proj1 __proj1, _Proj2 __proj2,
+                              bool __check_bounds, _FinalPosSaver __final_pos_saver) const
     {
         constexpr bool __is_set_difference = std::is_same_v<_SetTag, unseq_backend::_DifferenceTag>;
         constexpr bool __is_set_intersection = std::is_same_v<_SetTag, unseq_backend::_IntersectionTag>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -449,149 +449,9 @@ struct __gen_unique_mask
 
 // __parallel_set_write_a_b_op
 
-// Returns by reference: iterations consumed, and the number of elements copied to temp output.
-template <bool _CopyMatch, bool _CopyDiffSetA, bool _CopyDiffSetB, typename _InRng1, typename _Size1, typename _InRng2,
-          typename _Size2, typename _SizeType, typename _TempOutput, typename _Compare, typename _Proj1,
-          typename _Proj2, typename _FinalPosSaver>
-void
-__set_generic_operation_iteration(const _InRng1& __in_rng1, const _Size1 __size1, const _InRng2& __in_rng2,
-                                  const _Size2 __size2, std::size_t& __idx1, std::size_t& __idx2,
-                                  const _SizeType __num_eles_min, _TempOutput& __temp_out, _SizeType& __idx,
-                                  _SizeType& __count, const _Compare __comp, _Proj1 __proj1, _Proj2 __proj2,
-                                  bool __check_bounds, _FinalPosSaver __final_pos_saver)
-{
-    constexpr bool __is_set_intersection = _CopyMatch && !_CopyDiffSetA && !_CopyDiffSetB;
-    constexpr bool __is_set_difference = !_CopyMatch && _CopyDiffSetA && !_CopyDiffSetB;
-
-    // Make sense to calculate final positions only for set_intersection and set_difference operations,
-    // and only if the user provided a callback to save the final positions.
-    // Stop positions for set_union and set_symmetric_difference are not needed, because they are known in advance.
-    constexpr bool __need_call_final_pos_saver =
-        !std::is_same_v<std::decay_t<_FinalPosSaver>, __internal::__no_callback_tag> &&
-        (__is_set_intersection || __is_set_difference);
-
-    using _ValueTypeRng1 = typename oneapi::dpl::__internal::__value_t<_InRng1>;
-    using _ValueTypeRng2 = typename oneapi::dpl::__internal::__value_t<_InRng2>;
-
-    auto __write_temp_element = [&](const _SizeType __count_arg, const auto& __value, std::size_t __idx1,
-                                    std::size_t __idx2) {
-        if constexpr (_TempOutput::__capture_indexes_flag)
-            __temp_out.set(__count_arg, __value, {__idx1, __idx2});
-        else
-            __temp_out.set(__count_arg, __value);
-    };
-
-    // Merge-path indices captured at iteration entry. The global merge path is partitioned across
-    // work-items and walked exactly once, so the single step that first reaches the operation's natural
-    // termination boundary occurs in exactly one work-item at exactly one iteration. Comparing the entry
-    // indices against the post-step indices detects precisely that transition (the edge crossing), which
-    // lets a single work-item write the final source position directly, with no reduction and no atomics.
-    [[maybe_unused]] const std::size_t __idx1_at_entry = __idx1;
-    [[maybe_unused]] const std::size_t __idx2_at_entry = __idx2;
-
-    auto __process_final_pos = [&](std::size_t __idx1, std::size_t __idx2) {
-        if constexpr (__need_call_final_pos_saver)
-        {
-            // For set_intersection the operation terminates once either input is exhausted: the edge crossing
-            // is the step that moves from "strictly inside both inputs" to "at least one input exhausted".
-            if constexpr (__is_set_intersection)
-            {
-                if (__idx1_at_entry < __size1 && __idx2_at_entry < __size2 && (__idx1 == __size1 || __idx2 == __size2))
-                    __final_pos_saver({__idx1, __idx2});
-            }
-            // For set_difference the operation terminates once the first input (set A) is exhausted: the edge
-            // crossing is the step that moves idx1 to the end of set A. This also covers the tail-drain of set
-            // A performed after set B is exhausted.
-            else if constexpr (__is_set_difference)
-            {
-                if (__idx1_at_entry < __size1 && __idx1 == __size1)
-                    __final_pos_saver({__idx1, __idx2});
-            }
-        }
-    };
-
-    if (__check_bounds)
-    {
-        if (__idx1 == __size1)
-        {
-            if constexpr (_CopyDiffSetB)
-            {
-                // If we are at the end of rng1, copy the rest of rng2 within our diagonal's bounds
-                for (; __idx2 < __size2 && __idx < __num_eles_min; ++__idx2, ++__idx)
-                {
-                    __write_temp_element(__count, __in_rng2[__idx2], __idx1, __idx2);
-                    ++__count;
-                }
-            }
-            __idx = __num_eles_min;
-            if constexpr (__need_call_final_pos_saver)
-                __process_final_pos(__idx1, __idx2);
-            return;
-        }
-
-        if (__idx2 == __size2)
-        {
-            if constexpr (_CopyDiffSetA)
-            {
-                // If we are at the end of rng2, copy the rest of rng1 within our diagonal's bounds
-                for (; __idx1 < __size1 && __idx < __num_eles_min; ++__idx1, ++__idx)
-                {
-                    __write_temp_element(__count, __in_rng1[__idx1], __idx1, __idx2);
-                    ++__count;
-                }
-            }
-            __idx = __num_eles_min;
-            if constexpr (__need_call_final_pos_saver)
-                __process_final_pos(__idx1, __idx2);
-            return;
-        }
-    }
-
-    const _ValueTypeRng1& __ele_rng1 = __in_rng1[__idx1];
-    const _ValueTypeRng2& __ele_rng2 = __in_rng2[__idx2];
-    if (std::invoke(__comp, std::invoke(__proj1, __ele_rng1), std::invoke(__proj2, __ele_rng2)))
-    {
-        if constexpr (_CopyDiffSetA)
-        {
-            __write_temp_element(__count, __ele_rng1, __idx1, __idx2);
-            ++__count;
-        }
-        ++__idx1;
-        ++__idx;
-    }
-    else if (std::invoke(__comp, std::invoke(__proj2, __ele_rng2), std::invoke(__proj1, __ele_rng1)))
-    {
-        if constexpr (_CopyDiffSetB)
-        {
-            __write_temp_element(__count, __ele_rng2, __idx1, __idx2);
-            ++__count;
-        }
-        ++__idx2;
-        ++__idx;
-    }
-    else // if neither element is less than the other, they are equal
-    {
-        if constexpr (_CopyMatch)
-        {
-            __write_temp_element(__count, __ele_rng1, __idx1, __idx2);
-            ++__count;
-        }
-        ++__idx1;
-        ++__idx2;
-        __idx += 2;
-    }
-    // The edge crossing can only occur on a diagonal that can reach a range end, i.e. when bounds are
-    // checked. Keep the interior hot path free of the extra comparisons.
-    if constexpr (__need_call_final_pos_saver)
-    {
-        if (__check_bounds)
-            __process_final_pos(__idx1, __idx2);
-    }
-}
-
 // Set operation generic implementation, used for serial set operation of intersection, difference, union, and
 // symmetric difference.
-template <bool _CopyMatch, bool _CopyDiffSetA, bool _CopyDiffSetB>
+template <typename _SetTag>
 struct __set_generic_operation
 {
     template <typename _InRng1, typename _InRng2, typename _SizeType, typename _TempOutput, typename _Compare,
@@ -612,41 +472,156 @@ struct __set_generic_operation
         while (__idx < __num_eles_min)
         {
             // Bounds checks are enabled only when this diagonal can reach the end of either range.
-            __set_generic_operation_iteration<_CopyMatch, _CopyDiffSetA, _CopyDiffSetB>(
-                __in_rng1, __size1, __in_rng2, __size2, __idx1, __idx2, __num_eles_min, __temp_out, __idx, __count,
-                __comp, __proj1, __proj2, __check_bounds, __final_pos_saver);
+            __set_generic_operation_iteration(__in_rng1, __size1, __in_rng2, __size2, __idx1, __idx2, __num_eles_min,
+                                              __temp_out, __idx, __count, __comp, __proj1, __proj2, __check_bounds,
+                                              __final_pos_saver);
         }
 
         return __count;
     }
-};
 
-// Set operation implementations using the generic implementation
-using __set_intersection = __set_generic_operation<true, false, false>;
-using __set_difference = __set_generic_operation<false, true, false>;
-using __set_union = __set_generic_operation<true, true, true>;
-using __set_symmetric_difference = __set_generic_operation<false, true, true>;
+  protected:
+    // Returns by reference: iterations consumed, and the number of elements copied to temp output.
+    template <typename _InRng1, typename _Size1, typename _InRng2, typename _Size2, typename _SizeType,
+              typename _TempOutput, typename _Compare, typename _Proj1, typename _Proj2, typename _FinalPosSaver>
+    void
+    __set_generic_operation_iteration(const _InRng1& __in_rng1, const _Size1 __size1, const _InRng2& __in_rng2,
+                                      const _Size2 __size2, std::size_t& __idx1, std::size_t& __idx2,
+                                      const _SizeType __num_eles_min, _TempOutput& __temp_out, _SizeType& __idx,
+                                      _SizeType& __count, const _Compare __comp, _Proj1 __proj1, _Proj2 __proj2,
+                                      bool __check_bounds, _FinalPosSaver __final_pos_saver) const
+    {
+        constexpr bool __is_set_difference = std::is_same_v<_SetTag, unseq_backend::_DifferenceTag>;
+        constexpr bool __is_set_intersection = std::is_same_v<_SetTag, unseq_backend::_IntersectionTag>;
+        constexpr bool __is_set_union = std::is_same_v<_SetTag, unseq_backend::_UnionTag>;
+        constexpr bool __is_set_symmetric_difference = std::is_same_v<_SetTag, unseq_backend::_SymmetricDifferenceTag>;
 
-template <typename _SetTag>
-struct __get_set_operation;
+        // Make sense to calculate final positions only for set_intersection and set_difference operations,
+        // and only if the user provided a callback to save the final positions.
+        // Stop positions for set_union and set_symmetric_difference are not needed, because they are known in advance.
+        constexpr bool __need_call_final_pos_saver =
+            !std::is_same_v<std::decay_t<_FinalPosSaver>, __internal::__no_callback_tag> &&
+            (__is_set_intersection || __is_set_difference);
 
-template <>
-struct __get_set_operation<oneapi::dpl::unseq_backend::_IntersectionTag> : __set_intersection
-{
-};
+        using _ValueTypeRng1 = typename oneapi::dpl::__internal::__value_t<_InRng1>;
+        using _ValueTypeRng2 = typename oneapi::dpl::__internal::__value_t<_InRng2>;
 
-template <>
-struct __get_set_operation<oneapi::dpl::unseq_backend::_DifferenceTag> : __set_difference
-{
-};
-template <>
-struct __get_set_operation<oneapi::dpl::unseq_backend::_UnionTag> : __set_union
-{
-};
+        auto __write_temp_element = [&](const _SizeType __count_arg, const auto& __value, std::size_t __idx1,
+                                        std::size_t __idx2) {
+            if constexpr (_TempOutput::__capture_indexes_flag)
+                __temp_out.set(__count_arg, __value, {__idx1, __idx2});
+            else
+                __temp_out.set(__count_arg, __value);
+        };
 
-template <>
-struct __get_set_operation<oneapi::dpl::unseq_backend::_SymmetricDifferenceTag> : __set_symmetric_difference
-{
+        // Merge-path indices captured at iteration entry. The global merge path is partitioned across
+        // work-items and walked exactly once, so the single step that first reaches the operation's natural
+        // termination boundary occurs in exactly one work-item at exactly one iteration. Comparing the entry
+        // indices against the post-step indices detects precisely that transition (the edge crossing), which
+        // lets a single work-item write the final source position directly, with no reduction and no atomics.
+        [[maybe_unused]] const std::size_t __idx1_at_entry = __idx1;
+        [[maybe_unused]] const std::size_t __idx2_at_entry = __idx2;
+
+        auto __process_final_pos = [&](std::size_t __idx1, std::size_t __idx2) {
+            if constexpr (__need_call_final_pos_saver)
+            {
+                // For set_intersection the operation terminates once either input is exhausted: the edge crossing
+                // is the step that moves from "strictly inside both inputs" to "at least one input exhausted".
+                if constexpr (__is_set_intersection)
+                {
+                    if (__idx1_at_entry < __size1 && __idx2_at_entry < __size2 &&
+                        (__idx1 == __size1 || __idx2 == __size2))
+                        __final_pos_saver({__idx1, __idx2});
+                }
+                // For set_difference the operation terminates once the first input (set A) is exhausted: the edge
+                // crossing is the step that moves idx1 to the end of set A. This also covers the tail-drain of set
+                // A performed after set B is exhausted.
+                else if constexpr (__is_set_difference)
+                {
+                    if (__idx1_at_entry < __size1 && __idx1 == __size1)
+                        __final_pos_saver({__idx1, __idx2});
+                }
+            }
+        };
+
+        if (__check_bounds)
+        {
+            if (__idx1 == __size1)
+            {
+                if constexpr (__is_set_union || __is_set_symmetric_difference)
+                {
+                    // If we are at the end of rng1, copy the rest of rng2 within our diagonal's bounds
+                    for (; __idx2 < __size2 && __idx < __num_eles_min; ++__idx2, ++__idx)
+                    {
+                        __write_temp_element(__count, __in_rng2[__idx2], __idx1, __idx2);
+                        ++__count;
+                    }
+                }
+                __idx = __num_eles_min;
+                if constexpr (__need_call_final_pos_saver)
+                    __process_final_pos(__idx1, __idx2);
+                return;
+            }
+
+            if (__idx2 == __size2)
+            {
+                if constexpr (!__is_set_intersection)
+                {
+                    // If we are at the end of rng2, copy the rest of rng1 within our diagonal's bounds
+                    for (; __idx1 < __size1 && __idx < __num_eles_min; ++__idx1, ++__idx)
+                    {
+                        __write_temp_element(__count, __in_rng1[__idx1], __idx1, __idx2);
+                        ++__count;
+                    }
+                }
+                __idx = __num_eles_min;
+                if constexpr (__need_call_final_pos_saver)
+                    __process_final_pos(__idx1, __idx2);
+                return;
+            }
+        }
+
+        const _ValueTypeRng1& __ele_rng1 = __in_rng1[__idx1];
+        const _ValueTypeRng2& __ele_rng2 = __in_rng2[__idx2];
+        if (std::invoke(__comp, std::invoke(__proj1, __ele_rng1), std::invoke(__proj2, __ele_rng2)))
+        {
+            if constexpr (!__is_set_intersection)
+            {
+                __write_temp_element(__count, __ele_rng1, __idx1, __idx2);
+                ++__count;
+            }
+            ++__idx1;
+            ++__idx;
+        }
+        else if (std::invoke(__comp, std::invoke(__proj2, __ele_rng2), std::invoke(__proj1, __ele_rng1)))
+        {
+            if constexpr (__is_set_union || __is_set_symmetric_difference)
+            {
+                __write_temp_element(__count, __ele_rng2, __idx1, __idx2);
+                ++__count;
+            }
+            ++__idx2;
+            ++__idx;
+        }
+        else // if neither element is less than the other, they are equal
+        {
+            if constexpr (__is_set_intersection || __is_set_union)
+            {
+                __write_temp_element(__count, __ele_rng1, __idx1, __idx2);
+                ++__count;
+            }
+            ++__idx1;
+            ++__idx2;
+            __idx += 2;
+        }
+        // The edge crossing can only occur on a diagonal that can reach a range end, i.e. when bounds are
+        // checked. Keep the interior hot path free of the extra comparisons.
+        if constexpr (__need_call_final_pos_saver)
+        {
+            if (__check_bounds)
+                __process_final_pos(__idx1, __idx2);
+        }
+    }
 };
 
 template <bool __return_star, typename _Rng, typename _IdxT>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -496,6 +496,10 @@ struct __set_operation
         constexpr bool __is_set_union = std::is_same_v<_SetTag, unseq_backend::_UnionTag>;
         constexpr bool __is_set_symmetric_difference = std::is_same_v<_SetTag, unseq_backend::_SymmetricDifferenceTag>;
 
+        constexpr bool _CopyMatch = __is_set_intersection || __is_set_union;
+        constexpr bool _CopyDiffSetA = !__is_set_intersection;
+        constexpr bool _CopyDiffSetB = __is_set_union || __is_set_symmetric_difference;
+
         // Make sense to calculate final positions only for set_intersection and set_difference operations,
         // and only if the user provided a callback to save the final positions.
         // Stop positions for set_union and set_symmetric_difference are not needed, because they are known in advance.
@@ -548,7 +552,7 @@ struct __set_operation
         {
             if (__idx1 == __size1)
             {
-                if constexpr (__is_set_union || __is_set_symmetric_difference)
+                if constexpr (_CopyDiffSetB)
                 {
                     // If we are at the end of rng1, copy the rest of rng2 within our diagonal's bounds
                     for (; __idx2 < __size2 && __idx < __num_eles_min; ++__idx2, ++__idx)
@@ -565,7 +569,7 @@ struct __set_operation
 
             if (__idx2 == __size2)
             {
-                if constexpr (!__is_set_intersection)
+                if constexpr (_CopyDiffSetA)
                 {
                     // If we are at the end of rng2, copy the rest of rng1 within our diagonal's bounds
                     for (; __idx1 < __size1 && __idx < __num_eles_min; ++__idx1, ++__idx)
@@ -585,7 +589,7 @@ struct __set_operation
         const _ValueTypeRng2& __ele_rng2 = __in_rng2[__idx2];
         if (std::invoke(__comp, std::invoke(__proj1, __ele_rng1), std::invoke(__proj2, __ele_rng2)))
         {
-            if constexpr (!__is_set_intersection)
+            if constexpr (_CopyDiffSetA)
             {
                 __write_temp_element(__count, __ele_rng1, __idx1, __idx2);
                 ++__count;
@@ -595,7 +599,7 @@ struct __set_operation
         }
         else if (std::invoke(__comp, std::invoke(__proj2, __ele_rng2), std::invoke(__proj1, __ele_rng1)))
         {
-            if constexpr (__is_set_union || __is_set_symmetric_difference)
+            if constexpr (_CopyDiffSetB)
             {
                 __write_temp_element(__count, __ele_rng2, __idx1, __idx2);
                 ++__count;
@@ -605,7 +609,7 @@ struct __set_operation
         }
         else // if neither element is less than the other, they are equal
         {
-            if constexpr (__is_set_intersection || __is_set_union)
+            if constexpr (_CopyMatch)
             {
                 __write_temp_element(__count, __ele_rng1, __idx1, __idx2);
                 ++__count;

--- a/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
+++ b/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
@@ -57,7 +57,7 @@ test_serial_set_op_count(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__noop_temp_data __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -82,7 +82,7 @@ test_serial_set_op_count_and_write(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<10, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -115,7 +115,7 @@ test_serial_set_op_count_and_write2(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<10, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -148,7 +148,7 @@ test_serial_set_op_count_and_write_limited(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<11, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 4, 2, 10, __temp_data, std::less<int>(), oneapi::dpl::identity{},
                                    oneapi::dpl::identity{}, oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -183,7 +183,7 @@ test_serial_set_op_count_and_write2_large_setA(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<15, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -217,7 +217,7 @@ test_serial_set_op_count_and_write2_large_setB(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<15, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -363,7 +363,7 @@ template <typename _Rng1, typename _Rng2, typename _Comp>
 bool
 test_find_balanced_path_impl(_Rng1 __rng1, _Rng2 __rng2, _Comp __comp)
 {
-    using _SetOperation = oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>;
+    using _SetOperation = oneapi::dpl::__par_backend_hetero::__set_operation<oneapi::dpl::unseq_backend::_IntersectionTag>;
     using _BoundsProvider = oneapi::dpl::__par_backend_hetero::__get_bounds_simple;
 
     using _GenReduceInput =

--- a/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
+++ b/test/general/implementation_details/balanced_path_unit_tests.pass.cpp
@@ -57,7 +57,7 @@ test_serial_set_op_count(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__noop_temp_data __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__get_set_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -82,7 +82,7 @@ test_serial_set_op_count_and_write(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<10, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__get_set_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -115,7 +115,7 @@ test_serial_set_op_count_and_write2(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<10, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__get_set_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -148,7 +148,7 @@ test_serial_set_op_count_and_write_limited(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<11, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__get_set_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 4, 2, 10, __temp_data, std::less<int>(), oneapi::dpl::identity{},
                                    oneapi::dpl::identity{}, oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -183,7 +183,7 @@ test_serial_set_op_count_and_write2_large_setA(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<15, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__get_set_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -217,7 +217,7 @@ test_serial_set_op_count_and_write2_large_setB(SetTag set_tag)
     std::vector<int> v3(v1.size() + v2.size());
 
     oneapi::dpl::__par_backend_hetero::__temp_data_array<15, int> __temp_data{};
-    oneapi::dpl::__par_backend_hetero::__get_set_operation<SetTag> __set_op;
+    oneapi::dpl::__par_backend_hetero::__set_generic_operation<SetTag> __set_op;
     std::uint16_t count = __set_op(v1, v2, 0, 0, v1.size() + v2.size(), __temp_data, std::less<int>(), oneapi::dpl::identity{}, oneapi::dpl::identity{},
                                    oneapi::dpl::__par_backend_hetero::__internal::__no_callback_tag{});
 
@@ -363,7 +363,7 @@ template <typename _Rng1, typename _Rng2, typename _Comp>
 bool
 test_find_balanced_path_impl(_Rng1 __rng1, _Rng2 __rng2, _Comp __comp)
 {
-    using _SetOperation = oneapi::dpl::__par_backend_hetero::__get_set_operation<oneapi::dpl::unseq_backend::_IntersectionTag>;
+    using _SetOperation = oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>;
     using _BoundsProvider = oneapi::dpl::__par_backend_hetero::__get_bounds_simple;
 
     using _GenReduceInput =

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -175,7 +175,7 @@ test_device_copyable()
 
     //__gen_set_balanced_path
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
-                      oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
+                      oneapi::dpl::__par_backend_hetero::__set_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
                       oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_device_copyable,
                       binary_op_device_copyable, binary_op_device_copyable>>,
                   "__gen_set_balanced_path is not device copyable with device copyable types");
@@ -184,7 +184,7 @@ test_device_copyable()
     //__partition_set_balanced_path_submitter
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__partition_set_balanced_path_submitter<
                       oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
-                          oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
+                          oneapi::dpl::__par_backend_hetero::__set_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
                           oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_device_copyable,
                           binary_op_device_copyable, binary_op_device_copyable>,
                       oneapi::dpl::execution::DefaultKernelName>>,
@@ -194,7 +194,7 @@ test_device_copyable()
     //__gen_set_op_from_known_balanced_path
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
-            oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
+            oneapi::dpl::__par_backend_hetero::__set_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
             oneapi::dpl::__internal::__ignore_call_op, int, binary_op_device_copyable,
             binary_op_device_copyable, binary_op_device_copyable>>,
         "__gen_set_op_from_known_balanced_path is not device copyable with device copyable types");
@@ -493,7 +493,7 @@ test_non_device_copyable()
 
     //__gen_set_balanced_path
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
-                      oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
+                      oneapi::dpl::__par_backend_hetero::__set_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
                       oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_non_device_copyable,
                       binary_op_non_device_copyable, binary_op_non_device_copyable>>,
                   "__gen_set_balanced_path is device copyable with non device copyable types");
@@ -503,7 +503,7 @@ test_non_device_copyable()
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__partition_set_balanced_path_submitter<
             oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
-                oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
+                oneapi::dpl::__par_backend_hetero::__set_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
                 oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_non_device_copyable,
                 binary_op_non_device_copyable, binary_op_non_device_copyable>,
             oneapi::dpl::execution::DefaultKernelName>>,
@@ -513,7 +513,7 @@ test_non_device_copyable()
     //__gen_set_op_from_known_balanced_path
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
-            oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
+            oneapi::dpl::__par_backend_hetero::__set_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
             oneapi::dpl::__internal::__ignore_call_op, int, binary_op_non_device_copyable,
             binary_op_non_device_copyable, binary_op_non_device_copyable>>,
         "__gen_set_op_from_known_balanced_path is device copyable with non device copyable types");

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -175,7 +175,7 @@ test_device_copyable()
 
     //__gen_set_balanced_path
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
-                      oneapi::dpl::__par_backend_hetero::__set_intersection,
+                      oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
                       oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_device_copyable,
                       binary_op_device_copyable, binary_op_device_copyable>>,
                   "__gen_set_balanced_path is not device copyable with device copyable types");
@@ -184,7 +184,7 @@ test_device_copyable()
     //__partition_set_balanced_path_submitter
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__partition_set_balanced_path_submitter<
                       oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
-                          oneapi::dpl::__par_backend_hetero::__set_intersection,
+                          oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
                           oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_device_copyable,
                           binary_op_device_copyable, binary_op_device_copyable>,
                       oneapi::dpl::execution::DefaultKernelName>>,
@@ -194,7 +194,7 @@ test_device_copyable()
     //__gen_set_op_from_known_balanced_path
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
-            oneapi::dpl::__par_backend_hetero::__set_intersection,
+            oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
             oneapi::dpl::__internal::__ignore_call_op, int, binary_op_device_copyable,
             binary_op_device_copyable, binary_op_device_copyable>>,
         "__gen_set_op_from_known_balanced_path is not device copyable with device copyable types");
@@ -493,7 +493,7 @@ test_non_device_copyable()
 
     //__gen_set_balanced_path
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
-                      oneapi::dpl::__par_backend_hetero::__set_intersection,
+                      oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
                       oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_non_device_copyable,
                       binary_op_non_device_copyable, binary_op_non_device_copyable>>,
                   "__gen_set_balanced_path is device copyable with non device copyable types");
@@ -503,7 +503,7 @@ test_non_device_copyable()
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__partition_set_balanced_path_submitter<
             oneapi::dpl::__par_backend_hetero::__gen_set_balanced_path<
-                oneapi::dpl::__par_backend_hetero::__set_intersection,
+                oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
                 oneapi::dpl::__par_backend_hetero::__get_bounds_simple, int, binary_op_non_device_copyable,
                 binary_op_non_device_copyable, binary_op_non_device_copyable>,
             oneapi::dpl::execution::DefaultKernelName>>,
@@ -513,7 +513,7 @@ test_non_device_copyable()
     //__gen_set_op_from_known_balanced_path
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_set_op_from_known_balanced_path<
-            oneapi::dpl::__par_backend_hetero::__set_intersection,
+            oneapi::dpl::__par_backend_hetero::__set_generic_operation<oneapi::dpl::unseq_backend::_IntersectionTag>,
             oneapi::dpl::__internal::__ignore_call_op, int, binary_op_non_device_copyable,
             binary_op_non_device_copyable, binary_op_non_device_copyable>>,
         "__gen_set_op_from_known_balanced_path is device copyable with non device copyable types");


### PR DESCRIPTION
## Description

Non-functional refactoring + renaming of the serial set-operation helper used by the reduce-then-scan hetero backend (`__parallel_set_write_a_b_op`) for `set_intersection` / `set_difference` / `set_union` / `set_symmetric_difference`. No change in runtime behavior — this is a readability/structure cleanup on top of the bounded set-op hetero work.

## What changed

**1. Tag-based dispatch replaces boolean template flags**
- Removed the `__get_set_operation<_SetTag>` trait (primary template + 4 specializations) and the four `using` aliases (`__set_intersection`, `__set_difference`, `__set_union`, `__set_symmetric_difference`).
- `struct __set_generic_operation<bool _CopyMatch, bool _CopyDiffSetA, bool _CopyDiffSetB>` → `struct __set_operation<typename _SetTag>`. The per-branch copy decisions are now derived directly from the tag via `std::is_same_v` (`__is_set_intersection` / `__is_set_difference` / `__is_set_union` / `__is_set_symmetric_difference`), removing the extra indirection layer.

**2. Free helper folded into the class**
- The free function `__set_generic_operation_iteration<...>` is now a `protected` member `__set_operation_iteration` of `__set_operation`, so the explicit `<_CopyMatch, _CopyDiffSetA, _CopyDiffSetB>` template arguments are no longer needed at the call site.

**3. Rename**
- `__set_generic_operation` → `__set_operation`; the call site in `parallel_backend_sycl.h` (`_SetOperation` alias) is updated accordingly.

**4. Tests**
- `balanced_path_unit_tests.pass.cpp` and `device_copyable.pass.cpp` updated to reference `__set_operation<...Tag>` (the removed `__set_intersection` alias in the device-copyable checks becomes `__set_operation<unseq_backend::_IntersectionTag>`).

## Behavior preserved

The tag → copy-flag mapping is equivalent to the previous aliases:

| Set operation | copy match | copy from A | copy from B |
|---|:---:|:---:|:---:|
| `set_intersection` | yes | no | no |
| `set_difference` | no | yes | no |
| `set_union` | yes | yes | yes |
| `set_symmetric_difference` | no | yes | yes |

Serial traversal, final-position / OOB handling, and device-copyability constraints are unchanged.

## Testing

Covered by existing tests (no new tests required for this NFC change):
- `test/general/implementation_details/balanced_path_unit_tests.pass.cpp` — all four tags, count and count+write, large set A / set B, bounded output.
- `test/general/implementation_details/device_copyable.pass.cpp` — device-copyable / non-device-copyable checks for the set-op generators.
