### PR TITLE
sycl_iterator explicitly not device copyable 

### DIFF
--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -28,6 +28,11 @@
 #    define _ONEDPL_CPP20_CONCEPTS_PRESENT 0
 #endif
 
+// -- Check for C++20 requires-clause support --
+// This is the concepts language feature (a requires-clause, e.g. on a constrained partial specialization) and,
+// unlike _ONEDPL_CPP20_CONCEPTS_PRESENT, does not depend on the <concepts> library.
+#define _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT (__cpp_concepts >= 201907L)
+
 // -- Check for C++20 Ranges support --
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
 // Ranges library is available if the standard library provides it and concepts are supported

--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -30,8 +30,14 @@
 
 // -- Check for C++20 requires-clause support --
 // This is the concepts language feature (a requires-clause, e.g. on a constrained partial specialization) and,
-// unlike _ONEDPL_CPP20_CONCEPTS_PRESENT, does not depend on the <concepts> library.
-#define _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT (__cpp_concepts >= 201907L)
+// unlike _ONEDPL_CPP20_CONCEPTS_PRESENT, does not depend on the <concepts> library. Defined to a literal 0/1 so
+// it is usable both in #if directives and in ordinary expressions (where an undefined __cpp_concepts would be an
+// error rather than substituted with 0).
+#if __cpp_concepts >= 201907L
+#    define _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT 1
+#else
+#    define _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT 0
+#endif
 
 // -- Check for C++20 Ranges support --
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT

--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -29,10 +29,7 @@
 #endif
 
 // -- Check for C++20 requires-clause support --
-// This is the concepts language feature (a requires-clause, e.g. on a constrained partial specialization) and,
-// unlike _ONEDPL_CPP20_CONCEPTS_PRESENT, does not depend on the <concepts> library. Defined to a literal 0/1 so
-// it is usable both in #if directives and in ordinary expressions (where an undefined __cpp_concepts would be an
-// error rather than substituted with 0).
+// This is the concepts language feature (a requires-clause, e.g. on a constrained partial specialization)
 #if __cpp_concepts >= 201907L
 #    define _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT 1
 #else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -798,6 +798,24 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backen
 {
 };
 
+namespace oneapi::dpl::__internal
+{
+
+template <sycl::access_mode Mode, typename T, typename Allocator>
+struct sycl_iterator;
+
+} // namespace oneapi::dpl::__internal
+
+// sycl_iterator is not device_copyable: it wraps a sycl::buffer and is only usable on the host. This
+// specialization is more specialized than any user-provided template <class T> struct is_device_copyable<T>
+// specialization, so it takes precedence and keeps sycl_iterator from being mistaken for a directly-passable,
+// device-ready iterator.
+template <sycl::access_mode Mode, typename T, typename Allocator>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::sycl_iterator, Mode, T, Allocator)>
+    : std::false_type
+{
+};
+
 namespace oneapi::dpl::internal
 {
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -612,7 +612,8 @@ struct __get_sycl_range
 
     // for raw pointers and direct pass objects (for example, counting_iterator, iterator of USM-containers)
     template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
-    std::enable_if_t<oneapi::dpl::__ranges::__is_passed_directly_device_ready_v<_Iter>,
+    std::enable_if_t<!oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter> &&
+                         oneapi::dpl::__ranges::__is_passed_directly_device_ready_v<_Iter>,
                      __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>>
     __process_input_iter(_Iter __first, _Iter __last)
     {

--- a/test/general/implementation_details/device_copyable_sycl_iterator.pass.cpp
+++ b/test/general/implementation_details/device_copyable_sycl_iterator.pass.cpp
@@ -1,0 +1,39 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/test_config.h"
+
+#include _PSTL_TEST_HEADER(execution)
+#include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
+using namespace TestUtils;
+
+#if TEST_DPCPP_BACKEND_PRESENT
+
+#    include "support/utils_device_copyable.h"
+#    include "support/utils_sycl_defs.h"
+
+
+// The following is ill-advised, but we need to guard against such actions a user may take
+template <class T>
+requires(true)
+struct sycl::is_device_copyable<T> : std::true_type {};
+
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+std::int32_t
+main()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::sycl_iterator<sycl::access_mode::read, int>>,
+                  "sycl_iterator is device copyable but should never be");
+#endif // TEST_DPCPP_BACKEND_PRESENT
+    return done(TEST_DPCPP_BACKEND_PRESENT);
+}

--- a/test/general/implementation_details/device_copyable_sycl_iterator.pass.cpp
+++ b/test/general/implementation_details/device_copyable_sycl_iterator.pass.cpp
@@ -15,7 +15,9 @@
 #include "support/utils.h"
 using namespace TestUtils;
 
-#if TEST_DPCPP_BACKEND_PRESENT
+// The sweeping user specialization below uses a C++20 trailing requires-clause, which is required to make
+// a partial specialization whose argument pattern is a bare template parameter well-formed.
+#if TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT
 
 #    include "support/utils_device_copyable.h"
 #    include "support/utils_sycl_defs.h"
@@ -26,14 +28,14 @@ template <class T>
 requires(true)
 struct sycl::is_device_copyable<T> : std::true_type {};
 
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT
 
 std::int32_t
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT
+#if TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::sycl_iterator<sycl::access_mode::read, int>>,
                   "sycl_iterator is device copyable but should never be");
-#endif // TEST_DPCPP_BACKEND_PRESENT
-    return done(TEST_DPCPP_BACKEND_PRESENT);
+#endif // TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT
+    return done(TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT);
 }


### PR DESCRIPTION
This PR adds an explicit specialization for `is_device_copyable` for our sycl_iterator class buffer wrapper objects. 
This guards against any sweeping device copyable specializations that users may add which match sycl_iterator.

We also guard against a potential ambiguous overload for hetero_iterators which are not within oneDPL matching a similar device copyable specialization by guarding in the enable_if against hetero_iterators for the device copyable overload in our iterator processing code.