### PR TITLE
Adding broken macro for msvc complex double log/pow

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -231,7 +231,7 @@
 // MSVC STL implements the std::complex transcendentals log/log10/pow for double (and long double)
 // that reads the non-const global variable __isa_available. SYCL device code cannot reference non-const global
 // variables, so these operations fail to compile in the device pass.
-#define _PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN                                                                  \
+#define _PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN                                                             \
     (_MSVC_STL_VERSION && _MSVC_STL_UPDATE >= 202509L && __SYCL_DEVICE_ONLY__)
 
 #define _PSTL_ICC_TEST_UNDERLYING_TYPE_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 9)

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -228,6 +228,12 @@
 #define _PSTL_TEST_COMPLEX_DIV_COMPLEX_BROKEN _PSTL_TEST_COMPLEX_OP_BROKEN
 #define _PSTL_TEST_COMPLEX_DIV_COMPLEX_BROKEN_IN_INTEL_LLVM_COMPILER _PSTL_TEST_COMPLEX_OP_BROKEN_IN_INTEL_LLVM_COMPILER
 
+// MSVC STL implements the std::complex transcendentals log/log10/pow for double (and long double)
+// that reads the non-const global variable __isa_available. SYCL device code cannot reference non-const global
+// variables, so these operations fail to compile in the device pass.
+#define _PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN                                                                  \
+    (_MSVC_STL_VERSION && _MSVC_STL_UPDATE >= 202509L && __SYCL_DEVICE_ONLY__)
+
 #define _PSTL_ICC_TEST_UNDERLYING_TYPE_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 9)
 
 // Known limitation:

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -83,7 +83,7 @@ ONEDPL_TEST_NUM_MAIN
     // These pow overloads promote to complex<double> (or complex<long double>), which MSVC STL
     // implements via a runtime CPU-feature dispatch that reads a non-const global variable that
     // cannot be referenced from SYCL device code.
-#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#if !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(
 #if !_PSTL_GLIBCXX_TEST_COMPLEX_POW_BROKEN
                       test<int, float>();
@@ -104,7 +104,7 @@ ONEDPL_TEST_NUM_MAIN
                            test<double, long double>();
                            test<long double, float>();
                            test<long double, double>())
-#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#endif // !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
 
     return 0;
 }

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -80,6 +80,10 @@ test(::std::enable_if_t<!std::is_integral_v<T>>* = 0, ::std::enable_if_t<!std::i
 
 ONEDPL_TEST_NUM_MAIN
 {
+    // These pow overloads promote to complex<double> (or complex<long double>), which MSVC STL
+    // implements via a runtime CPU-feature dispatch that reads a non-const global variable that
+    // cannot be referenced from SYCL device code.
+#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(
 #if !_PSTL_GLIBCXX_TEST_COMPLEX_POW_BROKEN
                       test<int, float>();
@@ -100,6 +104,7 @@ ONEDPL_TEST_NUM_MAIN
                            test<double, long double>();
                            test<long double, float>();
                            test<long double, double>())
+#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
 
-  return 0;
+    return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/log.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/log.pass.cpp
@@ -130,9 +130,13 @@ ONEDPL_TEST_NUM_MAIN
     IF_DOUBLE_SUPPORT(test<float>())
 #endif
 
+    // log for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
+    // non-const global variable, which cannot be referenced from SYCL device code.
+#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
+#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
 
-  return 0;
+    return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/log.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/log.pass.cpp
@@ -132,11 +132,11 @@ ONEDPL_TEST_NUM_MAIN
 
     // log for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
     // non-const global variable, which cannot be referenced from SYCL device code.
-#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#if !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
-#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#endif // !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
 
     return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/log10.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/log10.pass.cpp
@@ -70,11 +70,11 @@ ONEDPL_TEST_NUM_MAIN
 
     // log10 for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
     // non-const global variable, which cannot be referenced from SYCL device code.
-#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#if !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
-#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#endif // !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
 
     return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/log10.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/log10.pass.cpp
@@ -68,9 +68,13 @@ ONEDPL_TEST_NUM_MAIN
     IF_DOUBLE_SUPPORT(test<float>())
 #endif
 
+    // log10 for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
+    // non-const global variable, which cannot be referenced from SYCL device code.
+#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
+#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
 
-  return 0;
+    return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_complex.pass.cpp
@@ -86,11 +86,11 @@ ONEDPL_TEST_NUM_MAIN
 #endif
     // pow for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
     // non-const global variable, which cannot be referenced from SYCL device code.
-#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#if !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
-#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#endif // !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
 
     return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_complex.pass.cpp
@@ -84,9 +84,13 @@ ONEDPL_TEST_NUM_MAIN
 #else
     test<float>();
 #endif
+    // pow for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
+    // non-const global variable, which cannot be referenced from SYCL device code.
+#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
+#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
 
-  return 0;
+    return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
@@ -78,9 +78,13 @@ ONEDPL_TEST_NUM_MAIN
 #else
     test<float>();
 #endif
+    // pow for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
+    // non-const global variable, which cannot be referenced from SYCL device code.
+#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
+#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
 
-  return 0;
+    return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
@@ -80,11 +80,11 @@ ONEDPL_TEST_NUM_MAIN
 #endif
     // pow for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
     // non-const global variable, which cannot be referenced from SYCL device code.
-#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#if !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
-#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#endif // !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
 
     return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
@@ -79,9 +79,13 @@ ONEDPL_TEST_NUM_MAIN
     IF_DOUBLE_SUPPORT(test<float>())
 #endif
 
+    // pow for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
+    // non-const global variable, which cannot be referenced from SYCL device code.
+#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
+#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
 
-  return 0;
+    return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
@@ -81,11 +81,11 @@ ONEDPL_TEST_NUM_MAIN
 
     // pow for double is implemented in MSVC STL via a runtime CPU-feature dispatch that reads a
     // non-const global variable, which cannot be referenced from SYCL device code.
-#if !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#if !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
     IF_DOUBLE_SUPPORT(test_edges())
-#endif // !_PSTL_TEST_COMPLEX_LOG_POW_SYCL_DEVICE_BROKEN
+#endif // !_PSTL_TEST_COMPLEX_MSVC_LOG_POW_SYCL_DEVICE_BROKEN
 
     return 0;
 }


### PR DESCRIPTION
MSVC STL implements complex double log / log10 and pow using a non-const global variable to check availability of instructions.   This is not supported on the device, so it cannot be used in SYCL kernels.  

This adds a broken macro to avoid this case for affected versions on windows.