### PR TITLE
Transform iterator assignment change

### DIFF
--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -516,14 +516,14 @@ class transform_iterator
     {
         __my_it_ = __input.__my_it_;
 
-        // If copy assignment is available, copy the functor, otherwise skip it.
-        // For non-copy assignable functors, this copy assignment operator departs from the sycl 2020 specification
-        // requirement of device copyable types for copy assignment to be the same as a bitwise copy of the object.
-        // TODO: Explore (ABI breaking) change to use std::optional or similar and using copy constructor to implement
-        //       copy assignment to better comply with SYCL 2020 specification.
-        if constexpr (std::is_copy_assignable_v<_UnaryFunc>)
+        // Implement functor copy assignment via destroy + copy-construct rather than _UnaryFunc::operator=.
+        // This supports copy assignment of functors which are not copy assignable (like c++17 lambdas).
+        // For a unary functor who's copy assignment operator differs from its copy constructor, the semantics of this
+        // copy assignment will follow that of its copy constructor.
+        if (this != std::addressof(__input))
         {
-            __my_unary_func_ = __input.__my_unary_func_;
+            __my_unary_func_.~_UnaryFunc();
+            ::new (std::addressof(__my_unary_func_)) _UnaryFunc(__input.__my_unary_func_);
         }
         return *this;
     }

--- a/test/parallel_api/iterator/transform_iterator_constructible.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator_constructible.pass.cpp
@@ -101,11 +101,11 @@ test_copy_assignment()
 
     EXPECT_EQ(9, trans6[5], "transform_iterator returns the incorrect result");
 
-    //should NOT copy __x state of functor (but still allows assignment of iterator)
+    //should still copy __x state of functor (despite not being copy-assignable)
     trans6 = trans5;
 
     //trans6 functor.__x remains the same, but iterator has been updated to be 100 elements later in the counting iter
-    EXPECT_EQ(109, trans6[5], "transform_iterator assignment with non-copy-assignable functor copies functor");
+    EXPECT_EQ(108, trans6[5], "transform_iterator assignment with non-copy-assignable functor still copies functor");
 }
 
 void


### PR DESCRIPTION
This PR switches `transform_iterator` copy assignment to use placement new copy construction for the unary functor.
(breaking change)
---

`transform_iterator` currently skips assignment of the unary functor if no copy assignment exists by checking constexpr `is_copy_assignable_v`. (explained [here](https://github.com/uxlfoundation/oneDPL/pull/1445#discussion_r1567382674) )
However, `is_copy_assignable_v` only checks for the existence of a copy assignment operator, rather than instantiating it.  If it is not well formed, then this breaks compilation.  

This originally was necessary to support the copy assignment of transform iterators based upon C++17 lambdas (which are not copy assignable).  

This PR provides a possible option for supporting copy assignment for functors lacking copy assignment without this ill-formed copy assignment operator trap.  

**I would call this a breaking change**, as it changes the semantics of copy assignment in a couple ways for a public API tranform_iterator.

1) In the rare case that (deletion followed by copy construction) vs (copy assignment operator) are defined with different semantics, the copy assignment of transform_iterator will follow copy construction semantics for the unary functor.  Note that for device copyable types this cannot be the case as both should be equivalent to bitwise copies and deletion should be a noop.
2) Copy assignment now *always* copies the unary functor rather than only when copy assignment exists.  This seems very unlikely to cause issues in reality for the same reason that we allowed skipping such cases in the first place.

Both of these are rare corner cases, but technically may affect existing user codes.  