### PR TITLE
Add ranges::partition_copy for standard aligned (CPU) policies

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1792,14 +1792,11 @@ std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
 __pattern_partition_copy(__serial_tag<_IsVector /*TODO: std::false_type*/>, _ExecutionPolicy&&, _InRange&& __in_r,
                          _OutRange1&& __out_true_r, _OutRange2&& __out_false_r, _Pred __pred, _Proj __proj)
 {
-    auto [__it_in, __it_out1, __it_out2] =
-        __brick_bounded_partition_copy(std::ranges::begin(__in_r), std::ranges::end(__in_r),
-                                       std::ranges::begin(__out_true_r),  std::ranges::end(__out_true_r),
-                                       std::ranges::begin(__out_false_r), std::ranges::end(__out_false_r),
-                                       [=](auto __it, std::size_t /*__i*/) -> bool
-                                       {
-                                           return std::invoke(__pred, std::invoke(__proj, *__it));
-                                       }, _IsVector{});
+    auto [__it_in, __it_out1, __it_out2] = __brick_bounded_partition_copy(
+        std::ranges::begin(__in_r), std::ranges::end(__in_r), std::ranges::begin(__out_true_r),
+        std::ranges::end(__out_true_r), std::ranges::begin(__out_false_r), std::ranges::end(__out_false_r),
+        [=](auto __it, std::size_t /*__i*/) -> bool { return std::invoke(__pred, std::invoke(__proj, *__it)); },
+        _IsVector{});
     return {__it_in, __it_out1, __it_out2};
 }
 
@@ -1839,7 +1836,7 @@ __pattern_partition_copy(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
                 },
                 [](const _OutputPos& __x, const _OutputPos& __y) -> _OutputPos { // Combine
                     return std::make_pair(__x.first + __y.first, __x.second + __y.second);
-                },                                                                      
+                },
                 [=, &__stop_in, &__stop_out1, &__stop_out2](std::intptr_t __i, std::intptr_t __len,
                                                             _OutputPos __initial) { // Scan
                     if (__initial.first > __n_out1 && __initial.second > __n_out2) // no place to write for the chunk

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1856,7 +1856,7 @@ __pattern_partition_copy_ranges(__parallel_tag<_IsVector> __tag, _ExecutionPolic
                         auto [__next_in, __next_out1, __next_out2] = __brick_bounded_partition_copy(
                             __begin + __i, __begin + (__i + __len), __out1_begin + __initial.first,
                             __out1_begin + __n_out1, __out2_begin + __initial.second, __out2_begin + __n_out2,
-                            [=](auto /*__it*/, std::intptr_t __j) { return __mask[__j]; }, _IsVector{});
+                            [=](auto /*__it*/, std::intptr_t __j) { return __mask[__i + __j]; }, _IsVector{});
                         // If the end of the chunk is not reached, then the stop positions are found.
                         if (__next_in - __begin < __i + __len)
                         {

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1751,6 +1751,136 @@ __pattern_unique_copy(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPoli
     }
     return {__it_in, __it_out};
 }
+
+//---------------------------------------------------------------------------------------------------------------------
+// __pattern_partition_copy
+//---------------------------------------------------------------------------------------------------------------------
+
+template <typename _IsVector, typename _ForwardIterator, typename _FwdSentinel, typename _OutIterator1,
+          typename _OutSentinel1, class _OutIterator2, class _OutSentinel2, typename _Condition>
+std::tuple<_ForwardIterator, _OutIterator1, _OutIterator2>
+__brick_bounded_partition_copy(_ForwardIterator __it_in, _FwdSentinel __end_in, _OutIterator1 __it_out1,
+                               _OutSentinel1 __end_out1, _OutIterator2 __it_out2, _OutSentinel2 __end_out2,
+                               _Condition __cond, _IsVector /*TODO: dispatch*/)
+{
+    std::size_t __i = 0;
+    for (; __it_in != __end_in; ++__it_in, ++__i)
+    {
+        if (__cond(__it_in, __i))
+        {
+            if (__it_out1 == __end_out1)
+                break;
+            *__it_out1 = *__it_in;
+            ++__it_out1;
+        }
+        else
+        {
+            if (__it_out2 == __end_out2)
+                break;
+            *__it_out2 = *__it_in;
+            ++__it_out2;
+        }
+    }
+    return {__it_in, __it_out1, __it_out2};
+}
+
+template <typename _IsVector, typename _ExecutionPolicy, typename _InRange, typename _OutRange1, typename _OutRange2,
+          typename _Pred, typename _Proj>
+std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
+                                   std::ranges::borrowed_iterator_t<_OutRange1>,
+                                   std::ranges::borrowed_iterator_t<_OutRange2>>
+__pattern_partition_copy(__serial_tag<_IsVector /*TODO: std::false_type*/>, _ExecutionPolicy&&, _InRange&& __in_r,
+                         _OutRange1&& __out_true_r, _OutRange2&& __out_false_r, _Pred __pred, _Proj __proj)
+{
+    auto [__it_in, __it_out1, __it_out2] =
+        __brick_bounded_partition_copy(std::ranges::begin(__in_r), std::ranges::end(__in_r),
+                                       std::ranges::begin(__out_true_r),  std::ranges::end(__out_true_r),
+                                       std::ranges::begin(__out_false_r), std::ranges::end(__out_false_r),
+                                       [=](auto __it, std::size_t /*__i*/) -> bool
+                                       {
+                                           return std::invoke(__pred, std::invoke(__proj, *__it));
+                                       }, _IsVector{});
+    return {__it_in, __it_out1, __it_out2};
+}
+
+template <typename _IsVector, typename _ExecutionPolicy, typename _InRange, typename _OutRange1, typename _OutRange2,
+          typename _Pred, typename _Proj>
+std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
+                                   std::ranges::borrowed_iterator_t<_OutRange1>,
+                                   std::ranges::borrowed_iterator_t<_OutRange2>>
+__pattern_partition_copy(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r,
+                         _OutRange1&& __out_true_r, _OutRange2&& __out_false_r, _Pred __pred, _Proj __proj)
+{
+    using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+    __internal::__pred_at_index __idx_pred{__internal::__unary_op<_Pred, _Proj>{__pred, __proj}};
+
+    const std::intptr_t __n = std::ranges::size(__in_r);
+    if (__n > 1)
+    {
+        using _OutputPos = std::pair<std::intptr_t, std::intptr_t>;
+        __par_backend::__buffer<bool> __mask_buf(__n);
+        bool* __mask = __mask_buf.get();
+        const std::intptr_t __n_out1 = std::ranges::size(__out_true_r);
+        const std::intptr_t __n_out2 = std::ranges::size(__out_false_r);
+        auto __begin = std::ranges::begin(__in_r);
+        auto __out1_begin = std::ranges::begin(__out_true_r);
+        auto __out2_begin = std::ranges::begin(__out_false_r);
+        auto __stop_in = __begin + __n;
+        auto __stop_out1 = __out1_begin + __n_out1;
+        auto __stop_out2 = __out2_begin + __n_out2;
+
+        __internal::__except_handler([=, &__exec, &__idx_pred, &__stop_in, &__stop_out1, &__stop_out2]() {
+            __par_backend::__parallel_strict_scan(
+                __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __n,
+                _OutputPos{std::intptr_t(0), std::intptr_t(0)},
+                [=, &__idx_pred](std::intptr_t __i, std::intptr_t __len) { // Reduce
+                    return __internal::__brick_compute_mask(__begin + __i, __len, __idx_pred, __mask + __i,
+                                                            _IsVector{});
+                },
+                [](const _OutputPos& __x, const _OutputPos& __y) -> _OutputPos { // Combine
+                    return std::make_pair(__x.first + __y.first, __x.second + __y.second);
+                },                                                                      
+                [=, &__stop_in, &__stop_out1, &__stop_out2](std::intptr_t __i, std::intptr_t __len,
+                                                            _OutputPos __initial) { // Scan
+                    if (__initial.first > __n_out1 && __initial.second > __n_out2) // no place to write for the chunk
+                        return;
+                    const std::intptr_t __safe_len = std::min(__n_out1 - __initial.first, __n_out2 - __initial.second);
+                    if (__safe_len >= __len)
+                    {
+                        __internal::__brick_partition_by_mask(
+                            __begin + __i, __begin + (__i + __len), __out1_begin + __initial.first,
+                            __out2_begin + __initial.second, __mask + __i, _IsVector{});
+                    }
+                    else
+                    {
+                        auto [__next_in, __next_out1, __next_out2] = __brick_bounded_partition_copy(
+                            __begin + __i, __begin + (__i + __len), __out1_begin + __initial.first,
+                            __out1_begin + __n_out1, __out2_begin + __initial.second, __out2_begin + __n_out2,
+                            [=](auto /*__it*/, std::intptr_t __j) { return __mask[__j]; }, _IsVector{});
+                        // If the end of the chunk is not reached, then the stop positions are found.
+                        if (__next_in - __begin < __i + __len)
+                        {
+                            __stop_in = __next_in;
+                            __stop_out1 = __next_out1;
+                            __stop_out2 = __next_out2;
+                        }
+                    }
+                },
+                [=, &__stop_out1, &__stop_out2](_OutputPos __total) { // Apex
+                    if (__total.first < __n_out1) // Output size is bigger than needed
+                        __stop_out1 = __out1_begin + __total.first;
+                    if (__total.second < __n_out2)
+                        __stop_out2 = __out2_begin + __total.second;
+                });
+        });
+        return {__stop_in, __stop_out1, __stop_out2};
+    }
+    // trivial sequence - use serial algorithm
+    return __pattern_partition_copy(__serial_tag<_IsVector>{}, std::forward<_ExecutionPolicy>(__exec),
+                                    std::forward<_InRange>(__in_r), std::forward<_OutRange1>(__out_true_r),
+                                    std::forward<_OutRange2>(__out_false_r), __pred, __proj);
+}
+
 } // namespace __ranges
 } // namespace __internal
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1789,8 +1789,8 @@ template <typename _IsVector, typename _ExecutionPolicy, typename _InRange, type
 std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
                                    std::ranges::borrowed_iterator_t<_OutRange1>,
                                    std::ranges::borrowed_iterator_t<_OutRange2>>
-__pattern_partition_copy(__serial_tag<_IsVector /*TODO: std::false_type*/>, _ExecutionPolicy&&, _InRange&& __in_r,
-                         _OutRange1&& __out_true_r, _OutRange2&& __out_false_r, _Pred __pred, _Proj __proj)
+__pattern_partition_copy_ranges(__serial_tag<_IsVector>, _ExecutionPolicy&&, _InRange&& __in_r,
+                                _OutRange1&& __out_true_r, _OutRange2&& __out_false_r, _Pred __pred, _Proj __proj)
 {
     auto [__it_in, __it_out1, __it_out2] = __brick_bounded_partition_copy(
         std::ranges::begin(__in_r), std::ranges::end(__in_r), std::ranges::begin(__out_true_r),
@@ -1805,8 +1805,8 @@ template <typename _IsVector, typename _ExecutionPolicy, typename _InRange, type
 std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
                                    std::ranges::borrowed_iterator_t<_OutRange1>,
                                    std::ranges::borrowed_iterator_t<_OutRange2>>
-__pattern_partition_copy(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r,
-                         _OutRange1&& __out_true_r, _OutRange2&& __out_false_r, _Pred __pred, _Proj __proj)
+__pattern_partition_copy_ranges(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _InRange&& __in_r,
+                                _OutRange1&& __out_true_r, _OutRange2&& __out_false_r, _Pred __pred, _Proj __proj)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
     __internal::__pred_at_index __idx_pred{__internal::__unary_op<_Pred, _Proj>{__pred, __proj}};
@@ -1873,9 +1873,9 @@ __pattern_partition_copy(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
         return {__stop_in, __stop_out1, __stop_out2};
     }
     // trivial sequence - use serial algorithm
-    return __pattern_partition_copy(__serial_tag<_IsVector>{}, std::forward<_ExecutionPolicy>(__exec),
-                                    std::forward<_InRange>(__in_r), std::forward<_OutRange1>(__out_true_r),
-                                    std::forward<_OutRange2>(__out_false_r), __pred, __proj);
+    return __pattern_partition_copy_ranges(__serial_tag<_IsVector>{}, std::forward<_ExecutionPolicy>(__exec),
+                                           std::forward<_InRange>(__in_r), std::forward<_OutRange1>(__out_true_r),
+                                           std::forward<_OutRange2>(__out_false_r), __pred, __proj);
 }
 
 } // namespace __ranges

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1839,7 +1839,10 @@ __pattern_partition_copy_ranges(__parallel_tag<_IsVector> __tag, _ExecutionPolic
                 },
                 [=, &__stop_in, &__stop_out1, &__stop_out2](std::intptr_t __i, std::intptr_t __len,
                                                             _OutputPos __initial) { // Scan
-                    if (__initial.first > __n_out1 && __initial.second > __n_out2) // no place to write for the chunk
+                    // __initial carries the numbers of true/false mask elements produced by preceding chunks,
+                    // which are also the starting output positions of this chunk. If any of these is greater
+                    // than the corresponding output size, the stop position is located in a preceding chunk.
+                    if (__initial.first > __n_out1 || __initial.second > __n_out2)
                         return;
                     const std::intptr_t __safe_len = std::min(__n_out1 - __initial.first, __n_out2 - __initial.second);
                     if (__safe_len >= __len)

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1812,73 +1812,66 @@ __pattern_partition_copy_ranges(__parallel_tag<_IsVector> __tag, _ExecutionPolic
     __internal::__pred_at_index __idx_pred{__internal::__unary_op<_Pred, _Proj>{__pred, __proj}};
 
     const std::intptr_t __n = std::ranges::size(__in_r);
-    if (__n > 1)
-    {
-        using _OutputPos = std::pair<std::intptr_t, std::intptr_t>;
-        __par_backend::__buffer<bool> __mask_buf(__n);
-        bool* __mask = __mask_buf.get();
-        const std::intptr_t __n_out1 = std::ranges::size(__out_true_r);
-        const std::intptr_t __n_out2 = std::ranges::size(__out_false_r);
-        auto __begin = std::ranges::begin(__in_r);
-        auto __out1_begin = std::ranges::begin(__out_true_r);
-        auto __out2_begin = std::ranges::begin(__out_false_r);
-        auto __stop_in = __begin + __n;
-        auto __stop_out1 = __out1_begin + __n_out1;
-        auto __stop_out2 = __out2_begin + __n_out2;
+    using _OutputPos = std::pair<std::intptr_t, std::intptr_t>;
+    __par_backend::__buffer<bool> __mask_buf(__n);
+    bool* __mask = __mask_buf.get();
+    const std::intptr_t __n_out1 = std::ranges::size(__out_true_r);
+    const std::intptr_t __n_out2 = std::ranges::size(__out_false_r);
+    auto __begin = std::ranges::begin(__in_r);
+    auto __out1_begin = std::ranges::begin(__out_true_r);
+    auto __out2_begin = std::ranges::begin(__out_false_r);
+    auto __stop_in = __begin + __n;
+    auto __stop_out1 = __out1_begin + __n_out1;
+    auto __stop_out2 = __out2_begin + __n_out2;
 
-        __internal::__except_handler([=, &__exec, &__idx_pred, &__stop_in, &__stop_out1, &__stop_out2]() {
-            __par_backend::__parallel_strict_scan(
-                __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __n,
-                _OutputPos{std::intptr_t(0), std::intptr_t(0)},
-                [=, &__idx_pred](std::intptr_t __i, std::intptr_t __len) { // Reduce
-                    return __internal::__brick_compute_mask(__begin + __i, __len, __idx_pred, __mask + __i,
-                                                            _IsVector{});
-                },
-                [](const _OutputPos& __x, const _OutputPos& __y) -> _OutputPos { // Combine
-                    return std::make_pair(__x.first + __y.first, __x.second + __y.second);
-                },
-                [=, &__stop_in, &__stop_out1, &__stop_out2](std::intptr_t __i, std::intptr_t __len,
-                                                            _OutputPos __initial) { // Scan
-                    // __initial carries the numbers of true/false mask elements produced by preceding chunks,
-                    // which are also the starting output positions of this chunk. If any of these is greater
-                    // than the corresponding output size, the stop position is located in a preceding chunk.
-                    if (__initial.first > __n_out1 || __initial.second > __n_out2)
-                        return;
-                    const std::intptr_t __safe_len = std::min(__n_out1 - __initial.first, __n_out2 - __initial.second);
-                    if (__safe_len >= __len)
+    __internal::__except_handler([=, &__exec, &__idx_pred, &__stop_in, &__stop_out1, &__stop_out2]() {
+        __par_backend::__parallel_strict_scan(
+            __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __n,
+            _OutputPos{std::intptr_t(0), std::intptr_t(0)},
+            [=, &__idx_pred](std::intptr_t __i, std::intptr_t __len) { // Reduce
+                return __internal::__brick_compute_mask(__begin + __i, __len, __idx_pred, __mask + __i,
+                                                        _IsVector{});
+            },
+            [](const _OutputPos& __x, const _OutputPos& __y) -> _OutputPos { // Combine
+                return std::make_pair(__x.first + __y.first, __x.second + __y.second);
+            },
+            [=, &__stop_in, &__stop_out1, &__stop_out2](std::intptr_t __i, std::intptr_t __len,
+                                                        _OutputPos __initial) { // Scan
+                // __initial carries the numbers of true/false mask elements produced by preceding chunks,
+                // which are also the starting output positions of this chunk. If any of these is greater
+                // than the corresponding output size, the stop position is located in a preceding chunk.
+                if (__initial.first > __n_out1 || __initial.second > __n_out2)
+                    return;
+                const std::intptr_t __safe_len = std::min(__n_out1 - __initial.first, __n_out2 - __initial.second);
+                if (__safe_len >= __len)
+                {
+                    __internal::__brick_partition_by_mask(
+                        __begin + __i, __begin + (__i + __len), __out1_begin + __initial.first,
+                        __out2_begin + __initial.second, __mask + __i, _IsVector{});
+                }
+                else
+                {
+                    auto [__next_in, __next_out1, __next_out2] = __brick_bounded_partition_copy(
+                        __begin + __i, __begin + (__i + __len), __out1_begin + __initial.first,
+                        __out1_begin + __n_out1, __out2_begin + __initial.second, __out2_begin + __n_out2,
+                        [=](auto /*__it*/, std::intptr_t __j) { return __mask[__i + __j]; }, _IsVector{});
+                    // If the end of the chunk is not reached, then the stop positions are found.
+                    if (__next_in - __begin < __i + __len)
                     {
-                        __internal::__brick_partition_by_mask(
-                            __begin + __i, __begin + (__i + __len), __out1_begin + __initial.first,
-                            __out2_begin + __initial.second, __mask + __i, _IsVector{});
+                        __stop_in = __next_in;
+                        __stop_out1 = __next_out1;
+                        __stop_out2 = __next_out2;
                     }
-                    else
-                    {
-                        auto [__next_in, __next_out1, __next_out2] = __brick_bounded_partition_copy(
-                            __begin + __i, __begin + (__i + __len), __out1_begin + __initial.first,
-                            __out1_begin + __n_out1, __out2_begin + __initial.second, __out2_begin + __n_out2,
-                            [=](auto /*__it*/, std::intptr_t __j) { return __mask[__i + __j]; }, _IsVector{});
-                        // If the end of the chunk is not reached, then the stop positions are found.
-                        if (__next_in - __begin < __i + __len)
-                        {
-                            __stop_in = __next_in;
-                            __stop_out1 = __next_out1;
-                            __stop_out2 = __next_out2;
-                        }
-                    }
-                },
-                [=, &__stop_out1, &__stop_out2](_OutputPos __total) { // Apex
-                    if (__total.first < __n_out1) // Output size is bigger than needed
-                        __stop_out1 = __out1_begin + __total.first;
-                    if (__total.second < __n_out2)
-                        __stop_out2 = __out2_begin + __total.second;
-                });
-        });
-        return {__stop_in, __stop_out1, __stop_out2};
-    }
-    // trivial sequence - use serial algorithm
-    return __pattern_partition_copy_ranges(__serial_tag<_IsVector>{}, std::forward<_ExecutionPolicy>(__exec),
-                                           std::forward<_InRange>(__in_r), std::forward<_OutRange1>(__out_true_r),
-                                           std::forward<_OutRange2>(__out_false_r), __pred, __proj);
+                }
+            },
+            [=, &__stop_out1, &__stop_out2](_OutputPos __total) { // Apex
+                if (__total.first < __n_out1) // Output size is bigger than needed
+                    __stop_out1 = __out1_begin + __total.first;
+                if (__total.second < __n_out2)
+                    __stop_out2 = __out2_begin + __total.second;
+            });
+    });
+    return {__stop_in, __stop_out1, __stop_out2};
 }
 
 } // namespace __ranges

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1829,8 +1829,7 @@ __pattern_partition_copy_ranges(__parallel_tag<_IsVector> __tag, _ExecutionPolic
             __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __n,
             _OutputPos{std::intptr_t(0), std::intptr_t(0)},
             [=, &__idx_pred](std::intptr_t __i, std::intptr_t __len) { // Reduce
-                return __internal::__brick_compute_mask(__begin + __i, __len, __idx_pred, __mask + __i,
-                                                        _IsVector{});
+                return __internal::__brick_compute_mask(__begin + __i, __len, __idx_pred, __mask + __i, _IsVector{});
             },
             [](const _OutputPos& __x, const _OutputPos& __y) -> _OutputPos { // Combine
                 return std::make_pair(__x.first + __y.first, __x.second + __y.second);

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -90,6 +90,7 @@ struct __remove_copy_if_fn;
 struct __remove_copy_fn;
 struct __unique_fn;
 struct __unique_copy_fn;
+struct __partition_copy_fn;
 } // namespace ranges::__internal
 #endif
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1440,7 +1440,7 @@ struct __internal::__partition_copy_fn
                _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_partition_copy(
+        return oneapi::dpl::__internal::__ranges::__pattern_partition_copy_ranges(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r),
             std::forward<_OutRange1>(__out_true_r), std::forward<_OutRange2>(__out_false_r), __pred, __proj);
     }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1419,6 +1419,34 @@ struct __internal::__unique_copy_fn
 }; //__unique_copy_fn
 inline constexpr __internal::__unique_copy_fn unique_copy;
 
+// [alg.partitions]
+
+struct __internal::__partition_copy_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+              std::ranges::random_access_range _OutRange1, std::ranges::random_access_range _OutRange2,
+              typename _Proj = std::identity,
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_InRange>, _Proj>> _Pred>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange1> &&
+                 std::ranges::sized_range<_OutRange2> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange1>> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange2>>
+
+    std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
+                                       std::ranges::borrowed_iterator_t<_OutRange1>,
+                                       std::ranges::borrowed_iterator_t<_OutRange2>>
+    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange1&& __out_true_r, _OutRange2&& __out_false_r,
+               _Pred __pred, _Proj __proj = {}) const
+    {
+        const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        return oneapi::dpl::__internal::__ranges::__pattern_partition_copy(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r),
+            std::forward<_OutRange1>(__out_true_r), std::forward<_OutRange2>(__out_false_r), __pred, __proj);
+    }
+}; //__partition_copy_fn
+inline constexpr __internal::__partition_copy_fn partition_copy;
+
 } //ranges
 
 #endif //_ONEDPL_CPP20_RANGES_PRESENT

--- a/test/parallel_api/ranges/std_ranges_partition_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partition_copy.pass.cpp
@@ -1,0 +1,71 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+#if _ENABLE_STD_RANGES_TESTING && !TEST_DPCPP_BACKEND_PRESENT
+struct
+{
+    template <std::ranges::random_access_range InRange, std::ranges::random_access_range OutRange1,
+              std::ranges::random_access_range OutRange2, typename Pred, typename Proj = std::identity>
+    auto operator()(InRange&& r_in, OutRange1&& r_true, OutRange2&& r_false, Pred pred, Proj proj = {})
+    {
+        using ret_type = std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<InRange>,
+                                                            std::ranges::borrowed_iterator_t<OutRange1>,
+                                                            std::ranges::borrowed_iterator_t<OutRange2>>;
+        auto in = std::ranges::begin(r_in);
+        auto out_true = std::ranges::begin(r_true);
+        auto out_false = std::ranges::begin(r_false);
+        std::size_t i = 0, j = 0, k = 0;
+        for(; i < std::ranges::size(r_in); ++i)
+        {
+             if (std::invoke(pred, std::invoke(proj, in[i])))
+             {
+                 if (j < std::ranges::size(r_true))
+                     out_true[j++] = in[i];
+                 else
+                     break;
+             }
+             else
+             {
+                 if (k < std::ranges::size(r_false))
+                     out_false[k++] = in[i];
+                 else
+                     break;
+             }
+        }
+        return ret_type{in + i, out_true + j, out_false + k};
+    }
+} partition_copy_checker;
+#endif // _ENABLE_STD_RANGES_TESTING
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING && !TEST_DPCPP_BACKEND_PRESENT
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    test_range_algo<0, int, data_in_out_out_lim>{217}(dpl_ranges::partition_copy, partition_copy_checker, pred);
+    test_range_algo<1, int, data_in_out_out_lim>{1234}(dpl_ranges::partition_copy, partition_copy_checker, even_odd);
+    test_range_algo<2, int, data_in_out_out_lim>{}(dpl_ranges::partition_copy, partition_copy_checker, select_many, proj);
+    test_range_algo<3, P2, data_in_out_out_lim>{}(dpl_ranges::partition_copy, partition_copy_checker, pred, &P2::x);
+    test_range_algo<4, P2, data_in_out_out_lim>{}(dpl_ranges::partition_copy, partition_copy_checker, even_odd, &P2::proj);
+    test_range_algo<5, int, data_in_out_out_lim>{get_scan_big_sz()}(dpl_ranges::partition_copy, partition_copy_checker, even_odd);
+    test_range_algo<6, int, data_in_out_out_lim>{get_scan_big_sz()}(dpl_ranges::partition_copy, partition_copy_checker, select_many);
+#endif // _ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_partition_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partition_copy.pass.cpp
@@ -5,12 +5,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// This file incorporates work covered by the following copyright and permission
-// notice:
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-//
 //===----------------------------------------------------------------------===//
 
 #include "std_ranges_test.h"

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -105,7 +105,8 @@ enum TestDataMode
     data_in_out_lim,
     data_in_in,
     data_in_in_out,
-    data_in_in_out_lim
+    data_in_in_out_lim,
+    data_in_out_out_lim
 };
 
 auto f_mutuable = [](auto&& val) { return val *= val; };
@@ -116,6 +117,7 @@ auto binary_f = [](auto&& val1, auto&& val2) { return val1 * val2; };
 auto proj = [](auto&& val){ return val * 2; };
 auto pred = [](auto&& val) { return val == 5; };
 auto select_many = [](int val) { return (val % 29) > 1; };
+auto even_odd = [](int val) { return (val % 2) == 0; };
 
 auto binary_pred = [](auto&& val1, auto&& val2) { return val1 == val2; };
 auto binary_pred_const = [](const auto& val1, const auto& val2) { return val1 == val2; };
@@ -215,6 +217,20 @@ static constexpr
 bool check_out<T, std::void_t<decltype(std::declval<T>().out)>> = true;
 
 template<typename, typename = void>
+static constexpr bool check_out1{};
+
+template<typename T>
+static constexpr
+bool check_out1<T, std::void_t<decltype(std::declval<T>().out1)>> = true;
+
+template<typename, typename = void>
+static constexpr bool check_out2{};
+
+template<typename T>
+static constexpr
+bool check_out2<T, std::void_t<decltype(std::declval<T>().out2)>> = true;
+
+template<typename, typename = void>
 static constexpr bool is_range{};
 
 template<typename T>
@@ -264,6 +280,12 @@ static constexpr bool check_in_in_out_result{};
 
 template <typename I1, typename I2, typename O>
 static constexpr bool check_in_in_out_result<std::ranges::in_in_out_result<I1, I2, O>> = true;
+
+template <typename T>
+static constexpr bool check_in_out_out_result{};
+
+template <typename I1, typename O1, typename O2>
+static constexpr bool check_in_out_out_result<std::ranges::in_out_out_result<I1, O1, O2>> = true;
 
 template <typename _ReturnType>
 struct all_dangling_in_result : std::false_type
@@ -704,6 +726,74 @@ private:
         }
     }
 
+    template<typename Policy, typename Algo, typename Checker, typename TransIn, typename TransOut,
+             TestDataMode mode = test_mode>
+    void
+    process_data_in_out_out(int max_n, int n_in, int n_out1, int n_out2, Policy&& exec, Algo algo, Checker& checker,
+                            TransIn tr_in, TransOut tr_out, auto... args)
+    {
+        static_assert(mode == data_in_out_out_lim);
+        assert(n_in <= max_n);
+
+        std::string names{typeid(Algo).name()};
+        names += "<" + std::string{typeid(Policy).name()} + ">";
+        std::string sizes{" for "};
+        sizes += std::to_string(n_in) + " elements, " + std::to_string(n_out1) + " and " + std::to_string(n_out2) + " space";
+
+        Container cont_in(exec, n_in, DataGen1{});
+        Container cont_out1(exec, n_out1, data_gen_unprocessed);
+        Container cont_out1_exp(exec, n_out1, data_gen_unprocessed);
+        Container cont_out2(exec, n_out2, data_gen_unprocessed);
+        Container cont_out2_exp(exec, n_out2, data_gen_unprocessed);
+
+        auto src_view = tr_in(std::views::all(cont_in()));
+        auto out1_exp_view = tr_out(std::views::all(cont_out1_exp()));
+        auto out2_exp_view = tr_out(std::views::all(cont_out2_exp()));
+        auto expected_res = checker(src_view, out1_exp_view, out2_exp_view, args...);
+
+        typename Container::type& A = cont_in();
+        typename Container::type& B = cont_out1();
+        typename Container::type& C = cont_out2();
+
+        auto res = algo(CLONE_TEST_POLICY(exec), tr_in(A), tr_out(B), tr_out(C), args...);
+
+        // check result types
+        static_assert(check_in_out_out_result<decltype(expected_res)>);
+        static_assert(std::is_same_v<decltype(res), decltype(expected_res)>, "Wrong return type");
+
+        EXPECT_EQ(ret_in_val(expected_res, src_view.begin()), ret_in_val(res, tr_in(A).begin()),
+                  (std::string("wrong input stop position with ") + typeid(Algo).name() + sizes).c_str());
+
+        EXPECT_EQ(ret_out_val<1>(expected_res, out1_exp_view.begin()), ret_out_val<1>(res, tr_out(B).begin()),
+                  (std::string("wrong 1st output stop position with ") + names + sizes).c_str());
+        EXPECT_EQ(ret_out_val<2>(expected_res, out2_exp_view.begin()), ret_out_val<2>(res, tr_out(C).begin()),
+                  (std::string("wrong 2nd output stop position with ") + names + sizes).c_str());
+
+        //check elements in the output
+        EXPECT_EQ_N(cont_out1_exp().begin(), cont_out1().begin(), std::ranges::size(out1_exp_view), 
+                    (std::string("1st output mismatch with ") + names + sizes).c_str());
+        EXPECT_EQ_N(cont_out2_exp().begin(), cont_out2().begin(), std::ranges::size(out2_exp_view), 
+                    (std::string("2nd output mismatch with ") + names + sizes).c_str());
+
+        if constexpr(!supress_dangling_iterators_check<std::remove_cvref_t<decltype(algo)>>)
+        {
+#if _ONEDPL_CPP20_OWNING_VIEW_PRESENT // Otherwise, `tr_in = std::views::all` leads to a compile error for `rvalue_container_t`.
+            // Check dangling iterators in return types for call with r-value ranges; 
+            // TransIn and TransOut may modify the non-borrowed range to a borrowed one, so we need to check it.
+            if constexpr(!std::ranges::borrowed_range<decltype(tr_in(std::declval<rvalue_container_t&&>()))>
+                         && !std::ranges::borrowed_range<decltype(tr_out(std::declval<rvalue_container_t&&>()))>)
+            {
+                using res_ret_t = decltype(algo(exec, tr_in(std::declval<rvalue_container_t&&>()),
+                                                tr_out(std::declval<rvalue_container_t&&>()),
+                                                tr_out(std::declval<rvalue_container_t&&>()), args...));
+                static_assert(all_dangling_in_result_v<res_ret_t>,
+                              "res_ret_t is expected to be or consist of std::ranges::dangling");
+            }
+#endif //_ONEDPL_CPP20_OWNING_VIEW_PRESENT
+        }
+    }
+
+
 public:
     template<typename Policy, typename Algo, typename Checker, TestDataMode mode = test_mode>
     std::enable_if_t<mode == data_in_in_out>
@@ -737,6 +827,35 @@ public:
         process_data_in_in_out(max_n, 0, r_size / 2, r_size / 4, CLONE_TEST_POLICY(exec), algo, checker, args...);
         process_data_in_in_out(max_n, r_size / 2, 0, r_size / 4, CLONE_TEST_POLICY(exec), algo, checker, args...);
     }
+
+    template<typename Policy, typename Algo, typename Checker, TestDataMode mode = test_mode>
+    std::enable_if_t<mode == data_in_out_out_lim>
+    operator()(int max_n, Policy&& exec, Algo algo, Checker& checker, auto... args)
+    {
+        const int r_size = max_n;
+        process_data_in_out_out(max_n, r_size, r_size, r_size, CLONE_TEST_POLICY(exec), algo, checker, args...);
+
+        //test case size of input range is less than size of output and vice-versa
+        process_data_in_out_out(max_n, r_size/2, r_size, r_size, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, r_size, r_size/2, r_size, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, r_size, r_size, r_size/2, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, r_size, r_size/3, r_size/3, CLONE_TEST_POLICY(exec), algo, checker, args...);
+
+        //test cases with an empty sequence and/or zero output capacity
+        process_data_in_out_out(max_n, 0, 0, 0, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, 0, r_size, 0, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, r_size, r_size, 0, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, r_size, 0, r_size, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, r_size, 0, r_size / 4, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, r_size, r_size / 4, 0, CLONE_TEST_POLICY(exec), algo, checker, args...);
+
+        //test cases with only one element and/or output capacity
+        process_data_in_out_out(max_n, r_size, 1, r_size, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, r_size, r_size, 1, CLONE_TEST_POLICY(exec), algo, checker, args...);
+        process_data_in_out_out(max_n, 1, r_size, r_size, CLONE_TEST_POLICY(exec), algo, checker, args...);
+    }
+
+
 private:
 
     template <std::size_t InIdx = 0, typename Ret, typename Begin>
@@ -782,16 +901,20 @@ private:
         }
     }
 
-    template<typename Ret, typename Begin>
+    template <std::size_t OutIdx = 0, typename Ret, typename Begin>
     auto ret_out_val(Ret&& ret, Begin&& begin)
     {
-        if constexpr (check_out<Ret>)
+        if constexpr (check_out<Ret> && OutIdx == 0)
             return std::distance(begin, ret.out);
-        else if constexpr (is_iterator<Ret>)
+        else if constexpr (check_out1<Ret> && OutIdx == 1)
+            return std::distance(begin, ret.out1);
+        else if constexpr (check_out2<Ret> && OutIdx == 2)
+            return std::distance(begin, ret.out2);
+        else if constexpr (is_iterator<Ret> && OutIdx == 0)
             return std::distance(begin, ret);
-        else if constexpr (check_in2<Ret>)
+        else if constexpr (check_in2<Ret> && OutIdx == 0)
             return std::distance(begin, ret.in2);
-        else if constexpr(is_range<Ret>)
+        else if constexpr(is_range<Ret> && OutIdx == 0)
             return std::pair{std::distance(begin, ret.begin()), std::ranges::distance(ret.begin(), ret.end())};
         else
             return ret;

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -762,7 +762,7 @@ private:
         static_assert(std::is_same_v<decltype(res), decltype(expected_res)>, "Wrong return type");
 
         EXPECT_EQ(ret_in_val(expected_res, src_view.begin()), ret_in_val(res, tr_in(A).begin()),
-                  (std::string("wrong input stop position with ") + typeid(Algo).name() + sizes).c_str());
+                  (std::string("wrong input stop position with ") + names + sizes).c_str());
 
         EXPECT_EQ(ret_out_val<1>(expected_res, out1_exp_view.begin()), ret_out_val<1>(res, tr_out(B).begin()),
                   (std::string("wrong 1st output stop position with ") + names + sizes).c_str());


### PR DESCRIPTION
`ranges::partition_copy` is special because it is the only algorithm with two output sequences, each of which might have different size, and also the actual number of the elements to write is determined dynamically. The behavior in case of insufficient output capacity is described in https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html#partition_copy - the returned iterators are those where a write by a serial loop would go out of bounds.

The implementation so far misses a vectorized brick (therefore unsequenced policies use a serial loop, which is OK) as well as the pattern for device policies (therefore calling `ranges::partition_copy` with a device policy will cause a compilation error), both to be addressed in other patches.

The pattern name `__pattern_partition_copy_ranges` is chosen to disambiguate with the iterator-based `__pattern_partition_copy` which unfortunately has the same number of parameters. I could explicitly use `__ranges` namespace instead when calling the pattern, but the suffix-based approach is already used for `__pattern_copy_if[_ranges]`.