### PR TITLE
Add serial cutoff to __parallel_strict_scan from oneTBB backend

### DIFF
--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -85,7 +85,8 @@ __parallel_strict_scan_body(_Index __n, _Tp __initial, _Rp __reduce, _Cp __combi
 {
     _Index __p = omp_get_num_threads();
     const _Index __slack = 4;
-    _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
+    constexpr _Index __min_tilesize = 1000;
+    _Index __tilesize = std::max(__min_tilesize, (__n - 1) / (__slack * __p) + 1);
     _Index __m = (__n - 1) / __tilesize;
     __buffer<_Tp> __buf(__m + 1);
     _Tp* __r = __buf.get();

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -85,8 +85,7 @@ __parallel_strict_scan_body(_Index __n, _Tp __initial, _Rp __reduce, _Cp __combi
 {
     _Index __p = omp_get_num_threads();
     const _Index __slack = 4;
-    constexpr _Index __min_tilesize = 1000;
-    _Index __tilesize = std::max(__min_tilesize, (__n - 1) / (__slack * __p) + 1);
+    _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
     _Index __m = (__n - 1) / __tilesize;
     __buffer<_Tp> __buf(__m + 1);
     _Tp* __r = __buf.get();

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -295,7 +295,7 @@ __split(_Index __m)
 // 1. Affinitize leaves of upsweep and leaves of downsweep.  For working sets that
 //    fit in cache, this might reduce memory interconnect load significantly.
 // 2. Add automatic tilesize adjustment.  Initial stealing during upsweep ought to provide a good hint.
-// 3. Use continuation-passing style for the tasks.  For downsweep, a binomial tree pattern is likely optimal.
+// 3. Use continuation-passing style for the tasks. For downsweep, a binomial tree pattern is likely optimal.
 
 template <typename _Index, typename _Tp, typename _Rp, typename _Cp>
 void
@@ -351,20 +351,25 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 // apex is called exactly once, after all calls to reduce and before all calls to scan.
 // For example, it's useful for allocating a __buffer used by scan but whose size is the sum of all reduction values.
 // T must have a trivial constructor and destructor.
-#if !defined(_ONEDPL_STRICT_SCAN_MIN_TILESIZE)
-#    define _ONEDPL_STRICT_SCAN_MIN_TILESIZE 2000
+#if !defined(_ONEDPL_STRICT_SCAN_SERIAL_CUTOFF)
+#    define _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF 2000
 #endif
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
 __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,
                        _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
 {
-    tbb::this_task_arena::isolate([=, &__combine]() {
-        if (__n > 1)
-        {
-            _Index __p = tbb::this_task_arena::max_concurrency();
-            const _Index __slack = 4;
-            _Index __tilesize = std::max(_ONEDPL_STRICT_SCAN_MIN_TILESIZE, (__n - 1) / (__slack * __p) + 1);
+    constexpr _Index __cutoff = _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF;
+    if (__n > __cutoff)
+    {
+        _Index __p_available = tbb::this_task_arena::max_concurrency();
+        _Index __p_needed = (__n - 1) / __cutoff + 1;
+        _Index __p = std::min(__p_available, __p_needed);
+        auto __scan_body = [=, &__combine]() {
+            // Tilesize may be smaller than cutoff,
+            // but this is fine because TBB needs some slack for load balancing.
+            constexpr _Index __slack = 4;
+            _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
             _Index __m = (__n - 1) / __tilesize;
             __tbb_backend::__buffer<_Tp> __buf(__m + 1);
             _Tp* __r = __buf.get();
@@ -383,15 +388,21 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
             __tbb_backend::__downsweep(_Index(0), _Index(__m + 1), __tilesize, __r, __n - __m * __tilesize, __initial,
                                        __combine, __scan);
             return;
-        }
-        // Fewer than 2 elements in sequence, or out of memory.  Handle has single block.
+        };
+        tbb::task_arena __arena(__p);
+        __arena.execute([=, &__scan_body]() {
+            tbb::this_task_arena::isolate([=, &__scan_body]() { __scan_body(); });
+        });
+    }
+    else // serial scan for small n
+    {
         _Tp __sum = __initial;
         if (__n)
             __sum = __combine(__sum, __reduce(_Index(0), __n));
         __apex(__sum);
         if (__n)
             __scan(_Index(0), __n, __initial);
-    });
+    }
 }
 
 template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -351,6 +351,9 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 // apex is called exactly once, after all calls to reduce and before all calls to scan.
 // For example, it's useful for allocating a __buffer used by scan but whose size is the sum of all reduction values.
 // T must have a trivial constructor and destructor.
+#if !defined(_ONEDPL_STRICT_SCAN_MIN_TILESIZE)
+#    define _ONEDPL_STRICT_SCAN_MIN_TILESIZE 2000
+#endif
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
 __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,
@@ -361,8 +364,7 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
         {
             _Index __p = tbb::this_task_arena::max_concurrency();
             const _Index __slack = 4;
-            constexpr _Index __min_tilesize = 1000;
-            _Index __tilesize = std::max(__min_tilesize, (__n - 1) / (__slack * __p) + 1);
+            _Index __tilesize = std::max(_ONEDPL_STRICT_SCAN_MIN_TILESIZE, (__n - 1) / (__slack * __p) + 1);
             _Index __m = (__n - 1) / __tilesize;
             __tbb_backend::__buffer<_Tp> __buf(__m + 1);
             _Tp* __r = __buf.get();

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -361,7 +361,8 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
         {
             _Index __p = tbb::this_task_arena::max_concurrency();
             const _Index __slack = 4;
-            _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
+            constexpr _Index __min_tilesize = 1000;
+            _Index __tilesize = std::max(__min_tilesize, (__n - 1) / (__slack * __p) + 1);
             _Index __m = (__n - 1) / __tilesize;
             __tbb_backend::__buffer<_Tp> __buf(__m + 1);
             _Tp* __r = __buf.get();

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -362,14 +362,12 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
     constexpr _Index __cutoff = _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF;
     if (__n > __cutoff)
     {
-        _Index __p_available = tbb::this_task_arena::max_concurrency();
-        _Index __p_needed = (__n - 1) / __cutoff + 1;
-        _Index __p = std::min(__p_available, __p_needed);
-        auto __scan_body = [=, &__combine]() {
+        tbb::this_task_arena::isolate([=, &__combine]() {
             // Tilesize may be smaller than cutoff,
             // but this is fine because TBB needs some slack for load balancing.
+            _Index __p = tbb::this_task_arena::max_concurrency();
             constexpr _Index __slack = 4;
-            _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
+            _Index __tilesize = std::max(__cutoff, (__n - 1) / (__slack * __p) + 1);
             _Index __m = (__n - 1) / __tilesize;
             __tbb_backend::__buffer<_Tp> __buf(__m + 1);
             _Tp* __r = __buf.get();
@@ -388,10 +386,6 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
             __tbb_backend::__downsweep(_Index(0), _Index(__m + 1), __tilesize, __r, __n - __m * __tilesize, __initial,
                                        __combine, __scan);
             return;
-        };
-        tbb::task_arena __arena(__p);
-        __arena.execute([=, &__scan_body]() {
-            tbb::this_task_arena::isolate([=, &__scan_body]() { __scan_body(); });
         });
     }
     else // serial scan for small n

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -351,7 +351,7 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 // apex is called exactly once, after all calls to reduce and before all calls to scan.
 // For example, it's useful for allocating a __buffer used by scan but whose size is the sum of all reduction values.
 // T must have a trivial constructor and destructor.
-#if !defined(_ONEDPL_STRICT_SCAN_SERIAL_CUTOFF)
+#if !defined(_ONEDPL_STRICT_SCAN_SERIAL_CUTOFF) // handle for benchmarking and tuning
 #    define _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF 2000
 #endif
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
@@ -359,12 +359,21 @@ void
 __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,
                        _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
 {
-    if (__n > _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF)
+    constexpr _Index __cutoff = _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF;
+    if (__n > __cutoff)
     {
         tbb::this_task_arena::isolate([=, &__combine]() {
             _Index __p = tbb::this_task_arena::max_concurrency();
-            constexpr _Index __slack = 4;
-            _Index __tilesize = std::max(_ONEDPL_STRICT_SCAN_SERIAL_CUTOFF, (__n - 1) / (__slack * __p) + 1);
+            // 4 tasks/thread for large N - to aid load balancing.
+            // <1 task/thread for small N - to avoid excessive synchronization overhead.
+            // 2 tasks/thread once half the threads would clear the cutoff - middle ground.
+            _Index __tilesize;
+            if (__n >= 4 * __p * __cutoff)
+                __tilesize = (__n - 1) / (4 * __p) + 1;
+            else if (__n >=  __p * __cutoff / 2)
+                __tilesize = (__n - 1) / (2 * __p) + 1;
+            else
+                __tilesize = __cutoff;
             _Index __m = (__n - 1) / __tilesize;
             __tbb_backend::__buffer<_Tp> __buf(__m + 1);
             _Tp* __r = __buf.get();

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -370,7 +370,7 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
             _Index __tilesize;
             if (__n >= 4 * __p * __cutoff)
                 __tilesize = (__n - 1) / (4 * __p) + 1;
-            else if (__n >=  __p * __cutoff / 2)
+            else if (__n >= __p * __cutoff / 2)
                 __tilesize = (__n - 1) / (2 * __p) + 1;
             else
                 __tilesize = __cutoff;

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -359,15 +359,12 @@ void
 __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,
                        _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
 {
-    constexpr _Index __cutoff = _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF;
-    if (__n > __cutoff)
+    if (__n > _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF)
     {
         tbb::this_task_arena::isolate([=, &__combine]() {
-            // Tilesize may be smaller than cutoff,
-            // but this is fine because TBB needs some slack for load balancing.
             _Index __p = tbb::this_task_arena::max_concurrency();
             constexpr _Index __slack = 4;
-            _Index __tilesize = std::max(__cutoff, (__n - 1) / (__slack * __p) + 1);
+            _Index __tilesize = std::max(_ONEDPL_STRICT_SCAN_SERIAL_CUTOFF, (__n - 1) / (__slack * __p) + 1);
             _Index __m = (__n - 1) / __tilesize;
             __tbb_backend::__buffer<_Tp> __buf(__m + 1);
             _Tp* __r = __buf.get();
@@ -388,7 +385,7 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
             return;
         });
     }
-    else // serial scan for small n
+    else
     {
         _Tp __sum = __initial;
         if (__n)

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -366,14 +366,10 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
             _Index __p = tbb::this_task_arena::max_concurrency();
             // 4 tasks/thread for large N - to aid load balancing.
             // <1 task/thread for small N - to avoid excessive synchronization overhead.
-            // 2 tasks/thread once half the threads would clear the cutoff - middle ground.
-            _Index __tilesize;
+            _Index __tilesize = __cutoff;
             if (__n >= 4 * __p * __cutoff)
                 __tilesize = (__n - 1) / (4 * __p) + 1;
-            else if (__n >= __p * __cutoff / 2)
-                __tilesize = (__n - 1) / (2 * __p) + 1;
-            else
-                __tilesize = __cutoff;
+
             _Index __m = (__n - 1) / __tilesize;
             __tbb_backend::__buffer<_Tp> __buf(__m + 1);
             _Tp* __r = __buf.get();

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -351,21 +351,20 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 // apex is called exactly once, after all calls to reduce and before all calls to scan.
 // For example, it's useful for allocating a __buffer used by scan but whose size is the sum of all reduction values.
 // T must have a trivial constructor and destructor.
-#define _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF 2000
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
 __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,
                        _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
 {
-    constexpr _Index __cutoff = _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF;
-    if (__n > __cutoff)
+    constexpr _Index __strict_scan_cutoff = 2000;
+    if (__n > __strict_scan_cutoff)
     {
         tbb::this_task_arena::isolate([=, &__combine]() {
             _Index __p = tbb::this_task_arena::max_concurrency();
             // 4 tasks/thread for large N - to aid load balancing.
             // <1 task/thread for small N - to avoid excessive synchronization overhead.
-            _Index __tilesize = __cutoff;
-            if (__n >= 4 * __p * __cutoff)
+            _Index __tilesize = __strict_scan_cutoff;
+            if (__n >= 4 * __p * __strict_scan_cutoff)
                 __tilesize = (__n - 1) / (4 * __p) + 1;
 
             _Index __m = (__n - 1) / __tilesize;

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -351,9 +351,7 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 // apex is called exactly once, after all calls to reduce and before all calls to scan.
 // For example, it's useful for allocating a __buffer used by scan but whose size is the sum of all reduction values.
 // T must have a trivial constructor and destructor.
-#if !defined(_ONEDPL_STRICT_SCAN_SERIAL_CUTOFF) // handle for benchmarking and tuning
-#    define _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF 2000
-#endif
+#define _ONEDPL_STRICT_SCAN_SERIAL_CUTOFF 2000
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
 __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy&&, _Index __n, _Tp __initial,


### PR DESCRIPTION
OpenMP backend already has it, although it does not limit the parallelism (all-or-nothing).

The motivation was that algorithms using `__parallel_strict_scan` with oneTBB backend underperform serial implementation with small size; this function stands out because its overhead scales with the available cores on the system, reaching up to 40us for 64-cores. There is no such increase for other patterns, e.g.  `__parallel_for` and `__parallel_reduce`, which rely `tbb::parallel_for` and `tbb::parallel_reduce` for load balancing. Neither sort and merge pattern had such an issue.

The solution is to introduce a serial cutoff and limit parallelism for small sizes. The cutoff is shared among all algorithms.

Tuning for a specific algorithm is possible, but it requires design changes to hint the algorithm at the backend level.

-----

I've analyzed how algorithms using `__parallel_strict_scan` perform with 2 cores to identify the best cutoff and an initial grain size.
Below is the summary of the ranges, or "goldilocks zones", when the parallel implementation performs 0.5x-1x relative to the serial one with float and double data types:

| Algorithm | Details | Range |
|-----------|---------|-------|
| copy_if | 50% copied | 8K-11K |
| inclusive_scan, exclusive_scan | std::plus | 6K-19K |
| remove | 1 item removed; other patterns are used | 100K-300K |
| remove_if | 50% removed; other patterns are used | 13K-19K |
| remove_copy | 1 item removed | 15K-130K |
| remove_copy_if | 50% removed | 8K-11K |
| set_difference | 50/50 relation, some copies | 2K-4.5K |
| set_intersection | 50/50 relation, some copies | 4K-6K |
| set_symmetric_difference | 50/50 relation, some copies | 4.5K-6K |
| set_union | 50/50 relation, some copies | 6K-7K |
| unique_copy | 100% unique | 20K-150K |
| partition_copy |  50/50 relation | 8K-11K |

I've selected 2000 as the common minimum to limit the number of changes and avoid overturning (e.g. heavy types may result in an earlier break-even point).


Speedup when comparing to the main branch (64 cores, float type, par policy):

| size | copy_if | exclusive_scan | remove | partition_copy | set_union | unique_copy |
|------|---------|----------------|--------|----------------|-----------|-------------|
| 256 | 133.76 | 267.70 | 2.15 | 152.04 | 1.07 | 111.73 |
| 512 | 76.85 | 151.29 | 2.61 | 86.71 | 1.01 | 72.37 |
| 1024 | 38.59 | 77.73 | 2.32 | 58.49 | 21.38 | 48.43 |
| 2048 | 20.65 | 26.47 | 2.18 | 19.64 | 10.06 | 18.30 |
| 4096 | 7.70 | 11.25 | 2.34 | 7.66 | 5.50 | 8.49 |
| 8192 | 4.67 | 5.97 | 1.65 | 3.51 | 2.55 | 3.79 |
| 16384 | 2.48 | 3.74 | 1.41 | 2.10 | 1.67 | 2.76 |
| 32768 | 1.08 | 2.17 | 1.31 | 1.15 | 1.42 | 1.61 |
| 65536 | 1.20 | 0.98 | 1.23 | 1.24 | 1.85 | 1.01 |
| 131072 | 1.00 | 1.26 | 1.36 | 1.20 | 1.39 | 0.98 |
| 262144 | 0.98 | 1.41 | 1.00 | 1.07 | 1.03 | 1.18 |
| 524288 | 1.03 | 0.95 | 1.05 | 0.99 | 0.90 | 0.96 |
| 1048576 | 0.96 | 0.94 | 1.03 | 1.31 | 1.02 | 1.02 |
| 2097152 | 1.01 | 0.98 | 0.98 | 1.01 | 0.98 | 0.98 |