### PR TITLE
Moving requires test only macro to tests

### DIFF
--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -28,14 +28,6 @@
 #    define _ONEDPL_CPP20_CONCEPTS_PRESENT 0
 #endif
 
-// -- Check for C++20 requires-clause support --
-// This is the concepts language feature (a requires-clause, e.g. on a constrained partial specialization)
-#if __cpp_concepts >= 201907L
-#    define _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT 1
-#else
-#    define _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT 0
-#endif
-
 // -- Check for C++20 Ranges support --
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
 // Ranges library is available if the standard library provides it and concepts are supported

--- a/test/general/implementation_details/device_copyable_sycl_iterator.pass.cpp
+++ b/test/general/implementation_details/device_copyable_sycl_iterator.pass.cpp
@@ -17,7 +17,7 @@ using namespace TestUtils;
 
 // The sweeping user specialization below uses a C++20 trailing requires-clause, which is required to make
 // a partial specialization whose argument pattern is a bare template parameter well-formed.
-#if TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT
+#if TEST_DPCPP_BACKEND_PRESENT && _TEST_CPP20_REQUIRES_CLAUSE_PRESENT
 
 #    include "support/utils_device_copyable.h"
 #    include "support/utils_sycl_defs.h"
@@ -28,14 +28,14 @@ template <class T>
 requires(true)
 struct sycl::is_device_copyable<T> : std::true_type {};
 
-#endif // TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && _TEST_CPP20_REQUIRES_CLAUSE_PRESENT
 
 std::int32_t
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT
+#if TEST_DPCPP_BACKEND_PRESENT && _TEST_CPP20_REQUIRES_CLAUSE_PRESENT
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::sycl_iterator<sycl::access_mode::read, int>>,
                   "sycl_iterator is device copyable but should never be");
-#endif // TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT
-    return done(TEST_DPCPP_BACKEND_PRESENT && _ONEDPL_CPP20_REQUIRES_CLAUSE_PRESENT);
+#endif // TEST_DPCPP_BACKEND_PRESENT && _TEST_CPP20_REQUIRES_CLAUSE_PRESENT
+    return done(TEST_DPCPP_BACKEND_PRESENT && _TEST_CPP20_REQUIRES_CLAUSE_PRESENT);
 }

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -337,6 +337,14 @@
 #    define TEST_STD_RANGES_VIEW_CONCEPT_REQUIRES_DEFAULT_INITIALIZABLE 0
 #endif
 
+// -- Check for C++20 requires-clause support --
+// This is the concepts language feature (a requires-clause, e.g. on a constrained partial specialization)
+#if __cpp_concepts >= 201907L
+#    define _TEST_CPP20_REQUIRES_CLAUSE_PRESENT 1
+#else
+#    define _TEST_CPP20_REQUIRES_CLAUSE_PRESENT 0
+#endif
+
 // P2325R3 also removed default_initializable from weakly_incrementable, which breaks
 // std::input_iterator and std::output_iterator on the same pre-P2325R3 implementations.
 #define _ONEDPL_CPP20_IN_OUT_ITERATOR_BROKEN TEST_STD_RANGES_VIEW_CONCEPT_REQUIRES_DEFAULT_INITIALIZABLE


### PR DESCRIPTION
In #2744, I added a macro which detects presence of the c++20 requires clause.  However this macro was added to the main oneDPL includes, and it is only used in the tests.  This relocates it to the tests to match conventions we have in oneDPL.