### PR TITLE
Fix group algorithm suitability checker

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_submitters.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_submitters.h
@@ -134,7 +134,7 @@ struct __radix_sort_onesweep_scan_submitter<
                 const auto __g = __nd_item.get_group();
                 std::uint32_t __count = __global_offset_data[__offset];
                 std::uint32_t __presum =
-                    __dpl_sycl::__exclusive_scan_over_group(__g, __count, __dpl_sycl::__plus<std::uint32_t>());
+                    __dpl_sycl::__exclusive_scan_over_group(__g, __count, sycl::plus<std::uint32_t>());
                 __global_offset_data[__offset] = __presum;
             });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -786,7 +786,7 @@ struct __parallel_find_forward_tag
     using _AtomicType = _IndexType;
 #endif
 
-    using _LocalResultsReduceOp = __dpl_sycl::__minimum<_AtomicType>;
+    using _LocalResultsReduceOp = sycl::minimum<_AtomicType>;
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _SrcDataSize>
@@ -825,7 +825,7 @@ struct __parallel_find_backward_tag
     using _AtomicType = _IndexType;
 #endif
 
-    using _LocalResultsReduceOp = __dpl_sycl::__maximum<_AtomicType>;
+    using _LocalResultsReduceOp = sycl::maximum<_AtomicType>;
 
     template <typename _SrcDataSize>
     constexpr static _AtomicType
@@ -1062,8 +1062,8 @@ struct __parallel_find_or_impl_one_wg<__or_tag_check, __internal::__optional_ker
                     __pred(__item, __rng_n, __iters_per_work_item, __wgroup_size, __found_local, __brick_tag,
                            __rngs...);
 
-                    // 3. Reduce over group: find __dpl_sycl::__minimum (for the __parallel_find_forward_tag),
-                    // find __dpl_sycl::__maximum (for the __parallel_find_backward_tag)
+                    // 3. Reduce over group: find sycl::minimum (for the __parallel_find_forward_tag),
+                    // find sycl::maximum (for the __parallel_find_backward_tag)
                     // or update state with __dpl_sycl::__any_of_group (for the __parallel_or_tag)
                     // inside all our group items
                     if constexpr (__or_tag_check)
@@ -1151,8 +1151,8 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
                     __pred(__item, __rng_n, __iters_per_work_item, __n_groups * __wgroup_size, __found_local,
                            __brick_tag, __rngs...);
 
-                    // 3. Reduce over group: find __dpl_sycl::__minimum (for the __parallel_find_forward_tag),
-                    // find __dpl_sycl::__maximum (for the __parallel_find_backward_tag)
+                    // 3. Reduce over group: find sycl::minimum (for the __parallel_find_forward_tag),
+                    // find sycl::maximum (for the __parallel_find_backward_tag)
                     // or update state with __dpl_sycl::__any_of_group (for the __parallel_or_tag)
                     // inside all our group items
                     if constexpr (__or_tag_check)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -411,7 +411,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
     {
         // TODO: Consider re-implementing single group scan to support types without known identities. This could also
         // allow us to use single wg scan for the last block of reduce-then-scan if it is sufficiently small.
-        constexpr bool __can_use_group_scan = unseq_backend::__has_known_identity<_BinaryOperation, _Type>::value;
+        constexpr bool __can_use_group_scan = unseq_backend::__can_use_group_reduce_scan<_BinaryOperation, _Type>::value;
         if constexpr (__can_use_group_scan)
         {
             // Next power of 2 greater than or equal to __n
@@ -1692,7 +1692,7 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
         oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
         std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys),
         std::forward<_Range4>(__out_values), __binary_pred, __binary_op,
-        oneapi::dpl::unseq_backend::__has_known_identity<_BinaryOperator, __val_type>{});
+        oneapi::dpl::unseq_backend::__can_use_group_reduce_scan<_BinaryOperator, __val_type>{});
 #endif
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1528,7 +1528,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
                                       _Range1&& __keys, _Range2&& __values, _Range3&& __out_keys,
                                       _Range4&& __out_values, _BinaryPredicate __binary_pred,
                                       _BinaryOperator __binary_op,
-                                      /*__can_use_group_reduce_scan*/std::false_type)
+                                      /*__can_use_group_reduce_scan*/ std::false_type)
 {
     const auto __n = oneapi::dpl::__ranges::__size(__keys);
     assert(__n > 0);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -755,7 +755,7 @@ struct __parallel_find_forward_tag
     using _AtomicType = _IndexType;
 #endif
 
-    using _LocalResultsReduceOp = __dpl_sycl::__minimum<_AtomicType>;
+    using _LocalResultsReduceOp = sycl::minimum<_AtomicType>;
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _SrcDataSize>
@@ -794,7 +794,7 @@ struct __parallel_find_backward_tag
     using _AtomicType = _IndexType;
 #endif
 
-    using _LocalResultsReduceOp = __dpl_sycl::__maximum<_AtomicType>;
+    using _LocalResultsReduceOp = sycl::maximum<_AtomicType>;
 
     template <typename _SrcDataSize>
     constexpr static _AtomicType
@@ -1031,8 +1031,8 @@ struct __parallel_find_or_impl_one_wg<__or_tag_check, __internal::__optional_ker
                     __pred(__item, __rng_n, __iters_per_work_item, __wgroup_size, __found_local, __brick_tag,
                            __rngs...);
 
-                    // 3. Reduce over group: find __dpl_sycl::__minimum (for the __parallel_find_forward_tag),
-                    // find __dpl_sycl::__maximum (for the __parallel_find_backward_tag)
+                    // 3. Reduce over group: find sycl::minimum (for the __parallel_find_forward_tag),
+                    // find sycl::maximum (for the __parallel_find_backward_tag)
                     // or update state with __dpl_sycl::__any_of_group (for the __parallel_or_tag)
                     // inside all our group items
                     if constexpr (__or_tag_check)
@@ -1120,8 +1120,8 @@ struct __parallel_find_or_impl_multiple_wgs<__or_tag_check, __internal::__option
                     __pred(__item, __rng_n, __iters_per_work_item, __n_groups * __wgroup_size, __found_local,
                            __brick_tag, __rngs...);
 
-                    // 3. Reduce over group: find __dpl_sycl::__minimum (for the __parallel_find_forward_tag),
-                    // find __dpl_sycl::__maximum (for the __parallel_find_backward_tag)
+                    // 3. Reduce over group: find sycl::minimum (for the __parallel_find_forward_tag),
+                    // find sycl::maximum (for the __parallel_find_backward_tag)
                     // or update state with __dpl_sycl::__any_of_group (for the __parallel_or_tag)
                     // inside all our group items
                     if constexpr (__or_tag_check)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -413,7 +413,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
     {
         // TODO: Consider re-implementing single group scan to support types without known identities. This could also
         // allow us to use single wg scan for the last block of reduce-then-scan if it is sufficiently small.
-        constexpr bool __can_use_group_scan = unseq_backend::__has_known_identity<_BinaryOperation, _Type>::value;
+        constexpr bool __can_use_group_scan = unseq_backend::__can_use_group_reduce_scan<_BinaryOperation, _Type>::value;
         if constexpr (__can_use_group_scan)
         {
             // Next power of 2 greater than or equal to __n
@@ -1661,7 +1661,7 @@ __parallel_reduce_by_segment(oneapi::dpl::__internal::__device_backend_tag, _Exe
         oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
         std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys),
         std::forward<_Range4>(__out_values), __binary_pred, __binary_op,
-        oneapi::dpl::unseq_backend::__has_known_identity<_BinaryOperator, __val_type>{});
+        oneapi::dpl::unseq_backend::__can_use_group_reduce_scan<_BinaryOperator, __val_type>{});
 #endif
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1559,7 +1559,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
                                       _Range1&& __keys, _Range2&& __values, _Range3&& __out_keys,
                                       _Range4&& __out_values, _BinaryPredicate __binary_pred,
                                       _BinaryOperator __binary_op,
-                                      /*__can_use_group_reduce_scan*/std::false_type)
+                                      /*__can_use_group_reduce_scan*/ std::false_type)
 {
     const auto __n = oneapi::dpl::__ranges::__size(__keys);
     assert(__n > 0);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -411,8 +411,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
     {
         // TODO: Consider re-implementing single group scan to support types without known identities. This could also
         // allow us to use single wg scan for the last block of reduce-then-scan if it is sufficiently small.
-        constexpr bool __can_use_group_scan = unseq_backend::__can_use_group_reduce_scan<_BinaryOperation, _Type>::value;
-        if constexpr (__can_use_group_scan)
+        if constexpr (unseq_backend::__can_use_group_reduce_scan<_BinaryOperation, _Type>::value)
         {
             // Next power of 2 greater than or equal to __n
             std::size_t __n_uniform = oneapi::dpl::__internal::__dpl_bit_ceil(__n);
@@ -1560,7 +1559,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
                                       _Range1&& __keys, _Range2&& __values, _Range3&& __out_keys,
                                       _Range4&& __out_values, _BinaryPredicate __binary_pred,
                                       _BinaryOperator __binary_op,
-                                      /*known_identity=*/std::false_type)
+                                      /*__can_use_group_reduce_scan*/std::false_type)
 {
     const auto __n = oneapi::dpl::__ranges::__size(__keys);
     assert(__n > 0);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -413,8 +413,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
     {
         // TODO: Consider re-implementing single group scan to support types without known identities. This could also
         // allow us to use single wg scan for the last block of reduce-then-scan if it is sufficiently small.
-        constexpr bool __can_use_group_scan = unseq_backend::__can_use_group_reduce_scan<_BinaryOperation, _Type>::value;
-        if constexpr (__can_use_group_scan)
+        if constexpr (unseq_backend::__can_use_group_reduce_scan<_BinaryOperation, _Type>::value)
         {
             // Next power of 2 greater than or equal to __n
             std::size_t __n_uniform = oneapi::dpl::__internal::__dpl_bit_ceil(__n);
@@ -1529,7 +1528,7 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
                                       _Range1&& __keys, _Range2&& __values, _Range3&& __out_keys,
                                       _Range4&& __out_values, _BinaryPredicate __binary_pred,
                                       _BinaryOperator __binary_op,
-                                      /*known_identity=*/std::false_type)
+                                      /*__can_use_group_reduce_scan*/std::false_type)
 {
     const auto __n = oneapi::dpl::__ranges::__size(__keys);
     assert(__n > 0);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -479,7 +479,7 @@ __radix_sort_scan_submit(sycl::queue& __q, std::size_t __scan_wg_size, std::size
                 sycl::global_ptr<_CountT> __begin = __count_rng.begin() + __scan_size * __self_item.get_group(0);
                 // TODO: consider another approach with use of local memory
                 __dpl_sycl::__joint_exclusive_scan(__self_item.get_group(), __begin, __begin + __scan_size, __begin,
-                                                   _CountT(0), __dpl_sycl::__plus<_CountT>{});
+                                                   _CountT(0), sycl::plus<_CountT>{});
                 const auto __wi = __self_item.get_local_linear_id();
                 //That condition may be truth (by algo semantic) just on one WG, one WI, so there is no race here.
                 if (__wi == __scan_wg_size - 1 && *(__begin + __scan_size - 1) == __n)
@@ -531,7 +531,7 @@ __radix_sort_exclusive_scan(sycl::sub_group __sub_group, _ValueType __val, [[may
     }
     return __inclusive - __val;
 #else
-    return __dpl_sycl::__exclusive_scan_over_group(__sub_group, __val, __dpl_sycl::__plus<_ValueType>());
+    return __dpl_sycl::__exclusive_scan_over_group(__sub_group, __val, sycl::plus<_ValueType>());
 #endif
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -252,7 +252,7 @@ struct __subgroup_radix_sort
                                     //exclusive scan local sum
                                     std::uint16_t __sum_scan = __dpl_sycl::__exclusive_scan_over_group(
                                         __g, __bin_sum[__bin_count - 1],
-                                        __dpl_sycl::__plus<std::uint16_t>());
+                                        sycl::plus<std::uint16_t>());
                                     //add to local sum, generate exclusive scan result
                                     _ONEDPL_PRAGMA_UNROLL
                                     for (std::uint16_t __i = 0; __i < __bin_count; ++__i)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -251,8 +251,7 @@ struct __subgroup_radix_sort
 
                                     //exclusive scan local sum
                                     std::uint16_t __sum_scan = __dpl_sycl::__exclusive_scan_over_group(
-                                        __g, __bin_sum[__bin_count - 1],
-                                        sycl::plus<std::uint16_t>());
+                                        __g, __bin_sum[__bin_count - 1], sycl::plus<std::uint16_t>());
                                     //add to local sum, generate exclusive scan result
                                     _ONEDPL_PRAGMA_UNROLL
                                     for (std::uint16_t __i = 0; __i < __bin_count; ++__i)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -122,7 +122,7 @@ using _SegReducePrefixPhase = __seg_reduce_prefix_kernel<_Name...>;
 template <typename _CustomName, typename _Range1, typename _Range2, typename _Range3, typename _Range4,
           typename _BinaryPredicate, typename _BinaryOperator>
 oneapi::dpl::__internal::__difference_t<_Range3>
-__parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Range1&& __keys, _Range2&& __values,
+__parallel_reduce_by_segment_fallback_with_group_algorithms(sycl::queue& __q, _Range1&& __keys, _Range2&& __values,
                                                          _Range3&& __out_keys, _Range4&& __out_values,
                                                          _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
 {
@@ -487,13 +487,13 @@ __parallel_reduce_by_segment_fallback(oneapi::dpl::__internal::__device_backend_
                                       _Range1&& __keys, _Range2&& __values, _Range3&& __out_keys,
                                       _Range4&& __out_values, _BinaryPredicate __binary_pred,
                                       _BinaryOperator __binary_op,
-                                      /*known_identity=*/std::true_type)
+                                      /*__can_use_group_reduce_scan=*/std::true_type)
 {
     using __CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
     sycl::queue __q_local = __exec.queue();
 
-    return __parallel_reduce_by_segment_fallback_has_known_identity<__CustomName>(
+    return __parallel_reduce_by_segment_fallback_with_group_algorithms<__CustomName>(
         __q_local, std::forward<_Range1>(__keys), std::forward<_Range2>(__values), std::forward<_Range3>(__out_keys),
         std::forward<_Range4>(__out_values), __binary_pred, __binary_op);
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -123,8 +123,8 @@ template <typename _CustomName, typename _Range1, typename _Range2, typename _Ra
           typename _BinaryPredicate, typename _BinaryOperator>
 oneapi::dpl::__internal::__difference_t<_Range3>
 __parallel_reduce_by_segment_fallback_with_group_algorithms(sycl::queue& __q, _Range1&& __keys, _Range2&& __values,
-                                                         _Range3&& __out_keys, _Range4&& __out_values,
-                                                         _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
+                                                            _Range3&& __out_keys, _Range4&& __out_values,
+                                                            _BinaryPredicate __binary_pred, _BinaryOperator __binary_op)
 {
     using _SegReduceCountKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
         _SegReduceCountPhase, _CustomName, _Range1, _Range2, _Range3, _Range4, _BinaryPredicate, _BinaryOperator>;
@@ -210,8 +210,8 @@ __parallel_reduce_by_segment_fallback_with_group_algorithms(sycl::queue& __q, _R
                         ++__item_segments;
 
                 // 1b. Work group reduction
-                std::size_t __num_segs = __dpl_sycl::__reduce_over_group(
-                    __group, __item_segments, sycl::plus<decltype(__item_segments)>());
+                std::size_t __num_segs =
+                    __dpl_sycl::__reduce_over_group(__group, __item_segments, sycl::plus<decltype(__item_segments)>());
 
                 // 1c. First work item writes segment count to global memory
                 if (__local_id == 0)
@@ -288,13 +288,13 @@ __parallel_reduce_by_segment_fallback_with_group_algorithms(sycl::queue& __q, _R
                 }
 
                 // 2c. Count the number of prior work segments cooperatively over group
-                std::size_t __prior_segs_in_wg = __dpl_sycl::__exclusive_scan_over_group(
-                    __group, __item_segments, sycl::plus<std::size_t>());
+                std::size_t __prior_segs_in_wg =
+                    __dpl_sycl::__exclusive_scan_over_group(__group, __item_segments, sycl::plus<std::size_t>());
                 std::size_t __start_idx = __wg_num_prior_segs + __prior_segs_in_wg;
 
                 // 2d. Find the greatest segment end less than the current index (inclusive)
-                std::size_t __closest_seg_id = __dpl_sycl::__inclusive_scan_over_group(
-                    __group, __max_end, sycl::maximum<std::size_t>());
+                std::size_t __closest_seg_id =
+                    __dpl_sycl::__inclusive_scan_over_group(__group, __max_end, sycl::maximum<std::size_t>());
 
                 // __wg_segmented_scan is a derivative work and responsible for the third header copyright
                 __val_type __carry_in = oneapi::dpl::__par_backend_hetero::__wg_segmented_scan(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -272,7 +272,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
 
                 std::size_t __max_end = 0;
                 std::size_t __item_segments = 0;
-                auto __identity = unseq_backend::__known_identity<_BinaryOperator, __val_type>;
+                auto __identity = sycl::known_identity<_BinaryOperator, __val_type>::value;
 
                 __val_type __accumulator = __identity;
                 for (std::size_t __i = __start; __i < __end; ++__i)
@@ -388,7 +388,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                     std::size_t __item_segments = 0;
 
                     std::int64_t __wg_agg_idx = __group_id - 1;
-                    __val_type __agg_collector = unseq_backend::__known_identity<_BinaryOperator, __val_type>;
+                    __val_type __agg_collector = sycl::known_identity<_BinaryOperator, __val_type>::value;
 
                     bool __ag_exists = false;
                     // 3a. Check to see if an aggregate exists and compute that value in the first
@@ -400,11 +400,11 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                         constexpr std::int32_t __vals_to_explore = 16;
                         bool __last_it = false;
                         __loc_seg_ends_acc[__local_id] = false;
-                        __loc_partials_acc[__local_id] = unseq_backend::__known_identity<_BinaryOperator, __val_type>;
+                        __loc_partials_acc[__local_id] = sycl::known_identity<_BinaryOperator, __val_type>::value;
                         for (std::int32_t __i = __wg_agg_idx - __vals_to_explore * __local_id; !__last_it;
                              __i -= __wgroup_size * __vals_to_explore)
                         {
-                            __val_type __local_collector = unseq_backend::__known_identity<_BinaryOperator, __val_type>;
+                            __val_type __local_collector = sycl::known_identity<_BinaryOperator, __val_type>::value;
                             // exploration phase
                             for (std::int32_t __j = __i;
                                  __j > __dpl_sycl::__maximum<std::int32_t>{}(-1L, __i - __vals_to_explore); --__j)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_by_segment.h
@@ -201,7 +201,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                 std::size_t __global_id = __item.get_global_id(0);
 
                 std::size_t __start = __global_id * __vals_per_item;
-                std::size_t __end = __dpl_sycl::__minimum<decltype(__n)>{}(__start + __vals_per_item, __n);
+                std::size_t __end = sycl::minimum<decltype(__n)>{}(__start + __vals_per_item, __n);
                 std::size_t __item_segments = 0;
 
                 // 1a. Work item scan to identify segment ends
@@ -211,7 +211,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
 
                 // 1b. Work group reduction
                 std::size_t __num_segs = __dpl_sycl::__reduce_over_group(
-                    __group, __item_segments, __dpl_sycl::__plus<decltype(__item_segments)>());
+                    __group, __item_segments, sycl::plus<decltype(__item_segments)>());
 
                 // 1c. First work item writes segment count to global memory
                 if (__local_id == 0)
@@ -268,7 +268,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                 // 2b. Perform a serial scan within the work item over assigned elements. Store partial
                 // reductions in work group local memory.
                 std::size_t __start = __global_id * __vals_per_item;
-                std::size_t __end = __dpl_sycl::__minimum<decltype(__n)>{}(__start + __vals_per_item, __n);
+                std::size_t __end = sycl::minimum<decltype(__n)>{}(__start + __vals_per_item, __n);
 
                 std::size_t __max_end = 0;
                 std::size_t __item_segments = 0;
@@ -289,12 +289,12 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
 
                 // 2c. Count the number of prior work segments cooperatively over group
                 std::size_t __prior_segs_in_wg = __dpl_sycl::__exclusive_scan_over_group(
-                    __group, __item_segments, __dpl_sycl::__plus<std::size_t>());
+                    __group, __item_segments, sycl::plus<std::size_t>());
                 std::size_t __start_idx = __wg_num_prior_segs + __prior_segs_in_wg;
 
                 // 2d. Find the greatest segment end less than the current index (inclusive)
                 std::size_t __closest_seg_id = __dpl_sycl::__inclusive_scan_over_group(
-                    __group, __max_end, __dpl_sycl::__maximum<std::size_t>());
+                    __group, __max_end, sycl::maximum<std::size_t>());
 
                 // __wg_segmented_scan is a derivative work and responsible for the third header copyright
                 __val_type __carry_in = oneapi::dpl::__par_backend_hetero::__wg_segmented_scan(
@@ -384,7 +384,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                     std::size_t __local_id = __item.get_local_id(0);
 
                     std::size_t __start = __global_id * __vals_per_item;
-                    std::size_t __end = __dpl_sycl::__minimum<decltype(__n)>{}(__start + __vals_per_item, __n);
+                    std::size_t __end = sycl::minimum<decltype(__n)>{}(__start + __vals_per_item, __n);
                     std::size_t __item_segments = 0;
 
                     std::int64_t __wg_agg_idx = __group_id - 1;
@@ -407,7 +407,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                             __val_type __local_collector = sycl::known_identity<_BinaryOperator, __val_type>::value;
                             // exploration phase
                             for (std::int32_t __j = __i;
-                                 __j > __dpl_sycl::__maximum<std::int32_t>{}(-1L, __i - __vals_to_explore); --__j)
+                                 __j > sycl::maximum<std::int32_t>{}(-1L, __i - __vals_to_explore); --__j)
                             {
                                 __local_collector = __binary_op(__partials_acc[__j], __local_collector);
                                 if (__seg_ends_acc[__j] || __j == 0)
@@ -447,7 +447,7 @@ __parallel_reduce_by_segment_fallback_has_known_identity(sycl::queue& __q, _Rang
                             ++__item_segments;
 
                     std::size_t __prior_segs_in_wg = __dpl_sycl::__exclusive_scan_over_group(
-                        __group, __item_segments, __dpl_sycl::__plus<decltype(__item_segments)>());
+                        __group, __item_segments, sycl::plus<decltype(__item_segments)>());
 
                     // 3c. Determine prior index
                     std::size_t __wg_num_prior_segs = __seg_ends_scan_acc[__group_id];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -66,7 +66,6 @@
 // Kernel bundle support is not expected in ACPP, see https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1296.
 #define _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT                                                                        \
     (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300) && !_ONEDPL_ACPP_VERSION)
-#define _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT           (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
 #define _ONEDPL_SYCL2020_REQD_SUB_GROUP_SIZE_PRESENT          (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
 #define _ONEDPL_SYCL2020_TARGET_PRESENT                       (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50400))
 #define _ONEDPL_SYCL2020_TARGET_DEVICE_PRESENT                (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50400))
@@ -143,29 +142,6 @@ using __no_init =
 #else
 #    error "sycl::property::no_init is not supported, and no alternative is available"
 #endif
-
-#if _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
-template <typename _T = void>
-using __plus = sycl::plus<_T>;
-
-template <typename _T = void>
-using __maximum = sycl::maximum<_T>;
-
-template <typename _T = void>
-using __minimum = sycl::minimum<_T>;
-#elif _ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300)
-template <typename _T>
-using __plus = sycl::ONEAPI::plus<_T>;
-
-template <typename _T>
-using __maximum = sycl::ONEAPI::maximum<_T>;
-
-template <typename _T>
-using __minimum = sycl::ONEAPI::minimum<_T>;
-
-#else
-#    error "sycl::plus, sycl::maximum, sycl::minimum are not supported, and no alternative is available"
-#endif // _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 
 #if _ONEDPL_SYCL2020_SUB_GROUP_PRESENT
 using __sub_group = sycl::sub_group;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -66,7 +66,6 @@
 // Kernel bundle support is not expected in ACPP, see https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1296.
 #define _ONEDPL_SYCL2020_KERNEL_BUNDLE_PRESENT                                                                        \
     (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300) && !_ONEDPL_ACPP_VERSION)
-#define _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT               (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
 #define _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT           (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
 #define _ONEDPL_SYCL2020_REQD_SUB_GROUP_SIZE_PRESENT          (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
 #define _ONEDPL_SYCL2020_TARGET_PRESENT                       (!_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50400))
@@ -86,7 +85,6 @@
 // Feature macros for DPC++ SYCL runtime library alternatives to non-supported SYCL 2020 features
 #define _ONEDPL_LIBSYCL_COLLECTIVES_PRESENT                   (_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
 #define _ONEDPL_LIBSYCL_PROGRAM_PRESENT                       (_ONEDPL_LIBSYCL_VERSION_LESS_THAN(50300))
-#define _ONEDPL_LIBSYCL_KNOWN_IDENTITY_PRESENT                (_ONEDPL_LIBSYCL_VERSION == 50200)
 #define _ONEDPL_LIBSYCL_SUB_GROUP_MASK_PRESENT                                                                         \
     (SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 1 && _ONEDPL_LIBSYCL_VERSION >= 50700)
 
@@ -145,27 +143,6 @@ using __no_init =
 #else
 #    error "sycl::property::no_init is not supported, and no alternative is available"
 #endif
-
-#if _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT
-template <typename _BinaryOp, typename _T>
-using __known_identity = sycl::known_identity<_BinaryOp, _T>;
-
-template <typename _BinaryOp, typename _T>
-using __has_known_identity = sycl::has_known_identity<_BinaryOp, _T>;
-
-#elif _ONEDPL_LIBSYCL_KNOWN_IDENTITY_PRESENT
-template <typename _BinaryOp, typename _T>
-using __known_identity = sycl::ONEAPI::known_identity<_BinaryOp, _T>;
-
-template <typename _BinaryOp, typename _T>
-using __has_known_identity = sycl::ONEAPI::has_known_identity<_BinaryOp, _T>;
-
-#else
-#    error "sycl::__known_identity is not supported, and no alternative is available"
-#endif // _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT
-
-template <typename _BinaryOp, typename _T>
-inline constexpr auto __known_identity_v = __known_identity<_BinaryOp, _T>::value;
 
 #if _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 template <typename _T = void>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -18,6 +18,9 @@
 #define _ONEDPL_UNSEQ_BACKEND_SYCL_H
 
 #include <type_traits>
+#if defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
+#    include <complex>
+#endif
 
 #include "../../onedpl_config.h"
 #include "../../utils.h"
@@ -49,12 +52,31 @@ using __is_one_of_ops = std::disjunction<std::is_same<std::decay_t<_BinaryOp>, _
                                          std::is_same<std::decay_t<_BinaryOp>, _Ops<void>>...>;
 
 #    if defined(SYCL_IMPLEMENTATION_INTEL)
+
+// Intel SYCL implementation provides correct results only for std::complex with plus.
+// It also works well with sycl::vec, fundamental types and a subset of functors,
+// but it is not included into __can_use_group_reduce_scan until documented and tested by the implementers.
+// See more details in https://github.com/uxlfoundation/oneDPL/pull/2762.
+#    if defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
+template <typename _Tp>
+using __is_complex_float_or_double =
+    std::disjunction<std::is_same<_Tp, std::complex<float>>, std::is_same<_Tp, std::complex<double>>>;
+
+template <typename _BinaryOp, typename _Tp>
+using __can_use_group_reduce_scan_for_complex =
+    std::conjunction<__is_complex_float_or_double<_Tp>, __is_one_of_ops<_BinaryOp, _Tp, std::plus, sycl::plus>>;
+#    else
+template <typename _BinaryOp, typename _Tp>
+using __can_use_group_reduce_scan_for_complex = std::false_type;
+#    endif // defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
+
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
     __workaround_igpu_64_bit_reduction<_Tp>,
     std::negation<std::is_same<_Tp, bool>>, // group algorithms are not implemented for bool in icpx as of 2026.0
     sycl::has_known_identity<_BinaryOp, _Tp>,
-    std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>>,
+    std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>,
+                      __can_use_group_reduce_scan_for_complex<_BinaryOp, _Tp>>,
     __is_one_of_ops<_BinaryOp, _Tp,
                     std::plus, sycl::plus,
                     std::multiplies, sycl::multiplies,
@@ -67,6 +89,7 @@ using __can_use_group_reduce_scan = std::conjunction<
                     // no std::minimum and std::maximum exist
                     sycl::minimum,
                     sycl::maximum>>;
+
 #    else  // Other SYCL implementations, assuming they are SYCL 2020 compliant
 // TODO: check acpp - it should support std::* ops as sycl::* ops are aliases to std::* ops.
 template <typename _BinaryOp, typename _Tp>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -53,6 +53,7 @@ template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
     __workaround_igpu_64_bit_reduction<_Tp>,
     std::negation<std::is_same<_Tp, bool>>, // group algorithms are not implemented for bool in icpx as of 2026.0
+    sycl::has_known_identity<_Tp, _BinaryOp>,
     std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>>,
     __is_one_of_ops<_BinaryOp, _Tp,
                     std::plus, sycl::plus,
@@ -71,6 +72,7 @@ using __can_use_group_reduce_scan = std::conjunction<
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
     std::is_arithmetic<_Tp>,
+    sycl::has_known_identity<_Tp, _BinaryOp>,
     __is_one_of_ops<_BinaryOp, _Tp,
                     sycl::plus,
                     sycl::multiplies,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -34,7 +34,6 @@ namespace unseq_backend
 {
 
 #if _ONEDPL_USE_GROUP_ALGOS
-#    if defined(SYCL_IMPLEMENTATION_INTEL)
 
 // When ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION is defined as non-zero, we avoid using known identity for 64-bit arithmetic data types
 template <typename _Tp>
@@ -49,6 +48,7 @@ template <typename _BinaryOp, typename _Tp, template <typename> class... _Ops>
 using __is_one_of_ops = std::disjunction<std::is_same<std::decay_t<_BinaryOp>, _Ops<_Tp>>...,
                                          std::is_same<std::decay_t<_BinaryOp>, _Ops<void>>...>;
 
+#    if defined(SYCL_IMPLEMENTATION_INTEL)
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
     __workaround_igpu_64_bit_reduction<_Tp>,
@@ -60,9 +60,9 @@ using __can_use_group_reduce_scan = std::conjunction<
                     std::bit_and, sycl::bit_and,
                     std::bit_or, sycl::bit_or,
                     std::bit_xor, sycl::bit_xor,
-                    // std::logical_and and std::logical_or are not accepted by icpx
-                    sycl::logical_and,
-                    sycl::logical_or,
+                    // std::logical_<and|or> are not accepted by icpx,
+                    // sycl::logical_<and|or> are off until group algorithms support bool.
+                    //
                     // no std::minimum and std::maximum exist
                     sycl::minimum,
                     sycl::maximum>>;
@@ -72,7 +72,7 @@ template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
     std::is_arithmetic<_Tp>,
     __is_one_of_ops<_BinaryOp, _Tp,
-                    std::plus,
+                    sycl::plus,
                     sycl::multiplies,
                     sycl::bit_and,
                     sycl::bit_or,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -54,9 +54,6 @@ using __is_one_of_ops = std::disjunction<std::is_same<std::decay_t<_BinaryOp>, _
 #    if defined(SYCL_IMPLEMENTATION_INTEL)
 
 // Intel SYCL implementation provides correct results only for std::complex with plus.
-// It also works well with sycl::vec, fundamental types and a subset of functors,
-// but it is not included into __can_use_group_reduce_scan until documented and tested by the implementers.
-// See more details in https://github.com/uxlfoundation/oneDPL/pull/2762.
 #        if defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
 template <typename _Tp>
 using __is_complex_float_or_double =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -57,7 +57,7 @@ using __is_one_of_ops = std::disjunction<std::is_same<std::decay_t<_BinaryOp>, _
 // It also works well with sycl::vec, fundamental types and a subset of functors,
 // but it is not included into __can_use_group_reduce_scan until documented and tested by the implementers.
 // See more details in https://github.com/uxlfoundation/oneDPL/pull/2762.
-#    if defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
+#        if defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
 template <typename _Tp>
 using __is_complex_float_or_double =
     std::disjunction<std::is_same<_Tp, std::complex<float>>, std::is_same<_Tp, std::complex<double>>>;
@@ -65,10 +65,10 @@ using __is_complex_float_or_double =
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan_for_complex =
     std::conjunction<__is_complex_float_or_double<_Tp>, __is_one_of_ops<_BinaryOp, _Tp, std::plus, sycl::plus>>;
-#    else
+#        else
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan_for_complex = std::false_type;
-#    endif // defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
+#        endif // defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
 
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
@@ -76,7 +76,7 @@ using __can_use_group_reduce_scan = std::conjunction<
     std::negation<std::is_same<_Tp, bool>>, // group algorithms are not implemented for bool in icpx as of 2026.0
     sycl::has_known_identity<_BinaryOp, _Tp>,
     std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>,
-                      __can_use_group_reduce_scan_for_complex<_BinaryOp, _Tp>>,
+                     __can_use_group_reduce_scan_for_complex<_BinaryOp, _Tp>>,
     __is_one_of_ops<_BinaryOp, _Tp,
                     std::plus, sycl::plus,
                     std::multiplies, sycl::multiplies,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -26,9 +26,6 @@
 #include "parallel_backend_sycl_utils.h"
 #include "../../functional_impl.h" // for oneapi::dpl::identity
 
-#define _ONEDPL_SYCL_KNOWN_IDENTITY_PRESENT                                                                            \
-    (_ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT || _ONEDPL_LIBSYCL_KNOWN_IDENTITY_PRESENT)
-
 namespace oneapi
 {
 namespace dpl
@@ -36,12 +33,14 @@ namespace dpl
 namespace unseq_backend
 {
 
-#if _ONEDPL_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
-//This optimization depends on Intel(R) oneAPI DPC++ Compiler implementation such as support of binary operators from std namespace.
+//This optimization depends on Intel(R) oneAPI DPC++ Compiler implementation such as:
+// - support of binary operators from std namespace. Note, ACPP also supports them.
+// - support of sycl::half.
 //We need to use defined(SYCL_IMPLEMENTATION_INTEL) macro as a guard.
-
+//TODO: guard only DPC++ compiler specific details.
+#if _ONEDPL_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
 template <typename _Tp>
-inline constexpr bool __can_use_known_identity =
+inline constexpr bool __enable_group_reduce_scan_for_type =
 #    if ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
     // When ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION is defined as non-zero, we avoid using known identity for 64-bit arithmetic data types
     !(::std::is_arithmetic_v<_Tp> && sizeof(_Tp) == sizeof(::std::uint64_t));
@@ -49,58 +48,29 @@ inline constexpr bool __can_use_known_identity =
     true;
 #    endif // ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
 
-//TODO: To change __has_known_identity implementation as soon as the Intel(R) oneAPI DPC++ Compiler implementation issues related to
+//TODO: To change __can_use_group_reduce_scan implementation as soon as the Intel(R) oneAPI DPC++ Compiler implementation issues related to
 //std::multiplies, std::bit_or, std::bit_and and std::bit_xor operations will be fixed.
 //std::logical_and and std::logical_or are not supported in Intel(R) oneAPI DPC++ Compiler to be used in sycl::inclusive_scan_over_group and sycl::reduce_over_group
 template <typename _BinaryOp, typename _Tp>
-using __has_known_identity = ::std::conditional_t<
-    __can_use_known_identity<_Tp>,
-#    if _ONEDPL_SYCL_KNOWN_IDENTITY_PRESENT
-    typename ::std::disjunction<
-        __dpl_sycl::__has_known_identity<_BinaryOp, _Tp>,
-        ::std::conjunction<::std::is_arithmetic<_Tp>,
-                           ::std::disjunction<::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>>,
-                                              ::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<void>>,
-                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
-                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>,
-                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<_Tp>>,
-                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<void>>,
-                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<_Tp>>,
-                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<void>>>>>,
-#    else
-    typename ::std::conjunction<
-        ::std::is_arithmetic<_Tp>,
-        ::std::disjunction<::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>>,
-                           ::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<void>>,
-                           ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
-                           ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>>>,
-#    endif
-    ::std::false_type>;     // This is for the case of __can_use_known_identity<_Tp>==false
-
+using __can_use_group_reduce_scan = std::conditional_t<
+    __enable_group_reduce_scan_for_type<_Tp>,
+    typename std::conjunction<
+        std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>>,
+        std::disjunction<std::is_same<std::decay_t<_BinaryOp>, std::plus<_Tp>>,
+                            std::is_same<std::decay_t<_BinaryOp>, std::plus<void>>,
+                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
+                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>,
+                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<_Tp>>,
+                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<void>>,
+                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<_Tp>>,
+                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<void>>>>,
+    std::false_type>;     // This is for the case of __can_use_group_scan_reduce<_Tp>==false
 #else //_ONEDPL_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
 
 template <typename _BinaryOp, typename _Tp>
-using __has_known_identity = std::false_type;
+using __can_use_group_reduce_scan = std::false_type;
 
 #endif //_ONEDPL_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
-
-template <typename _BinaryOp, typename _Tp>
-struct __known_identity_for_plus
-{
-    static_assert(::std::is_same_v<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>> ||
-                  ::std::is_same_v<::std::decay_t<_BinaryOp>, ::std::plus<void>> ||
-                  ::std::is_same_v<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>> ||
-                  ::std::is_same_v<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>);
-    static constexpr _Tp value = 0;
-};
-
-template <typename _BinaryOp, typename _Tp>
-inline constexpr _Tp __known_identity =
-#if _ONEDPL_SYCL_KNOWN_IDENTITY_PRESENT
-    __dpl_sycl::__known_identity<_BinaryOp, _Tp>::value;
-#else
-    __known_identity_for_plus<_BinaryOp, _Tp>::value; //for plus only
-#endif
 
 template <typename _F>
 struct walk_n
@@ -476,7 +446,8 @@ struct reduce_over_group
     {
         const _Size __global_idx = __item.get_global_id(0);
         return __dpl_sycl::__reduce_over_group(
-            __item.get_group(), __global_idx >= __n ? __known_identity<_BinaryOperation1, _Tp> : __val.__v, __bin_op1);
+            __item.get_group(),
+            __global_idx >= __n ? sycl::known_identity<_BinaryOperation1, _Tp>::value : __val.__v, __bin_op1);
     }
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>
@@ -512,7 +483,7 @@ struct reduce_over_group
     operator()(const _NDItemId __item, const _Size __n, oneapi::dpl::__internal::__lazy_ctor_storage<_Tp>& __val,
                const _AccLocal& __local_mem) const
     {
-        return reduce_impl(__item, __n, __val, __local_mem, __has_known_identity<_BinaryOperation1, _Tp>{});
+        return reduce_impl(__item, __n, __val, __local_mem, __can_use_group_reduce_scan<_BinaryOperation1, _Tp>{});
     }
 
     template <typename _InitType, typename _Result>
@@ -525,7 +496,7 @@ struct reduce_over_group
     inline std::size_t
     local_mem_req(const std::uint16_t& __work_group_size) const
     {
-        if constexpr (__has_known_identity<_BinaryOperation1, _Tp>{})
+        if constexpr (__can_use_group_reduce_scan<_BinaryOperation1, _Tp>{})
             return 0;
 
         return __work_group_size;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -459,7 +459,7 @@ struct reduce_over_group
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
     reduce_impl(const _NDItemId __item, const _Size __n, oneapi::dpl::__internal::__lazy_ctor_storage<_Tp>& __val,
-                const _AccLocal& /*__local_mem*/, std::true_type /*has_known_identity*/) const
+                const _AccLocal& /*__local_mem*/, std::true_type /*__can_use_group_reduce_scan*/) const
     {
         const _Size __global_idx = __item.get_global_id(0);
         return __dpl_sycl::__reduce_over_group(
@@ -470,7 +470,7 @@ struct reduce_over_group
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
     reduce_impl(const _NDItemId __item, const _Size __n, oneapi::dpl::__internal::__lazy_ctor_storage<_Tp>& __val,
-                const _AccLocal& __local_mem, std::false_type /*has_known_identity*/) const
+                const _AccLocal& __local_mem, std::false_type /*__can_use_group_reduce_scan*/) const
     {
         auto __local_idx = __item.get_local_id(0);
         auto __group_size = __item.get_local_range().size();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -53,7 +53,7 @@ template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
     __workaround_igpu_64_bit_reduction<_Tp>,
     std::negation<std::is_same<_Tp, bool>>, // group algorithms are not implemented for bool in icpx as of 2026.0
-    sycl::has_known_identity<_Tp, _BinaryOp>,
+    sycl::has_known_identity<_BinaryOp, _Tp>,
     std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>>,
     __is_one_of_ops<_BinaryOp, _Tp,
                     std::plus, sycl::plus,
@@ -71,8 +71,9 @@ using __can_use_group_reduce_scan = std::conjunction<
 // TODO: check acpp - it should support std::* ops as sycl::* ops are aliases to std::* ops.
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
+    __workaround_igpu_64_bit_reduction<_Tp>,
     std::is_arithmetic<_Tp>,
-    sycl::has_known_identity<_Tp, _BinaryOp>,
+    sycl::has_known_identity<_BinaryOp, _Tp>,
     __is_one_of_ops<_BinaryOp, _Tp,
                     sycl::plus,
                     sycl::multiplies,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -48,22 +48,27 @@ inline constexpr bool __enable_group_reduce_scan_for_type =
     true;
 #    endif // ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
 
-//TODO: To change __can_use_group_reduce_scan implementation as soon as the Intel(R) oneAPI DPC++ Compiler implementation issues related to
-//std::multiplies, std::bit_or, std::bit_and and std::bit_xor operations will be fixed.
-//std::logical_and and std::logical_or are not supported in Intel(R) oneAPI DPC++ Compiler to be used in sycl::inclusive_scan_over_group and sycl::reduce_over_group
+// True if _BinaryOp (decayed) is an instantiation of any of _Ops<_Tp> or _Ops<void>
+template <typename _BinaryOp, typename _Tp, template <typename> class... _Ops>
+inline constexpr bool __is_one_of_ops_v =
+    std::disjunction_v<std::is_same<std::decay_t<_BinaryOp>, _Ops<_Tp>>...,
+                       std::is_same<std::decay_t<_BinaryOp>, _Ops<void>>...>;
+
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conditional_t<
     __enable_group_reduce_scan_for_type<_Tp>,
     typename std::conjunction<
         std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>>,
-        std::disjunction<std::is_same<std::decay_t<_BinaryOp>, std::plus<_Tp>>,
-                            std::is_same<std::decay_t<_BinaryOp>, std::plus<void>>,
-                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
-                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>,
-                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<_Tp>>,
-                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<void>>,
-                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<_Tp>>,
-                            std::is_same<std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<void>>>>,
+        std::bool_constant<__is_one_of_ops_v<_BinaryOp, _Tp,
+                          std::plus, sycl::plus,
+                          std::multiplies, sycl::multiplies,
+                          std::bit_and, sycl::bit_and,
+                          std::bit_or, sycl::bit_or,
+                          std::bit_xor, sycl::bit_xor,
+                          std::logical_and, sycl::logical_and,
+                          std::logical_or, sycl::logical_or,
+                          sycl::minimum,
+                          sycl::maximum>>>,
     std::false_type>;     // This is for the case of __can_use_group_scan_reduce<_Tp>==false
 #else //_ONEDPL_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -34,16 +34,16 @@ namespace unseq_backend
 {
 
 #if _ONEDPL_USE_GROUP_ALGOS
-#if defined(SYCL_IMPLEMENTATION_INTEL)
+#    if defined(SYCL_IMPLEMENTATION_INTEL)
 
 // When ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION is defined as non-zero, we avoid using known identity for 64-bit arithmetic data types
 template <typename _Tp>
 using __workaround_igpu_64_bit_reduction =
-#    if ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
+#        if ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
     std::bool_constant<!(::std::is_arithmetic_v<_Tp> && sizeof(_Tp) == sizeof(::std::uint64_t))>;
-#    else
+#        else
     std::true_type;
-#    endif // ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
+#        endif // ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
 
 template <typename _BinaryOp, typename _Tp, template <typename> class... _Ops>
 using __is_one_of_ops = std::disjunction<std::is_same<std::decay_t<_BinaryOp>, _Ops<_Tp>>...,
@@ -66,7 +66,7 @@ using __can_use_group_reduce_scan = std::conjunction<
                     // no std::minimum and std::maximum exist
                     sycl::minimum,
                     sycl::maximum>>;
-#else // Other SYCL implementations, assuming they are SYCL 2020 compliant
+#    else  // Other SYCL implementations, assuming they are SYCL 2020 compliant
 // TODO: check acpp - it should support std::* ops as sycl::* ops are aliases to std::* ops.
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
@@ -81,8 +81,8 @@ using __can_use_group_reduce_scan = std::conjunction<
                     sycl::logical_or,
                     sycl::minimum,
                     sycl::maximum>>;
-#endif // defined(SYCL_IMPLEMENTATION_INTEL)
-#else // _ONEDPL_USE_GROUP_ALGOS
+#    endif // defined(SYCL_IMPLEMENTATION_INTEL)
+#else      // _ONEDPL_USE_GROUP_ALGOS
 
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::false_type;
@@ -463,8 +463,8 @@ struct reduce_over_group
     {
         const _Size __global_idx = __item.get_global_id(0);
         return __dpl_sycl::__reduce_over_group(
-            __item.get_group(),
-            __global_idx >= __n ? sycl::known_identity<_BinaryOperation1, _Tp>::value : __val.__v, __bin_op1);
+            __item.get_group(), __global_idx >= __n ? sycl::known_identity<_BinaryOperation1, _Tp>::value : __val.__v,
+            __bin_op1);
     }
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -33,49 +33,61 @@ namespace dpl
 namespace unseq_backend
 {
 
-//This optimization depends on Intel(R) oneAPI DPC++ Compiler implementation such as:
-// - support of binary operators from std namespace. Note, ACPP also supports them.
-// - support of sycl::half.
-//We need to use defined(SYCL_IMPLEMENTATION_INTEL) macro as a guard.
-//TODO: guard only DPC++ compiler specific details.
-#if _ONEDPL_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
+#if _ONEDPL_USE_GROUP_ALGOS
+#if defined(SYCL_IMPLEMENTATION_INTEL)
+
+// When ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION is defined as non-zero, we avoid using known identity for 64-bit arithmetic data types
 template <typename _Tp>
-inline constexpr bool __enable_group_reduce_scan_for_type =
+using __workaround_igpu_64_bit_reduction =
 #    if ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-    // When ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION is defined as non-zero, we avoid using known identity for 64-bit arithmetic data types
-    !(::std::is_arithmetic_v<_Tp> && sizeof(_Tp) == sizeof(::std::uint64_t));
+    std::bool_constant<!(::std::is_arithmetic_v<_Tp> && sizeof(_Tp) == sizeof(::std::uint64_t))>;
 #    else
-    true;
+    std::true_type;
 #    endif // ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
 
-// True if _BinaryOp (decayed) is an instantiation of any of _Ops<_Tp> or _Ops<void>
 template <typename _BinaryOp, typename _Tp, template <typename> class... _Ops>
-inline constexpr bool __is_one_of_ops_v =
-    std::disjunction_v<std::is_same<std::decay_t<_BinaryOp>, _Ops<_Tp>>...,
-                       std::is_same<std::decay_t<_BinaryOp>, _Ops<void>>...>;
+using __is_one_of_ops = std::disjunction<std::is_same<std::decay_t<_BinaryOp>, _Ops<_Tp>>...,
+                                         std::is_same<std::decay_t<_BinaryOp>, _Ops<void>>...>;
 
 template <typename _BinaryOp, typename _Tp>
-using __can_use_group_reduce_scan = std::conditional_t<
-    __enable_group_reduce_scan_for_type<_Tp>,
-    typename std::conjunction<
-        std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>>,
-        std::bool_constant<__is_one_of_ops_v<_BinaryOp, _Tp,
-                          std::plus, sycl::plus,
-                          std::multiplies, sycl::multiplies,
-                          std::bit_and, sycl::bit_and,
-                          std::bit_or, sycl::bit_or,
-                          std::bit_xor, sycl::bit_xor,
-                          std::logical_and, sycl::logical_and,
-                          std::logical_or, sycl::logical_or,
-                          sycl::minimum,
-                          sycl::maximum>>>,
-    std::false_type>;     // This is for the case of __can_use_group_scan_reduce<_Tp>==false
-#else //_ONEDPL_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
+using __can_use_group_reduce_scan = std::conjunction<
+    __workaround_igpu_64_bit_reduction<_Tp>,
+    std::negation<std::is_same<_Tp, bool>>, // group algorithms are not implemented for bool in icpx as of 2026.0
+    std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>>,
+    __is_one_of_ops<_BinaryOp, _Tp,
+                    std::plus, sycl::plus,
+                    std::multiplies, sycl::multiplies,
+                    std::bit_and, sycl::bit_and,
+                    std::bit_or, sycl::bit_or,
+                    std::bit_xor, sycl::bit_xor,
+                    // std::logical_and and std::logical_or are not accepted by icpx
+                    sycl::logical_and,
+                    sycl::logical_or,
+                    // no std::minimum and std::maximum exist
+                    sycl::minimum,
+                    sycl::maximum>>;
+#else // Other SYCL implementations, assuming they are SYCL 2020 compliant
+// TODO: check acpp - it should support std::* ops as sycl::* ops are aliases to std::* ops.
+template <typename _BinaryOp, typename _Tp>
+using __can_use_group_reduce_scan = std::conjunction<
+    std::is_arithmetic<_Tp>,
+    __is_one_of_ops<_BinaryOp, _Tp,
+                    std::plus,
+                    sycl::multiplies,
+                    sycl::bit_and,
+                    sycl::bit_or,
+                    sycl::bit_xor,
+                    sycl::logical_and,
+                    sycl::logical_or,
+                    sycl::minimum,
+                    sycl::maximum>>;
+#endif // defined(SYCL_IMPLEMENTATION_INTEL)
+#else // _ONEDPL_USE_GROUP_ALGOS
 
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::false_type;
 
-#endif //_ONEDPL_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
+#endif // _ONEDPL_USE_GROUP_ALGOS
 
 template <typename _F>
 struct walk_n

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -23,6 +23,7 @@
 #include "support/scan_serial_impl.h"
 
 #include <iostream>
+#include <complex>
 #include <cstdint>
 #include <vector>
 
@@ -204,6 +205,48 @@ test_usm_impl(Policy&& exec)
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
+void
+test_with_complex(std::size_t n)
+{
+    using T = std::complex<float>;
+    std::vector<T> in(n), out_seq(n), out_unseq(n), out_par(n), out_parunseq(n), expected(n);
+
+    for (std::size_t i = 0; i < n; ++i)
+        in[i] = T(float(i % 5 + 1), float(i % 3 + 1));
+
+    exclusive_scan_serial(in.begin(), in.end(), expected.begin(), T(0, 0), std::plus<T>());
+
+    oneapi::dpl::exclusive_scan(oneapi::dpl::execution::seq, in.begin(), in.end(), out_seq.begin(), T(0, 0),
+                                std::plus<T>());
+    EXPECT_EQ_N(expected.begin(), out_seq.begin(), n, "wrong effect with seq, std::complex<float> and std::plus");
+
+    oneapi::dpl::exclusive_scan(oneapi::dpl::execution::unseq, in.begin(), in.end(), out_unseq.begin(), T(0, 0),
+                                std::plus<T>());
+    EXPECT_EQ_N(expected.begin(), out_unseq.begin(), n, "wrong effect with unseq, std::complex<float> and std::plus");
+
+    oneapi::dpl::exclusive_scan(oneapi::dpl::execution::par, in.begin(), in.end(), out_par.begin(), T(0, 0),
+                                std::plus<T>());
+    EXPECT_EQ_N(expected.begin(), out_par.begin(), n, "wrong effect with par, std::complex<float> and std::plus");
+
+    oneapi::dpl::exclusive_scan(oneapi::dpl::execution::par_unseq, in.begin(), in.end(), out_parunseq.begin(), T(0, 0),
+                                std::plus<T>());
+    EXPECT_EQ_N(expected.begin(), out_parunseq.begin(), n, "wrong effect with par_unseq, std::complex<float> and std::plus");
+
+#if TEST_DPCPP_BACKEND_PRESENT && defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
+    auto q = TestUtils::get_test_queue();
+    T* in_d = sycl::malloc_shared<T>(n, q);
+    T* out_d = sycl::malloc_shared<T>(n, q);
+    std::copy(in.begin(), in.end(), in_d);
+
+    auto policy = oneapi::dpl::execution::make_device_policy(q);
+    oneapi::dpl::exclusive_scan(policy, in_d, in_d + n, out_d, T(0, 0), std::plus<T>());
+
+    EXPECT_EQ_N(expected.begin(), out_d, n, "wrong effect with device, std::complex<float> and std::plus");
+    sycl::free(in_d, q);
+    sycl::free(out_d, q);
+#endif // TEST_DPCPP_BACKEND_PRESENT && defined(SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS)
+}
+
 int
 main()
 {
@@ -217,6 +260,9 @@ main()
     // When testing from bool to uint32_t, we must give a uint32_t init type to scan over integers
     test_with_plus<bool, std::uint32_t, std::uint32_t>(0, 123456,
                                                        [](std::uint32_t k) { return std::uint32_t{k % 2 == 0}; });
+
+    test_with_complex(1000);
+    test_with_complex(35000);
 
 #if TEST_DPCPP_BACKEND_PRESENT
     auto policy = TestUtils::get_dpcpp_test_policy();

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -126,8 +126,21 @@ void test_with_bfloat16(std::size_t n)
         std::size_t offset = seg * row_n;
         oneapi::dpl::inclusive_scan(policy, in + offset, in + offset + row_n, out + offset, std::plus<T>());
     }
-    EXPECT_EQ_N(expected.data(), out, total_n, "Wrong effect for bfloat16");
 
+    // Validation
+    // EXPECT_EQ* utilities cannot be used because their precision requirements are too strict for bfloat16
+    // 1% relative tolerance, 0.01 absolute tolerance for values near zero
+    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.01 * std::fabs(exp), 1e-2); };
+    for (std::size_t i = 0; i < total_n; ++i)
+    {
+        if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))
+        {
+            std::string message = "inclusive_scan failed for bfloat16 at index " + std::to_string(i) +
+                                  ": expected " + std::to_string(static_cast<float>(expected[i])) +
+                                  ", got " + std::to_string(static_cast<float>(out[i]));
+            EXPECT_TRUE(false, message.c_str());
+        }
+    }
     sycl::free(in, q);
     sycl::free(out, q);
 }

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -91,6 +91,60 @@ test_with_plus(Init init, Out trash, Convert convert)
 #endif // TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
 }
 
+#if TEST_DPCPP_BACKEND_PRESENT && defined(SYCL_IMPLEMENTATION_INTEL)
+// Immitate segmented scan to avoid too large precision errors
+void test_with_bfloat16(std::size_t n)
+{
+    using T = sycl::ext::oneapi::bfloat16;
+    // Truncate n to be a multiple of num_segments for simplicity
+    const std::size_t num_segments = n / 100;
+    const std::size_t row_n = n / num_segments;
+    const std::size_t total_n = row_n * num_segments;
+
+    auto q = TestUtils::get_test_queue();
+
+    std::vector<T> expected(n);
+    T* in = sycl::malloc_shared<T>(n, q);
+    T* out = sycl::malloc_shared<T>(n, q);
+
+    // Initialize and compute expected results
+    for (std::size_t seg = 0; seg < num_segments; ++seg)
+    {
+        T prefix = 0;
+        for (std::size_t i = 0; i < row_n; ++i)
+        {
+            T value = static_cast<T>(i % 3 + 1); // 1, 2, 3, 1, 2, 3, ...
+            in[seg * row_n + i] = value;
+            prefix += value;
+            expected[seg * row_n + i] = prefix;
+        }
+    }
+
+    auto policy = oneapi::dpl::execution::make_device_policy(q);
+    for (std::size_t seg = 0; seg < num_segments; ++seg)
+    {
+        std::size_t offset = seg * row_n;
+        oneapi::dpl::inclusive_scan(policy, in + offset, in + offset + row_n, out + offset, std::plus<T>());
+    }
+
+    // Validation
+    // EXPECT_EQ* utilities cannot be used because their precision requirements are too strict for bfloat16
+    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= 0.01 * std::fabs(exp); }; // 1% tolerance
+    for (std::size_t i = 0; i < total_n; ++i)
+    {
+        if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))
+        {
+            std::string message = "inclusive_scan failed for bfloat16 at index " + std::to_string(i) +
+                                  ": expected " + std::to_string(static_cast<float>(expected[i])) +
+                                  ", got " + std::to_string(static_cast<float>(out[i]));
+            EXPECT_TRUE(false, message.c_str());
+        }
+    }
+    sycl::free(in, q);
+    sycl::free(out, q);
+}
+#endif
+
 int
 main()
 {
@@ -104,6 +158,11 @@ main()
     // When testing from bool to uint32_t, we must give a uint32_t init type to scan over integers
     test_with_plus<bool, std::uint32_t, std::uint32_t>(0, 123456,
                                                        [](std::uint32_t k) { return std::uint32_t{k % 2 == 0}; });
+
+#if TEST_DPCPP_BACKEND_PRESENT && defined(SYCL_IMPLEMENTATION_INTEL)
+    test_with_bfloat16(1000);
+    test_with_bfloat16(35000);
+#endif
 
     return done();
 }

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -103,9 +103,9 @@ void test_with_bfloat16(std::size_t n)
 
     auto q = TestUtils::get_test_queue();
 
-    std::vector<T> expected(n);
-    T* in = sycl::malloc_shared<T>(n, q);
-    T* out = sycl::malloc_shared<T>(n, q);
+    std::vector<T> expected(total_n);
+    T* in = sycl::malloc_shared<T>(total_n, q);
+    T* out = sycl::malloc_shared<T>(total_n, q);
 
     // Initialize and compute expected results
     for (std::size_t seg = 0; seg < num_segments; ++seg)

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -131,7 +131,7 @@ void test_with_bfloat16(std::size_t n)
     sycl::free(in, q);
     sycl::free(out, q);
 }
-#endif
+#endif // TEST_DPCPP_BACKEND_PRESENT && defined(SYCL_IMPLEMENTATION_INTEL)
 
 int
 main()

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -126,20 +126,8 @@ void test_with_bfloat16(std::size_t n)
         std::size_t offset = seg * row_n;
         oneapi::dpl::inclusive_scan(policy, in + offset, in + offset + row_n, out + offset, std::plus<T>());
     }
+    EXPECT_EQ_N(expected.data(), out, total_n, "Wrong effect for bfloat16");
 
-    // Validation
-    // EXPECT_EQ* utilities cannot be used because their precision requirements are too strict for bfloat16
-    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= 0.01 * std::fabs(exp); }; // 1% tolerance
-    for (std::size_t i = 0; i < total_n; ++i)
-    {
-        if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))
-        {
-            std::string message = "inclusive_scan failed for bfloat16 at index " + std::to_string(i) +
-                                  ": expected " + std::to_string(static_cast<float>(expected[i])) +
-                                  ", got " + std::to_string(static_cast<float>(out[i]));
-            EXPECT_TRUE(false, message.c_str());
-        }
-    }
     sycl::free(in, q);
     sycl::free(out, q);
 }

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -129,8 +129,8 @@ void test_with_bfloat16(std::size_t n)
 
     // Validation
     // EXPECT_EQ* utilities cannot be used because their precision requirements are too strict for bfloat16
-    // 1% relative tolerance, 0.01 absolute tolerance for values near zero
-    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.01 * std::fabs(exp), 1e-2); };
+    // 2% relative tolerance, 0.02 absolute tolerance for values near zero
+    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.02 * std::fabs(exp), 0.02f); };
     for (std::size_t i = 0; i < total_n; ++i)
     {
         if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -92,7 +92,7 @@ test_with_plus(Init init, Out trash, Convert convert)
 }
 
 #if TEST_DPCPP_BACKEND_PRESENT && defined(SYCL_IMPLEMENTATION_INTEL)
-// Immitate segmented scan to avoid too large precision errors
+// Imitate segmented scan to avoid too large precision errors
 void test_with_bfloat16(std::size_t n)
 {
     using T = sycl::ext::oneapi::bfloat16;

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan.pass.cpp
@@ -130,7 +130,7 @@ void test_with_bfloat16(std::size_t n)
     // Validation
     // EXPECT_EQ* utilities cannot be used because their precision requirements are too strict for bfloat16
     // 2% relative tolerance, 0.02 absolute tolerance for values near zero
-    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.02 * std::fabs(exp), 0.02f); };
+    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.02f * std::fabs(exp), 0.02f); };
     for (std::size_t i = 0; i < total_n; ++i)
     {
         if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -242,9 +242,10 @@ void test_with_bfloat16(std::size_t n)
     {
         if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))
         {
-            std::cout << "inclusive_scan_by_segment failed for bfloat16 at index " << i
-                      << ": expected " << static_cast<float>(expected[i])
-                      << ", got " << static_cast<float>(out[i]) << "\n";
+            std::string message = "inclusive_scan_by_segment failed for bfloat16 at index " + std::to_string(i) +
+                                  ": expected " + std::to_string(static_cast<float>(expected[i])) +
+                                  ", got " + std::to_string(static_cast<float>(out[i]));
+            EXPECT_TRUE(false, message.c_str());
         }
     }
     sycl::free(in, q);

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -233,8 +233,20 @@ void test_with_bfloat16(std::size_t n)
     oneapi::dpl::inclusive_scan_by_segment(
         policy, col_iter, col_iter + total_n, in, out, std::equal_to<std::size_t>(), std::plus<T>()
     );
-    EXPECT_EQ_N(expected.data(), out, total_n, "Wrong effect for bfloat16");
 
+    // Validation
+    // EXPECT* utilities cannot be used because their precision requirements are too strict for bfloat16
+    // 1% relative tolerance, 0.01 absolute tolerance for values near zero
+    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.01 * std::fabs(exp), 1e-2); }; 
+    for (std::size_t i = 0; i < total_n; ++i)
+    {
+        if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))
+        {
+            std::cout << "inclusive_scan_by_segment failed for bfloat16 at index " << i
+                      << ": expected " << static_cast<float>(expected[i])
+                      << ", got " << static_cast<float>(out[i]) << "\n";
+        }
+    }
     sycl::free(in, q);
     sycl::free(out, q);
 }

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -237,7 +237,7 @@ void test_with_bfloat16(std::size_t n)
     // Validation
     // EXPECT* utilities cannot be used because their precision requirements are too strict for bfloat16
     // 1% relative tolerance, 0.01 absolute tolerance for values near zero
-    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.01 * std::fabs(exp), 1e-2); }; 
+    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.01 * std::fabs(exp), 1e-2); };
     for (std::size_t i = 0; i < total_n; ++i)
     {
         if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -208,9 +208,9 @@ void test_with_bfloat16(std::size_t n)
 
     auto q = TestUtils::get_test_queue();
 
-    std::vector<T> expected(n);
-    T* in = sycl::malloc_shared<T>(n, q);
-    T* out = sycl::malloc_shared<T>(n, q);
+    std::vector<T> expected(total_n);
+    T* in = sycl::malloc_shared<T>(total_n, q);
+    T* out = sycl::malloc_shared<T>(total_n, q);
 
     // Initialize and compute expected results
     for (std::size_t seg = 0; seg < num_segments; ++seg)
@@ -228,17 +228,17 @@ void test_with_bfloat16(std::size_t n)
     auto policy = oneapi::dpl::execution::make_device_policy(q);
     auto idx_iter = oneapi::dpl::counting_iterator<std::size_t>(0);
     auto col_iter = oneapi::dpl::make_transform_iterator(
-        idx_iter, [n, num_segments, row_n](std::size_t i) { return i / row_n; }
+        idx_iter, [row_n](std::size_t i) { return i / row_n; }
     );
     oneapi::dpl::inclusive_scan_by_segment(
-        policy, col_iter, col_iter + n, in, out, std::equal_to<std::size_t>(), std::plus<T>()
+        policy, col_iter, col_iter + total_n, in, out, std::equal_to<std::size_t>(), std::plus<T>()
     );
     EXPECT_EQ_N(expected.data(), out, total_n, "Wrong effect for bfloat16");
 
     sycl::free(in, q);
     sycl::free(out, q);
 }
-#endif
+#endif // TEST_DPCPP_BACKEND_PRESENT && defined(SYCL_IMPLEMENTATION_INTEL)
 
 int
 main()

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -236,8 +236,8 @@ void test_with_bfloat16(std::size_t n)
 
     // Validation
     // EXPECT* utilities cannot be used because their precision requirements are too strict for bfloat16
-    // 1% relative tolerance, 0.01 absolute tolerance for values near zero
-    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.01 * std::fabs(exp), 1e-2); };
+    // 2% relative tolerance, 0.02 absolute tolerance for values near zero
+    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.02 * std::fabs(exp), 0.02f); };
     for (std::size_t i = 0; i < total_n; ++i)
     {
         if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -233,19 +233,8 @@ void test_with_bfloat16(std::size_t n)
     oneapi::dpl::inclusive_scan_by_segment(
         policy, col_iter, col_iter + n, in, out, std::equal_to<std::size_t>(), std::plus<T>()
     );
+    EXPECT_EQ_N(expected.data(), out, total_n, "Wrong effect for bfloat16");
 
-    // Validation
-    // EXPECT* utilities cannot be used because their precision requirements are too strict for bfloat16
-    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= 0.01 * std::fabs(exp); }; // 1% tolerance
-    for (std::size_t i = 0; i < total_n; ++i)
-    {
-        if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))
-        {
-            std::cout << "inclusive_scan_by_segment failed for bfloat16 at index " << i
-                      << ": expected " << static_cast<float>(expected[i])
-                      << ", got " << static_cast<float>(out[i]) << "\n";
-        }
-    }
     sycl::free(in, q);
     sycl::free(out, q);
 }

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -197,6 +197,60 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     }
 };
 
+#if TEST_DPCPP_BACKEND_PRESENT && defined(SYCL_IMPLEMENTATION_INTEL)
+void test_with_bfloat16(std::size_t n)
+{
+    using T = sycl::ext::oneapi::bfloat16;
+    // Truncate n to be a multiple of num_segments for simplicity
+    const std::size_t num_segments = n / 100;
+    const std::size_t row_n = n / num_segments;
+    const std::size_t total_n = row_n * num_segments;
+
+    auto q = TestUtils::get_test_queue();
+
+    std::vector<T> expected(n);
+    T* in = sycl::malloc_shared<T>(n, q);
+    T* out = sycl::malloc_shared<T>(n, q);
+
+    // Initialize and compute expected results
+    for (std::size_t seg = 0; seg < num_segments; ++seg)
+    {
+        T prefix = 0;
+        for (std::size_t i = 0; i < row_n; ++i)
+        {
+            T value = static_cast<T>(i % 3 + 1); // 1, 2, 3, 1, 2, 3, ...
+            in[seg * row_n + i] = value;
+            prefix += value;
+            expected[seg * row_n + i] = prefix;
+        }
+    }
+
+    auto policy = oneapi::dpl::execution::make_device_policy(q);
+    auto idx_iter = oneapi::dpl::counting_iterator<std::size_t>(0);
+    auto col_iter = oneapi::dpl::make_transform_iterator(
+        idx_iter, [n, num_segments, row_n](std::size_t i) { return i / row_n; }
+    );
+    oneapi::dpl::inclusive_scan_by_segment(
+        policy, col_iter, col_iter + n, in, out, std::equal_to<std::size_t>(), std::plus<T>()
+    );
+
+    // Validation
+    // EXPECT* utilities cannot be used because their precision requirements are too strict for bfloat16
+    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= 0.01 * std::fabs(exp); }; // 1% tolerance
+    for (std::size_t i = 0; i < total_n; ++i)
+    {
+        if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))
+        {
+            std::cout << "inclusive_scan_by_segment failed for bfloat16 at index " << i
+                      << ": expected " << static_cast<float>(expected[i])
+                      << ", got " << static_cast<float>(out[i]) << "\n";
+        }
+    }
+    sycl::free(in, q);
+    sycl::free(out, q);
+}
+#endif
+
 int
 main()
 {
@@ -241,6 +295,11 @@ main()
         test_algo_three_sequences<ValueType, test_inclusive_scan_by_segment<BinaryPredicate, BinaryOperation>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
     }
+
+#if TEST_DPCPP_BACKEND_PRESENT && defined(SYCL_IMPLEMENTATION_INTEL)
+    test_with_bfloat16(1000);
+    test_with_bfloat16(35000);
+#endif
 
     return TestUtils::done();
 }

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -237,7 +237,7 @@ void test_with_bfloat16(std::size_t n)
     // Validation
     // EXPECT* utilities cannot be used because their precision requirements are too strict for bfloat16
     // 2% relative tolerance, 0.02 absolute tolerance for values near zero
-    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.02 * std::fabs(exp), 0.02f); };
+    auto approx_equal = [](float act, float exp) {return std::fabs(act - exp) <= std::max(0.02f * std::fabs(exp), 0.02f); };
     for (std::size_t i = 0; i < total_n; ++i)
     {
         if (!approx_equal(static_cast<float>(out[i]), static_cast<float>(expected[i])))

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -110,63 +110,18 @@ expect(bool expected, bool condition, const char* file, std::int32_t line, const
     }
 }
 
-template <typename T>
-bool
-is_close(T a, T b)
-{
-    // abs_tol is for rounding errors near zero.
-    // It is a multiple of an epsilon to tolerate accumulated errors.
-    // The larger the type, the larger the multiple to allow for more accumulations.
-    // rel_tol is selected intuitively.
-    T rel_tol = T(0.001); // 0.1%
-    T abs_tol = T(1e-5); // ~100x of the epsilon for float
-    if constexpr (sizeof(T) > sizeof(float))
-    {
-        rel_tol = T(0.0001); // 0.01%, 10x of the relative difference of any nearest number
-        abs_tol = T(1e-12); // ~1000x of the epsilon
-    }
-#if TEST_DPCPP_BACKEND_PRESENT
-    else if constexpr (std::is_same_v<T, sycl::half>)
-    {
-        rel_tol = T(0.005); // 0.5%
-        abs_tol = T(1e-3); // ~10x of the epsilon
-    }
-#if defined(SYCL_IMPLEMENTATION_INTEL)
-    else if constexpr (std::is_same_v<T, sycl::ext::oneapi::bfloat16>)
-    {
-        rel_tol = T(0.02); // 2%
-        abs_tol = T(1e-2); // ~10x of the epsilon
-    }
-#endif
-#endif
-    const T tol = std::max(rel_tol * std::max(std::fabs(a), std::fabs(b)), abs_tol);
-    return std::fabs(a - b) < tol;
-}
-
-template <typename T>
-constexpr bool is_non_standard_float_v = false;
-
-#if TEST_DPCPP_BACKEND_PRESENT
-template <>
-constexpr bool is_non_standard_float_v<sycl::half> = true;
-#if defined(SYCL_IMPLEMENTATION_INTEL)
-template <>
-constexpr bool is_non_standard_float_v<sycl::ext::oneapi::bfloat16> = true;
-#endif
-#endif
-
 // Do not change signature to const T&.
 // Function must be able to detect const differences between expected and actual.
 template <typename T1, typename T2>
-// TODO: alongside the close comparison of floats, allow the exact comparison for non-numeric algorithms.
 bool
 is_equal_val(const T1& val1, const T2& val2)
 {
     using T = std::common_type_t<T1, T2>;
 
-    if constexpr (std::is_floating_point_v<T> || is_non_standard_float_v<T>)
+    if constexpr (std::is_floating_point_v<T>)
     {
-        return is_close<T>(val1, val2);
+        const auto eps = std::numeric_limits<T>::epsilon();
+        return std::fabs(T(val1) - T(val2)) < eps;
     }
     else if constexpr (std::is_same_v<T1, T2>)
     {

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -158,6 +158,7 @@ constexpr bool is_non_standard_float_v<sycl::ext::oneapi::bfloat16> = true;
 // Do not change signature to const T&.
 // Function must be able to detect const differences between expected and actual.
 template <typename T1, typename T2>
+// TODO: alongside the close comparison of floats, allow the exact comparison for non-numeric algorithms.
 bool
 is_equal_val(const T1& val1, const T2& val2)
 {

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -155,13 +155,12 @@ constexpr bool is_non_standard_float_v<sycl::ext::oneapi::bfloat16> = true;
 #endif
 #endif
 
+// Do not change signature to const T&.
+// Function must be able to detect const differences between expected and actual.
 template <typename T1, typename T2>
 bool
-is_equal_val(T1&& val1, T2&& val2)
+is_equal_val(const T1& val1, const T2& val2)
 {
-    static_assert(std::is_const_v<std::remove_reference_t<T1>> == std::is_const_v<std::remove_reference_t<T2>>,
-                  "is_equal_val: expected and actual must have the same const-qualification");
-
     using DT1 = std::decay_t<T1>;
     using DT2 = std::decay_t<T2>;
     using T = std::common_type_t<DT1, DT2>;
@@ -233,12 +232,12 @@ template <typename TStream, typename Tag, typename TValue>
     }
 }
 
+// Do not change signature to const T&.
+// Function must be able to detect const differences between expected and actual.
 template <typename T1, typename T2>
 void
-expect_equal_val(T1&& expected, T2&& actual, const char* file, std::int32_t line, const char* message)
+expect_equal_val(const T1& expected, const T2& actual, const char* file, std::int32_t line, const char* message)
 {
-    static_assert(std::is_const_v<std::remove_reference_t<T1>> == std::is_const_v<std::remove_reference_t<T2>>,
-                  "is_equal_val: expected and actual must have the same const-qualification");
     if (!is_equal_val(expected, actual))
     {
         std::stringstream outstr;

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -118,24 +118,24 @@ is_close(T a, T b)
     // It is a multiple of an epsilon to tolerate accumulated errors.
     // The larger the type, the larger the multiple to allow for more accumulations.
     // rel_tol is selected intuitively.
-    T rel_tol = 0.001; // 0.1%
-    T abs_tol = 1e-5; // ~100x of the epsilon for float
+    T rel_tol = T(0.001); // 0.1%
+    T abs_tol = T(1e-5); // ~100x of the epsilon for float
     if constexpr (sizeof(T) > sizeof(float))
     {
-        rel_tol = 0.0001; // 0.01%, 10x of the relative difference of any nearest number
-        abs_tol = 1e-12; // ~1000x of the epsilon
+        rel_tol = T(0.0001); // 0.01%, 10x of the relative difference of any nearest number
+        abs_tol = T(1e-12); // ~1000x of the epsilon
     }
 #if TEST_DPCPP_BACKEND_PRESENT
     else if constexpr (std::is_same_v<T, sycl::half>)
     {
-        rel_tol = 0.005; // 0.5%
-        abs_tol = 1e-3; // ~10x of the epsilon
+        rel_tol = T(0.005); // 0.5%
+        abs_tol = T(1e-3); // ~10x of the epsilon
     }
 #if defined(SYCL_IMPLEMENTATION_INTEL)
     else if constexpr (std::is_same_v<T, sycl::ext::oneapi::bfloat16>)
     {
-        rel_tol = 0.02; // 2%
-        abs_tol = 1e-2; // ~10x of the epsilon
+        rel_tol = T(0.02); // 2%
+        abs_tol = T(1e-2); // ~10x of the epsilon
     }
 #endif
 #endif

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -110,18 +110,63 @@ expect(bool expected, bool condition, const char* file, std::int32_t line, const
     }
 }
 
-// Do not change signature to const T&.
-// Function must be able to detect const differences between expected and actual.
+template <typename T>
+bool
+is_close(T a, T b)
+{
+    // abs_tol is for rounding errors near zero.
+    // It is a multiple of an epsilon to tolerate accumulated errors.
+    // The larger the type, the larger the multiple to allow for more accumulations.
+    // rel_tol is selected intuitively.
+    T rel_tol = 0.001; // 0.1%
+    T abs_tol = 1e-5; // ~100x of the epsilon for float
+    if constexpr (sizeof(T) > sizeof(float))
+    {
+        rel_tol = 0.0001; // 0.01%, 10x of the relative difference of any nearest number
+        abs_tol = 1e-12; // ~1000x of the epsilon
+    }
+#if TEST_DPCPP_BACKEND_PRESENT
+    else if constexpr (std::is_same_v<T, sycl::half>)
+    {
+        rel_tol = 0.005; // 0.5%
+        abs_tol = 1e-3; // ~10x of the epsilon
+    }
+#if defined(SYCL_IMPLEMENTATION_INTEL)
+    else if constexpr (std::is_same_v<T, sycl::ext::oneapi::bfloat16>)
+    {
+        rel_tol = 0.02; // 2%
+        abs_tol = 1e-2; // ~10x of the epsilon
+    }
+#endif
+#endif
+    const T tol = std::max(rel_tol * std::max(std::fabs(a), std::fabs(b)), abs_tol);
+    return std::fabs(a - b) < tol;
+}
+
+template <typename T>
+constexpr bool is_non_standard_float_v = false;
+
+#if TEST_DPCPP_BACKEND_PRESENT
+template <>
+constexpr bool is_non_standard_float_v<sycl::half> = true;
+#if defined(SYCL_IMPLEMENTATION_INTEL)
+template <>
+constexpr bool is_non_standard_float_v<sycl::ext::oneapi::bfloat16> = true;
+#endif
+#endif
+
 template <typename T1, typename T2>
 bool
-is_equal_val(const T1& val1, const T2& val2)
+is_equal_val(T1 val1, T2 val2)
 {
+    static_assert(std::is_const_v<T1> == std::is_const_v<T2>,
+                  "is_equal_val: expected and actual must have the same const-qualification");
+
     using T = std::common_type_t<T1, T2>;
 
-    if constexpr (std::is_floating_point_v<T>)
+    if constexpr (std::is_floating_point_v<T> || is_non_standard_float_v<T>)
     {
-        const auto eps = std::numeric_limits<T>::epsilon();
-        return std::fabs(T(val1) - T(val2)) < eps;
+        return is_close<T>(val1, val2);
     }
     else if constexpr (std::is_same_v<T1, T2>)
     {
@@ -186,12 +231,12 @@ template <typename TStream, typename Tag, typename TValue>
     }
 }
 
-// Do not change signature to const T&.
-// Function must be able to detect const differences between expected and actual.
 template <typename T1, typename T2>
 void
-expect_equal_val(const T1& expected, const T2& actual, const char* file, std::int32_t line, const char* message)
+expect_equal_val(T1 expected, T2 actual, const char* file, std::int32_t line, const char* message)
 {
+    static_assert(std::is_const_v<T1> == std::is_const_v<T2>,
+                  "is_equal_val: expected and actual must have the same const-qualification");
     if (!is_equal_val(expected, actual))
     {
         std::stringstream outstr;

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -161,15 +161,13 @@ template <typename T1, typename T2>
 bool
 is_equal_val(const T1& val1, const T2& val2)
 {
-    using DT1 = std::decay_t<T1>;
-    using DT2 = std::decay_t<T2>;
-    using T = std::common_type_t<DT1, DT2>;
+    using T = std::common_type_t<T1, T2>;
 
     if constexpr (std::is_floating_point_v<T> || is_non_standard_float_v<T>)
     {
         return is_close<T>(val1, val2);
     }
-    else if constexpr (std::is_same_v<DT1, DT2>)
+    else if constexpr (std::is_same_v<T1, T2>)
     {
         return val1 == val2;
     }

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -157,18 +157,20 @@ constexpr bool is_non_standard_float_v<sycl::ext::oneapi::bfloat16> = true;
 
 template <typename T1, typename T2>
 bool
-is_equal_val(T1 val1, T2 val2)
+is_equal_val(T1&& val1, T2&& val2)
 {
-    static_assert(std::is_const_v<T1> == std::is_const_v<T2>,
+    static_assert(std::is_const_v<std::remove_reference_t<T1>> == std::is_const_v<std::remove_reference_t<T2>>,
                   "is_equal_val: expected and actual must have the same const-qualification");
 
-    using T = std::common_type_t<T1, T2>;
+    using DT1 = std::decay_t<T1>;
+    using DT2 = std::decay_t<T2>;
+    using T = std::common_type_t<DT1, DT2>;
 
     if constexpr (std::is_floating_point_v<T> || is_non_standard_float_v<T>)
     {
         return is_close<T>(val1, val2);
     }
-    else if constexpr (std::is_same_v<T1, T2>)
+    else if constexpr (std::is_same_v<DT1, DT2>)
     {
         return val1 == val2;
     }
@@ -233,9 +235,9 @@ template <typename TStream, typename Tag, typename TValue>
 
 template <typename T1, typename T2>
 void
-expect_equal_val(T1 expected, T2 actual, const char* file, std::int32_t line, const char* message)
+expect_equal_val(T1&& expected, T2&& actual, const char* file, std::int32_t line, const char* message)
 {
-    static_assert(std::is_const_v<T1> == std::is_const_v<T2>,
+    static_assert(std::is_const_v<std::remove_reference_t<T1>> == std::is_const_v<std::remove_reference_t<T2>>,
                   "is_equal_val: expected and actual must have the same const-qualification");
     if (!is_equal_val(expected, actual))
     {


### PR DESCRIPTION
The PR does several things:
1) Rename `__has_known_identity` and fix its logical flaw. It is used to ensure we can use scan and reduce group algorithms, which is orthogonal to having an identity or not; for example, `sycl::ext::oneapi::bfloat16` has an identity, but the group algorithms do not support it, which does not violate the SYCL spec.
2) Remove outdated know_identity, has_know_identity, plus, minimum and maximum wrappers used with old icpx versions (2022 or even older) - everything being touched in (1). 
4) Enable group algorithms for other compilers than icpx if SYCL 2020 spec conditions are satisfied. I do not consider this as a breaking change - oneDPL mandates a compiler to be SYCL 2020 compliant. I could not pass it by as this was again related to `__has_known_identity` function and could be easily done.

Motivation: fix the compilation issue with `bfloat16` usage with inclusive_scan (requested by a user).

Let me know if the PR should be broken into pieces.

---

Here are some details on using known identity and correctness of the group algorithms with icpx: 
[can_use_group_reduce_scan.md](https://github.com/user-attachments/files/30981418/can_use_group_reduce_scan.md). The data were gathered with [can_use_group_reduce_scan.txt](https://github.com/user-attachments/files/30981432/can_use_group_reduce_scan.txt) test.

