### PR TITLE
Improve implementation of the `__dpl_ceiling_div()` function

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -759,7 +759,7 @@ struct __gen_set_balanced_path
 
         // Calculate the number of "unmatched" repeats in the first set, add one and divide by two to round up for a
         // possible star diagonal.
-        _Index __fwd_search_count = (__rng1_repeats - __rng2_repeats_bck + 1) / 2;
+        _Index __fwd_search_count = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_repeats - __rng2_repeats_bck, 2);
 
         // Calculate the max location to search in the second set for future repeats, limiting to the edge of the range
         _Index __fwd_search_bound = std::min(__merge_path_rng2 + __fwd_search_count, __rng2_end);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -757,7 +757,7 @@ struct __gen_set_balanced_path
             return std::make_tuple(__merge_path_rng1, __merge_path_rng2, false);
         }
 
-        // Calculate the number of "unmatched" repeats in the first set, add one and divide by two to round up for a
+        // Calculate the number of "unmatched" repeats in the first set, dividing by two and rounding up to account for a
         // possible star diagonal.
         _Index __fwd_search_count = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_repeats - __rng2_repeats_bck, 2);
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -647,7 +647,7 @@ template <typename _T1, typename _T2>
 constexpr auto
 __dpl_ceiling_div(_T1 __number, _T2 __divisor)
 {
-    return (__number - 1) / __divisor + 1;
+    return (__number + __divisor - 1) / __divisor;
 }
 
 template <typename _T>


### PR DESCRIPTION
### Summary
This PR fixes a latent correctness bug in the internal helper `oneapi::dpl::__internal::__dpl_ceiling_div()` and switches one hand-rolled ceiling-division expression to use the helper.

### Problem
The previous implementation in `include/oneapi/dpl/pstl/utils.h` was:

```cpp
template <typename _T1, typename _T2>
constexpr auto
__dpl_ceiling_div(_T1 __number, _T2 __divisor)
{
    return (__number - 1) / __divisor + 1;
}
```

This form is incorrect when `__number == 0`:

- **Unsigned `__number` (the common case):** `__number - 1` wraps around to the maximum value of the type, so `(0 - 1) / __divisor + 1` produces a huge, completely wrong result instead of `0`.
- **Signed `__number`:** `(-1) / __divisor + 1 == 1`, whereas `ceil(0 / __divisor)` must be `0`.

`ceil(0) == 0` is a perfectly valid input for many of the call sites, and almost all of them use unsigned types, which is exactly the case that wraps around.

### Fix
Use the canonical, zero-safe form:

```cpp
template <typename _T1, typename _T2>
constexpr auto
__dpl_ceiling_div(_T1 __number, _T2 __divisor)
{
    return (__number + __divisor - 1) / __divisor;
}
```

For `__number == 0` this returns `(__divisor - 1) / __divisor == 0` as expected, and it yields identical results to the old formula for all positive inputs.

### Why this matters — real call sites with `0`-valued inputs
The helper is used throughout the SYCL backends to compute group/tile/iteration counts from runtime sizes that can legitimately be `0` (empty or fully-consumed ranges). All of these use unsigned counters, so the old formula could underflow. Examples from existing code:

- `parallel_backend_sycl_reduce.h` — number of groups from element count:
```cpp
const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
```
- `parallel_backend_sycl_reduce_by_segment.h`:
```cpp
std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
```
- `unseq_backend_sycl.h` — remainder of the last work-group (naturally can be `0`):
```cpp
_Size __last_wg_vec = oneapi::dpl::__internal::__dpl_ceiling_div(__last_wg_remainder, _VecSize);
```
- `parallel_backend_sycl_reduce_then_scan.h` — remaining/active work computed from partially consumed blocks:
```cpp
... = oneapi::dpl::__internal::__dpl_ceiling_div(static_cast<std::uint32_t>(__inputs_remaining), __inputs_per_item);
... = oneapi::dpl::__internal::__dpl_ceiling_div(__active_subgroups, __sub_group_size);
... = oneapi::dpl::__internal::__dpl_ceiling_div(__elements_to_process, __sub_group_size);
```
- `single_pass_scan.h`:
```cpp
_TileIdxT __num_wgs = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __elems_in_tile);
```

With the old implementation, any of these evaluating with a `0` numerator would compute an enormous count instead of `0`.

### Second change — use the helper instead of a manual expression
In `parallel_backend_sycl_reduce_then_scan.h`, `__gen_set_balanced_path::__find_balanced_path_start_point()` computed a ceiling division by hand:

```cpp
// before
_Index __fwd_search_count = (__rng1_repeats - __rng2_repeats_bck + 1) / 2;
// after
_Index __fwd_search_count =
    oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_repeats - __rng2_repeats_bck, 2);
```

This is numerically identical for the intended non-negative operand (`(x + 1) / 2 == __dpl_ceiling_div(x, 2)`), and it makes the "round up" intent from the surrounding comment explicit.

### Notes / risks
- The new form assumes `__number + __divisor - 1` does not overflow the operand type. This holds for all current call sites (counts divided by small divisors); the important practical case being fixed is the `0`-numerator underflow.
- No public API or behavior change for valid positive inputs; behavior only changes for the previously-broken `0` case.
