### PR TITLE
Remove ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,16 +265,6 @@ if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
             endif()
         endif()
 
-        if (DEFINED ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION)
-            if(ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION)
-                message(STATUS "Adding -DONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION=1 option")
-                target_compile_options(oneDPL INTERFACE "-DONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION=1")
-            else()
-                message(STATUS "Adding -DONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION=0 option")
-                target_compile_options(oneDPL INTERFACE "-DONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION=0")
-            endif()
-        endif()
-
         # DPC++ specific link options
         target_link_libraries(oneDPL INTERFACE ${FSYCL_OPTION_IF_SUPPORTED})
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -14,7 +14,6 @@ The following variables are provided for oneDPL configuration:
 | ONEDPL_CMAKE_QUIET_CHECKS                | BOOL   | Silence compiler/header check output during CMake configuration. Set to OFF to see verbose output for debugging | ON            |
 | ONEDPL_TEST_EXPLICIT_KERNEL_NAMES   | STRING | Control kernel naming. Affects only oneDPL test targets. Supported values: AUTO, ALWAYS. AUTO: rely on the compiler if "Unnamed SYCL lambda kernels" feature is on, otherwise provide kernel names explicitly; ALWAYS: provide kernel names explicitly | AUTO          |
 | ONEDPL_TEST_WIN_ICX_FIXES     | BOOL   | Affects only oneDPL test targets.  Enable icx, icx-cl workarounds to fix issues in CMake for Windows.                      | ON            |
-| ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION | BOOL | Use as a workaround for incorrect results, which may be produced by reduction algorithms with 64-bit data types compiled by the Intel&reg; oneAPI DPC++/C++ Compiler and executed on GPU devices. |               |
 
 Some useful CMake variables ([here](https://cmake.org/cmake/help/latest/manual/cmake-variables.7.html) you can find a full list of CMake variables for the latest version):
 

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -8,6 +8,12 @@ The Intel® oneAPI DPC++ Library (oneDPL) accompanies the Intel® oneAPI DPC++/C
 and provides high-productivity APIs aimed to minimize programming efforts of C++ developers
 creating efficient heterogeneous applications.
 
+New in 2022.14.0
+================
+
+- ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION now has no effect on the library behavior as
+  the underlying issue is now fixed in all relevant versions of Intel® Graphics Driver.
+
 New in 2022.13.0
 ================
 

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -8,6 +8,15 @@ The Intel® oneAPI DPC++ Library (oneDPL) accompanies the Intel® oneAPI DPC++/C
 and provides high-productivity APIs aimed to minimize programming efforts of C++ developers
 creating efficient heterogeneous applications.
 
+New in 2022.15.0
+================
+
+Fixed Issues
+------------
+
+- The workaround macro ``ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION`` has been removed, and it no longer affects
+  the library behavior as the underlying issue is now fixed in all relevant versions of Intel® Graphics Driver.
+
 New in 2022.14.0
 ================
 New Features
@@ -73,7 +82,6 @@ See oneDPL Guide for other `restrictions and known limitations`_.
   * ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union`` with both host
     and device policies require an output value type constructible from input reference types and
     a non-proxy output iterator.
- 
 
 New in 2022.13.0
 ================

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -231,6 +231,10 @@ See oneDPL Guide for other `restrictions and known limitations`_.
   with ``unseq`` or ``par_unseq`` policy when compiled by Intel® oneAPI DPC++/C++ Compiler 2024.1 or earlier
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
+- Incorrect results may be produced by ``reduce``, ``reduce_by_segment``, and ``transform_reduce``
+  with 64-bit data types when compiled by Intel® oneAPI DPC++/C++ Compiler versions 2021.3 and newer
+  and executed on a GPU device. For a workaround, define the ``ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION``
+  macro to ``1`` before including oneDPL header files.
 
 New in 2022.10.0
 ================
@@ -503,10 +507,6 @@ See oneDPL Guide for other `restrictions and known limitations`_.
   with ``unseq`` or ``par_unseq`` policy when compiled by Intel® oneAPI DPC++/C++ Compiler
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
-- Incorrect results may be produced by ``reduce``, ``reduce_by_segment``, and ``transform_reduce``
-  with 64-bit data types when compiled by Intel® oneAPI DPC++/C++ Compiler versions 2021.3 and newer
-  and executed on a GPU device. For a workaround, define the ``ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION``
-  macro to ``1`` before including oneDPL header files.
 - ``std::tuple``, ``std::pair`` cannot be used with SYCL buffers to transfer data between host and device.
 - ``std::array`` cannot be swapped in DPC++ kernels with ``std::swap`` function or ``swap`` member function
   in the Microsoft* Visual C++ standard library.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -36,22 +36,12 @@ namespace unseq_backend
 #if _ONEDPL_USE_GROUP_ALGOS
 #    if defined(SYCL_IMPLEMENTATION_INTEL)
 
-// When ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION is defined as non-zero, we avoid using known identity for 64-bit arithmetic data types
-template <typename _Tp>
-using __workaround_igpu_64_bit_reduction =
-#        if ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-    std::bool_constant<!(::std::is_arithmetic_v<_Tp> && sizeof(_Tp) == sizeof(::std::uint64_t))>;
-#        else
-    std::true_type;
-#        endif // ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-
 template <typename _BinaryOp, typename _Tp, template <typename> class... _Ops>
 using __is_one_of_ops = std::disjunction<std::is_same<std::decay_t<_BinaryOp>, _Ops<_Tp>>...,
                                          std::is_same<std::decay_t<_BinaryOp>, _Ops<void>>...>;
 
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
-    __workaround_igpu_64_bit_reduction<_Tp>,
     std::negation<std::is_same<_Tp, bool>>, // group algorithms are not implemented for bool in icpx as of 2026.0
     std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>>,
     __is_one_of_ops<_BinaryOp, _Tp,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -38,15 +38,6 @@ namespace unseq_backend
 
 #if _ONEDPL_USE_GROUP_ALGOS
 
-// When ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION is defined as non-zero, we avoid using known identity for 64-bit arithmetic data types
-template <typename _Tp>
-using __workaround_igpu_64_bit_reduction =
-#        if ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-    std::bool_constant<!(::std::is_arithmetic_v<_Tp> && sizeof(_Tp) == sizeof(::std::uint64_t))>;
-#        else
-    std::true_type;
-#        endif // ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-
 template <typename _BinaryOp, typename _Tp, template <typename> class... _Ops>
 using __is_one_of_ops = std::disjunction<std::is_same<std::decay_t<_BinaryOp>, _Ops<_Tp>>...,
                                          std::is_same<std::decay_t<_BinaryOp>, _Ops<void>>...>;
@@ -69,7 +60,6 @@ using __can_use_group_reduce_scan_for_complex = std::false_type;
 
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
-    __workaround_igpu_64_bit_reduction<_Tp>,
     std::negation<std::is_same<_Tp, bool>>, // group algorithms are not implemented for bool in icpx as of 2026.0
     sycl::has_known_identity<_BinaryOp, _Tp>,
     std::disjunction<std::is_arithmetic<_Tp>, std::is_same<_Tp, sycl::half>,
@@ -91,7 +81,6 @@ using __can_use_group_reduce_scan = std::conjunction<
 // TODO: check acpp - it should support std::* ops as sycl::* ops are aliases to std::* ops.
 template <typename _BinaryOp, typename _Tp>
 using __can_use_group_reduce_scan = std::conjunction<
-    __workaround_igpu_64_bit_reduction<_Tp>,
     std::is_arithmetic<_Tp>,
     sycl::has_known_identity<_BinaryOp, _Tp>,
     __is_one_of_ops<_BinaryOp, _Tp,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -182,7 +182,6 @@ macro(onedpl_add_test test_source_file switch_off_checked_iterators)
     string(REPLACE "\.cpp" "" _test_name ${_test_name})
 
     set(coal_tests "reduce.pass" "transform_reduce.pass" "count.pass" "sycl_iterator_reduce.pass" "minmax_element.pass")
-    set(workaround_for_igpu_64bit_reduction_tests "reduce_by_segment.pass")
     # mark those tests with pstloffload_smoke_tests label
     set (pstloffload_smoke_tests "adjacent_find.pass" "copy_move.pass" "merge.pass" "partial_sort.pass" "remove_copy.pass"
         "transform_reduce.pass" "transform_reduce.pass.coal" "transform_scan.pass" "algorithm.pass"
@@ -200,10 +199,6 @@ macro(onedpl_add_test test_source_file switch_off_checked_iterators)
     if (_test_name IN_LIST coal_tests)
         onedpl_construct_exec(${test_source_file} ${_test_name} ${switch_off_checked_iterators} "-D_ONEDPL_DETECT_SPIRV_COMPILATION=1" "${extra_test_label}")
         onedpl_construct_exec(${test_source_file} ${_test_name}.coal ${switch_off_checked_iterators} "-D_ONEDPL_DETECT_SPIRV_COMPILATION=0" "${extra_test_label}")
-    elseif (_test_name IN_LIST workaround_for_igpu_64bit_reduction_tests)
-        onedpl_construct_exec(${test_source_file} ${_test_name} ${switch_off_checked_iterators} "" "${extra_test_label}")
-        string(REPLACE "\.pass" "_workaround_64bit_reduction\.pass" _test_name ${_test_name})
-        onedpl_construct_exec(${test_source_file} ${_test_name} ${switch_off_checked_iterators} "-D_ONEDPL_TEST_FORCE_WORKAROUND_FOR_IGPU_64BIT_REDUCTION=1" "${extra_test_label}")
     elseif(_test_name STREQUAL "free_after_unload.pass")
         onedpl_construct_exec(${test_source_file} ${_test_name} ${switch_off_checked_iterators} "" "${extra_test_label}")
         onedpl_construct_exec(${test_source_file} ${_test_name}.after_pstl_offload ${switch_off_checked_iterators} "" "${extra_test_label}")

--- a/test/kt/single_pass_scan.cpp
+++ b/test/kt/single_pass_scan.cpp
@@ -199,15 +199,7 @@ void
 test_all_cases(sycl::queue q, std::size_t size, KernelParam param)
 {
     test_general_cases<T>(q, size, std::plus<T>{}, TestUtils::create_new_kernel_param_idx<0>(param));
-#if _PSTL_GROUP_REDUCTION_MULT_INT64_BROKEN
-    static constexpr bool int64_mult_broken = std::is_integral_v<T> && (sizeof(T) == 8);
-#else
-    static constexpr bool int64_mult_broken = 0;
-#endif
-    if constexpr (!int64_mult_broken)
-    {
-        test_general_cases<T>(q, size, std::multiplies<T>{}, TestUtils::create_new_kernel_param_idx<1>(param));
-    }
+    test_general_cases<T>(q, size, std::multiplies<T>{}, TestUtils::create_new_kernel_param_idx<1>(param));
     // Custom operator test
     if constexpr (std::is_integral_v<T>)
     {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -13,14 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if defined(ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION)
-#undef ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-#endif
-
-#if defined(_ONEDPL_TEST_FORCE_WORKAROUND_FOR_IGPU_64BIT_REDUCTION)
-#    define ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION _ONEDPL_TEST_FORCE_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-#endif
-
 #include "support/test_config.h"
 
 #include "oneapi/dpl/execution"
@@ -312,16 +304,10 @@ void
 run_test_on_device()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    // Skip 64-byte types testing when the algorithm is broken and there is no the workaround
-#if _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES && !ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-    if constexpr (sizeof(ValueType) != 8)
-#endif
+    if (TestUtils::has_type_support<ValueType>(TestUtils::get_test_queue().get_device()))
     {
-        if (TestUtils::has_type_support<ValueType>(TestUtils::get_test_queue().get_device()))
-        {
-            constexpr sycl::usm::alloc allocation_type = use_device_alloc ? sycl::usm::alloc::device : sycl::usm::alloc::shared;
-            test4buffers<allocation_type, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
-        }
+        constexpr sycl::usm::alloc allocation_type = use_device_alloc ? sycl::usm::alloc::device : sycl::usm::alloc::shared;
+        test4buffers<allocation_type, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
     }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 }

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -269,19 +269,6 @@
 #   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH 0
 #endif
 
-// If the workaround macro for the 64-bit type bug is not defined by the user, then exclude 64-bit type testing
-// in reduce_by_segment.pass.cpp.
-// TODO: When a driver fix is provided to resolve this issue, consider altering this macro or checking the driver version at runtime
-// of the underlying sycl::device to determine whether to include or exclude 64-bit type tests.
-#if !PSTL_USE_DEBUG && defined(__INTEL_LLVM_COMPILER)
-#    define _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES 1
-#endif
-
-// Group reduction produces wrong results with multiplication of 64-bit for certain driver versions
-// TODO: When a driver fix is provided to resolve this issue, consider altering this macro or checking the driver version at runtime
-// of the underlying sycl::device to determine whether to include or exclude 64-bit type tests.
-#define _PSTL_GROUP_REDUCTION_MULT_INT64_BROKEN 1
-
 // oneAPI DPC++ compiler 2022.2 an below show an internal compiler error during the backend code generation of
 // minmax_element.pass.cpp affecting min_element, max_element, and minmax_element calls.
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -254,19 +254,6 @@
 #   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH 0
 #endif
 
-// If the workaround macro for the 64-bit type bug is not defined by the user, then exclude 64-bit type testing
-// in reduce_by_segment.pass.cpp.
-// TODO: When a driver fix is provided to resolve this issue, consider altering this macro or checking the driver version at runtime
-// of the underlying sycl::device to determine whether to include or exclude 64-bit type tests.
-#if !PSTL_USE_DEBUG && defined(__INTEL_LLVM_COMPILER)
-#    define _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES 1
-#endif
-
-// Group reduction produces wrong results with multiplication of 64-bit for certain driver versions
-// TODO: When a driver fix is provided to resolve this issue, consider altering this macro or checking the driver version at runtime
-// of the underlying sycl::device to determine whether to include or exclude 64-bit type tests.
-#define _PSTL_GROUP_REDUCTION_MULT_INT64_BROKEN 1
-
 // oneAPI DPC++ compiler 2022.2 an below show an internal compiler error during the backend code generation of
 // minmax_element.pass.cpp affecting min_element, max_element, and minmax_element calls.
 


### PR DESCRIPTION
The underlying issue was fixed ~2 years ago in the Intel® Graphics Driver. Even the oldest maintained LTS driver has the fix.

The fix in IGC: https://github.com/intel/intel-graphics-compiler/commit/c7f30fdc02034f9753d1f04d0e9c526a25679e65 (October 2024).

[LTS driver](https://dgpu-docs.intel.com/overview/release-notes/lts-drivers-and-packages.html) without the fix: 2350.150 (no longer maintained, but still promises limited support).
[LTS driver](https://dgpu-docs.intel.com/overview/release-notes/lts-drivers-and-packages.html) with the fix: any 2523.x and newer.