### PR TITLE
Add implementation for `std::ranges::is_partitioned`

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1549,6 +1549,31 @@ __pattern_nth_element(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPoli
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// __pattern_is_partitioned
+//---------------------------------------------------------------------------------------------------------------------
+
+template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Pred, typename _Proj>
+bool
+__pattern_is_partitioned(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj)
+{
+    static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
+
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+
+    return oneapi::dpl::__internal::__pattern_is_partitioned(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        oneapi::dpl::__internal::__unary_op<_Pred, _Proj>{__pred, __proj});
+}
+
+template <typename _ExecutionPolicy, typename _R, typename _Pred, typename _Proj>
+bool
+__pattern_is_partitioned(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&&, _R&& __r, _Pred __pred,
+                         _Proj __proj)
+{
+    return std::ranges::is_partitioned(std::forward<_R>(__r), __pred, __proj);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // __pattern_remove_if
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -91,6 +91,7 @@ struct __remove_copy_if_fn;
 struct __remove_copy_fn;
 struct __unique_fn;
 struct __unique_copy_fn;
+struct __is_partitioned_fn;
 } // namespace ranges::__internal
 #endif
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1439,6 +1439,24 @@ struct __internal::__nth_element_fn
 }; //__nth_element_fn
 inline constexpr __internal::__nth_element_fn nth_element;
 
+// [alg.is.partitioned]
+
+struct __internal::__is_partitioned_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
+    bool
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
+    {
+        const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        return oneapi::dpl::__internal::__ranges::__pattern_is_partitioned(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __pred, __proj);
+    }
+}; //__is_partitioned_fn
+inline constexpr __internal::__is_partitioned_fn is_partitioned;
+
 } //ranges
 
 #endif //_ONEDPL_CPP20_RANGES_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -753,6 +753,24 @@ __pattern_nth_element(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 #endif // #if _ONEDPL_CPP20_RANGES_PRESENT
 
 //------------------------------------------------------------------------
+// is_partitioned
+//------------------------------------------------------------------------
+
+#if _ONEDPL_CPP20_RANGES_PRESENT
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Pred, typename _Proj>
+bool
+__pattern_is_partitioned(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Range&& __r, _Pred __pred,
+                         _Proj __proj)
+{
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+
+    return oneapi::dpl::__internal::__pattern_is_partitioned(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        oneapi::dpl::__internal::__unary_op<_Pred, _Proj>{__pred, __proj});
+}
+#endif // #if _ONEDPL_CPP20_RANGES_PRESENT
+
+//------------------------------------------------------------------------
 // remove_if
 //------------------------------------------------------------------------
 

--- a/test/parallel_api/ranges/std_ranges_is_partitioned.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_partitioned.pass.cpp
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    auto is_partitioned_checker = TEST_PREPARE_CALLABLE(std::ranges::is_partitioned);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::is_partitioned, is_partitioned_checker, pred1);
+    test_range_algo<1>{}(dpl_ranges::is_partitioned, is_partitioned_checker, pred1, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::is_partitioned, is_partitioned_checker, pred1, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::is_partitioned, is_partitioned_checker, pred1, &P2::proj);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_is_partitioned.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_partitioned.pass.cpp
@@ -18,7 +18,11 @@ main()
 
     auto is_partitioned_checker = TEST_PREPARE_CALLABLE(std::ranges::is_partitioned);
 
-    test_range_algo<0>{big_sz}(dpl_ranges::is_partitioned, is_partitioned_checker, pred1);
+    // Partitioned (true): positive values first, then non-positive.
+    auto partitioned_true_gen = [](auto i) { return i < 17 ? static_cast<int>(i) + 1 : 0; };
+    test_range_algo<0, int, data_in, decltype(partitioned_true_gen)>{big_sz}(dpl_ranges::is_partitioned, is_partitioned_checker, pred1);
+
+    // Partitioned (false): default ascending data [0,1,2,...] violates pred1 (>0).
     test_range_algo<1>{}(dpl_ranges::is_partitioned, is_partitioned_checker, pred1, proj);
     test_range_algo<2, P2>{}(dpl_ranges::is_partitioned, is_partitioned_checker, pred1, &P2::x);
     test_range_algo<3, P2>{}(dpl_ranges::is_partitioned, is_partitioned_checker, pred1, &P2::proj);


### PR DESCRIPTION
## Summary

This PR adds a parallel range-based implementation of `std::ranges::is_partitioned` to oneDPL, following the same design already used for the other std-ranges-style oneDPL algorithms.

Reference: C++ standard, [alg.partitions](https://eel.is/c++draft/alg.partitions).

## Details

`oneapi::dpl::ranges::is_partitioned` checks whether a range is partitioned with respect to the projected predicate, i.e. whether all elements for which the predicate returns `true` precede all elements for which it returns `false`. It returns `bool`.

Declared signature:

```cpp
template <typename ExecutionPolicy, std::ranges::random_access_range R, typename Proj = std::identity,
          std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<R>, Proj>> Pred>
  requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
           std::ranges::sized_range<R>
bool
is_partitioned (ExecutionPolicy&& pol, R&& r, Pred pred, Proj proj = {});
```

## Changes

- `include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h` — forward declaration of `__is_partitioned_fn`.
- `include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h` — public `__is_partitioned_fn` niebloid and `oneapi::dpl::ranges::is_partitioned` object, selecting the backend via `__select_backend` and dispatching to the internal pattern.
- `include/oneapi/dpl/pstl/algorithm_ranges_impl.h` — host `__pattern_is_partitioned` (parallel/vector path forwarding to the existing iterator-based `oneapi::dpl::__internal::__pattern_is_partitioned`, wrapping the predicate and projection in `__unary_op`, and a serial fallback to `std::ranges::is_partitioned`).
- `include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h` — device `__pattern_is_partitioned` for the SYCL backend.
- `test/parallel_api/ranges/std_ranges_is_partitioned.pass.cpp` — new test.

## Conformance with [alg.partitions](https://eel.is/c++draft/alg.partitions)

The implementation is consistent with the standard specification of `ranges::is_partitioned`:

- **Effects / result**: returns `true` if the elements for which the projected predicate holds precede the elements for which it does not; otherwise returns `false`. The serial path forwards directly to `std::ranges::is_partitioned`; the parallel and device paths reuse the existing iterator-based `is_partitioned` patterns, so no new algorithm logic is duplicated.
- **Requirements**: the standard requires `input_range` and `indirect_unary_predicate<projected<iterator_t<R>, Proj>>`. oneDPL intentionally constrains the input more tightly with `random_access_range` and `sized_range`, as required by the parallel/device backends; this is the established convention for all oneDPL parallel range algorithms and does not change the observable semantics.

## Testing

`test/parallel_api/ranges/std_ranges_is_partitioned.pass.cpp` verifies the result against `std::ranges::is_partitioned` as the reference. Coverage includes a large-size case (`big_sz`) with a plain predicate, a predicate with projection, and pointer-to-member data/function projections (`&P2::x`, `&P2::proj`), across serial, parallel, and device policies. The test is guarded by `_ENABLE_STD_RANGES_TESTING` and finished with `TestUtils::done(...)`.

## Notes

- All new code paths are gated behind `_ONEDPL_CPP20_RANGES_PRESENT` and rely on existing internal `__pattern_is_partitioned` implementations — this is purely a ranges-interface wrapper plus tests.
- C++20 concepts (`indirect_unary_predicate`, `random_access_range`, `sized_range`) are used, consistent with the surrounding ranges code.
