### PR TITLE
Additional modifications in reduce-then-scan

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -445,8 +445,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
 
     // Each work-item iteration reads a single input element and applies __unary_op to it. The input element size, not
     // the size of the scanned type produced by __unary_op, is what determines the input footprint of a block.
-    constexpr std::uint32_t __bytes_per_work_item_iter =
-        sizeof(oneapi::dpl::__internal::__value_t<std::decay_t<_Range1>>);
+    constexpr std::uint32_t __bytes_per_work_item_iter = sizeof(oneapi::dpl::__internal::__value_t<_Range1>);
 
     auto&& [__event, __payload] = __parallel_transform_reduce_then_scan<
         /*_Bounded*/ false, __bytes_per_work_item_iter, _CustomName>(
@@ -469,8 +468,7 @@ __parallel_reduce_then_scan_copy(sycl::queue& __q, _InRng&& __in_rng, _OutRng&& 
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     // Each work-item iteration reads a single input element to evaluate the mask and to copy it to the output.
-    constexpr std::uint32_t __bytes_per_work_item_iter =
-        sizeof(oneapi::dpl::__internal::__value_t<std::decay_t<_InRng>>);
+    constexpr std::uint32_t __bytes_per_work_item_iter = sizeof(oneapi::dpl::__internal::__value_t<_InRng>);
 
     return __parallel_transform_reduce_then_scan<_Bounded, __bytes_per_work_item_iter, _CustomName>(
         __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), _GenReduceInput{__generate_mask},
@@ -587,9 +585,10 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag, _Execut
         oneapi::dpl::__internal::make_tuple(std::forward<_Range2>(__out_true), std::forward<_Range3>(__out_false));
 
     sycl::queue __q_local = __exec.queue();
-    constexpr std::uint32_t __bytes_per_iter = sizeof(oneapi::dpl::__internal::__value_t<_Range1>);
+    // Each work-item iteration reads a single input element to evaluate the mask and to copy it to the output.
+    constexpr std::uint32_t __bytes_per_work_item_iter = sizeof(oneapi::dpl::__internal::__value_t<_Range1>);
 
-    std::tuple __res = __parallel_transform_reduce_then_scan<_Bounded, __bytes_per_iter, _CustomName>(
+    std::tuple __res = __parallel_transform_reduce_then_scan<_Bounded, __bytes_per_work_item_iter, _CustomName>(
         __q_local, __n, std::forward<_Range1>(__rng), std::move(__zipped_output), _GenReduceInput{_GenMask{__pred}},
         std::plus<diff_t>{}, _GenScanInput{_GenMask{__pred}}, _ScanInputTransform{}, _WriteOp{__n_out1, __n_out2},
         oneapi::dpl::unseq_backend::__no_init_value<diff_t>{}, /*_Inclusive=*/std::true_type{},

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -68,7 +68,6 @@ namespace dpl
 namespace __par_backend_hetero
 {
 
-
 // set of class templates to name kernels
 
 template <typename... _Name>
@@ -743,9 +742,6 @@ __parallel_set_write_a_b_op(_SetTag __set_tag, sycl::queue& __q, _Range1&& __rng
         __partition_event);
 }
 
-template <typename _CustomName>
-struct reduce_then_scan_wrapper;
-
 template <bool _Bounded, typename _SetTag, typename _ExecutionPolicy, typename _Range1, typename _Range2,
           typename _Range3, typename _Compare, typename _Proj1, typename _Proj2>
 __set_op_impl_return_t<_Bounded, _Range1, _Range2, _Range3>
@@ -757,7 +753,7 @@ __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag, _SetTag __set_t
 
     sycl::queue __q_local = __exec.queue();
 
-    auto __res = __parallel_set_write_a_b_op<_Bounded, reduce_then_scan_wrapper<_CustomName>>(
+    auto __res = __parallel_set_write_a_b_op<_Bounded, _CustomName>(
         __set_tag, __q_local, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
         std::forward<_Range3>(__result), __comp, __proj1, __proj2);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -443,8 +443,13 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
 
     _GenInput __gen_transform{__unary_op};
 
+    // Each work-item iteration reads a single input element and applies __unary_op to it. The input element size, not
+    // the size of the scanned type produced by __unary_op, is what determines the input footprint of a block.
+    constexpr std::uint32_t __bytes_per_work_item_iter =
+        sizeof(oneapi::dpl::__internal::__value_t<std::decay_t<_Range1>>);
+
     auto&& [__event, __payload] = __parallel_transform_reduce_then_scan<
-        /*_Bounded*/ false, sizeof(typename _InitType::__value_type), _CustomName>(
+        /*_Bounded*/ false, __bytes_per_work_item_iter, _CustomName>(
         __q_local, __n, std::forward<_Range1>(__in_rng), std::forward<_Range2>(__out_rng), __gen_transform, __binary_op,
         __gen_transform, _ScanInputTransform{}, _WriteOp{}, __init, _Inclusive{},
         /*_IsUniquePattern=*/std::false_type{});
@@ -463,9 +468,11 @@ __parallel_reduce_then_scan_copy(sycl::queue& __q, _InRng&& __in_rng, _OutRng&& 
     using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask, _Size>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
-    constexpr std::uint32_t __bytes_per_iter = sizeof(oneapi::dpl::__internal::__value_t<_InRng>);
+    // Each work-item iteration reads a single input element to evaluate the mask and to copy it to the output.
+    constexpr std::uint32_t __bytes_per_work_item_iter =
+        sizeof(oneapi::dpl::__internal::__value_t<std::decay_t<_InRng>>);
 
-    return __parallel_transform_reduce_then_scan<_Bounded, __bytes_per_iter, _CustomName>(
+    return __parallel_transform_reduce_then_scan<_Bounded, __bytes_per_work_item_iter, _CustomName>(
         __q, __n, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), _GenReduceInput{__generate_mask},
         _ReduceOp{}, _GenScanInput{__generate_mask}, _ScanInputTransform{}, __write_op,
         oneapi::dpl::unseq_backend::__no_init_value<_Size>{}, /*_Inclusive=*/std::true_type{}, __is_unique_pattern,
@@ -538,12 +545,18 @@ __parallel_reduce_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys
     using _ScanInputTransform = __get_zeroth_element;
     // Writes current segment's output reduction and the next segment's output key
     using _WriteOp = __write_red_by_seg<_BinaryPredicate>;
+    using _KeyType = oneapi::dpl::__internal::__value_t<_Range1>;
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
     std::size_t __n = oneapi::dpl::__ranges::__size(__keys);
     // __gen_red_by_seg_scan_input requires that __n > 1
     assert(__n > 1);
+
+    // Each work-item iteration reads one key and one value from the zipped input. The comparison against the previous
+    // key is not counted separately, as that key is read by the adjacent index's iteration.
+    constexpr std::uint32_t __bytes_per_work_item_iter = sizeof(_KeyType) + sizeof(_ValueType);
+
     auto&& [__event, __payload] = __parallel_transform_reduce_then_scan<
-        /*_Bounded*/ false, sizeof(oneapi::dpl::__internal::tuple<std::size_t, _ValueType>), _CustomName>(
+        /*_Bounded*/ false, __bytes_per_work_item_iter, _CustomName>(
         __q, __n, oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__keys), std::forward<_Range2>(__values)),
         oneapi::dpl::__ranges::make_zip_view(std::forward<_Range3>(__out_keys), std::forward<_Range4>(__out_values)),
         _GenReduceInput{__binary_pred}, _ReduceOp{__binary_op}, _GenScanInput{__binary_pred, __n},
@@ -1705,6 +1718,7 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
     using _ReduceOp = __scan_by_seg_op<_BinaryOperator>;
     using _GenScanInput = __gen_scan_by_seg_scan_input<_BinaryPredicate>;
     using _ScanInputTransform = __get_zeroth_element;
+    using _KeyType = oneapi::dpl::__internal::__value_t<_Range1>;
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
     const std::size_t __n = oneapi::dpl::__ranges::__size(__keys);
     // TODO: A bool type may be used here for a smaller footprint in registers / temp storage but results in IGC crashes
@@ -1717,8 +1731,12 @@ __parallel_scan_by_segment_reduce_then_scan(sycl::queue& __q, _Range1&& __keys, 
     // and functions differently than the typical scan init which is only applied once in a single location.
     oneapi::dpl::unseq_backend::__no_init_value<_PackedFlagValueType> __placeholder_no_init{};
     using _WriteOp = __write_scan_by_seg<__is_inclusive, _InitType, _BinaryOperator>;
+
+    // Each work-item iteration reads one key and one value from the zipped input.
+    constexpr std::uint32_t __bytes_per_work_item_iter = sizeof(_KeyType) + sizeof(_ValueType);
+
     auto&& [__event, __payload] = __parallel_transform_reduce_then_scan<
-        /*_Bounded*/ false, sizeof(_PackedFlagValueType), _CustomName>(
+        /*_Bounded*/ false, __bytes_per_work_item_iter, _CustomName>(
         __q, __n, oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__keys), std::forward<_Range2>(__values)),
         std::forward<_Range3>(__out_values), _GenReduceInput{__binary_pred}, _ReduceOp{__binary_op}, _GenScanInput{},
         _ScanInputTransform{}, _WriteOp{__init, __binary_op}, __placeholder_no_init,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -403,10 +403,9 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
                           _BinaryOperation __binary_op, _Inclusive)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+    using _Type = typename _InitType::__value_type;
 
     sycl::queue __q_local = __exec.queue();
-
-    using _Type = typename _InitType::__value_type;
 
     // The single work-group implementation requires a fundamental type which must be trivially copyable.
     if constexpr (std::is_trivially_copyable_v<_Type>)
@@ -436,8 +435,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag, _Execut
             }
         }
     }
-    using _GenInput =
-        oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation, typename _InitType::__value_type>;
+    using _GenInput = oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation, _Type>;
     using _ScanInputTransform = oneapi::dpl::identity;
     using _WriteOp = oneapi::dpl::__par_backend_hetero::__simple_write_to_id;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2506,6 +2506,10 @@ __parallel_transform_reduce_then_scan_impl(sycl::queue& __q, const std::size_t _
 // _ReduceOp - a binary function which is used in the reduction and scan operations
 // _WriteOp - a function which accepts output range, index, and output of `_GenScanInput` applied to the input range
 //            and performs the final write to output operation
+// __bytes_per_work_item_iter - the number of bytes of *input* data which a single work-item reads from global memory
+//            for a single iteration of its serial loop over a block. It is used only as a block sizing heuristic: we
+//            try to make a block's total input footprint fit within the last level cache so that the scan kernel can
+//            re-read the input from LLC rather than paying for a second read from global memory.
 template <bool _Bounded, std::uint32_t __bytes_per_work_item_iter, typename _CustomName, typename _InRng,
           typename _OutRng, typename _GenReduceInput, typename _ReduceOp, typename _GenScanInput,
           typename _ScanInputTransform, typename _WriteOp, typename _InitType, typename _Inclusive,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -1774,11 +1774,10 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __is_inclusive, __
 {
     // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
     // input buffer
-    template <typename _InRng, typename _TmpStorageAcc, typename _StopPosStorage, typename _StopPosInitState>
+    template <typename _InRng, typename _TmpStorage, typename _StopPosStorage, typename _StopPosInitState>
     sycl::event
-    operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng,
-               _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
-               const std::uint32_t __inputs_per_item, const std::size_t __block_num,
+    operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _TmpStorage& __scratch_storage,
+               const sycl::event& __prior_event, const std::uint32_t __inputs_per_item, const std::size_t __block_num,
                _StopPosStorage& __stop_pos_storage, _StopPosInitState __stop_pos_initial_state) const
     {
         using _InitValueType = typename _InitType::__value_type;
@@ -1791,7 +1790,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<_Bounded, __is_inclusive, __
             auto __comm_acc_or_placeholder = __comm_handler.__get_accessor_or_placeholder(__work_group_size, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
-            auto __temp_acc = __get_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
+            auto __temp_acc = __get_accessor(sycl::write_only, __scratch_storage, __cgh, __dpl_sycl::__no_init{});
             auto __stop_pos_acc =
                 __internal::__get_stop_pos_accessor_opt<_Bounded>(sycl::write_only, __cgh, __stop_pos_storage);
             __cgh.parallel_for<_KernelName...>(__nd_range, [=, *this](sycl::nd_item<1> __ndi)
@@ -1955,12 +1954,11 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __is_inclusive, __is
         __tmp_acc[__num_sub_groups_global + 1 - (__block_num % 2)] = __block_carry_out;
     }
 
-    template <typename _InRng, typename _OutRng, typename _TmpStorageAcc, typename _StopPosStorage>
+    template <typename _InRng, typename _OutRng, typename _TmpStorage, typename _StopPosStorage>
     sycl::event
     operator()(sycl::queue& __q, const sycl::nd_range<1> __nd_range, _InRng&& __in_rng, _OutRng&& __out_rng,
-               _TmpStorageAcc& __scratch_container, const sycl::event& __prior_event,
-               const std::uint32_t __inputs_per_item, const std::size_t __block_num,
-               _StopPosStorage& __stop_pos_storage) const
+               _TmpStorage& __scratch_storage, const sycl::event& __prior_event, const std::uint32_t __inputs_per_item,
+               const std::size_t __block_num, _StopPosStorage& __stop_pos_storage) const
     {
         // Size-independent, host-computed inputs-per-work-item; see the reduce submitter for why it is passed in
         // rather than re-derived on the device.
@@ -1985,9 +1983,8 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __is_inclusive, __is
 
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
-            auto __temp_acc = __get_accessor(sycl::read_write, __scratch_container, __cgh);
-            auto __res_acc =
-                __get_result_accessor(sycl::write_only, __scratch_container, __cgh, __dpl_sycl::__no_init{});
+            auto __temp_acc = __get_accessor(sycl::read_write, __scratch_storage, __cgh);
+            auto __res_acc = __get_result_accessor(sycl::write_only, __scratch_storage, __cgh, __dpl_sycl::__no_init{});
             auto __stop_pos_acc =
                 __internal::__get_stop_pos_accessor_opt<_Bounded>(sycl::read_write, __cgh, __stop_pos_storage);
 
@@ -2213,6 +2210,7 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __is_inclusive, __is
                         std::size_t __start_id_on_oob = __start_id;
                         typename _WriteOp::__position_type __oob_position{};
                         bool __oob_detected = false;
+                        auto& __stop_pos_acc_data = __stop_pos_acc.__data()[0];
 
                         auto __on_oob_reached = [&](std::size_t __start_id, typename _WriteOp::__position_type __pos) {
                             __start_id_on_oob = __start_id;
@@ -2223,27 +2221,23 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __is_inclusive, __is
                         if constexpr (_PosTools::__has_src_final_pos)
                         {
                             __call_scan_through_elements_helper(__on_oob_reached, [&](__src_final_pos_t __final_pos) {
-                                // Exactly one work-item reaches the edge crossing, so no synchronization
-                                // is needed to store the shared final position.
-                                _PosTools::__store_final_pos(__stop_pos_acc, __final_pos);
+                                // Exactly one work-item reaches the edge crossing, so no synchronization is needed
+                                // to store the shared final position.
+                                __stop_pos_acc_data.__final_pos = __final_pos;
                             });
+                            if (__oob_detected)
+                            {
+                                // Exactly one work-item reaches the OOB position, so no synchronization is needed
+                                // to update __stop_pos_acc.
+                                __stop_pos_acc_data.__oob_pos = _PosTools::__finalize_oob_pos(
+                                    __in_rng, __oob_position, __start_id_on_oob, __gen_scan_input);
+                            }
                         }
                         else
                         {
                             __call_scan_through_elements_helper(__on_oob_reached, __internal::__no_callback_tag{});
-                        }
-
-                        // The OOB position may be reached only in one work-item, so no synchronization is needed
-                        // to update __stop_pos_acc.
-                        if (__oob_detected)
-                        {
-                            if constexpr (_PosTools::__has_src_final_pos)
-                            {
-                                _PosTools::__finalize_and_store_oob_pos(__in_rng, __oob_position, __start_id_on_oob,
-                                                                        __gen_scan_input, __stop_pos_acc);
-                            }
-                            else
-                                __stop_pos_acc.__data()[0] = __oob_position;
+                            if (__oob_detected)
+                                __stop_pos_acc_data = __oob_position;
                         }
                     }
                     else
@@ -2453,14 +2447,8 @@ __parallel_transform_reduce_then_scan_impl(sycl::queue& __q, const std::size_t _
                                     __init,
                                     __use_subgroup_ops};
 
-    // Allocate storage for stop pos and out-of-bounds position if needed
-    auto __create_stop_pos_storage_opt = [](sycl::queue& __q) {
-        if constexpr (_Bounded)
-            return __result_storage<_StopPosInitState>(__q, 1);
-        else
-            return __internal::__no_stop_pos_acc_tag{};
-    };
-    auto __stop_pos_storage = __create_stop_pos_storage_opt(__q);
+    // Allocate storage for stop and out-of-bounds position if needed
+    auto __stop_pos_storage = __internal::__create_stop_pos_storage_opt<_Bounded, _StopPosInitState>(__q);
 
     // Data is processed in 2-kernel blocks to allow contiguous input segment to persist in LLC between the first and second kernel for accelerators
     // with sufficiently large L2 / L3 caches.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -2193,9 +2193,6 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __is_inclusive, __is
                         __group_start_id + (std::size_t{__get_sub_group_base(__ndi)} * __inputs_per_item);
                     std::size_t __start_id = __subgroup_start_id + __sub_group_local_id;
 
-                    using _PosTools =
-                        __internal::__parallel_reduce_then_scan_stop_oob_pos_tools<_Bounded, _StopPosStorage>;
-
                     auto __call_scan_through_elements_helper = [&](auto __on_oob_reached, auto __final_pos_saver) {
                         __scan_through_elements_helper<_Bounded, __is_inclusive, __is_unique_pattern_v>(
                             __ndi, __gen_scan_input, __scan_input_transform, __reduce_op, __write_op, __sub_group_carry,
@@ -2205,8 +2202,6 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __is_inclusive, __is
 
                     if constexpr (_Bounded)
                     {
-                        using __src_final_pos_t = typename _PosTools::__src_final_pos_t;
-
                         std::size_t __start_id_on_oob = __start_id;
                         typename _WriteOp::__position_type __oob_position{};
                         bool __oob_detected = false;
@@ -2218,9 +2213,11 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __is_inclusive, __is
                             __oob_detected = true;
                         };
 
-                        if constexpr (_PosTools::__has_src_final_pos)
+                        using __stop_pos_handler_type = typename _StopPosStorage::type;
+                        if constexpr (__internal::__has_final_pos<__stop_pos_handler_type>)
                         {
-                            __call_scan_through_elements_helper(__on_oob_reached, [&](__src_final_pos_t __final_pos) {
+                            using __final_pos_t = typename __stop_pos_handler_type::__final_pos_t;
+                            __call_scan_through_elements_helper(__on_oob_reached, [&](__final_pos_t __final_pos) {
                                 // Exactly one work-item reaches the edge crossing, so no synchronization is needed
                                 // to store the shared final position.
                                 __stop_pos_acc_data.__final_pos = __final_pos;
@@ -2229,7 +2226,7 @@ struct __parallel_reduce_then_scan_scan_submitter<_Bounded, __is_inclusive, __is
                             {
                                 // Exactly one work-item reaches the OOB position, so no synchronization is needed
                                 // to update __stop_pos_acc.
-                                __stop_pos_acc_data.__oob_pos = _PosTools::__finalize_oob_pos(
+                                __stop_pos_acc_data.__oob_pos = __internal::__finalize_oob_pos<__final_pos_t>(
                                     __in_rng, __oob_position, __start_id_on_oob, __gen_scan_input);
                             }
                         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan_pos_tools.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan_pos_tools.h
@@ -38,6 +38,7 @@ struct _SetOpFinalAndOOBPosTypeImpl
     using _Size1 = oneapi::dpl::__internal::__difference_t<_Range1>;
     using _Size2 = oneapi::dpl::__internal::__difference_t<_Range2>;
     using _PositionT = oneapi::dpl::__internal::tuple<_Size1, _Size2>;
+    using __final_pos_t = _PositionT;
 
     _PositionT __final_pos = {}; // Describes final position after set operation in source ranges
     _PositionT __oob_pos = {};   // Describes OOB position during set operation in source ranges
@@ -79,26 +80,16 @@ using _SetOpFinalAndOOBPosType = _SetOpFinalAndOOBPosTypeImpl<std::decay_t<_Rang
 
 namespace __internal
 {
-// Detecting _PositionT type alias in the specified structure
-template <typename _T, typename = void>
-struct __final_pos_type_selector : std::false_type
-{
-    // This means we only deal with the OOB position here.
-    using type = _T;
-};
+// Describes whether we have a final-position type in the storage or not
+template <typename _StopPosStorage>
+constexpr bool __has_final_pos = false;
 
 template <typename _Range1, typename _Range2>
-struct __final_pos_type_selector<_SetOpFinalAndOOBPosTypeImpl<_Range1, _Range2>,
-                                 std::void_t<typename _SetOpFinalAndOOBPosTypeImpl<_Range1, _Range2>::_PositionT>>
-    : std::true_type
-{
-    // This means we deal with both final and OOB positions together here.
-    using type = typename _SetOpFinalAndOOBPosType<_Range1, _Range2>::_PositionT;
-};
+constexpr bool __has_final_pos<_SetOpFinalAndOOBPosTypeImpl<_Range1, _Range2>> = true;
 
 // Temporary data stand-in which discards the stored values and instead captures
 // the source position of the element at a specific index during a reduce then scan operation.
-template <typename _SrcDataPosT>
+template <typename _FinalPosT>
 struct __src_pos_capturing_temp_data
 {
   public:
@@ -109,13 +100,13 @@ struct __src_pos_capturing_temp_data
 
     template <typename _ValueT2>
     void
-    set(std::uint16_t __idx, const _ValueT2&, _SrcDataPosT __src_idx)
+    set(std::uint16_t __idx, const _ValueT2&, _FinalPosT __src_idx)
     {
         if (__idx == __idx_for_src_pos)
             __saved_src_pos = __src_idx;
     }
 
-    _SrcDataPosT
+    _FinalPosT
     __get_saved_src_pos() const
     {
         return __saved_src_pos;
@@ -123,7 +114,7 @@ struct __src_pos_capturing_temp_data
 
   private:
     const std::uint16_t __idx_for_src_pos = 0;
-    _SrcDataPosT __saved_src_pos = {};
+    _FinalPosT __saved_src_pos = {};
 };
 
 // Tag type to indicate that no callback is provided
@@ -137,6 +128,18 @@ struct __no_stop_pos_acc_tag
     // No stop position is tracked when _Bounded=false, so std::size_t is just a harmless default.
     using type = std::size_t;
 };
+
+// The second part of two-pass OOB processing: if the OOB position is reached in the first pass,
+// here we recover the source indexes for the diagonal where it happened and store the OOB position from them.
+template <typename _FinalPosT, typename _InRng, typename _OOBPositionT, typename _GenScanInput>
+static _FinalPosT
+__finalize_oob_pos(_InRng&& __in_rng, _OOBPositionT __detected_oob_pos, const std::size_t __start_id_reached_on_oob,
+                   _GenScanInput __gen_scan_input)
+{
+    __src_pos_capturing_temp_data<_FinalPosT> __pos_catcher(__detected_oob_pos);
+    __gen_scan_input(std::forward<_InRng>(__in_rng), __start_id_reached_on_oob, __pos_catcher, __no_callback_tag{});
+    return __pos_catcher.__get_saved_src_pos();
+}
 
 template <bool _Bounded, typename _StopPosInitState>
 auto
@@ -157,30 +160,6 @@ __get_stop_pos_accessor_opt(_ModeTagT __mode, sycl::handler& __cgh, _StopPosStor
     else
         return __no_stop_pos_acc_tag{};
 }
-
-template <bool _Bounded, typename _StopPosStorage>
-struct __parallel_reduce_then_scan_stop_oob_pos_tools
-{
-    using __storage_data_t = typename _StopPosStorage::type;
-
-    // Describes whether we have a final-position type in the storage or not
-    static constexpr bool __has_src_final_pos = __final_pos_type_selector<std::decay_t<__storage_data_t>>::value;
-
-    // Describes final position type (if any) in the storage
-    using __src_final_pos_t = typename __final_pos_type_selector<std::decay_t<__storage_data_t>>::type;
-
-    // The second part of two-pass OOB processing: if the OOB position is reached in the first pass,
-    // here we recover the source indexes for the diagonal where it happened and store the OOB position from them.
-    template <typename _InRng, typename _OOBPositionT, typename _GenScanInput>
-    static __src_final_pos_t
-    __finalize_oob_pos(_InRng&& __in_rng, _OOBPositionT __detected_oob_pos, const std::size_t __start_id_reached_on_oob,
-                       _GenScanInput __gen_scan_input)
-    {
-        __src_pos_capturing_temp_data<__src_final_pos_t> __pos_catcher(__detected_oob_pos);
-        __gen_scan_input(std::forward<_InRng>(__in_rng), __start_id_reached_on_oob, __pos_catcher, __no_callback_tag{});
-        return __pos_catcher.__get_saved_src_pos();
-    }
-};
 
 } // namespace __internal
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan_pos_tools.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan_pos_tools.h
@@ -82,10 +82,10 @@ namespace __internal
 {
 // Describes whether we have a final-position type in the storage or not
 template <typename _StopPosStorage>
-constexpr bool __has_final_pos = false;
+inline constexpr bool __has_final_pos = false;
 
 template <typename _Range1, typename _Range2>
-constexpr bool __has_final_pos<_SetOpFinalAndOOBPosTypeImpl<_Range1, _Range2>> = true;
+inline constexpr bool __has_final_pos<_SetOpFinalAndOOBPosTypeImpl<_Range1, _Range2>> = true;
 
 // Temporary data stand-in which discards the stored values and instead captures
 // the source position of the element at a specific index during a reduce then scan operation.
@@ -132,7 +132,7 @@ struct __no_stop_pos_acc_tag
 // The second part of two-pass OOB processing: if the OOB position is reached in the first pass,
 // here we recover the source indexes for the diagonal where it happened and store the OOB position from them.
 template <typename _FinalPosT, typename _InRng, typename _OOBPositionT, typename _GenScanInput>
-static _FinalPosT
+_FinalPosT
 __finalize_oob_pos(_InRng&& __in_rng, _OOBPositionT __detected_oob_pos, const std::size_t __start_id_reached_on_oob,
                    _GenScanInput __gen_scan_input)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan_pos_tools.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan_pos_tools.h
@@ -138,6 +138,16 @@ struct __no_stop_pos_acc_tag
     using type = std::size_t;
 };
 
+template <bool _Bounded, typename _StopPosInitState>
+auto
+__create_stop_pos_storage_opt(sycl::queue& __q)
+{
+    if constexpr (_Bounded)
+        return __result_storage<_StopPosInitState>(__q, 1);
+    else
+        return __internal::__no_stop_pos_acc_tag{};
+}
+
 template <bool _Bounded, typename _ModeTagT, typename _StopPosStorage>
 auto
 __get_stop_pos_accessor_opt(_ModeTagT __mode, sycl::handler& __cgh, _StopPosStorage& __stop_pos_storage)
@@ -159,26 +169,16 @@ struct __parallel_reduce_then_scan_stop_oob_pos_tools
     // Describes final position type (if any) in the storage
     using __src_final_pos_t = typename __final_pos_type_selector<std::decay_t<__storage_data_t>>::type;
 
-    template <typename __FinalAndOOBPosAcc>
-    static void
-    __store_final_pos(__FinalAndOOBPosAcc& __final_and_oob_pos_acc, const __src_final_pos_t& __final_pos)
-    {
-        auto& __final_and_oob_pos = __final_and_oob_pos_acc.__data()[0];
-        __final_and_oob_pos.__final_pos = __final_pos;
-    }
-
     // The second part of two-pass OOB processing: if the OOB position is reached in the first pass,
     // here we recover the source indexes for the diagonal where it happened and store the OOB position from them.
-    template <typename _InRng, typename _OOBPositionT, typename _GenScanInput, typename __FinalAndOOBPosAcc>
-    static void
-    __finalize_and_store_oob_pos(_InRng&& __in_rng, _OOBPositionT __detected_oob_pos,
-                                 const std::size_t __start_id_reached_on_oob, _GenScanInput __gen_scan_input,
-                                 __FinalAndOOBPosAcc& __final_and_oob_pos_acc)
+    template <typename _InRng, typename _OOBPositionT, typename _GenScanInput>
+    static __src_final_pos_t
+    __finalize_oob_pos(_InRng&& __in_rng, _OOBPositionT __detected_oob_pos, const std::size_t __start_id_reached_on_oob,
+                       _GenScanInput __gen_scan_input)
     {
-        auto& __final_and_oob_pos = __final_and_oob_pos_acc.__data()[0];
         __src_pos_capturing_temp_data<__src_final_pos_t> __pos_catcher(__detected_oob_pos);
         __gen_scan_input(std::forward<_InRng>(__in_rng), __start_id_reached_on_oob, __pos_catcher, __no_callback_tag{});
-        __final_and_oob_pos.__oob_pos = __pos_catcher.__get_saved_src_pos();
+        return __pos_catcher.__get_saved_src_pos();
     }
 };
 


### PR DESCRIPTION
`__bytes_per_work_item_iter` is the number of input read bytes which are read by RTS kernels per workitem per iteration.

It is used to try to size the input reads to fit within last level cache so that the scan kernel can have a cached read rather than a global read.  This was unclear, and this PR adds a comment and corrects a few usages of this for oneDPL APIs.

Updated by akukanov: I added other refactoring and cosmetic changes explored recently by myself and @SergeyKopienko