### PR TITLE
Add ranges::(rotate|shift_left|shift_right)

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -84,6 +84,8 @@ struct __reverse_fn;
 struct __reverse_copy_fn;
 struct __rotate_fn;
 struct __rotate_copy_fn;
+struct __shift_left_fn;
+struct __shift_right_fn;
 struct __mismatch_fn;
 struct __starts_with_fn;
 struct __ends_with_fn;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -82,6 +82,7 @@ struct __replace_copy_if_fn;
 struct __replace_copy_fn;
 struct __reverse_fn;
 struct __reverse_copy_fn;
+struct __rotate_fn;
 struct __rotate_copy_fn;
 struct __mismatch_fn;
 struct __starts_with_fn;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1303,7 +1303,7 @@ struct __internal::__shift_left_fn
         }
     }
 }; //__shift_left_fn
-inline constexpr __internal::__shift_left_fn __shift_left;
+inline constexpr __internal::__shift_left_fn shift_left;
 
 struct __internal::__shift_right_fn
 {
@@ -1322,7 +1322,7 @@ struct __internal::__shift_right_fn
         return {__res.end().base(), __last};
     }
 }; //__shift_right_fn
-inline constexpr __internal::__shift_right_fn __shift_right;
+inline constexpr __internal::__shift_right_fn shift_right;
 
 // [alg.mismatch]
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1279,11 +1279,15 @@ struct __internal::__shift_left_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
     {
         using __dispatch_tag_t = decltype(oneapi::dpl::__ranges::__select_backend(__exec));
+        std::ranges::iterator_t<_R> __first = std::ranges::begin(__r);
+        std::ranges::range_difference_t<_R> __sz = std::ranges::size(__r);
         if constexpr (std::is_same_v<__dispatch_tag_t, oneapi::dpl::__internal::__serial_tag<std::false_type>>)
-            return std::ranges::shift_left(std::forward<_R>(__r), __shift);
+        {
+            // std::ranges::shift_left is only available since C++23
+            return {__first, std::shift_left(__first, __first + __sz, __shift)};
+        }
         else 
         {
-            auto __first = std::ranges::begin(__r);
 #if _ONEDPL_HETERO_BACKEND
             if constexpr (oneapi::dpl::__internal::__is_hetero_backend_tag_v<__dispatch_tag_t>)
             {
@@ -1294,7 +1298,7 @@ struct __internal::__shift_left_fn
             }
 #endif
             auto __res = oneapi::dpl::__internal::__pattern_shift_left(__dispatch_tag_t{},
-                std::forward<_ExecutionPolicy>(__exec), __first, __first + std::ranges::size(__r), __shift);
+                std::forward<_ExecutionPolicy>(__exec), __first, __first + __sz, __shift);
             return {__first, __res};
         }
     }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1214,13 +1214,12 @@ struct __internal::__rotate_fn
             return std::ranges::rotate(std::forward<_R>(__r), __middle);
         else
         {
-            auto __first = std::ranges::begin(__r);
-            auto __last = __first + std::ranges::size(__r);
+            auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
 #if _ONEDPL_HETERO_BACKEND
             if constexpr (oneapi::dpl::__internal::__is_hetero_backend_tag_v<__dispatch_tag_t>)
             {
                 auto __res = __first + (__last - __middle);
-                std::size_t __pivot = __middle - __first;
+                const std::size_t __pivot = __middle - __first;
                 oneapi::dpl::__internal::__pattern_rotate(
                     __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec),
                     oneapi::dpl::__ranges::__get_subscription_view(std::forward<_R>(__r)), __pivot);
@@ -1279,12 +1278,11 @@ struct __internal::__shift_left_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
     {
         using __dispatch_tag_t = decltype(oneapi::dpl::__ranges::__select_backend(__exec));
-        std::ranges::iterator_t<_R> __first = std::ranges::begin(__r);
-        std::ranges::range_difference_t<_R> __sz = std::ranges::size(__r);
+        auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
         if constexpr (std::is_same_v<__dispatch_tag_t, oneapi::dpl::__internal::__serial_tag<std::false_type>>)
         {
             // std::ranges::shift_left is only available since C++23
-            return {__first, std::shift_left(__first, __first + __sz, __shift)};
+            return {__first, std::shift_left(__first, __last, __shift)};
         }
         else
         {
@@ -1298,7 +1296,7 @@ struct __internal::__shift_left_fn
             }
 #endif
             auto __res = oneapi::dpl::__internal::__pattern_shift_left(
-                __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __first + __sz, __shift);
+                __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __last, __shift);
             return {__first, __res};
         }
     }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1200,6 +1200,30 @@ inline constexpr __internal::__reverse_copy_fn reverse_copy;
 
 // [alg.rotate]
 
+struct __internal::__rotate_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::permutable<std::ranges::iterator_t<_R>> && std::ranges::sized_range<_R>
+
+    std::ranges::borrowed_subrange_t<_R>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle) const
+    {
+        using __dispatch_tag_t = decltype(oneapi::dpl::__ranges::__select_backend(__exec));
+        if constexpr (std::is_same_v<__dispatch_tag_t, oneapi::dpl::__internal::__serial_tag<std::false_type>>)
+            return std::ranges::rotate(std::forward<_R>(__r), __middle);
+        else
+        {
+            auto __first = std::ranges::begin(__r);
+            auto __last = __first + std::ranges::size(__r);
+            auto __res = oneapi::dpl::__internal::__pattern_rotate(
+                __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last);
+            return {__res, __last};
+        }
+    }
+}; //__rotate_fn
+inline constexpr __internal::__rotate_fn rotate;
+
 struct __internal::__rotate_copy_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1305,6 +1305,25 @@ struct __internal::__shift_left_fn
 }; //__shift_left_fn
 inline constexpr __internal::__shift_left_fn __shift_left;
 
+struct __internal::__shift_right_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::permutable<std::ranges::iterator_t<_R>> && std::ranges::sized_range<_R>
+
+    std::ranges::borrowed_subrange_t<_R>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
+    {
+        std::ranges::reverse_view __reverse_r{__r};
+
+        auto __res = oneapi::dpl::ranges::shift_left(std::forward<_ExecutionPolicy>(__exec), __reverse_r, __shift);
+
+        auto __last = std::ranges::begin(__r) + std::ranges::size(__r);
+        return {__res.end().base(), __last};
+    }
+}; //__shift_right_fn
+inline constexpr __internal::__shift_right_fn __shift_right;
+
 // [alg.mismatch]
 
 struct __internal::__mismatch_fn

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1212,13 +1212,25 @@ struct __internal::__rotate_fn
         using __dispatch_tag_t = decltype(oneapi::dpl::__ranges::__select_backend(__exec));
         if constexpr (std::is_same_v<__dispatch_tag_t, oneapi::dpl::__internal::__serial_tag<std::false_type>>)
             return std::ranges::rotate(std::forward<_R>(__r), __middle);
-        else
+        else 
         {
             auto __first = std::ranges::begin(__r);
             auto __last = __first + std::ranges::size(__r);
-            auto __res = oneapi::dpl::__internal::__pattern_rotate(
-                __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last);
-            return {__res, __last};
+            if constexpr (oneapi::dpl::__internal::__is_hetero_backend_tag_v<__dispatch_tag_t>)
+            {
+                auto __res = __first + (__last - __middle);
+                std::size_t __pivot = __middle - __first;
+                oneapi::dpl::__internal::__pattern_rotate(
+                    __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec),
+                    oneapi::dpl::__ranges::__get_subscription_view(std::forward<_R>(__r)), __pivot);
+                return {__res, __last};
+            }
+            else
+            {
+                auto __res = oneapi::dpl::__internal::__pattern_rotate(
+                    __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last);
+                return {__res, __last};
+            }
         }
     }
 }; //__rotate_fn

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1297,8 +1297,8 @@ struct __internal::__shift_left_fn
                 return {__first, __first + __res};
             }
 #endif
-            auto __res = oneapi::dpl::__internal::__pattern_shift_left(__dispatch_tag_t{},
-                std::forward<_ExecutionPolicy>(__exec), __first, __first + __sz, __shift);
+            auto __res = oneapi::dpl::__internal::__pattern_shift_left(
+                __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __first + __sz, __shift);
             return {__first, __res};
         }
     }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1212,7 +1212,7 @@ struct __internal::__rotate_fn
         using __dispatch_tag_t = decltype(oneapi::dpl::__ranges::__select_backend(__exec));
         if constexpr (std::is_same_v<__dispatch_tag_t, oneapi::dpl::__internal::__serial_tag<std::false_type>>)
             return std::ranges::rotate(std::forward<_R>(__r), __middle);
-        else 
+        else
         {
             auto __first = std::ranges::begin(__r);
             auto __last = __first + std::ranges::size(__r);
@@ -1286,7 +1286,7 @@ struct __internal::__shift_left_fn
             // std::ranges::shift_left is only available since C++23
             return {__first, std::shift_left(__first, __first + __sz, __shift)};
         }
-        else 
+        else
         {
 #if _ONEDPL_HETERO_BACKEND
             if constexpr (oneapi::dpl::__internal::__is_hetero_backend_tag_v<__dispatch_tag_t>)

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1267,6 +1267,40 @@ struct __internal::__rotate_copy_fn
 }; //__rotate_copy_fn
 inline constexpr __internal::__rotate_copy_fn rotate_copy;
 
+// [alg.shift]
+
+struct __internal::__shift_left_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::permutable<std::ranges::iterator_t<_R>> && std::ranges::sized_range<_R>
+
+    std::ranges::borrowed_subrange_t<_R>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
+    {
+        using __dispatch_tag_t = decltype(oneapi::dpl::__ranges::__select_backend(__exec));
+        if constexpr (std::is_same_v<__dispatch_tag_t, oneapi::dpl::__internal::__serial_tag<std::false_type>>)
+            return std::ranges::shift_left(std::forward<_R>(__r), __shift);
+        else 
+        {
+            auto __first = std::ranges::begin(__r);
+#if _ONEDPL_HETERO_BACKEND
+            if constexpr (oneapi::dpl::__internal::__is_hetero_backend_tag_v<__dispatch_tag_t>)
+            {
+                std::ranges::range_difference_t<_R> __res = oneapi::dpl::__internal::__pattern_shift_left(
+                    __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec),
+                    oneapi::dpl::__ranges::__get_subscription_view(std::forward<_R>(__r)), __shift);
+                return {__first, __first + __res};
+            }
+#endif
+            auto __res = oneapi::dpl::__internal::__pattern_shift_left(__dispatch_tag_t{},
+                std::forward<_ExecutionPolicy>(__exec), __first, __first + std::ranges::size(__r), __shift);
+            return {__first, __res};
+        }
+    }
+}; //__shift_left_fn
+inline constexpr __internal::__shift_left_fn __shift_left;
+
 // [alg.mismatch]
 
 struct __internal::__mismatch_fn

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1216,6 +1216,7 @@ struct __internal::__rotate_fn
         {
             auto __first = std::ranges::begin(__r);
             auto __last = __first + std::ranges::size(__r);
+#if _ONEDPL_HETERO_BACKEND
             if constexpr (oneapi::dpl::__internal::__is_hetero_backend_tag_v<__dispatch_tag_t>)
             {
                 auto __res = __first + (__last - __middle);
@@ -1225,12 +1226,10 @@ struct __internal::__rotate_fn
                     oneapi::dpl::__ranges::__get_subscription_view(std::forward<_R>(__r)), __pivot);
                 return {__res, __last};
             }
-            else
-            {
-                auto __res = oneapi::dpl::__internal::__pattern_rotate(
-                    __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last);
-                return {__res, __last};
-            }
+#endif
+            auto __res = oneapi::dpl::__internal::__pattern_rotate(
+                __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last);
+            return {__res, __last};
         }
     }
 }; //__rotate_fn

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1674,11 +1674,13 @@ __pattern_rotate(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
     if (__n == 0)
         return __first;
 
-    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write>();
-    auto __buf = __keep(__first, __last);
     const std::size_t __pivot = __new_first - __first;
-    __pattern_rotate(__tag, std::forward<_ExecutionPolicy>(__exec), __buf.all_view(), __pivot);
-
+    if (__pivot > 0 && __pivot < __n)
+    {
+        auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write>();
+        auto __buf = __keep(__first, __last);
+        __pattern_rotate(__tag, std::forward<_ExecutionPolicy>(__exec), __buf.all_view(), __pivot);
+    }
     return __first + (__last - __new_first);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1630,9 +1630,44 @@ __pattern_reverse_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bi
 template <typename Name>
 struct __rotate_dual_reverse;
 
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Range>
+void
+__pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __r, std::size_t __pivot)
+{
+    const std::size_t __n = oneapi::dpl::__ranges::__size(__r);
+    if (__pivot > 0 && __pivot < __n)
+    {
+        if (__pivot > 1 && __pivot < __n - 1)
+        {
+            // Reverse the ranges before and after the shift point, in one kernel
+            auto __dbrick = oneapi::dpl::__par_backend_hetero::__dual_brick{
+                unseq_backend::__reverse_functor{__pivot}, unseq_backend::__reverse_functor{__n - __pivot, __pivot},
+                __pivot / 2 /*iterations in the first reverse*/};
+            oneapi::dpl::__par_backend_hetero::__parallel_for(
+                _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_dual_reverse>(__exec),
+                __dbrick, __pivot / 2 + (__n - __pivot) / 2, __r)
+                .wait();
+        }
+        else if (__n > 2)
+        {
+            // For a non-trivial single-position shift, reverse only the bigger part
+            oneapi::dpl::__par_backend_hetero::__parallel_for(
+                _BackendTag{}, __exec, unseq_backend::__reverse_functor{__n - 1, __pivot == 1 ? 1u : 0u},
+                (__n - 1) / 2, __r)
+                .wait();
+        }
+        // TODO: need a non-blocking dependency between the kernels
+
+        // Now reverse the whole range
+        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                                                          unseq_backend::__reverse_functor{__n}, __n / 2, __r)
+            .__checked_deferrable_wait();
+    }
+}
+
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator>
 _Iterator
-__pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __new_first,
+__pattern_rotate(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __new_first,
                  _Iterator __last)
 {
     const std::size_t __n = __last - __first;
@@ -1641,37 +1676,9 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write>();
     auto __buf = __keep(__first, __last);
-    const std::size_t __shift = __new_first - __first;
+    const std::size_t __pivot = __new_first - __first;
+    __pattern_rotate(__tag, std::forward<_ExecutionPolicy>(__exec), __buf.all_view(), __pivot);
 
-    if (__shift > 0 && __shift < __n)
-    {
-        if (__shift > 1 && __shift < __n - 1)
-        {
-            // Reverse the ranges before and after the shift point, in one kernel
-            auto __dbrick = oneapi::dpl::__par_backend_hetero::__dual_brick{
-                unseq_backend::__reverse_functor{__shift}, unseq_backend::__reverse_functor{__n - __shift, __shift},
-                __shift / 2 /*iterations in the first reverse*/};
-            oneapi::dpl::__par_backend_hetero::__parallel_for(
-                _BackendTag{}, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__rotate_dual_reverse>(__exec),
-                __dbrick, __shift / 2 + (__n - __shift) / 2, __buf.all_view())
-                .wait();
-        }
-        else if (__n > 2)
-        {
-            // For a non-trivial single-position shift, reverse only the bigger part
-            oneapi::dpl::__par_backend_hetero::__parallel_for(
-                _BackendTag{}, __exec, unseq_backend::__reverse_functor{__n - 1, __shift == 1 ? 1u : 0u},
-                (__n - 1) / 2, __buf.all_view())
-                .wait();
-        }
-        // TODO: need a non-blocking dependency between the kernels
-
-        // Now reverse the whole range
-        oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                                                          unseq_backend::__reverse_functor{__n}, __n / 2,
-                                                          __buf.all_view())
-            .__checked_deferrable_wait();
-    }
     return __first + (__last - __new_first);
 }
 

--- a/test/parallel_api/ranges/std_ranges_remove.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_remove.pass.cpp
@@ -16,14 +16,14 @@
 #include "std_ranges_test.h"
 
 #if _ENABLE_STD_RANGES_TESTING
-namespace test_std_ranges
-{
+namespace dpl_ranges = oneapi::dpl::ranges;
+
 template<>
-constexpr int calc_res_size<std::remove_cvref_t<decltype(oneapi::dpl::ranges::remove)>>(int n, int res_n)
+constexpr std::pair<int, int>
+test_std_ranges::range_to_verify<std::remove_cvref_t<decltype(dpl_ranges::remove)>>(int total_size, int result_size)
 { 
-    return n - res_n; //res_n - number of elements to be removed
+    return {0, total_size - result_size}; // in the result are the elements to remove
 }
-} //test_std_ranges
 #endif
 
 std::int32_t
@@ -31,7 +31,6 @@ main()
 {
 #if _ENABLE_STD_RANGES_TESTING
     using namespace test_std_ranges;
-    namespace dpl_ranges = oneapi::dpl::ranges;
 
     auto remove_checker = TEST_PREPARE_CALLABLE(std::ranges::remove);
 

--- a/test/parallel_api/ranges/std_ranges_remove_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_remove_if.pass.cpp
@@ -16,14 +16,14 @@
 #include "std_ranges_test.h"
 
 #if _ENABLE_STD_RANGES_TESTING
-namespace test_std_ranges
-{
+namespace dpl_ranges = oneapi::dpl::ranges;
+
 template<>
-constexpr int calc_res_size<std::remove_cvref_t<decltype(oneapi::dpl::ranges::remove)>>(int n, int res_n)
+constexpr std::pair<int, int>
+test_std_ranges::range_to_verify<std::remove_cvref_t<decltype(dpl_ranges::remove_if)>>(int total_size, int result_size)
 { 
-    return n - res_n; //res_n - number of elements to be removed
+    return {0, total_size - result_size}; // in the result are the elements to remove
 }
-} //test_std_ranges
 #endif
 
 std::int32_t
@@ -31,7 +31,6 @@ main()
 {
 #if _ENABLE_STD_RANGES_TESTING
     using namespace test_std_ranges;
-    namespace dpl_ranges = oneapi::dpl::ranges;
 
     auto remove_if_checker = TEST_PREPARE_CALLABLE(std::ranges::remove_if);
 

--- a/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
@@ -1,0 +1,49 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+#if _ENABLE_STD_RANGES_TESTING
+// Wrapper to adjust rotate to the format expected by the test harness
+struct
+{
+    template <typename Policy, std::ranges::random_access_range Range>
+    auto operator()(Policy&& exec, Range&& r, int pivot_pos = -1)
+    {
+        const int in_size = std::ranges::size(r);
+        auto middle = std::ranges::begin(r) + ((pivot_pos < 0)? in_size/3 : std::min<int>(pivot_pos, in_size));
+
+        return oneapi::dpl::ranges::rotate(std::forward<Policy>(exec), std::forward<InRange>(r), middle);
+    }
+} rotate_tester;
+#endif // _ENABLE_STD_RANGES_TESTING
+
+int
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+
+    auto rotate_checker = [](std::ranges::random_access_range auto&& r, int pivot_pos = -1)
+    {
+        // calculate the pivot point exactly like in the tester above
+        const int in_size = std::ranges::size(r);
+        auto middle = std::ranges::begin(r) + ((pivot_pos < 0)? in_size/3 : std::min<int>(pivot_pos, in_size));
+        return std::ranges::rotate(std::forward<InRange>(r), middle);
+    };
+
+    const int test_sz = 13192;
+    test_range_algo<0>{big_sz}(rotate_tester, rotate_checker);
+    test_range_algo<1, P2>{test_sz}(rotate_tester, rotate_checker, 0);
+    test_range_algo<2>(rotate_tester, rotate_checker, 1);
+    test_range_algo<3, float>{test_sz}(rotate_tester, rotate_checker, test_sz - 1);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
@@ -19,7 +19,7 @@ struct
         const int in_size = std::ranges::size(r);
         auto middle = std::ranges::begin(r) + ((pivot_pos < 0)? in_size/3 : std::min<int>(pivot_pos, in_size));
 
-        return oneapi::dpl::ranges::rotate(std::forward<Policy>(exec), std::forward<InRange>(r), middle);
+        return oneapi::dpl::ranges::rotate(std::forward<Policy>(exec), std::forward<Range>(r), middle);
     }
 } rotate_tester;
 #endif // _ENABLE_STD_RANGES_TESTING
@@ -35,7 +35,7 @@ main()
         // calculate the pivot point exactly like in the tester above
         const int in_size = std::ranges::size(r);
         auto middle = std::ranges::begin(r) + ((pivot_pos < 0)? in_size/3 : std::min<int>(pivot_pos, in_size));
-        return std::ranges::rotate(std::forward<InRange>(r), middle);
+        return std::ranges::rotate(std::forward<decltype(r)>(r), middle);
     };
 
     const int test_sz = 13192;

--- a/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
@@ -15,7 +15,7 @@ struct
 {
     template <typename Policy, std::ranges::random_access_range Range>
     std::ranges::borrowed_subrange_t<Range>
-    operator()(Policy&& exec, Range&& r, int pivot_pos = -1)
+    operator()(Policy&& exec, Range&& r, int pivot_pos = -1) const
     {
         const int in_size = std::ranges::size(r);
         auto middle = std::ranges::begin(r) + ((pivot_pos < 0)? in_size/3 : std::min<int>(pivot_pos, in_size));

--- a/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
@@ -41,7 +41,7 @@ main()
     const int test_sz = 13192;
     test_range_algo<0>{big_sz}(rotate_tester, rotate_checker);
     test_range_algo<1, P2>{test_sz}(rotate_tester, rotate_checker, 0);
-    test_range_algo<2>(rotate_tester, rotate_checker, 1);
+    test_range_algo<2>{}(rotate_tester, rotate_checker, 1);
     test_range_algo<3, float>{test_sz}(rotate_tester, rotate_checker, test_sz - 1);
 #endif //_ENABLE_STD_RANGES_TESTING
 

--- a/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_rotate.pass.cpp
@@ -14,7 +14,8 @@
 struct
 {
     template <typename Policy, std::ranges::random_access_range Range>
-    auto operator()(Policy&& exec, Range&& r, int pivot_pos = -1)
+    std::ranges::borrowed_subrange_t<Range>
+    operator()(Policy&& exec, Range&& r, int pivot_pos = -1)
     {
         const int in_size = std::ranges::size(r);
         auto middle = std::ranges::begin(r) + ((pivot_pos < 0)? in_size/3 : std::min<int>(pivot_pos, in_size));

--- a/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
@@ -16,14 +16,18 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto reverse_checker = TEST_PREPARE_CALLABLE(std::ranges::shift_left);
+    auto checker = [](std::ranges::random_access_range auto&& r, int shift)
+    {
+        auto new_last = std::shift_left(std::ranges::begin(r), std::ranges::end(r), shift);
+        return std::borrowed_subrange_t<decltype(r)>{std::ranges::begin(r), new_last)};
+    };
 
     const int test_sz = (1<<18) + 953; // 256K+
-    test_range_algo<0>{test_sz}(dpl_ranges::shift_left, reverse_checker, test_sz/4);
-    test_range_algo<1>{test_sz}(dpl_ranges::shift_left, reverse_checker, 3 * test_sz/4);
-    test_range_algo<2>{small_size}(dpl_ranges::shift_left, reverse_checker, small_size + 2);
-    test_range_algo<3>{small_size}(dpl_ranges::shift_left, reverse_checker, 0);
-    test_range_algo<4>{small_size}(dpl_ranges::shift_left, reverse_checker, -2);
+    test_range_algo<0>{test_sz}(dpl_ranges::shift_left, checker, test_sz/4);
+    test_range_algo<1>{test_sz}(dpl_ranges::shift_left, checker, 3 * test_sz/4);
+    test_range_algo<2>{small_size}(dpl_ranges::shift_left, checker, small_size + 2);
+    test_range_algo<3>{small_size}(dpl_ranges::shift_left, checker, 0);
+    test_range_algo<4>{small_size}(dpl_ranges::shift_left, checker, -2);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
@@ -27,7 +27,6 @@ main()
     test_range_algo<1>{test_sz}(dpl_ranges::shift_left, checker, 3 * test_sz/4);
     test_range_algo<2>{small_size}(dpl_ranges::shift_left, checker, small_size + 2);
     test_range_algo<3>{small_size}(dpl_ranges::shift_left, checker, 0);
-    test_range_algo<4>{small_size}(dpl_ranges::shift_left, checker, -2);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
@@ -1,0 +1,30 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+int
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    auto reverse_checker = TEST_PREPARE_CALLABLE(std::ranges::shift_left);
+
+    const int test_sz = (1<<18) + 953; // 256K+
+    test_range_algo<0>{test_sz}(dpl_ranges::shift_left, reverse_checker, test_sz/4);
+    test_range_algo<1>{test_sz}(dpl_ranges::shift_left, reverse_checker, 3 * test_sz/4);
+    test_range_algo<2>{small_size}(dpl_ranges::shift_left, reverse_checker, small_size + 2);
+    test_range_algo<3>{small_size}(dpl_ranges::shift_left, reverse_checker, 0);
+    test_range_algo<4>{small_size}(dpl_ranges::shift_left, reverse_checker, -2);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
@@ -9,12 +9,22 @@
 
 #include "std_ranges_test.h"
 
+#if _ENABLE_STD_RANGES_TESTING
+namespace dpl_ranges = oneapi::dpl::ranges;
+
+template<>
+constexpr std::pair<int, int>
+test_std_ranges::range_to_verify<std::remove_cvref_t<decltype(dpl_ranges::shift_left)>>(int, int result_size)
+{ 
+    return {0, result_size}; // in the result are the shifted elements
+}
+#endif
+
 int
 main()
 {
 #if _ENABLE_STD_RANGES_TESTING
     using namespace test_std_ranges;
-    namespace dpl_ranges = oneapi::dpl::ranges;
 
     auto checker = [](std::ranges::random_access_range auto&& r, int shift)
     {

--- a/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_shift_left.pass.cpp
@@ -19,7 +19,7 @@ main()
     auto checker = [](std::ranges::random_access_range auto&& r, int shift)
     {
         auto new_last = std::shift_left(std::ranges::begin(r), std::ranges::end(r), shift);
-        return std::borrowed_subrange_t<decltype(r)>{std::ranges::begin(r), new_last)};
+        return std::ranges::borrowed_subrange_t<decltype(r)>{std::ranges::begin(r), new_last};
     };
 
     const int test_sz = (1<<18) + 953; // 256K+

--- a/test/parallel_api/ranges/std_ranges_shift_right.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_shift_right.pass.cpp
@@ -27,7 +27,6 @@ main()
     test_range_algo<1>{test_sz}(dpl_ranges::shift_right, checker, 3 * test_sz/4);
     test_range_algo<2>{small_size}(dpl_ranges::shift_right, checker, small_size + 2);
     test_range_algo<3>{small_size}(dpl_ranges::shift_right, checker, 0);
-    test_range_algo<4>{small_size}(dpl_ranges::shift_right, checker, -2);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_shift_right.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_shift_right.pass.cpp
@@ -9,12 +9,22 @@
 
 #include "std_ranges_test.h"
 
+#if _ENABLE_STD_RANGES_TESTING
+namespace dpl_ranges = oneapi::dpl::ranges;
+
+template<>
+constexpr std::pair<int, int>
+test_std_ranges::range_to_verify<std::remove_cvref_t<decltype(dpl_ranges::shift_right)>>(int total_size, int result_size)
+{ 
+    return {total_size - result_size, result_size}; // in the result are the shifted elements
+}
+#endif
+
 int
 main()
 {
 #if _ENABLE_STD_RANGES_TESTING
     using namespace test_std_ranges;
-    namespace dpl_ranges = oneapi::dpl::ranges;
 
     auto checker = [](std::ranges::random_access_range auto&& r, int shift)
     {

--- a/test/parallel_api/ranges/std_ranges_shift_right.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_shift_right.pass.cpp
@@ -1,0 +1,34 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+int
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    auto checker = [](std::ranges::random_access_range auto&& r, int shift)
+    {
+        auto new_first = std::shift_right(std::ranges::begin(r), std::ranges::end(r), shift);
+        return std::borrowed_subrange_t<decltype(r)>{new_first, std::ranges::end(r)};
+    };
+
+    const int test_sz = (1<<18) + 739; // 256K+
+    test_range_algo<0>{test_sz}(dpl_ranges::shift_right, checker, test_sz/4);
+    test_range_algo<1>{test_sz}(dpl_ranges::shift_right, checker, 3 * test_sz/4);
+    test_range_algo<2>{small_size}(dpl_ranges::shift_right, checker, small_size + 2);
+    test_range_algo<3>{small_size}(dpl_ranges::shift_right, checker, 0);
+    test_range_algo<4>{small_size}(dpl_ranges::shift_right, checker, -2);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_shift_right.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_shift_right.pass.cpp
@@ -19,7 +19,7 @@ main()
     auto checker = [](std::ranges::random_access_range auto&& r, int shift)
     {
         auto new_first = std::shift_right(std::ranges::begin(r), std::ranges::end(r), shift);
-        return std::borrowed_subrange_t<decltype(r)>{new_first, std::ranges::end(r)};
+        return std::ranges::borrowed_subrange_t<decltype(r)>{new_first, std::ranges::end(r)};
     };
 
     const int test_sz = (1<<18) + 739; // 256K+

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -1146,6 +1146,7 @@ struct test_range_algo
     void
     test_range_algo_impl_host(auto algo, auto& checker, auto... args)
     {
+        std::cout << "Test ID " << call_id << ", host policies" << std::endl;
         auto subrange_view = subrange_view_fo{};
 #    if TEST_CPP20_SPAN_PRESENT && ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
         auto span_view = span_view_fo{};
@@ -1167,6 +1168,7 @@ struct test_range_algo
     template <typename Policy>
     void test_range_algo_impl_hetero(Policy&& exec, auto algo, auto& checker, auto... args)
     {
+        std::cout << "Test ID " << call_id << ", hetero policies" << std::endl;
         auto subrange_view = subrange_view_fo{};
 #        if TEST_CPP20_SPAN_PRESENT && ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
         auto span_view = span_view_fo{};

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -1146,7 +1146,6 @@ struct test_range_algo
     void
     test_range_algo_impl_host(auto algo, auto& checker, auto... args)
     {
-        std::cout << "Test ID " << call_id << ", host policies" << std::endl;
         auto subrange_view = subrange_view_fo{};
 #    if TEST_CPP20_SPAN_PRESENT && ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
         auto span_view = span_view_fo{};
@@ -1168,7 +1167,6 @@ struct test_range_algo
     template <typename Policy>
     void test_range_algo_impl_hetero(Policy&& exec, auto algo, auto& checker, auto... args)
     {
-        std::cout << "Test ID " << call_id << ", hetero policies" << std::endl;
         auto subrange_view = subrange_view_fo{};
 #        if TEST_CPP20_SPAN_PRESENT && ONEDPL_STD_RANGES_TEST_ALL_PERMUTATIONS
         auto span_view = span_view_fo{};

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -231,7 +231,7 @@ static constexpr
 bool check_out2<T, std::void_t<decltype(std::declval<T>().out2)>> = true;
 
 template<typename, typename = void>
-static constexpr bool is_range{};
+static constexpr bool is_range = false;
 
 template<typename T>
 static constexpr
@@ -248,7 +248,7 @@ template<typename>
 constexpr int trivial_size{0};
 
 template<typename>
-constexpr int calc_res_size(int n, int) { return n; }
+constexpr std::pair<int, int> range_to_verify(int total_size, int /*result_size*/) { return {0, total_size}; }
 
 // If in1 range is empty, then the out range is always empty
 // Can be specialized with an algorithm type if the behaviour is different, e.g. see set_union test.
@@ -396,12 +396,14 @@ private:
                        typeid(decltype(tr_in(std::declval<Container&>()()))).name() + sizes).c_str());
         }
 
-        //check result
-        auto n = std::ranges::size(expected_view);
+        // check data
+        int total_size = std::ranges::size(expected_view);
+        int result_size = total_size;
         if constexpr(is_range<std::remove_cvref_t<decltype(res)>>)
-            n = calc_res_size<std::remove_cvref_t<Algo>>(n, std::ranges::size(res));
+            result_size = std::ranges::size(res);
+        auto [start, n] = range_to_verify<std::remove_cvref_t<Algo>>(total_size, result_size);
 
-        EXPECT_EQ_N(cont_exp().begin(), cont_in().begin(), n, (std::string("data mismatch with ")
+        EXPECT_EQ_N(cont_exp().begin() + start, cont_in().begin() + start, n, (std::string("data mismatch with ")
             + typeid(Algo).name() + typeid(decltype(tr_in(std::declval<Container&>()()))).name() + sizes).c_str());
 
         if constexpr(!supress_dangling_iterators_check<std::remove_cvref_t<decltype(algo)>>)

--- a/test/parallel_api/ranges/std_ranges_unique.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_unique.pass.cpp
@@ -16,14 +16,14 @@
 #include "std_ranges_test.h"
 
 #if _ENABLE_STD_RANGES_TESTING
-namespace test_std_ranges
-{
+namespace dpl_ranges = oneapi::dpl::ranges;
+
 template<>
-constexpr int calc_res_size<std::remove_cvref_t<decltype(oneapi::dpl::ranges::unique)>>(int n, int res_n)
+constexpr std::pair<int, int>
+test_std_ranges::range_to_verify<std::remove_cvref_t<decltype(dpl_ranges::unique)>>(int total_size, int result_size)
 { 
-    return n - res_n; //res_n - number of elements to be removed
+    return {0, total_size - result_size}; // in the result are the elements to remove
 }
-} //test_std_ranges
 #endif
 
 int
@@ -31,7 +31,6 @@ main()
 {
 #if _ENABLE_STD_RANGES_TESTING
     using namespace test_std_ranges;
-    namespace dpl_ranges = oneapi::dpl::ranges;
 
     auto unique_checker = TEST_PREPARE_CALLABLE(std::ranges::unique);
 


### PR DESCRIPTION
The patch adds `rotate`, `shift_left` and `shift_right` range algorithms.

For the first two, the common three implementations - serial, parallel/vector, and hetero - all seemed simple enough to combine into a single function with `if constexpr` without introducing three tag-based overloads. The hetero `__pattern_rotate` was split to a range-based core and iterator-based redirection (and `__pattern_shift_left` is already organized this way), as this allows handling device-accessible ranges without extra data copies.

`shift_right` simply redirects to `shift_left` with `reverse_view`.

Since `std::ranges::shift*` algorithms are only available since C++23, these cannot be used in the implementation or tests, so I use iterator-based ones from `std` instead.