### PR TITLE
Add implementation of `std::ranges::stable_partition`

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1861,6 +1861,33 @@ __pattern_partition(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// __pattern_stable_partition
+//---------------------------------------------------------------------------------------------------------------------
+
+template <class _Tag, typename _ExecutionPolicy, typename _R, typename _Pred, typename _Proj>
+std::ranges::borrowed_subrange_t<_R>
+__pattern_stable_partition(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj)
+{
+    static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
+
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+
+    auto __res = oneapi::dpl::__internal::__pattern_stable_partition(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        oneapi::dpl::__internal::__unary_op<_Pred, _Proj>{__pred, __proj});
+
+    return {__res, oneapi::dpl::__ranges::__end(__r)};
+}
+
+template <typename _ExecutionPolicy, typename _R, typename _Pred, typename _Proj>
+std::ranges::borrowed_subrange_t<_R>
+__pattern_stable_partition(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&&, _R&& __r, _Pred __pred,
+    _Proj __proj)
+{
+    return std::ranges::stable_partition(std::forward<_R>(__r), __pred, __proj);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // __pattern_partition_copy
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1882,7 +1882,7 @@ __pattern_stable_partition(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pre
 template <typename _ExecutionPolicy, typename _R, typename _Pred, typename _Proj>
 std::ranges::borrowed_subrange_t<_R>
 __pattern_stable_partition(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&&, _R&& __r, _Pred __pred,
-    _Proj __proj)
+                           _Proj __proj)
 {
     return std::ranges::stable_partition(std::forward<_R>(__r), __pred, __proj);
 }

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -775,7 +775,7 @@ __pattern_inplace_merge_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, 
         __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
         oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
 
-    return oneapi::dpl::__ranges::__end(__r);
+    return __last;
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -1872,11 +1872,11 @@ __pattern_stable_partition(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pre
 
     auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
 
-    auto __res = oneapi::dpl::__internal::__pattern_stable_partition(
+    auto __middle = oneapi::dpl::__internal::__pattern_stable_partition(
         __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
         oneapi::dpl::__internal::__unary_op<_Pred, _Proj>{__pred, __proj});
 
-    return {__res, oneapi::dpl::__ranges::__end(__r)};
+    return {__middle, __last};
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _Pred, typename _Proj>

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -94,6 +94,7 @@ struct __remove_copy_fn;
 struct __unique_fn;
 struct __unique_copy_fn;
 struct __partition_fn;
+struct __stable_partition_fn;
 struct __partition_copy_fn;
 struct __is_partitioned_fn;
 } // namespace ranges::__internal

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1490,6 +1490,22 @@ struct __internal::__partition_fn
 }; //__partition_fn
 inline constexpr __internal::__partition_fn partition;
 
+struct __internal::__stable_partition_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
+    std::ranges::borrowed_subrange_t<_R>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
+    {
+        const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        return oneapi::dpl::__internal::__ranges::__pattern_stable_partition(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __pred, __proj);
+    }
+}; //__stable_partition_fn
+inline constexpr __internal::__stable_partition_fn stable_partition;
+
 struct __internal::__partition_copy_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -752,6 +752,26 @@ __pattern_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 #endif // _ONEDPL_CPP20_RANGES_PRESENT
 
 //------------------------------------------------------------------------
+// stable_partition
+//------------------------------------------------------------------------
+
+#if _ONEDPL_CPP20_RANGES_PRESENT
+template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename _Pred, typename _Proj>
+std::ranges::borrowed_subrange_t<_R>
+__pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _Pred __pred,
+                           _Proj __proj)
+{
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+
+    auto __middle = oneapi::dpl::__internal::__pattern_stable_partition(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        oneapi::dpl::__internal::__unary_op<_Pred, _Proj>{__pred, __proj});
+
+    return {__middle, oneapi::dpl::__ranges::__end(__r)};
+}
+#endif // _ONEDPL_CPP20_RANGES_PRESENT
+
+//------------------------------------------------------------------------
 // partition_copy
 //------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -767,7 +767,7 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
         __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
         oneapi::dpl::__internal::__unary_op<_Pred, _Proj>{__pred, __proj});
 
-    return {__middle, oneapi::dpl::__ranges::__end(__r)};
+    return {__middle, __last};
 }
 #endif // _ONEDPL_CPP20_RANGES_PRESENT
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1222,7 +1222,7 @@ __pattern_inplace_merge_ranges(__hetero_tag<_Tag> __tag, _ExecutionPolicy&& __ex
         __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
         oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
 
-    return oneapi::dpl::__ranges::__end(__r);
+    return __last;
 }
 #endif //_ONEDPL_CPP20_RANGES_PRESENT
 

--- a/test/parallel_api/ranges/std_ranges_stable_partition.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_partition.pass.cpp
@@ -16,9 +16,6 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    // std::ranges::stable_partition is a stable algorithm: it preserves the relative order of the
-    // elements in both partitions, so the whole range can be compared element-wise against the
-    // reference (the default calc_res_size returns the full size).
     auto stable_partition_checker = TEST_PREPARE_CALLABLE(std::ranges::stable_partition);
 
     test_range_algo<0>{get_scan_big_sz()}(dpl_ranges::stable_partition, stable_partition_checker, pred);

--- a/test/parallel_api/ranges/std_ranges_stable_partition.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_partition.pass.cpp
@@ -1,0 +1,31 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    // std::ranges::stable_partition is a stable algorithm: it preserves the relative order of the
+    // elements in both partitions, so the whole range can be compared element-wise against the
+    // reference (the default calc_res_size returns the full size).
+    auto stable_partition_checker = TEST_PREPARE_CALLABLE(std::ranges::stable_partition);
+
+    test_range_algo<0>{get_scan_big_sz()}(dpl_ranges::stable_partition, stable_partition_checker, pred);
+    test_range_algo<1>{}(dpl_ranges::stable_partition, stable_partition_checker, pred, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::stable_partition, stable_partition_checker, pred, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::stable_partition, stable_partition_checker, pred, &P2::proj);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}


### PR DESCRIPTION
## Summary

This PR adds a parallel range-based implementation of `std::ranges::stable_partition` to oneDPL, following the same design already used for `std::ranges::partition`.

Reference: C++ standard, [alg.partitions](https://eel.is/c++draft/alg.partitions).

## Details

`oneapi::dpl::ranges::stable_partition` reorders the elements of a range so that all elements for which the projected predicate returns `true` precede those for which it returns `false`, **preserving the relative order** within each group (this is the difference from `partition`, which is unstable). It returns a `borrowed_subrange_t<R>` denoting the second group `[pivot, end(r))`.

Declared signature (matches `documentation/specification/parallel_api/parallel_range_api.rst`):

```cpp
template <typename ExecutionPolicy, std::ranges::random_access_range R,
          typename Proj = std::identity,
          std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<R>, Proj>> Pred>
  requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
           std::ranges::sized_range<R> && std::permutable<std::ranges::iterator_t<R>>
std::ranges::borrowed_subrange_t<R>
stable_partition (ExecutionPolicy&& pol, R&& r, Pred pred, Proj proj = {});
```

## Conformance with [alg.partitions](https://eel.is/c++draft/alg.partitions)

The implementation is consistent with the standard specification of `ranges::stable_partition`:

- **Effects / stability**: elements satisfying `pred` (after projection) are placed before those that do not, and the relative order within each group is preserved. The serial path forwards directly to `std::ranges::stable_partition`; the parallel and device paths reuse the existing stable-partition patterns.
- **Return value**: returns `{pivot, end(r)}` as a `borrowed_subrange_t<R>`, where `pivot` is the partition point (the begin of the group that does not satisfy `pred`). Every code path returns `{middle, __end(r)}` accordingly.
- **Requirements**: the standard requires `bidirectional_range` and `permutable<iterator_t<R>>`. oneDPL intentionally constrains the input more tightly with `random_access_range` and `sized_range` (in addition to `permutable`), as required by the parallel/device backends; this is the established convention for all oneDPL parallel range algorithms and does not change the observable semantics.

## Additional changes

Fixed some calls `oneapi::dpl::__ranges::__end()` calls - now we just return already evaluated iterator.
