### PR TITLE
Add implementation of the `std::ranges::inplace_merge`

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -764,8 +764,8 @@ __pattern_merge_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& 
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
 std::ranges::borrowed_iterator_t<_R>
-__pattern_inplace_merge_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r,
-                               std::ranges::iterator_t<_R> __middle, _Comp __comp, _Proj __proj)
+__pattern_inplace_merge_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle,
+                               _Comp __comp, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -759,6 +759,35 @@ __pattern_merge_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R1&& __r1, _R2&& 
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// pattern_inplace_merge_ranges
+//---------------------------------------------------------------------------------------------------------------------
+
+template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
+std::ranges::borrowed_iterator_t<_R>
+__pattern_inplace_merge_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r,
+                               std::ranges::iterator_t<_R> __middle, _Comp __comp, _Proj __proj)
+{
+    static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
+
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+
+    oneapi::dpl::__internal::__pattern_inplace_merge(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
+
+    return oneapi::dpl::__ranges::__end(__r);
+}
+
+template <typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
+std::ranges::borrowed_iterator_t<_R>
+__pattern_inplace_merge_ranges(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&& __exec, _R&& __r,
+                               std::ranges::iterator_t<_R> __middle, _Comp __comp, _Proj __proj)
+{
+    std::ranges::inplace_merge(__r, __middle, __comp, __proj);
+    return oneapi::dpl::__ranges::__end(__r);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // includes
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -68,6 +68,7 @@ struct __minmax_fn;
 struct __copy_fn;
 struct __copy_if_fn;
 struct __merge_fn;
+struct __inplace_merge_fn;
 struct __includes_fn;
 struct __set_union_fn;
 struct __set_intersection_fn;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -833,6 +833,24 @@ struct __internal::__merge_fn
 }; //__merge_fn
 inline constexpr __internal::__merge_fn merge;
 
+struct __internal::__inplace_merge_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,
+              typename _Proj = std::identity>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
+    std::ranges::borrowed_iterator_t<_R>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle, _Comp __comp = {},
+               _Proj __proj = {}) const
+    {
+        const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        return oneapi::dpl::__internal::__ranges::__pattern_inplace_merge_ranges(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __middle, __comp, __proj);
+    }
+
+}; //__inplace_merge_fn
+inline constexpr __internal::__inplace_merge_fn inplace_merge;
+
 // [includes]
 
 struct __internal::__includes_fn

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1118,6 +1118,26 @@ __pattern_merge_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exe
 }
 #endif //_ONEDPL_CPP20_RANGES_PRESENT
 
+//------------------------------------------------------------------------
+// inplace_merge_ranges
+//------------------------------------------------------------------------
+
+#if _ONEDPL_CPP20_RANGES_PRESENT
+template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
+std::ranges::borrowed_iterator_t<_R>
+__pattern_inplace_merge_ranges(__hetero_tag<_Tag> __tag, _ExecutionPolicy&& __exec, _R&& __r,
+                               std::ranges::iterator_t<_R> __middle, _Comp __comp, _Proj __proj)
+{
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+
+    oneapi::dpl::__internal::__pattern_inplace_merge(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
+
+    return oneapi::dpl::__ranges::__end(__r);
+}
+#endif //_ONEDPL_CPP20_RANGES_PRESENT
+
 #if _ONEDPL_CPP20_RANGES_PRESENT
 
 //------------------------------------------------------------------------

--- a/test/parallel_api/ranges/std_ranges_inplace_merge.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_inplace_merge.pass.cpp
@@ -40,11 +40,6 @@ struct inplace_merge_checker_fn
     }
 } inplace_merge_checker;
 
-// Data generator producing equal projected keys (P2::x) with distinct payloads (P2::y).
-// With all keys equal, both halves [begin, middle) and [middle, end) are trivially sorted and the
-// duplicates span the boundary, so the element-wise comparison against std::ranges::inplace_merge
-// validates the stable ordering guarantee (elements of the first half must precede equal elements
-// of the second half).
 struct stable_data_gen_fn
 {
     test_std_ranges::P2

--- a/test/parallel_api/ranges/std_ranges_inplace_merge.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_inplace_merge.pass.cpp
@@ -1,0 +1,68 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+#if _ENABLE_STD_RANGES_TESTING
+// oneapi::dpl::ranges::inplace_merge and std::ranges::inplace_merge require a "middle" iterator
+// pointing inside the range. The test harness passes the same trailing arguments to both the
+// algorithm under test and the reference checker, so the wrappers below compute "middle" from the
+// range itself (begin + size/2). This keeps the two consecutive sub-ranges [begin, middle) and
+// [middle, end) consistent between the reference and the algorithm under test.
+struct inplace_merge_dpl_fn
+{
+    template <typename Policy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,
+              typename _Proj = std::identity>
+    std::ranges::borrowed_iterator_t<_R>
+    operator()(Policy&& exec, _R&& r, _Comp comp = {}, _Proj proj = {}) const
+    {
+        auto middle = std::ranges::begin(r) + std::ranges::size(r) / 2;
+        return oneapi::dpl::ranges::inplace_merge(std::forward<Policy>(exec), std::forward<_R>(r), middle, comp, proj);
+    }
+} inplace_merge_dpl;
+
+struct inplace_merge_checker_fn
+{
+    template <std::ranges::random_access_range _R, typename _Comp = std::ranges::less, typename _Proj = std::identity>
+    std::ranges::borrowed_iterator_t<_R>
+    operator()(_R&& r, _Comp comp = {}, _Proj proj = {}) const
+    {
+        auto middle = std::ranges::begin(r) + std::ranges::size(r) / 2;
+        return std::ranges::inplace_merge(std::forward<_R>(r), middle, comp, proj);
+    }
+} inplace_merge_checker;
+#endif //_ENABLE_STD_RANGES_TESTING
+
+int
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    // The default data generator (std::identity) produces an ascending sequence, so both halves
+    // [begin, middle) and [middle, end) are sorted with respect to std::ranges::less.
+
+    test_range_algo<0>{big_sz}(inplace_merge_dpl, inplace_merge_checker);
+    test_range_algo<1>{}(inplace_merge_dpl, inplace_merge_checker, std::ranges::less{});
+
+    test_range_algo<2>{}(inplace_merge_dpl, inplace_merge_checker, std::ranges::less{}, proj);
+
+    test_range_algo<3, P2>{}(inplace_merge_dpl, inplace_merge_checker, std::ranges::less{}, &P2::x);
+    test_range_algo<4, P2>{}(inplace_merge_dpl, inplace_merge_checker, std::ranges::less{}, &P2::proj);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_inplace_merge.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_inplace_merge.pass.cpp
@@ -16,11 +16,7 @@
 #include "std_ranges_test.h"
 
 #if _ENABLE_STD_RANGES_TESTING
-// oneapi::dpl::ranges::inplace_merge and std::ranges::inplace_merge require a "middle" iterator
-// pointing inside the range. The test harness passes the same trailing arguments to both the
-// algorithm under test and the reference checker, so the wrappers below compute "middle" from the
-// range itself (begin + size/2). This keeps the two consecutive sub-ranges [begin, middle) and
-// [middle, end) consistent between the reference and the algorithm under test.
+// Adaptors for the test harness to pass a middle iterator.
 struct inplace_merge_dpl_fn
 {
     template <typename Policy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,

--- a/test/parallel_api/ranges/std_ranges_inplace_merge.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_inplace_merge.pass.cpp
@@ -43,6 +43,20 @@ struct inplace_merge_checker_fn
         return std::ranges::inplace_merge(std::forward<_R>(r), middle, comp, proj);
     }
 } inplace_merge_checker;
+
+// Data generator producing equal projected keys (P2::x) with distinct payloads (P2::y).
+// With all keys equal, both halves [begin, middle) and [middle, end) are trivially sorted and the
+// duplicates span the boundary, so the element-wise comparison against std::ranges::inplace_merge
+// validates the stable ordering guarantee (elements of the first half must precede equal elements
+// of the second half).
+struct stable_data_gen_fn
+{
+    test_std_ranges::P2
+    operator()(int i) const
+    {
+        return test_std_ranges::P2(/*x = key*/ 0, /*y = payload*/ i);
+    }
+};
 #endif //_ENABLE_STD_RANGES_TESTING
 
 int
@@ -62,6 +76,10 @@ main()
 
     test_range_algo<3, P2>{}(inplace_merge_dpl, inplace_merge_checker, std::ranges::less{}, &P2::x);
     test_range_algo<4, P2>{}(inplace_merge_dpl, inplace_merge_checker, std::ranges::less{}, &P2::proj);
+
+    // Stability check: equal projected keys with distinct payloads must preserve relative order.
+    test_range_algo<5, P2, data_in, stable_data_gen_fn>{}(inplace_merge_dpl, inplace_merge_checker,
+                                                          std::ranges::less{}, &P2::x);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);


### PR DESCRIPTION
## Summary

This PR adds a parallel range-based implementation of `std::ranges::inplace_merge` to oneDPL, following the same design already used for `std::ranges::merge`.

Reference: C++ standard, [alg.merge](https://eel.is/c++draft/alg.merge).

## Details

`oneapi::dpl::ranges::inplace_merge` merges the two consecutive sorted sub-ranges `[begin(r), middle)` and `[middle, end(r))` in place, producing a single sorted range `[begin(r), end(r))`, preserving the relative order of equivalent elements (stable). It returns `end(r)` as a `borrowed_iterator_t<R>`.

Declared signature (matches `documentation/specification/parallel_api/parallel_range_api.rst`):

```cpp
template <typename ExecutionPolicy, std::ranges::random_access_range R,
          typename Comp = std::ranges::less, typename Proj = std::identity>
  requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
           std::ranges::sized_range<R> && std::sortable<std::ranges::iterator_t<R>, Comp, Proj>
std::ranges::borrowed_iterator_t<R>
inplace_merge (ExecutionPolicy&& pol, R&& r, std::ranges::iterator_t<R> middle, Comp comp = {}, Proj proj = {});
```

## Conformance with [alg.merge](https://eel.is/c++draft/alg.merge)

The implementation is consistent with the standard specification of `ranges::inplace_merge`:

- **Effects / stability**: the two consecutive sorted sub-ranges `[begin, middle)` and `[middle, end)` are merged in place into one sorted range, preserving the relative order of equivalent elements. The serial path forwards directly to `std::ranges::inplace_merge`; the parallel and device paths reuse the existing stable `__pattern_inplace_merge` patterns.
- **Return value**: returns `end(r)` as a `borrowed_iterator_t<R>`. Every code path returns `oneapi::dpl::__ranges::__end(r)` accordingly.
- **Projection**: comparisons apply the projection to both operands via `__binary_op<Comp, Proj, Proj>{comp, proj, proj}`, affecting only ordering while the elements themselves are moved.
- **Requirements**: the standard requires `bidirectional_range` and `sortable<iterator_t<R>, Comp, Proj>`. oneDPL intentionally constrains the input more tightly with `random_access_range` and `sized_range` (in addition to `sortable`), as required by the parallel/device backends; this is the established convention for all oneDPL parallel range algorithms and does not change the observable semantics.
