### PR TITLE
Add implementation of `std::ranges::partial_sort`

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -478,9 +478,6 @@ __pattern_partial_sort_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, s
 
     auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
 
-    if (__middle == __first)
-        return __last;
-
     oneapi::dpl::__internal::__pattern_partial_sort(
         __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
         oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -466,6 +466,34 @@ __pattern_sort_ranges(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPoli
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// pattern_partial_sort_ranges
+//---------------------------------------------------------------------------------------------------------------------
+
+template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
+std::ranges::borrowed_iterator_t<_R>
+__pattern_partial_sort_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle,
+                              _Comp __comp, _Proj __proj)
+{
+    static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
+
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+
+    oneapi::dpl::__internal::__pattern_partial_sort(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
+
+    return __last;
+}
+
+template <typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
+std::ranges::borrowed_iterator_t<_R>
+__pattern_partial_sort_ranges(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&& __exec, _R&& __r,
+    std::ranges::iterator_t<_R> __middle, _Comp __comp, _Proj __proj)
+{
+    return std::ranges::partial_sort(std::forward<_R>(__r), __middle, __comp, __proj);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // pattern_is_heap
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -488,7 +488,7 @@ __pattern_partial_sort_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, s
 template <typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
 std::ranges::borrowed_iterator_t<_R>
 __pattern_partial_sort_ranges(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&& __exec, _R&& __r,
-    std::ranges::iterator_t<_R> __middle, _Comp __comp, _Proj __proj)
+                              std::ranges::iterator_t<_R> __middle, _Comp __comp, _Proj __proj)
 {
     return std::ranges::partial_sort(std::forward<_R>(__r), __middle, __comp, __proj);
 }

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -478,6 +478,9 @@ __pattern_partial_sort_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, s
 
     auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
 
+    if (__middle == __first)
+        return __last;
+
     oneapi::dpl::__internal::__pattern_partial_sort(
         __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
         oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -57,6 +57,7 @@ struct __stable_sort_leaf;
 struct __stable_sort_fn;
 struct __sort_leaf;
 struct __sort_fn;
+struct __partial_sort_fn;
 struct __is_heap_fn;
 struct __is_heap_until_fn;
 struct __min_element_fn;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -614,6 +614,23 @@ struct __internal::__sort_fn
 }; //__sort_fn
 inline constexpr __internal::__sort_fn sort;
 
+struct __internal::__partial_sort_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,
+              typename _Proj = std::identity>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
+    std::ranges::borrowed_iterator_t<_R>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle, _Comp __comp = {},
+               _Proj __proj = {}) const
+    {
+        const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        return oneapi::dpl::__internal::__ranges::__pattern_partial_sort_ranges(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __middle, __comp, __proj);
+    }
+}; //__partial_sort_fn
+inline constexpr __internal::__partial_sort_fn partial_sort;
+
 // [is.heap]
 
 struct __internal::__is_heap_fn

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1447,6 +1447,9 @@ __pattern_partial_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _It
     if (__last - __first < 2)
         return;
 
+    if (__mid == __first)
+        return;
+
     __par_backend_hetero::__parallel_partial_sort(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __first, __mid,
                                                   __last, __comp)
         .__checked_deferrable_wait();

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1512,6 +1512,9 @@ __pattern_partial_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
 {
     auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
 
+    if (__middle == __first)
+        return __last;
+
     oneapi::dpl::__internal::__pattern_partial_sort(
         __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
         oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1504,6 +1504,22 @@ __pattern_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 }
 #endif //_ONEDPL_CPP20_RANGES_PRESENT
 
+#if _ONEDPL_CPP20_RANGES_PRESENT
+template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
+std::ranges::borrowed_iterator_t<_R>
+__pattern_partial_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r,
+                              std::ranges::iterator_t<_R> __middle, _Comp __comp, _Proj __proj)
+{
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+
+    oneapi::dpl::__internal::__pattern_partial_sort(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});
+
+    return __last;
+}
+#endif //_ONEDPL_CPP20_RANGES_PRESENT
+
 //------------------------------------------------------------------------
 // min_element
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1512,9 +1512,6 @@ __pattern_partial_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
 {
     auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
 
-    if (__middle == __first)
-        return __last;
-
     oneapi::dpl::__internal::__pattern_partial_sort(
         __tag, std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
         oneapi::dpl::__internal::__binary_op<_Comp, _Proj, _Proj>{__comp, __proj, __proj});

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -96,9 +96,7 @@ main()
         auto middle = get_middle<middle_pos::first>(r);
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
-
-    test_range_algo<8>{big_sz}(partial_sort_none_algo, partial_sort_none_checker);
-    test_range_algo<9>{}(partial_sort_none_algo, partial_sort_none_checker, std::ranges::greater{}, proj);
+    test_range_algo<8>{}(partial_sort_none_algo, partial_sort_none_checker);
 
     // Boundary case: middle == end(r), the whole range is sorted
     auto partial_sort_all_algo = partial_sort_fn<middle_pos::last>{};

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -96,7 +96,9 @@ main()
         auto middle = get_middle<middle_pos::first>(r);
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
-    test_range_algo<8>{}(partial_sort_none_algo, partial_sort_none_checker);
+
+    test_range_algo<8>{big_sz}(partial_sort_none_algo, partial_sort_none_checker);
+    test_range_algo<9>{}(partial_sort_none_algo, partial_sort_none_checker, std::ranges::greater{}, proj);
 
     // Boundary case: middle == end(r), the whole range is sorted
     auto partial_sort_all_algo = partial_sort_fn<middle_pos::last>{};

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -10,20 +10,37 @@
 #include "std_ranges_test.h"
 
 #if _ENABLE_STD_RANGES_TESTING
-template <std::ranges::range R>
+
+// The position of "middle" within the tested range:
+// "first" and "last" are the boundary cases, required by [alg.sort.partial]:
+// with "first" the algorithm is a no-op, with "last" it performs a full sort.
+enum class middle_pos
+{
+    first,
+    half,
+    last
+};
+
+template <middle_pos Pos, std::ranges::range R>
 auto
 get_middle(R&& r)
 {
-    return std::ranges::begin(r) + std::ranges::size(r) / 2;
+    if constexpr (Pos == middle_pos::first)
+        return std::ranges::begin(r);
+    else if constexpr (Pos == middle_pos::half)
+        return std::ranges::begin(r) + std::ranges::size(r) / 2;
+    else
+        return std::ranges::begin(r) + std::ranges::size(r);
 }
 
+template <middle_pos Pos>
 struct partial_sort_fn
 {
     template <typename Policy, typename R, typename... Args>
     std::ranges::borrowed_iterator_t<R>
     operator()(Policy&& exec, R&& r, Args&&... args) const
     {
-        auto middle = get_middle(r);
+        auto middle = get_middle<Pos>(r);
         return oneapi::dpl::ranges::partial_sort(std::forward<Policy>(exec), std::forward<R>(r), middle,
                                                  std::forward<Args>(args)...);
     }
@@ -31,9 +48,23 @@ struct partial_sort_fn
 
 template <>
 constexpr std::pair<int, int>
-test_std_ranges::range_to_verify<partial_sort_fn>(int total_size, int /*result_size*/)
+test_std_ranges::range_to_verify<partial_sort_fn<middle_pos::first>>(int /*total_size*/, int /*result_size*/)
+{
+    return {0, 0};
+}
+
+template <>
+constexpr std::pair<int, int>
+test_std_ranges::range_to_verify<partial_sort_fn<middle_pos::half>>(int total_size, int /*result_size*/)
 {
     return {0, total_size / 2};
+}
+
+template <>
+constexpr std::pair<int, int>
+test_std_ranges::range_to_verify<partial_sort_fn<middle_pos::last>>(int total_size, int /*result_size*/)
+{
+    return {0, total_size};
 }
 #endif //_ENABLE_STD_RANGES_TESTING
 
@@ -43,10 +74,10 @@ main()
 #if _ENABLE_STD_RANGES_TESTING
     using namespace test_std_ranges;
 
-    auto partial_sort_algo = partial_sort_fn{};
+    auto partial_sort_algo = partial_sort_fn<middle_pos::half>{};
 
     auto partial_sort_checker = [](auto&& r, auto&&... args) {
-        auto middle = get_middle(r);
+        auto middle = get_middle<middle_pos::half>(r);
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
 
@@ -61,6 +92,26 @@ main()
 
     test_range_algo<6, P2>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{}, &P2::proj);
     test_range_algo<7, P2>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{}, &P2::proj);
+
+    // Boundary case: middle == begin(r), the algorithm is a no-op
+    auto partial_sort_none_algo = partial_sort_fn<middle_pos::first>{};
+    auto partial_sort_none_checker = [](auto&& r, auto&&... args) {
+        auto middle = get_middle<middle_pos::first>(r);
+        return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
+    };
+
+    test_range_algo<8>{big_sz}(partial_sort_none_algo, partial_sort_none_checker);
+    test_range_algo<9>{}(partial_sort_none_algo, partial_sort_none_checker, std::ranges::greater{}, proj);
+
+    // Boundary case: middle == end(r), the whole range is sorted
+    auto partial_sort_all_algo = partial_sort_fn<middle_pos::last>{};
+    auto partial_sort_all_checker = [](auto&& r, auto&&... args) {
+        auto middle = get_middle<middle_pos::last>(r);
+        return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
+    };
+
+    test_range_algo<10>{big_sz}(partial_sort_all_algo, partial_sort_all_checker);
+    test_range_algo<11>{}(partial_sort_all_algo, partial_sort_all_checker, std::ranges::greater{}, proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -11,7 +11,7 @@
 
 #if _ENABLE_STD_RANGES_TESTING
 template <std::ranges::range R>
-auto
+std::ranges::iterator_t<R>
 get_middle(R&& r)
 {
     return std::ranges::begin(r) + std::ranges::size(r) / 2;

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -78,8 +78,8 @@ main()
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
 
-    test_range_algo<0>{big_sz}(partial_sort_algo, partial_sort_checker);
-    test_range_algo<1>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{});
+    test_range_algo<0>{}(partial_sort_algo, partial_sort_checker);
+    test_range_algo<1>{big_sz}(partial_sort_algo, partial_sort_checker, std::ranges::greater{});
 
     test_range_algo<2>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{}, proj);

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -19,7 +19,7 @@ enum class middle_pos
 };
 
 template <middle_pos Pos, std::ranges::range R>
-auto
+std::ranges::borrowed_iterator_t<R>
 get_middle(R&& r)
 {
     if constexpr (Pos == middle_pos::first)
@@ -73,7 +73,7 @@ main()
 
     auto partial_sort_algo = partial_sort_fn<middle_pos::half>{};
 
-    auto partial_sort_checker = [](auto&& r, auto&&... args) {
+    auto partial_sort_checker = [](auto&& r, auto&&... args) -> std::ranges::borrowed_iterator_t<decltype(r)> {
         auto middle = get_middle<middle_pos::half>(r);
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
@@ -92,7 +92,7 @@ main()
 
     // Boundary case: middle == begin(r), the algorithm is a no-op
     auto partial_sort_none_algo = partial_sort_fn<middle_pos::first>{};
-    auto partial_sort_none_checker = [](auto&& r, auto&&... args) {
+    auto partial_sort_none_checker = [](auto&& r, auto&&... args) -> std::ranges::borrowed_iterator_t<decltype(r)> {
         auto middle = get_middle<middle_pos::first>(r);
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -10,37 +10,20 @@
 #include "std_ranges_test.h"
 
 #if _ENABLE_STD_RANGES_TESTING
-
-// The position of "middle" within the tested range:
-// "first" and "last" are the boundary cases, required by [alg.sort.partial]:
-// with "first" the algorithm is a no-op, with "last" it performs a full sort.
-enum class middle_pos
-{
-    first,
-    half,
-    last
-};
-
-template <middle_pos Pos, std::ranges::range R>
+template <std::ranges::range R>
 auto
 get_middle(R&& r)
 {
-    if constexpr (Pos == middle_pos::first)
-        return std::ranges::begin(r);
-    else if constexpr (Pos == middle_pos::half)
-        return std::ranges::begin(r) + std::ranges::size(r) / 2;
-    else
-        return std::ranges::begin(r) + std::ranges::size(r);
+    return std::ranges::begin(r) + std::ranges::size(r) / 2;
 }
 
-template <middle_pos Pos>
 struct partial_sort_fn
 {
     template <typename Policy, typename R, typename... Args>
     std::ranges::borrowed_iterator_t<R>
     operator()(Policy&& exec, R&& r, Args&&... args) const
     {
-        auto middle = get_middle<Pos>(r);
+        auto middle = get_middle(r);
         return oneapi::dpl::ranges::partial_sort(std::forward<Policy>(exec), std::forward<R>(r), middle,
                                                  std::forward<Args>(args)...);
     }
@@ -48,23 +31,9 @@ struct partial_sort_fn
 
 template <>
 constexpr std::pair<int, int>
-test_std_ranges::range_to_verify<partial_sort_fn<middle_pos::first>>(int /*total_size*/, int /*result_size*/)
-{
-    return {0, 0};
-}
-
-template <>
-constexpr std::pair<int, int>
-test_std_ranges::range_to_verify<partial_sort_fn<middle_pos::half>>(int total_size, int /*result_size*/)
+test_std_ranges::range_to_verify<partial_sort_fn>(int total_size, int /*result_size*/)
 {
     return {0, total_size / 2};
-}
-
-template <>
-constexpr std::pair<int, int>
-test_std_ranges::range_to_verify<partial_sort_fn<middle_pos::last>>(int total_size, int /*result_size*/)
-{
-    return {0, total_size};
 }
 #endif //_ENABLE_STD_RANGES_TESTING
 
@@ -74,10 +43,10 @@ main()
 #if _ENABLE_STD_RANGES_TESTING
     using namespace test_std_ranges;
 
-    auto partial_sort_algo = partial_sort_fn<middle_pos::half>{};
+    auto partial_sort_algo = partial_sort_fn{};
 
     auto partial_sort_checker = [](auto&& r, auto&&... args) {
-        auto middle = get_middle<middle_pos::half>(r);
+        auto middle = get_middle(r);
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
 
@@ -92,26 +61,6 @@ main()
 
     test_range_algo<6, P2>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{}, &P2::proj);
     test_range_algo<7, P2>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{}, &P2::proj);
-
-    // Boundary case: middle == begin(r), the algorithm is a no-op
-    auto partial_sort_none_algo = partial_sort_fn<middle_pos::first>{};
-    auto partial_sort_none_checker = [](auto&& r, auto&&... args) {
-        auto middle = get_middle<middle_pos::first>(r);
-        return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
-    };
-
-    test_range_algo<8>{big_sz}(partial_sort_none_algo, partial_sort_none_checker);
-    test_range_algo<9>{}(partial_sort_none_algo, partial_sort_none_checker, std::ranges::greater{}, proj);
-
-    // Boundary case: middle == end(r), the whole range is sorted
-    auto partial_sort_all_algo = partial_sort_fn<middle_pos::last>{};
-    auto partial_sort_all_checker = [](auto&& r, auto&&... args) {
-        auto middle = get_middle<middle_pos::last>(r);
-        return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
-    };
-
-    test_range_algo<10>{big_sz}(partial_sort_all_algo, partial_sort_all_checker);
-    test_range_algo<11>{}(partial_sort_all_algo, partial_sort_all_checker, std::ranges::greater{}, proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -19,7 +19,7 @@ enum class middle_pos
 };
 
 template <middle_pos Pos, std::ranges::range R>
-std::ranges::borrowed_iterator_t<R>
+auto
 get_middle(R&& r)
 {
     if constexpr (Pos == middle_pos::first)
@@ -73,7 +73,7 @@ main()
 
     auto partial_sort_algo = partial_sort_fn<middle_pos::half>{};
 
-    auto partial_sort_checker = [](auto&& r, auto&&... args) -> std::ranges::borrowed_iterator_t<decltype(r)> {
+    auto partial_sort_checker = [](auto&& r, auto&&... args) {
         auto middle = get_middle<middle_pos::half>(r);
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
@@ -92,7 +92,7 @@ main()
 
     // Boundary case: middle == begin(r), the algorithm is a no-op
     auto partial_sort_none_algo = partial_sort_fn<middle_pos::first>{};
-    auto partial_sort_none_checker = [](auto&& r, auto&&... args) -> std::ranges::borrowed_iterator_t<decltype(r)> {
+    auto partial_sort_none_checker = [](auto&& r, auto&&... args) {
         auto middle = get_middle<middle_pos::first>(r);
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -11,9 +11,6 @@
 
 #if _ENABLE_STD_RANGES_TESTING
 
-// The position of "middle" within the tested range:
-// "first" and "last" are the boundary cases, required by [alg.sort.partial]:
-// with "first" the algorithm is a no-op, with "last" it performs a full sort.
 enum class middle_pos
 {
     first,

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -19,7 +19,7 @@ enum class middle_pos
 };
 
 template <middle_pos Pos, std::ranges::range R>
-std::ranges::iterator_t<R>
+std::ranges::borrowed_iterator_t<R>
 get_middle(R&& r)
 {
     if constexpr (Pos == middle_pos::first)

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -1,0 +1,67 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+#if _ENABLE_STD_RANGES_TESTING
+template <std::ranges::range R>
+auto
+get_middle(R&& r)
+{
+    return std::ranges::begin(r) + std::ranges::size(r) / 2;
+}
+
+struct partial_sort_fn
+{
+    template <typename Policy, typename R, typename... Args>
+    std::ranges::borrowed_iterator_t<R>
+    operator()(Policy&& exec, R&& r, Args&&... args) const
+    {
+        auto middle = get_middle(r);
+        return oneapi::dpl::ranges::partial_sort(std::forward<Policy>(exec), std::forward<R>(r), middle,
+                                                 std::forward<Args>(args)...);
+    }
+};
+
+template <>
+constexpr std::pair<int, int>
+test_std_ranges::range_to_verify<partial_sort_fn>(int total_size, int /*result_size*/)
+{
+    return {0, total_size / 2};
+}
+#endif //_ENABLE_STD_RANGES_TESTING
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+
+    auto partial_sort_algo = partial_sort_fn{};
+
+    auto partial_sort_checker = [](auto&& r, auto&&... args) {
+        auto middle = get_middle(r);
+        return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
+    };
+
+    test_range_algo<0>{big_sz}(partial_sort_algo, partial_sort_checker);
+    test_range_algo<1>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{});
+
+    test_range_algo<2>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{}, proj);
+    test_range_algo<3>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{}, proj);
+
+    test_range_algo<4, P2>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{}, &P2::x);
+    test_range_algo<5, P2>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{}, &P2::x);
+
+    test_range_algo<6, P2>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{}, &P2::proj);
+    test_range_algo<7, P2>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{}, &P2::proj);
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -78,8 +78,8 @@ main()
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
 
-    test_range_algo<0>{}(partial_sort_algo, partial_sort_checker);
-    test_range_algo<1>{big_sz}(partial_sort_algo, partial_sort_checker, std::ranges::greater{});
+    test_range_algo<0>{big_sz}(partial_sort_algo, partial_sort_checker);
+    test_range_algo<1>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{});
 
     test_range_algo<2>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{}, proj);

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -11,6 +11,9 @@
 
 #if _ENABLE_STD_RANGES_TESTING
 
+// The position of "middle" within the tested range:
+// "first" and "last" are the boundary cases, required by [alg.sort.partial]:
+// with "first" the algorithm is a no-op, with "last" it performs a full sort.
 enum class middle_pos
 {
     first,

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -50,8 +50,8 @@ main()
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
 
-    test_range_algo<0>{}(partial_sort_algo, partial_sort_checker);
-    test_range_algo<1>{big_sz}(partial_sort_algo, partial_sort_checker, std::ranges::greater{});
+    test_range_algo<0>{big_sz}(partial_sort_algo, partial_sort_checker);
+    test_range_algo<1>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{});
 
     test_range_algo<2>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{}, proj);

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -50,8 +50,8 @@ main()
         return std::ranges::partial_sort(std::forward<decltype(r)>(r), middle, std::forward<decltype(args)>(args)...);
     };
 
-    test_range_algo<0>{big_sz}(partial_sort_algo, partial_sort_checker);
-    test_range_algo<1>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{});
+    test_range_algo<0>{}(partial_sort_algo, partial_sort_checker);
+    test_range_algo<1>{big_sz}(partial_sort_algo, partial_sort_checker, std::ranges::greater{});
 
     test_range_algo<2>{}(partial_sort_algo, partial_sort_checker, std::ranges::less{}, proj);
     test_range_algo<3>{}(partial_sort_algo, partial_sort_checker, std::ranges::greater{}, proj);

--- a/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort.pass.cpp
@@ -19,7 +19,7 @@ enum class middle_pos
 };
 
 template <middle_pos Pos, std::ranges::range R>
-std::ranges::borrowed_iterator_t<R>
+std::ranges::iterator_t<R>
 get_middle(R&& r)
 {
     if constexpr (Pos == middle_pos::first)


### PR DESCRIPTION
## Summary

This PR adds a parallel range-based implementation of `std::ranges::partial_sort` to oneDPL, following the same design already used for the other range-based sorting algorithms.

Reference: C++ standard, [partial.sort](https://eel.is/c++draft/alg.sort#partial.sort).

## Details

`oneapi::dpl::ranges::partial_sort` reorders the elements of a range so that the sub-range `[begin(r), middle)` contains the smallest `middle - begin(r)` elements of the whole range in sorted order (with respect to the projected comparator), while the order of the remaining elements `[middle, end(r))` is unspecified. It returns a `borrowed_iterator_t` equal to `end(r)`.

Declared signature (matches `documentation/specification/parallel_api/parallel_range_api.rst`):

```cpp
template <typename ExecutionPolicy, typename R, typename Comp = std::ranges::less, typename Proj = std::identity>
  requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
           std::ranges::sized_range<R> &&
           std::sortable<std::ranges::iterator_t<R>, Comp, Proj>
std::ranges::borrowed_iterator_t<R>
partial_sort(ExecutionPolicy&& pol, R&& r, std::ranges::iterator_t<R> middle, Comp comp = {}, Proj proj = {});
```

## Conformance with [partial.sort](https://eel.is/c++draft/alg.sort#partial.sort)

The implementation is consistent with the standard specification of `ranges::partial_sort`:

- **Effects**: the first `middle - begin(r)` elements in sorted order are placed into `[begin(r), middle)`; the order of `[middle, end(r))` is unspecified. The serial path forwards directly to `std::ranges::partial_sort`; the parallel and device paths reuse the existing `__pattern_partial_sort()` implementation with a `__binary_op<_Comp, _Proj, _Proj>` comparator.
- **Return value**: returns `end(r)` as a `borrowed_iterator_t` on every code path.
- **Requirements**: the standard requires `random_access_range` and `sortable<iterator_t<R>, Comp, Proj>`. oneDPL additionally constrains the input with `sized_range`, as required by the parallel/device backends; this is the established convention for all oneDPL parallel range algorithms and does not change the observable semantics.
