### PR TITLE
Add ranges::partial_sort_copy

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2562,18 +2562,17 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
         }
         else
         {
-            using _T1 = typename std::iterator_traits<_RandomAccessIterator1>::value_type;
             using _T2 = typename std::iterator_traits<_RandomAccessIterator2>::value_type;
-            __par_backend::__buffer<_T1> __buf(__n1);
-            _T1* __r = __buf.get();
+            __par_backend::__buffer<_T2> __buf(__n1);
+            _T2* __r = __buf.get();
 
             __par_backend::__parallel_stable_sort(
                 __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n1, __comp,
-                [__n2, __first, __r](_T1* __i, _T1* __j, _Compare __comp) {
+                [__n2, __first, __r](_T2* __i, _T2* __j, _Compare __comp) {
                     _RandomAccessIterator1 __it = __first + (__i - __r);
 
                     // 1. Copy elements from input to raw memory
-                    for (_T1* __k = __i; __k != __j; ++__k, (void)++__it)
+                    for (_T2* __k = __i; __k != __j; ++__k, (void)++__it)
                     {
                         ::new (__k) _T2(*__it);
                     }
@@ -2588,7 +2587,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
 
             // 3. Move elements from temporary buffer to output
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
-                                          [__r, __d_first](_T1* __i, _T1* __j) {
+                                          [__r, __d_first](_T2* __i, _T2* __j) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
                                           });
@@ -2596,7 +2595,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
             if constexpr (!::std::is_trivially_destructible_v<_T1>)
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
                                               __r + __n1,
-                                              [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); });
+                                              [](_T2* __i, _T2* __j) { __brick_destroy(__i, __j, _IsVector{}); });
 
             return __d_first + __n2;
         }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2592,7 +2592,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
                                           });
 
-            if constexpr (!::std::is_trivially_destructible_v<_T1>)
+            if constexpr (!::std::is_trivially_destructible_v<_T2>)
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
                                               __r + __n1,
                                               [](_T2* __i, _T2* __j) { __brick_destroy(__i, __j, _IsVector{}); });

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2525,7 +2525,7 @@ __pattern_partial_sort_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator __first, 
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    return ::std::partial_sort_copy(__first, __last, __d_first, __d_last, __comp);
+    return std::partial_sort_copy(__first, __last, __d_first, __d_last, __comp);
 }
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
@@ -2547,7 +2547,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
         if (__n2 >= __n1)
         {
             __par_backend::__parallel_stable_sort(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __d_first, __d_first + __n1, __comp,
+                __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __d_first, __d_first + __n1, __comp,
                 [__first, __d_first](_RandomAccessIterator2 __i, _RandomAccessIterator2 __j, _Compare __comp) {
                     _RandomAccessIterator1 __i1 = __first + (__i - __d_first);
                     _RandomAccessIterator1 __j1 = __first + (__j - __d_first);
@@ -2555,7 +2555,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                     // 1. Copy elements from input to output
                     __brick_copy<__parallel_tag<_IsVector>>{}(__i1, __j1, __i, _IsVector{});
                     // 2. Sort elements in output sequence
-                    ::std::sort(__i, __j, __comp);
+                    std::sort(__i, __j, __comp);
                 },
                 __n1);
             return __d_first + __n1;
@@ -2567,7 +2567,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
             _T2* __r = __buf.get();
 
             __par_backend::__parallel_stable_sort(
-                __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n1, __comp,
+                __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __r, __r + __n1, __comp,
                 [__n2, __first, __r](_T2* __i, _T2* __j, _Compare __comp) {
                     _RandomAccessIterator1 __it = __first + (__i - __r);
 
@@ -2579,21 +2579,21 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
 
                     // 2. Sort elements in temporary buffer
                     if (__n2 < __j - __i)
-                        ::std::partial_sort(__i, __i + __n2, __j, __comp);
+                        std::partial_sort(__i, __i + __n2, __j, __comp);
                     else
-                        ::std::sort(__i, __j, __comp);
+                        std::sort(__i, __j, __comp);
                 },
                 __n2);
 
             // 3. Move elements from temporary buffer to output
-            __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
+            __par_backend::__parallel_for(__backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
                                           [__r, __d_first](_T2* __i, _T2* __j) {
                                               __brick_move_destroy<__parallel_tag<_IsVector>>{}(
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
                                           });
 
-            if constexpr (!::std::is_trivially_destructible_v<_T2>)
-                __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
+            if constexpr (!std::is_trivially_destructible_v<_T2>)
+                __par_backend::__parallel_for(__backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __r + __n2,
                                               __r + __n1,
                                               [](_T2* __i, _T2* __j) { __brick_destroy(__i, __j, _IsVector{}); });
 

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -494,6 +494,35 @@ __pattern_partial_sort_ranges(__serial_tag</*IsVector*/ std::false_type>, _Execu
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// pattern_partial_sort_copy_ranges
+//---------------------------------------------------------------------------------------------------------------------
+template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _OutR, typename _Comp, typename _Proj1,
+          typename _Proj2>
+std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
+__pattern_partial_sort_copy_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Comp __comp,
+                                   _Proj1 __proj1, _Proj2 __proj2)
+{
+    static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
+
+    auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
+    auto [__out_first, __out_last] = oneapi::dpl::__ranges::__bounds(__out_r);
+
+    auto __out_finish = oneapi::dpl::__internal::__pattern_partial_sort_copy(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __out_first, __out_last,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj1, _Proj2>{__comp, __proj1, __proj2});
+
+    return {__last, __out_finish};
+}
+
+template <typename _ExecutionPolicy, typename _R, typename _OutR, typename _Comp, typename _Proj1, typename _Proj2>
+std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
+__pattern_partial_sort_copy_ranges(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&& __exec, _R&& __r,
+                                   _OutR&& __out_r, _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
+{
+    return std::ranges::partial_sort_copy(std::forward<_R>(__r), std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // pattern_is_heap
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -500,16 +500,17 @@ template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _OutR,
           typename _Proj2>
 std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
 __pattern_partial_sort_copy_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Comp __comp,
-                                   _Proj1 __proj1, _Proj2 __proj2)
+                                   _Proj1, _Proj2 __proj2)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
     auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
     auto [__out_first, __out_last] = oneapi::dpl::__ranges::__bounds(__out_r);
+    // __pattern_partial_sort_copy sorts after copying, so _Proj1 is not used
+    oneapi::dpl::__internal::__binary_op<_Comp, _Proj2, _Proj2> __comp_proj2{__comp, __proj2, __proj2};
 
     auto __out_finish = oneapi::dpl::__internal::__pattern_partial_sort_copy(
-        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __out_first, __out_last,
-        oneapi::dpl::__internal::__binary_op<_Comp, _Proj1, _Proj2>{__comp, __proj1, __proj2});
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __out_first, __out_last, __comp_proj2);
 
     return {__last, __out_finish};
 }

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -506,11 +506,11 @@ __pattern_partial_sort_copy_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& _
 
     auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
     auto [__out_first, __out_last] = oneapi::dpl::__ranges::__bounds(__out_r);
-    // __pattern_partial_sort_copy sorts after copying, so _Proj1 is not used
-    oneapi::dpl::__internal::__binary_op<_Comp, _Proj2, _Proj2> __comp_proj2{__comp, __proj2, __proj2};
 
+    // __pattern_partial_sort_copy sorts after copying, so _Proj1 is not used
     auto __out_finish = oneapi::dpl::__internal::__pattern_partial_sort_copy(
-        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __out_first, __out_last, __comp_proj2);
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first, __last, __out_first, __out_last,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj2, _Proj2>{__comp, __proj2, __proj2});
 
     return {__last, __out_finish};
 }

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -520,7 +520,8 @@ std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std:
 __pattern_partial_sort_copy_ranges(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&& __exec, _R&& __r,
                                    _OutR&& __out_r, _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
 {
-    return std::ranges::partial_sort_copy(std::forward<_R>(__r), std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
+    return std::ranges::partial_sort_copy(
+        std::forward<_R>(__r), std::forward<_OutR>(__out_r),__comp, __proj1, __proj2);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -518,12 +518,12 @@ __pattern_partial_sort_copy_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& _
 template <typename _IsVector, typename _ExecutionPolicy, typename _R, typename _OutR, typename _Comp, typename _Proj1,
           typename _Proj2>
 std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-__pattern_partial_sort_copy_ranges(__serial_tag<_IsVector>, _ExecutionPolicy&& __exec, _R&& __r,
-                                   _OutR&& __out_r, _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
+__pattern_partial_sort_copy_ranges(__serial_tag<_IsVector>, _ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r,
+                                   _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
 {
     // Use the standard implementation for both seq and unseq policies
-    return std::ranges::partial_sort_copy(
-        std::forward<_R>(__r), std::forward<_OutR>(__out_r),__comp, __proj1, __proj2);
+    return std::ranges::partial_sort_copy(std::forward<_R>(__r), std::forward<_OutR>(__out_r), __comp, __proj1,
+                                          __proj2);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -515,11 +515,13 @@ __pattern_partial_sort_copy_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& _
     return {__last, __out_finish};
 }
 
-template <typename _ExecutionPolicy, typename _R, typename _OutR, typename _Comp, typename _Proj1, typename _Proj2>
+template <typename _IsVector, typename _ExecutionPolicy, typename _R, typename _OutR, typename _Comp, typename _Proj1,
+          typename _Proj2>
 std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-__pattern_partial_sort_copy_ranges(__serial_tag</*IsVector*/ std::false_type>, _ExecutionPolicy&& __exec, _R&& __r,
+__pattern_partial_sort_copy_ranges(__serial_tag<_IsVector>, _ExecutionPolicy&& __exec, _R&& __r,
                                    _OutR&& __out_r, _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
 {
+    // Use the standard implementation for both seq and unseq policies
     return std::ranges::partial_sort_copy(
         std::forward<_R>(__r), std::forward<_OutR>(__out_r),__comp, __proj1, __proj2);
 }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -58,6 +58,7 @@ struct __stable_sort_fn;
 struct __sort_leaf;
 struct __sort_fn;
 struct __partial_sort_fn;
+struct __partial_sort_copy_fn;
 struct __is_heap_fn;
 struct __is_heap_until_fn;
 struct __min_element_fn;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -631,6 +631,28 @@ struct __internal::__partial_sort_fn
 }; //__partial_sort_fn
 inline constexpr __internal::__partial_sort_fn partial_sort;
 
+struct __internal::__partial_sort_copy_fn
+{
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, std::ranges::random_access_range _OutR,
+              typename _Comp = std::ranges::less, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> && std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>> &&
+                 std::sortable<std::ranges::iterator_t<_OutR>, _Comp, _Proj2> &&
+                 std::indirect_strict_weak_order<_Comp, std::projected<std::ranges::iterator_t<_R>, _Proj1>,
+                                                 std::projected<std::ranges::iterator_t<_OutR>, _Proj2>>
+    std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, _Comp __comp = {}, _Proj1 __proj1 = {},
+               _Proj2 __proj2 = {}) const
+    {
+        const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        return oneapi::dpl::__internal::__ranges::__pattern_partial_sort_copy_ranges(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
+            std::forward<_OutR>(__result), __comp, __proj1, __proj2);
+    }
+}; //__partial_sort_copy_fn
+inline constexpr __internal::__partial_sort_copy_fn partial_sort_copy;
+
 // [is.heap]
 
 struct __internal::__is_heap_fn

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1519,8 +1519,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         // Use regular sort as partial_sort isn't required to be stable.
         //__pattern_sort is a blocking call.
         __pattern_sort(
-            __tag,
-            __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(std::forward<_ExecutionPolicy>(__exec)),
+            __tag, __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(std::forward<_ExecutionPolicy>(__exec)),
             __out_first, __out_end, __comp);
 
         return __out_end;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1490,7 +1490,7 @@ _OutIterator
 __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _InIterator __first,
                             _InIterator __last, _OutIterator __out_first, _OutIterator __out_last, _Compare __comp)
 {
-    using _ValueType = typename ::std::iterator_traits<_OutIterator>::value_type;
+    using _ValueType = typename std::iterator_traits<_OutIterator>::value_type;
 
     auto __in_size = __last - __first;
     auto __out_size = __out_last - __out_first;
@@ -1520,7 +1520,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         //__pattern_sort is a blocking call.
         __pattern_sort(
             __tag,
-            __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(::std::forward<_ExecutionPolicy>(__exec)),
+            __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(std::forward<_ExecutionPolicy>(__exec)),
             __out_first, __out_end, __comp);
 
         return __out_end;
@@ -1553,7 +1553,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
         return __pattern_hetero_walk2<__par_backend_hetero::__deferrable_mode, __par_backend_hetero::access_mode::write,
                                       /*_IsOutNoInitRequested=*/true>(
-            __tag, __par_backend_hetero::make_wrapped_policy<__copy_back>(::std::forward<_ExecutionPolicy>(__exec)),
+            __tag, __par_backend_hetero::make_wrapped_policy<__copy_back>(std::forward<_ExecutionPolicy>(__exec)),
             __buf_first, __buf_mid, __out_first, __brick_copy<__hetero_tag<_BackendTag>>{});
 
         // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1490,7 +1490,7 @@ _OutIterator
 __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _InIterator __first,
                             _InIterator __last, _OutIterator __out_first, _OutIterator __out_last, _Compare __comp)
 {
-    using _ValueType = typename ::std::iterator_traits<_InIterator>::value_type;
+    using _ValueType = typename ::std::iterator_traits<_OutIterator>::value_type;
 
     auto __in_size = __last - __first;
     auto __out_size = __out_last - __out_first;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1525,14 +1525,15 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename
           typename _Proj2>
 std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
 __pattern_partial_sort_copy_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r,
-                                   _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
+                                   _Comp __comp, _Proj1, _Proj2 __proj2)
 {
     auto [__first1, __last1] = oneapi::dpl::__ranges::__bounds(__r);
     auto [__out_it, __out_end] = oneapi::dpl::__ranges::__bounds(__out_r);
+    // __pattern_partial_sort_copy sorts after copying, so _Proj1 is not used
+    oneapi::dpl::__internal::__binary_op<_Comp, _Proj2, _Proj2> __comp_proj2{__comp, __proj2, __proj2};
 
     auto __out_finish = oneapi::dpl::__internal::__pattern_partial_sort_copy(
-        __tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __out_it, __out_end,
-        oneapi::dpl::__internal::__binary_op<_Comp, _Proj1, _Proj2>{__comp, __proj1, __proj2});
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __out_it, __out_end, __comp_proj2);
 
     return {__last1, __out_finish};
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1529,11 +1529,11 @@ __pattern_partial_sort_copy_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPo
 {
     auto [__first1, __last1] = oneapi::dpl::__ranges::__bounds(__r);
     auto [__out_it, __out_end] = oneapi::dpl::__ranges::__bounds(__out_r);
-    // __pattern_partial_sort_copy sorts after copying, so _Proj1 is not used
-    oneapi::dpl::__internal::__binary_op<_Comp, _Proj2, _Proj2> __comp_proj2{__comp, __proj2, __proj2};
 
+    // __pattern_partial_sort_copy sorts after copying, so _Proj1 is not used
     auto __out_finish = oneapi::dpl::__internal::__pattern_partial_sort_copy(
-        __tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __out_it, __out_end, __comp_proj2);
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __out_it, __out_end,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj2, _Proj2>{__comp, __proj2, __proj2});
 
     return {__last1, __out_finish};
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1524,8 +1524,8 @@ __pattern_partial_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
 template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename _OutR, typename _Comp, typename _Proj1,
           typename _Proj2>
 std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-__pattern_partial_sort_copy_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r,
-                                   _Comp __comp, _Proj1, _Proj2 __proj2)
+__pattern_partial_sort_copy_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r,
+                                   _OutR&& __out_r, _Comp __comp, _Proj1, _Proj2 __proj2)
 {
     auto [__first1, __last1] = oneapi::dpl::__ranges::__bounds(__r);
     auto [__out_it, __out_end] = oneapi::dpl::__ranges::__bounds(__out_r);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -1520,6 +1520,24 @@ __pattern_partial_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
 }
 #endif //_ONEDPL_CPP20_RANGES_PRESENT
 
+#if _ONEDPL_CPP20_RANGES_PRESENT
+template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename _OutR, typename _Comp, typename _Proj1,
+          typename _Proj2>
+std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
+__pattern_partial_sort_copy_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r,
+                                   _Comp __comp, _Proj1 __proj1, _Proj2 __proj2)
+{
+    auto [__first1, __last1] = oneapi::dpl::__ranges::__bounds(__r);
+    auto [__out_it, __out_end] = oneapi::dpl::__ranges::__bounds(__out_r);
+
+    auto __out_finish = oneapi::dpl::__internal::__pattern_partial_sort_copy(
+        __tag, std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __out_it, __out_end,
+        oneapi::dpl::__internal::__binary_op<_Comp, _Proj1, _Proj2>{__comp, __proj1, __proj2});
+
+    return {__last1, __out_finish};
+}
+#endif //_ONEDPL_CPP20_RANGES_PRESENT
+
 //------------------------------------------------------------------------
 // min_element
 //------------------------------------------------------------------------

--- a/test/parallel_api/ranges/std_ranges_partial_sort_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort_copy.pass.cpp
@@ -20,10 +20,10 @@ void test_mixed_types()
 
     std::vector<int> out_expected = {0, 1, 2, 2, 3};
 
-    std::vector<B> out_seq(out_expected.size(), 0xCD);
-    std::vector<B> out_par(out_expected.size(), 0xCD);
-    std::vector<B> out_unseq(out_expected.size(), 0xCD);
-    std::vector<B> out_par_unseq(out_expected.size(), 0xCD);
+    std::vector<B> out_seq(out_expected.size(), B{0xCD});
+    std::vector<B> out_par(out_expected.size(), B{0xCD});
+    std::vector<B> out_unseq(out_expected.size(), B{0xCD});
+    std::vector<B> out_par_unseq(out_expected.size(), B{0xCD});
 
     dpl_ranges::partial_sort_copy(oneapi::dpl::execution::seq,       r1, out_seq,  std::ranges::less{}, proj_a, proj_b);
     dpl_ranges::partial_sort_copy(oneapi::dpl::execution::par,       r1, out_par,  std::ranges::less{}, proj_a, proj_b);

--- a/test/parallel_api/ranges/std_ranges_partial_sort_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort_copy.pass.cpp
@@ -1,0 +1,71 @@
+// -*- C++ -*-
+//===------------------------------------------------------===//
+//
+// Copyright (C) UXL Foundation Contributors
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+#if _ENABLE_STD_RANGES_TESTING
+namespace dpl_ranges = oneapi::dpl::ranges;
+
+void test_mixed_types()
+{
+    using namespace test_std_ranges;
+
+    std::vector<A> r1 = {{1}, {2}, {5}, {0}, {2}, {7}, {3}};
+
+    std::vector<int> out_expected = {0, 1, 2, 2, 3};
+
+    std::vector<B> out_seq(out_expected.size(), 0xCD);
+    std::vector<B> out_par(out_expected.size(), 0xCD);
+    std::vector<B> out_unseq(out_expected.size(), 0xCD);
+    std::vector<B> out_par_unseq(out_expected.size(), 0xCD);
+
+    dpl_ranges::partial_sort_copy(oneapi::dpl::execution::seq,       r1, out_seq,  std::ranges::less{}, proj_a, proj_b);
+    dpl_ranges::partial_sort_copy(oneapi::dpl::execution::par,       r1, out_par,  std::ranges::less{}, proj_a, proj_b);
+    dpl_ranges::partial_sort_copy(oneapi::dpl::execution::unseq,     r1, out_unseq,     std::less{}, proj_a, proj_b);
+    dpl_ranges::partial_sort_copy(oneapi::dpl::execution::par_unseq, r1, out_par_unseq, std::less{}, proj_a, proj_b);
+
+    EXPECT_EQ_RANGES(out_expected, out_seq, "wrong result with seq policy");
+    EXPECT_EQ_RANGES(out_expected, out_par, "wrong result with par policy");
+    EXPECT_EQ_RANGES(out_expected, out_unseq, "wrong result with unseq policy");
+    EXPECT_EQ_RANGES(out_expected, out_par_unseq, "wrong result with par_unseq policy");
+#if TEST_DPCPP_BACKEND_PRESENT
+    auto policy = TestUtils::get_dpcpp_test_policy();
+    sycl::queue q = policy.queue();
+    if (q.get_device().has(sycl::aspect::usm_shared_allocations))
+    {
+        using r1_alloc_t = sycl::usm_allocator<A, sycl::usm::alloc::shared>;
+        using out_alloc_t = sycl::usm_allocator<B, sycl::usm::alloc::shared>;
+        std::vector<A, r1_alloc_t> v1(r1.begin(), r1.end(), r1_alloc_t(q));
+        std::vector<B, out_alloc_t> out(out_expected.size(), B{0xCD}, out_alloc_t(q));
+
+        dpl_ranges::partial_sort_copy(policy, std::ranges::subrange(v1), std::ranges::subrange(out), std::ranges::less{}, proj_a, proj_b);
+        EXPECT_EQ_RANGES(out_expected, out, "wrong result with device policy");
+    }
+#endif // TEST_DPCPP_BACKEND_PRESENT
+}
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+
+    auto checker = TEST_PREPARE_CALLABLE(std::ranges::partial_sort_copy);
+
+    test_range_algo<0, int, data_in_out_lim>{big_sz}(dpl_ranges::partial_sort_copy, checker);
+    test_range_algo<1, int, data_in_out_lim>{}(dpl_ranges::partial_sort_copy, checker, std::greater{}, proj, proj);
+    test_range_algo<2, P2, data_in_out_lim>{}(dpl_ranges::partial_sort_copy, checker, std::less{}, &P2::proj, &P2::x);
+    test_range_algo<3, P2, data_in_out_lim>{}(dpl_ranges::partial_sort_copy, checker, std::greater{}, &P2::x, &P2::proj);
+
+    // Check if projections are applied to the right sequences and trigger a compile-time error if not
+    test_mixed_types();
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/std_ranges_partial_sort_copy.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_partial_sort_copy.pass.cpp
@@ -49,6 +49,7 @@ void test_mixed_types()
     }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 }
+#endif //_ENABLE_STD_RANGES_TESTING
 
 std::int32_t
 main()

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -161,7 +161,7 @@ struct B
 {
     int b;
     operator int() const { return b; }
-    B& operator=(const A& a) { b = int(a); }
+    B& operator=(const A& a) { b = int(a); return *this; }
 };
 
 auto proj_a = [](const A& a) { return a.a; };

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -161,6 +161,7 @@ struct B
 {
     int b;
     operator int() const { return b; }
+    B& operator=(const A& a) { b = int(a); }
 };
 
 auto proj_a = [](const A& a) { return a.a; };


### PR DESCRIPTION
The only special thing in the implementation of `ranges::partial_sort_copy` is dealing with projections. The standard does not specify how the comparator applies, and seemingly it is possible to use it with either input values, or output values, or even with an input and an output value (and so with respective projections).

Therefore in order to fit the new API to the existing patterns that do not take projections we need to define how the comparator is used internally. It appears that our parallel and hetero implementations use the copy-then-sort approach, with the "copy" made either directly into the output data sequence or into a temporary buffer. So the best course seems to always compare the output values, and so only use the second projection. For that, I changed the temporary buffers to use the output value type.

The rest of the implementation is rather typical for oneDPL parallel range algorithms.