### PR TITLE
Add bfloat16_t support to radix sort

### DIFF
--- a/documentation/library_guide/kernel_templates/sycl/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/sycl/radix_sort.rst
@@ -97,7 +97,7 @@ Parameters
 **Type Requirements**:
 
 - The element type of sequence(s) to sort must be a C++ integral or floating-point type
-  other than ``bool`` with a width of up to 64 bits.
+  other than ``bool`` with a width of up to 64 bits, ``sycl::half``, or ``sycl::ext::oneapi::bfloat16``.
 
 .. note::
 

--- a/documentation/library_guide/kernel_templates/sycl/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/sycl/radix_sort.rst
@@ -100,7 +100,7 @@ Parameters
 
    - A C++ integral or floating-point type other than ``bool`` with a width of up to 64 bits.
    - ``sycl::half``.
-   - ``sycl::ext::oneapi::bfloat16``.
+   - ``sycl::ext::oneapi::bfloat16`` (requires Intel® oneAPI DPC++/C++ Compiler 2026.0 or greater).
 
 .. note::
 

--- a/documentation/library_guide/kernel_templates/sycl/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/sycl/radix_sort.rst
@@ -96,8 +96,11 @@ Parameters
 
 **Type Requirements**:
 
-- The element type of sequence(s) to sort must be a C++ integral or floating-point type
-  other than ``bool`` with a width of up to 64 bits, ``sycl::half``, or ``sycl::ext::oneapi::bfloat16``.
+- The element type of sequence(s) to sort must be one of the following:
+
+   - A C++ integral or floating-point type other than ``bool`` with a width of up to 64 bits.
+   - ``sycl::half``.
+   - ``sycl::ext::oneapi::bfloat16_t``.
 
 .. note::
 

--- a/documentation/library_guide/kernel_templates/sycl/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/sycl/radix_sort.rst
@@ -100,7 +100,7 @@ Parameters
 
    - A C++ integral or floating-point type other than ``bool`` with a width of up to 64 bits.
    - ``sycl::half``.
-   - ``sycl::ext::oneapi::bfloat16_t``.
+   - ``sycl::ext::oneapi::bfloat16``.
 
 .. note::
 

--- a/documentation/library_guide/kernel_templates/sycl/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/sycl/radix_sort_by_key.rst
@@ -103,8 +103,11 @@ Parameters
 
 **Type Requirements**:
 
-- The element type of sequence(s) to sort must be a C++ integral or floating-point type
-  other than ``bool`` with a width of up to 64 bits, ``sycl::half``, or ``sycl::ext::oneapi::bfloat16``.
+- The element type of sequence(s) to sort must be one of the following:
+
+   - A C++ integral or floating-point type other than ``bool`` with a width of up to 64 bits.
+   - ``sycl::half``.
+   - ``sycl::ext::oneapi::bfloat16_t``.
 
 .. note::
 

--- a/documentation/library_guide/kernel_templates/sycl/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/sycl/radix_sort_by_key.rst
@@ -104,7 +104,7 @@ Parameters
 **Type Requirements**:
 
 - The element type of sequence(s) to sort must be a C++ integral or floating-point type
-  other than ``bool`` with a width of up to 64 bits.
+  other than ``bool`` with a width of up to 64 bits, ``sycl::half``, or ``sycl::ext::oneapi::bfloat16``.
 
 .. note::
 

--- a/documentation/library_guide/kernel_templates/sycl/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/sycl/radix_sort_by_key.rst
@@ -107,7 +107,7 @@ Parameters
 
    - A C++ integral or floating-point type other than ``bool`` with a width of up to 64 bits.
    - ``sycl::half``.
-   - ``sycl::ext::oneapi::bfloat16``.
+   - ``sycl::ext::oneapi::bfloat16`` (requires Intel® oneAPI DPC++/C++ Compiler 2026.0 or greater).
 
 .. note::
 

--- a/documentation/library_guide/kernel_templates/sycl/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/sycl/radix_sort_by_key.rst
@@ -107,7 +107,7 @@ Parameters
 
    - A C++ integral or floating-point type other than ``bool`` with a width of up to 64 bits.
    - ``sycl::half``.
-   - ``sycl::ext::oneapi::bfloat16_t``.
+   - ``sycl::ext::oneapi::bfloat16``.
 
 .. note::
 

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -26,6 +26,9 @@ New Features
   ``transform_exclusive_scan`` with device policies for non-trivially-copyable value types on GPU devices.
 - Improved performance of the ``histogram_even`` and ``histogram_range`` algorithms with device policies for a small
   number of bins on GPU devices.
+- ``sort``, ``stable_sort``, ``sort_by_key`` algorithms, as well as the ``kt::gpu::radix_sort`` and
+  ``kt::gpu::radix_sort_by_key`` kernel templates, now use Radix sort [#fnote1]_ for sorting
+  ``sycl::ext::oneapi::bfloat16`` elements compared with ``std::less`` or ``std::greater``.
 
 Known Issues and Limitations
 ----------------------------
@@ -1176,9 +1179,10 @@ Known Issues and Limitations
   (including ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision.
 
-.. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types and
-  ``sycl::half`` (since oneDPL 2022.6) compared with ``less`` or ``greater`` from
-  the ``std`` and ``std::ranges`` (since oneDPL 2022.13) namespaces, otherwise Merge sort.
+.. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types,
+  ``sycl::half`` (since oneDPL 2022.6), and ``sycl::ext::oneapi::bfloat16`` (since oneDPL 2022.13)
+  compared with ``less`` or ``greater`` from the ``std`` and ``std::ranges`` (since oneDPL 2022.13)
+  namespaces, otherwise Merge sort.
 .. _`oneDPL Guide`: https://uxlfoundation.github.io/oneDPL/library_guide/index.html
 .. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
 .. _`restrictions and known limitations`: https://uxlfoundation.github.io/oneDPL/library_guide/introduction.html#restrictions.

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -8,6 +8,14 @@ The Intel® oneAPI DPC++ Library (oneDPL) accompanies the Intel® oneAPI DPC++/C
 and provides high-productivity APIs aimed to minimize programming efforts of C++ developers
 creating efficient heterogeneous applications.
 
+
+New in 2022.14.0
+================
+-  ``radix_sort`` and ``radix_sort_by_key`` algorithms from ``oneapi::dpl::experimental::kt::gpu`` namespace
+  now support ``sycl::ext::oneapi::bfloat16`` type,
+  and ``sort``, ``stable_sort``, ``sort_by_key``, ``stable_sort_by_key`` algorithms with device policies
+  now use use Radix sort [#fnote1]_ for sorting elements of this type .
+
 New in 2022.13.0
 ================
 
@@ -26,9 +34,6 @@ New Features
   ``transform_exclusive_scan`` with device policies for non-trivially-copyable value types on GPU devices.
 - Improved performance of the ``histogram_even`` and ``histogram_range`` algorithms with device policies for a small
   number of bins on GPU devices.
-- ``sort``, ``stable_sort``, ``sort_by_key`` algorithms, as well as the ``kt::gpu::radix_sort`` and
-  ``kt::gpu::radix_sort_by_key`` kernel templates, now use Radix sort [#fnote1]_ for sorting
-  ``sycl::ext::oneapi::bfloat16`` elements compared with ``std::less`` or ``std::greater``.
 
 Known Issues and Limitations
 ----------------------------
@@ -1180,7 +1185,7 @@ Known Issues and Limitations
   for double precision.
 
 .. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types,
-  ``sycl::half`` (since oneDPL 2022.6), and ``sycl::ext::oneapi::bfloat16`` (since oneDPL 2022.13)
+  ``sycl::half`` (since oneDPL 2022.6), and ``sycl::ext::oneapi::bfloat16`` (since oneDPL 2022.14)
   compared with ``less`` or ``greater`` from the ``std`` and ``std::ranges`` (since oneDPL 2022.13)
   namespaces, otherwise Merge sort.
 .. _`oneDPL Guide`: https://uxlfoundation.github.io/oneDPL/library_guide/index.html

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -8,14 +8,6 @@ The Intel® oneAPI DPC++ Library (oneDPL) accompanies the Intel® oneAPI DPC++/C
 and provides high-productivity APIs aimed to minimize programming efforts of C++ developers
 creating efficient heterogeneous applications.
 
-
-New in 2022.14.0
-================
--  ``radix_sort`` and ``radix_sort_by_key`` algorithms from ``oneapi::dpl::experimental::kt::gpu`` namespace
-  now support ``sycl::ext::oneapi::bfloat16`` type,
-  and ``sort``, ``stable_sort``, ``sort_by_key``, ``stable_sort_by_key`` algorithms with device policies
-  now use use Radix sort [#fnote1]_ for sorting elements of this type .
-
 New in 2022.13.0
 ================
 
@@ -1184,10 +1176,9 @@ Known Issues and Limitations
   (including ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision.
 
-.. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types,
-  ``sycl::half`` (since oneDPL 2022.6), and ``sycl::ext::oneapi::bfloat16`` (since oneDPL 2022.14)
-  compared with ``less`` or ``greater`` from the ``std`` and ``std::ranges`` (since oneDPL 2022.13)
-  namespaces, otherwise Merge sort.
+.. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types and
+  ``sycl::half`` (since oneDPL 2022.6) compared with ``less`` or ``greater`` from
+  the ``std`` and ``std::ranges`` (since oneDPL 2022.13) namespaces, otherwise Merge sort.
 .. _`oneDPL Guide`: https://uxlfoundation.github.io/oneDPL/library_guide/index.html
 .. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
 .. _`restrictions and known limitations`: https://uxlfoundation.github.io/oneDPL/library_guide/introduction.html#restrictions.

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -92,81 +92,6 @@ __get_bucket_scalar(_T __value, std::uint32_t __radix_offset)
     return std::uint16_t(__value >> __radix_offset) & __radix_mask;
 }
 
-// Order-preserving cast for bool - scalar version
-// Do not use bool directly - other unsupported types may be implicitly converted to bool
-template <bool __is_ascending, typename _BoolT, std::enable_if_t<std::is_same_v<_BoolT, bool>, int> = 0>
-bool
-__order_preserving_cast_scalar(_BoolT __src)
-{
-    if constexpr (__is_ascending)
-        return __src;
-    else
-        return !__src;
-}
-
-// Order-preserving cast for unsigned integers - scalar version
-template <bool __is_ascending, typename _UInt,
-          std::enable_if_t<std::is_unsigned_v<_UInt> && !std::is_same_v<_UInt, bool>, int> = 0>
-_UInt
-__order_preserving_cast_scalar(_UInt __src)
-{
-    if constexpr (__is_ascending)
-        return __src;
-    else
-        return ~__src; // bitwise inversion
-}
-
-// Order-preserving cast for signed integers - scalar version
-template <bool __is_ascending, typename _Int,
-          std::enable_if_t<std::is_integral_v<_Int> && std::is_signed_v<_Int>, int> = 0>
-std::make_unsigned_t<_Int>
-__order_preserving_cast_scalar(_Int __src)
-{
-    using _UInt = std::make_unsigned_t<_Int>;
-    // __mask: 100..0 for ascending, 011..1 for descending
-    constexpr _UInt __mask =
-        (__is_ascending) ? _UInt(1) << std::numeric_limits<_Int>::digits : std::numeric_limits<_UInt>::max() >> 1;
-    return sycl::bit_cast<_UInt>(__src) ^ __mask;
-}
-
-template <std::size_t __size>
-struct __uint_for_size;
-template <> struct __uint_for_size<2> { using type = std::uint16_t; };
-template <> struct __uint_for_size<4> { using type = std::uint32_t; };
-template <> struct __uint_for_size<8> { using type = std::uint64_t; };
-template <std::size_t __size>
-using __uint_for_size_t = typename __uint_for_size<__size>::type;
-
-template <typename _T>
-inline constexpr bool __is_radix_sort_float_v =
-    std::is_same_v<_T, sycl::half>
-#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
-    || std::is_same_v<_T, sycl::ext::oneapi::bfloat16>
-#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
-    || (std::is_floating_point_v<_T> && (sizeof(_T) == sizeof(std::uint32_t) || sizeof(_T) == sizeof(std::uint64_t)));
-
-// Order-preserving cast for floating-point types - scalar version
-template <bool __is_ascending, typename _Float, std::enable_if_t<__is_radix_sort_float_v<_Float>, int> = 0>
-__uint_for_size_t<sizeof(_Float)>
-__order_preserving_cast_scalar(_Float __src)
-{
-    using _UInt = __uint_for_size_t<sizeof(_Float)>;
-    constexpr int __bits = std::numeric_limits<_UInt>::digits;
-    constexpr _UInt __sign_mask = _UInt(1) << (__bits - 1);
-    constexpr _UInt __magnitude_mask = _UInt(__sign_mask - 1);
-
-    _UInt __uint_src = sycl::bit_cast<_UInt>(__src);
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
-    if ((__uint_src & __magnitude_mask) == 0)
-        return __sign_mask;
-    _UInt __mask;
-    if constexpr (__is_ascending)
-        __mask = ((__uint_src & __sign_mask) == 0) ? __sign_mask : std::numeric_limits<_UInt>::max();
-    else
-        __mask = ((__uint_src & __sign_mask) == 0) ? __magnitude_mask : _UInt(0);
-    return __uint_src ^ __mask;
-}
-
 //-----------------------------------------------------------------------------
 // Sort identity values - used to pad incomplete blocks during sorting
 //-----------------------------------------------------------------------------
@@ -185,11 +110,12 @@ __sort_identity()
 // They do not set the smallest exponent bit (i.e. the max is 7F7FFFFF for 32bit float),
 // thus such an identity is not guaranteed to be put at the end of the sorted sequence after each radix sort stage,
 // e.g. 00FF0000 numbers will be pushed out by 7F7FFFFF identities when sorting 16-23 bits.
-template <typename _T, bool __is_ascending, std::enable_if_t<__is_radix_sort_float_v<_T>, int> = 0>
+template <typename _T, bool __is_ascending,
+          std::enable_if_t<oneapi::dpl::__internal::__is_radix_sort_float_v<_T>, int> = 0>
 constexpr _T
 __sort_identity()
 {
-    using _UInt = __uint_for_size_t<sizeof(_T)>;
+    using _UInt = oneapi::dpl::__internal::__uint_for_size_t<sizeof(_T)>;
     if constexpr (__is_ascending)
         return sycl::bit_cast<_T>(_UInt(std::numeric_limits<_UInt>::max() >> 1));
     else

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -93,9 +93,10 @@ __get_bucket_scalar(_T __value, std::uint32_t __radix_offset)
 }
 
 // Order-preserving cast for bool - scalar version
-template <bool __is_ascending>
+// Do not use bool directly - other unsupported types may be implicitly converted to bool
+template <bool __is_ascending, typename _BoolT, std::enable_if_t<std::is_same_v<_BoolT, bool>, int> = 0>
 bool
-__order_preserving_cast_scalar(bool __src)
+__order_preserving_cast_scalar(_BoolT __src)
 {
     if constexpr (__is_ascending)
         return __src;
@@ -104,7 +105,8 @@ __order_preserving_cast_scalar(bool __src)
 }
 
 // Order-preserving cast for unsigned integers - scalar version
-template <bool __is_ascending, typename _UInt, std::enable_if_t<std::is_unsigned_v<_UInt>, int> = 0>
+template <bool __is_ascending, typename _UInt,
+          std::enable_if_t<std::is_unsigned_v<_UInt> && !std::is_same_v<_UInt, bool>, int> = 0>
 _UInt
 __order_preserving_cast_scalar(_UInt __src)
 {

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -105,11 +105,6 @@ __sort_identity()
         return std::numeric_limits<_T>::lowest();
 }
 
-// std::numeric_limits<_T>::max and std::numeric_limits<_T>::lowest cannot be used as an identity for
-// performing radix sort of floating point numbers.
-// They do not set the smallest exponent bit (i.e. the max is 7F7FFFFF for 32bit float),
-// thus such an identity is not guaranteed to be put at the end of the sorted sequence after each radix sort stage,
-// e.g. 00FF0000 numbers will be pushed out by 7F7FFFFF identities when sorting 16-23 bits.
 template <typename _T, bool __is_ascending,
           std::enable_if_t<oneapi::dpl::__internal::__is_radix_sort_float_v<_T>, int> = 0>
 constexpr _T

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -127,98 +127,42 @@ __order_preserving_cast_scalar(_Int __src)
     return sycl::bit_cast<_UInt>(__src) ^ __mask;
 }
 
-// Order-preserving cast for 16-bit floats - scalar version
-template <bool __is_ascending>
-std::uint16_t
-__order_preserving_cast_scalar(sycl::half __src)
-{
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
-    if (__src == sycl::half{0})
-        return 0x8000u;
-    std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
-    std::uint16_t __mask;
-    bool __sign_bit_is_zero = (__uint16_src >> 15 == 0);
-    if constexpr (__is_ascending)
-    {
-        __mask = __sign_bit_is_zero ? 0x8000u : 0xFFFFu;
-    }
-    else
-    {
-        __mask = __sign_bit_is_zero ? 0x7FFFu : std::uint16_t(0);
-    }
-    return __uint16_src ^ __mask;
-}
+template <std::size_t __size>
+struct __uint_for_size;
+template <> struct __uint_for_size<2> { using type = std::uint16_t; };
+template <> struct __uint_for_size<4> { using type = std::uint32_t; };
+template <> struct __uint_for_size<8> { using type = std::uint64_t; };
+template <std::size_t __size>
+using __uint_for_size_t = typename __uint_for_size<__size>::type;
 
+template <typename _T>
+inline constexpr bool __is_radix_sort_float_v =
+    std::is_same_v<_T, sycl::half>
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16)
-// Order-preserving cast for bfloat16 - scalar version
-template <bool __is_ascending>
-std::uint16_t
-__order_preserving_cast_scalar(sycl::ext::oneapi::bfloat16 __src)
-{
-    std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
-    // Detected via the bit pattern (rather than a floating-point comparison with 0) because bfloat16 denormals
-    // widen to float32 subnormals, which a floating-point comparison may flush to zero.
-    if ((__uint16_src & 0x7FFFu) == 0)
-        return 0x8000u;
-    std::uint16_t __mask;
-    bool __sign_bit_is_zero = (__uint16_src >> 15 == 0);
-    if constexpr (__is_ascending)
-    {
-        __mask = __sign_bit_is_zero ? 0x8000u : 0xFFFFu;
-    }
-    else
-    {
-        __mask = __sign_bit_is_zero ? 0x7FFFu : std::uint16_t(0);
-    }
-    return __uint16_src ^ __mask;
-}
+    || std::is_same_v<_T, sycl::ext::oneapi::bfloat16>
 #endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
+    || (std::is_floating_point_v<_T> && (sizeof(_T) == sizeof(std::uint32_t) || sizeof(_T) == sizeof(std::uint64_t)));
 
-// Order-preserving cast for 32-bit floats - scalar version
-template <bool __is_ascending, typename _Float,
-          std::enable_if_t<std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(std::uint32_t), int> = 0>
-std::uint32_t
+// Order-preserving cast for floating-point types - scalar version
+template <bool __is_ascending, typename _Float, std::enable_if_t<__is_radix_sort_float_v<_Float>, int> = 0>
+__uint_for_size_t<sizeof(_Float)>
 __order_preserving_cast_scalar(_Float __src)
 {
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
-    if (__src == _Float{0})
-        return 0x80000000u;
-    std::uint32_t __uint32_src = sycl::bit_cast<std::uint32_t>(__src);
-    std::uint32_t __mask;
-    bool __sign_bit_is_zero = (__uint32_src >> 31 == 0);
-    if constexpr (__is_ascending)
-    {
-        __mask = __sign_bit_is_zero ? 0x80000000u : 0xFFFFFFFFu;
-    }
-    else
-    {
-        __mask = __sign_bit_is_zero ? 0x7FFFFFFFu : std::uint32_t(0);
-    }
-    return __uint32_src ^ __mask;
-}
+    using _UInt = __uint_for_size_t<sizeof(_Float)>;
+    constexpr int __bits = std::numeric_limits<_UInt>::digits;
+    constexpr _UInt __sign_mask = _UInt(1) << (__bits - 1);
+    constexpr _UInt __magnitude_mask = _UInt(__sign_mask - 1);
 
-// Order-preserving cast for 64-bit floats - scalar version
-template <bool __is_ascending, typename _Float,
-          std::enable_if_t<std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(std::uint64_t), int> = 0>
-std::uint64_t
-__order_preserving_cast_scalar(_Float __src)
-{
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
-    if (__src == _Float{0})
-        return 0x8000000000000000u;
-    std::uint64_t __uint64_src = sycl::bit_cast<std::uint64_t>(__src);
-    std::uint64_t __mask;
-    bool __sign_bit_is_zero = (__uint64_src >> 63 == 0);
+    _UInt __uint_src = sycl::bit_cast<_UInt>(__src);
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
+    if ((__uint_src & __magnitude_mask) == 0)
+        return __sign_mask;
+    _UInt __mask;
     if constexpr (__is_ascending)
-    {
-        __mask = __sign_bit_is_zero ? 0x8000000000000000u : 0xFFFFFFFFFFFFFFFFu;
-    }
+        __mask = ((__uint_src & __sign_mask) == 0) ? __sign_mask : std::numeric_limits<_UInt>::max();
     else
-    {
-        __mask = __sign_bit_is_zero ? 0x7FFFFFFFFFFFFFFFu : std::uint64_t(0);
-    }
-    return __uint64_src ^ __mask;
+        __mask = ((__uint_src & __sign_mask) == 0) ? __magnitude_mask : _UInt(0);
+    return __uint_src ^ __mask;
 }
 
 //-----------------------------------------------------------------------------
@@ -239,48 +183,15 @@ __sort_identity()
 // They do not set the smallest exponent bit (i.e. the max is 7F7FFFFF for 32bit float),
 // thus such an identity is not guaranteed to be put at the end of the sorted sequence after each radix sort stage,
 // e.g. 00FF0000 numbers will be pushed out by 7F7FFFFF identities when sorting 16-23 bits.
-template <typename _T, bool __is_ascending, std::enable_if_t<std::is_same_v<_T, sycl::half>, int> = 0>
+template <typename _T, bool __is_ascending, std::enable_if_t<__is_radix_sort_float_v<_T>, int> = 0>
 constexpr _T
 __sort_identity()
 {
+    using _UInt = __uint_for_size_t<sizeof(_T)>;
     if constexpr (__is_ascending)
-        return sycl::bit_cast<_T>(std::uint16_t(0x7FFFu));
+        return sycl::bit_cast<_T>(_UInt(std::numeric_limits<_UInt>::max() >> 1));
     else
-        return sycl::bit_cast<_T>(std::uint16_t(0xFFFFu));
-}
-
-#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
-template <typename _T, bool __is_ascending, std::enable_if_t<std::is_same_v<_T, sycl::ext::oneapi::bfloat16>, int> = 0>
-constexpr _T
-__sort_identity()
-{
-    if constexpr (__is_ascending)
-        return sycl::bit_cast<_T>(std::uint16_t(0x7FFFu));
-    else
-        return sycl::bit_cast<_T>(std::uint16_t(0xFFFFu));
-}
-#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
-
-template <typename _T, bool __is_ascending,
-          std::enable_if_t<std::is_floating_point_v<_T> && sizeof(_T) == sizeof(std::uint32_t), int> = 0>
-constexpr _T
-__sort_identity()
-{
-    if constexpr (__is_ascending)
-        return sycl::bit_cast<_T>(0x7FFF'FFFFu);
-    else
-        return sycl::bit_cast<_T>(0xFFFF'FFFFu);
-}
-
-template <typename _T, bool __is_ascending,
-          std::enable_if_t<std::is_floating_point_v<_T> && sizeof(_T) == sizeof(std::uint64_t), int> = 0>
-constexpr _T
-__sort_identity()
-{
-    if constexpr (__is_ascending)
-        return sycl::bit_cast<_T>(0x7FFF'FFFF'FFFF'FFFFu);
-    else
-        return sycl::bit_cast<_T>(0xFFFF'FFFF'FFFF'FFFFu);
+        return sycl::bit_cast<_T>(std::numeric_limits<_UInt>::max());
 }
 
 template <std::uint16_t _N, typename _KeyT>

--- a/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/radix_sort_utils.h
@@ -149,6 +149,32 @@ __order_preserving_cast_scalar(sycl::half __src)
     return __uint16_src ^ __mask;
 }
 
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+// Order-preserving cast for bfloat16 - scalar version
+template <bool __is_ascending>
+std::uint16_t
+__order_preserving_cast_scalar(sycl::ext::oneapi::bfloat16 __src)
+{
+    std::uint16_t __uint16_src = sycl::bit_cast<std::uint16_t>(__src);
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
+    // Detected via the bit pattern (rather than a floating-point comparison with 0) because bfloat16 denormals
+    // widen to float32 subnormals, which a floating-point comparison may flush to zero.
+    if ((__uint16_src & 0x7FFFu) == 0)
+        return 0x8000u;
+    std::uint16_t __mask;
+    bool __sign_bit_is_zero = (__uint16_src >> 15 == 0);
+    if constexpr (__is_ascending)
+    {
+        __mask = __sign_bit_is_zero ? 0x8000u : 0xFFFFu;
+    }
+    else
+    {
+        __mask = __sign_bit_is_zero ? 0x7FFFu : std::uint16_t(0);
+    }
+    return __uint16_src ^ __mask;
+}
+#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
+
 // Order-preserving cast for 32-bit floats - scalar version
 template <bool __is_ascending, typename _Float,
           std::enable_if_t<std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(std::uint32_t), int> = 0>
@@ -222,6 +248,18 @@ __sort_identity()
     else
         return sycl::bit_cast<_T>(std::uint16_t(0xFFFFu));
 }
+
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+template <typename _T, bool __is_ascending, std::enable_if_t<std::is_same_v<_T, sycl::ext::oneapi::bfloat16>, int> = 0>
+constexpr _T
+__sort_identity()
+{
+    if constexpr (__is_ascending)
+        return sycl::bit_cast<_T>(std::uint16_t(0x7FFFu));
+    else
+        return sycl::bit_cast<_T>(std::uint16_t(0xFFFFu));
+}
+#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
 
 template <typename _T, bool __is_ascending,
           std::enable_if_t<std::is_floating_point_v<_T> && sizeof(_T) == sizeof(std::uint32_t), int> = 0>

--- a/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/sycl_radix_sort_kernels.h
@@ -129,7 +129,8 @@ struct __global_histogram<__sycl_tag, __is_ascending, __radix_bits, __hist_work_
                 for (std::uint32_t __i = 0; __i < __hist_data_per_work_item; ++__i)
                 {
                     _BinT __bucket = __get_bucket_scalar<__mask>(
-                        __order_preserving_cast_scalar<__is_ascending>(__keys[__i]), __stage * __radix_bits);
+                        oneapi::dpl::__internal::__order_preserving_cast<__is_ascending>(__keys[__i]),
+                        __stage * __radix_bits);
                     _GlobOffsetT __bin = __stage * __bin_count + __bucket;
                     using _SLMAtomicRef =
                         sycl::atomic_ref<_GlobOffsetT, sycl::memory_order::relaxed, sycl::memory_scope::work_group,
@@ -662,8 +663,8 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
         {
             _LocIdxT __slm_idx = __keys_slm_offset + __i * __sub_group_size + __sub_group_local_id;
             _KeyT __key = __slm_keys[__slm_idx];
-            _LocIdxT __bin = __get_bucket_scalar<__mask>(__order_preserving_cast_scalar<__is_ascending>(__key),
-                                                         __stage * __radix_bits);
+            _LocIdxT __bin = __get_bucket_scalar<__mask>(
+                oneapi::dpl::__internal::__order_preserving_cast<__is_ascending>(__key), __stage * __radix_bits);
             _GlobOffsetT __global_fix = __slm_global_fix[__bin];
             _GlobOffsetT __out_idx = __global_fix + __slm_idx;
 
@@ -710,7 +711,8 @@ struct __radix_sort_onesweep_kernel<__sycl_tag, __is_ascending, __radix_bits, __
             _ONEDPL_PRAGMA_UNROLL
             for (std::uint32_t __i = 0; __i < __data_per_work_item; ++__i)
             {
-                const auto __ordered = __order_preserving_cast_scalar<__is_ascending>(__values_pack.__keys[__i]);
+                const auto __ordered =
+                    oneapi::dpl::__internal::__order_preserving_cast<__is_ascending>(__values_pack.__keys[__i]);
                 __bins[__i] = __get_bucket_scalar<__mask>(__ordered, __stage * __radix_bits);
             }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1430,9 +1430,9 @@ struct __is_radix_sort_usable_for_type
 {
     static constexpr bool value =
 #if _ONEDPL_USE_RADIX_SORT
-        (::std::is_integral_v<_T> || oneapi::dpl::__internal::__is_radix_sort_float_v<_T>) &&
-        (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
-         __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
+        (std::is_integral_v<_T> || __internal::__is_radix_sort_float_v<_T>) &&
+        (__internal::__is_comp_ascending<std::decay_t<_Compare>>::value ||
+         __internal::__is_comp_descending<std::decay_t<_Compare>>::value);
 #else
         false;
 #endif // _ONEDPL_USE_RADIX_SORT

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1430,7 +1430,7 @@ struct __is_radix_sort_usable_for_type
 {
     static constexpr bool value =
 #if _ONEDPL_USE_RADIX_SORT
-        (std::is_integral_v<_T> || __internal::__is_radix_sort_float_v<_T>) &&
+        (std::is_integral_v<_T> || oneapi::dpl::__internal::__is_radix_sort_float_v<_T>) &&
         (__internal::__is_comp_ascending<std::decay_t<_Compare>>::value ||
          __internal::__is_comp_descending<std::decay_t<_Compare>>::value);
 #else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1430,7 +1430,11 @@ struct __is_radix_sort_usable_for_type
 {
     static constexpr bool value =
 #if _ONEDPL_USE_RADIX_SORT
-        (::std::is_arithmetic_v<_T> || ::std::is_same_v<sycl::half, _T>) &&
+        (::std::is_arithmetic_v<_T> || ::std::is_same_v<sycl::half, _T>
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+         || ::std::is_same_v<sycl::ext::oneapi::bfloat16, _T>
+#endif
+         ) &&
             (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
             __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
 #else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1430,7 +1430,7 @@ struct __is_radix_sort_usable_for_type
 {
     static constexpr bool value =
 #if _ONEDPL_USE_RADIX_SORT
-        (::std::is_integral_v<_T> || __is_radix_sort_float_v<_T>) &&
+        (::std::is_integral_v<_T> || oneapi::dpl::__internal::__is_radix_sort_float_v<_T>) &&
         (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
          __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
 #else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1430,13 +1430,9 @@ struct __is_radix_sort_usable_for_type
 {
     static constexpr bool value =
 #if _ONEDPL_USE_RADIX_SORT
-        (::std::is_arithmetic_v<_T> || ::std::is_same_v<sycl::half, _T>
-#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
-         || ::std::is_same_v<sycl::ext::oneapi::bfloat16, _T>
-#endif
-         ) &&
-            (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
-            __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
+        (::std::is_integral_v<_T> || __is_radix_sort_float_v<_T>) &&
+        (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
+         __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
 #else
         false;
 #endif // _ONEDPL_USE_RADIX_SORT

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -88,6 +88,27 @@ __order_preserving_cast(sycl::half __val)
     return __uint16_val ^ __mask;
 }
 
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+template <bool __is_ascending>
+::std::uint16_t
+__order_preserving_cast(sycl::ext::oneapi::bfloat16 __val)
+{
+    std::uint16_t __uint16_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint16_t>(__val);
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
+    // Detected via the bit pattern (rather than a floating-point comparison with 0) because bfloat16 denormals
+    // widen to float32 subnormals, which a floating-point comparison may flush to zero.
+    if ((__uint16_val & 0x7FFFu) == 0)
+        return 0x8000u;
+    ::std::uint16_t __mask;
+    // __uint16_val >> 15 takes the sign bit of the original value
+    if constexpr (__is_ascending)
+        __mask = (__uint16_val >> 15 == 0) ? 0x8000u : 0xFFFFu;
+    else
+        __mask = (__uint16_val >> 15 == 0) ? 0x7FFFu : ::std::uint16_t(0);
+    return __uint16_val ^ __mask;
+}
+#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
+
 template <bool __is_ascending, typename _Float,
           ::std::enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint32_t), int> = 0>
 ::std::uint32_t

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -73,12 +73,9 @@ __order_preserving_cast(_Int __val)
 
 template <std::size_t __size>
 struct __uint_for_size;
-template <>
-struct __uint_for_size<2> { using type = std::uint16_t; };
-template <>
-struct __uint_for_size<4> { using type = std::uint32_t; };
-template <>
-struct __uint_for_size<8> { using type = std::uint64_t; };
+template <> struct __uint_for_size<2> { using type = std::uint16_t; };
+template <> struct __uint_for_size<4> { using type = std::uint32_t; };
+template <> struct __uint_for_size<8> { using type = std::uint64_t; };
 template <std::size_t __size>
 using __uint_for_size_t = typename __uint_for_size<__size>::type;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -39,9 +39,10 @@ namespace __par_backend_hetero
 // radix sort: bitwise order-preserving conversions to unsigned integrals
 //------------------------------------------------------------------------
 
-template <bool __is_ascending>
+// Do not use bool directly - other unsupported types may be implicitly converted to bool
+template <bool __is_ascending, typename _BoolT, ::std::enable_if_t<::std::is_same_v<_BoolT, bool>, int> = 0>
 bool
-__order_preserving_cast(bool __val)
+__order_preserving_cast(_BoolT __val)
 {
     if constexpr (__is_ascending)
         return __val;
@@ -49,7 +50,8 @@ __order_preserving_cast(bool __val)
         return !__val;
 }
 
-template <bool __is_ascending, typename _UInt, ::std::enable_if_t<::std::is_unsigned_v<_UInt>, int> = 0>
+template <bool __is_ascending, typename _UInt,
+          ::std::enable_if_t<::std::is_unsigned_v<_UInt> && !::std::is_same_v<_UInt, bool>, int> = 0>
 _UInt
 __order_preserving_cast(_UInt __val)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -26,6 +26,7 @@
 #include "sycl_defs.h"
 #include "parallel_backend_sycl_utils.h"
 #include "execution_sycl_defs.h"
+#include "../../utils.h" // for __order_preserving_cast, __dpl_ceiling_div
 
 #include "sycl_traits.h" //SYCL traits specialization for some oneDPL types.
 
@@ -35,81 +36,6 @@ namespace dpl
 {
 namespace __par_backend_hetero
 {
-//------------------------------------------------------------------------
-// radix sort: bitwise order-preserving conversions to unsigned integrals
-//------------------------------------------------------------------------
-
-// Do not use bool directly - other unsupported types may be implicitly converted to bool
-template <bool __is_ascending, typename _BoolT, ::std::enable_if_t<::std::is_same_v<_BoolT, bool>, int> = 0>
-bool
-__order_preserving_cast(_BoolT __val)
-{
-    if constexpr (__is_ascending)
-        return __val;
-    else
-        return !__val;
-}
-
-template <bool __is_ascending, typename _UInt,
-          ::std::enable_if_t<::std::is_unsigned_v<_UInt> && !::std::is_same_v<_UInt, bool>, int> = 0>
-_UInt
-__order_preserving_cast(_UInt __val)
-{
-    if constexpr (__is_ascending)
-        return __val;
-    else
-        return ~__val; //bitwise inversion
-}
-
-template <bool __is_ascending, typename _Int,
-          ::std::enable_if_t<::std::is_integral_v<_Int> && ::std::is_signed_v<_Int>, int> = 0>
-::std::make_unsigned_t<_Int>
-__order_preserving_cast(_Int __val)
-{
-    using _UInt = ::std::make_unsigned_t<_Int>;
-    // mask: 100..0 for ascending, 011..1 for descending
-    constexpr _UInt __mask =
-        (__is_ascending) ? _UInt(1) << ::std::numeric_limits<_Int>::digits : ::std::numeric_limits<_UInt>::max() >> 1;
-    return __val ^ __mask;
-}
-
-template <std::size_t __size>
-struct __uint_for_size;
-template <> struct __uint_for_size<2> { using type = std::uint16_t; };
-template <> struct __uint_for_size<4> { using type = std::uint32_t; };
-template <> struct __uint_for_size<8> { using type = std::uint64_t; };
-template <std::size_t __size>
-using __uint_for_size_t = typename __uint_for_size<__size>::type;
-
-template <typename _T>
-inline constexpr bool __is_radix_sort_float_v =
-    std::is_same_v<_T, sycl::half>
-#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
-    || std::is_same_v<_T, sycl::ext::oneapi::bfloat16>
-#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
-    || (std::is_floating_point_v<_T> && (sizeof(_T) == sizeof(std::uint32_t) || sizeof(_T) == sizeof(std::uint64_t)));
-
-template <bool __is_ascending, typename _Float, std::enable_if_t<__is_radix_sort_float_v<_Float>, int> = 0>
-__uint_for_size_t<sizeof(_Float)>
-__order_preserving_cast(_Float __val)
-{
-    using _UInt = __uint_for_size_t<sizeof(_Float)>;
-    constexpr int __bits = std::numeric_limits<_UInt>::digits;
-    constexpr _UInt __sign_mask = _UInt(1) << (__bits - 1);
-    constexpr _UInt __magnitude_mask = _UInt(__sign_mask - 1);
-
-    _UInt __uint_val = oneapi::dpl::__internal::__dpl_bit_cast<_UInt>(__val);
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
-    if ((__uint_val & __magnitude_mask) == 0)
-        return __sign_mask;
-    _UInt __mask;
-    if constexpr (__is_ascending)
-        __mask = ((__uint_val & __sign_mask) == 0) ? __sign_mask : std::numeric_limits<_UInt>::max();
-    else
-        __mask = ((__uint_val & __sign_mask) == 0) ? __magnitude_mask : _UInt(0);
-    return __uint_val ^ __mask;
-}
-
 //------------------------------------------------------------------------
 // radix sort: bucket functions
 //------------------------------------------------------------------------
@@ -204,7 +130,7 @@ __radix_sort_count_impl(_InputRange& __input, _Proj __proj, std::uint32_t __radi
         _ONEDPL_PRAGMA_UNROLL
         for (std::size_t __unroll = 0; __unroll < __unroll_elements; ++__unroll)
         {
-            auto __val = __order_preserving_cast<__is_ascending>(
+            auto __val = oneapi::dpl::__internal::__order_preserving_cast<__is_ascending>(
                 std::invoke(__proj, __input[__base_idx + __unroll * __sg_size]));
             std::uint32_t __bucket = __get_bucket<(1 << __radix_bits) - 1>(__val, __radix_offset);
             ++__slm_buckets[__views.__get_bucket_idx(__bucket, __self_lidx)];
@@ -221,7 +147,8 @@ __radix_sort_count_impl(_InputRange& __input, _Proj __proj, std::uint32_t __radi
             std::size_t __curr_idx = __base_idx + __unroll * __sg_size;
             if (__curr_idx < __sg_chunk_end)
             {
-                auto __val = __order_preserving_cast<__is_ascending>(std::invoke(__proj, __input[__curr_idx]));
+                auto __val = oneapi::dpl::__internal::__order_preserving_cast<__is_ascending>(
+                    std::invoke(__proj, __input[__curr_idx]));
                 std::uint32_t __bucket = __get_bucket<(1 << __radix_bits) - 1>(__val, __radix_offset);
                 ++__slm_buckets[__views.__get_bucket_idx(__bucket, __self_lidx)];
             }
@@ -543,7 +470,8 @@ __radix_sort_reorder_impl(_InputRange& __input, _OutputRange& __output, _OffsetR
         std::uint32_t __local_counts[__radix_states] = {0};
         for (std::size_t __idx = __wi_start; __idx < __wi_end; ++__idx)
         {
-            auto __val = __order_preserving_cast<__is_ascending>(std::invoke(__proj, __input[__idx]));
+            auto __val =
+                oneapi::dpl::__internal::__order_preserving_cast<__is_ascending>(std::invoke(__proj, __input[__idx]));
             ++__local_counts[__get_bucket<(1 << __radix_bits) - 1>(__val, __radix_offset)];
         }
 
@@ -612,7 +540,8 @@ __radix_sort_reorder_impl(_InputRange& __input, _OutputRange& __output, _OffsetR
     {
         auto __in_val = __input[__idx];
         std::uint32_t __bucket = __get_bucket<(1 << __radix_bits) - 1>(
-            __order_preserving_cast<__is_ascending>(std::invoke(__proj, __in_val)), __radix_offset);
+            oneapi::dpl::__internal::__order_preserving_cast<__is_ascending>(std::invoke(__proj, __in_val)),
+            __radix_offset);
         __output[__offsets[__bucket]++] = std::move(__in_val);
     }
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -71,78 +71,44 @@ __order_preserving_cast(_Int __val)
     return __val ^ __mask;
 }
 
-template <bool __is_ascending>
-::std::uint16_t
-__order_preserving_cast(sycl::half __val)
-{
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
-    if (__val == sycl::half{0})
-        return 0x8000u;
-    std::uint16_t __uint16_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint16_t>(__val);
-    ::std::uint16_t __mask;
-    // __uint16_val >> 15 takes the sign bit of the original value
-    if constexpr (__is_ascending)
-        __mask = (__uint16_val >> 15 == 0) ? 0x8000u : 0xFFFFu;
-    else
-        __mask = (__uint16_val >> 15 == 0) ? 0x7FFFu : ::std::uint16_t(0);
-    return __uint16_val ^ __mask;
-}
+template <std::size_t __size>
+struct __uint_for_size;
+template <>
+struct __uint_for_size<2> { using type = std::uint16_t; };
+template <>
+struct __uint_for_size<4> { using type = std::uint32_t; };
+template <>
+struct __uint_for_size<8> { using type = std::uint64_t; };
+template <std::size_t __size>
+using __uint_for_size_t = typename __uint_for_size<__size>::type;
 
+template <typename _T>
+inline constexpr bool __is_radix_sort_float_v =
+    std::is_same_v<_T, sycl::half>
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16)
-template <bool __is_ascending>
-::std::uint16_t
-__order_preserving_cast(sycl::ext::oneapi::bfloat16 __val)
-{
-    std::uint16_t __uint16_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint16_t>(__val);
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
-    // Detected via the bit pattern (rather than a floating-point comparison with 0) because bfloat16 denormals
-    // widen to float32 subnormals, which a floating-point comparison may flush to zero.
-    if ((__uint16_val & 0x7FFFu) == 0)
-        return 0x8000u;
-    ::std::uint16_t __mask;
-    // __uint16_val >> 15 takes the sign bit of the original value
-    if constexpr (__is_ascending)
-        __mask = (__uint16_val >> 15 == 0) ? 0x8000u : 0xFFFFu;
-    else
-        __mask = (__uint16_val >> 15 == 0) ? 0x7FFFu : ::std::uint16_t(0);
-    return __uint16_val ^ __mask;
-}
+    || std::is_same_v<_T, sycl::ext::oneapi::bfloat16>
 #endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
+    || (std::is_floating_point_v<_T> && (sizeof(_T) == sizeof(std::uint32_t) || sizeof(_T) == sizeof(std::uint64_t)));
 
-template <bool __is_ascending, typename _Float,
-          ::std::enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint32_t), int> = 0>
-::std::uint32_t
+template <bool __is_ascending, typename _Float, std::enable_if_t<__is_radix_sort_float_v<_Float>, int> = 0>
+__uint_for_size_t<sizeof(_Float)>
 __order_preserving_cast(_Float __val)
 {
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
-    if (__val == _Float{0})
-        return 0x80000000u;
-    std::uint32_t __uint32_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint32_t>(__val);
-    ::std::uint32_t __mask;
-    // __uint32_val >> 31 takes the sign bit of the original value
-    if constexpr (__is_ascending)
-        __mask = (__uint32_val >> 31 == 0) ? 0x80000000u : 0xFFFFFFFFu;
-    else
-        __mask = (__uint32_val >> 31 == 0) ? 0x7FFFFFFFu : ::std::uint32_t(0);
-    return __uint32_val ^ __mask;
-}
+    using _UInt = __uint_for_size_t<sizeof(_Float)>;
+    constexpr int __bits = std::numeric_limits<_UInt>::digits;
+    constexpr _UInt __sign_mask = _UInt(1) << (__bits - 1);
+    constexpr _UInt __magnitude_mask = _UInt(__sign_mask - 1);
 
-template <bool __is_ascending, typename _Float,
-          ::std::enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint64_t), int> = 0>
-::std::uint64_t
-__order_preserving_cast(_Float __val)
-{
-    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation
-    if (__val == _Float{0})
-        return 0x8000000000000000u;
-    std::uint64_t __uint64_val = oneapi::dpl::__internal::__dpl_bit_cast<std::uint64_t>(__val);
-    ::std::uint64_t __mask;
-    // __uint64_val >> 63 takes the sign bit of the original value
+    _UInt __uint_val = oneapi::dpl::__internal::__dpl_bit_cast<_UInt>(__val);
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
+    if ((__uint_val & __magnitude_mask) == 0)
+        return __sign_mask;
+    _UInt __mask;
     if constexpr (__is_ascending)
-        __mask = (__uint64_val >> 63 == 0) ? 0x8000000000000000u : 0xFFFFFFFFFFFFFFFFu;
+        __mask = ((__uint_val & __sign_mask) == 0) ? __sign_mask : std::numeric_limits<_UInt>::max();
     else
-        __mask = (__uint64_val >> 63 == 0) ? 0x7FFFFFFFFFFFFFFFu : ::std::uint64_t(0);
-    return __uint64_val ^ __mask;
+        __mask = ((__uint_val & __sign_mask) == 0) ? __magnitude_mask : _UInt(0);
+    return __uint_val ^ __mask;
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -223,7 +223,7 @@ struct __subgroup_radix_sort
                                     const std::uint16_t __bin =
                                         __idx < __n
                                             ? __get_bucket</*mask*/ __bin_count - 1>(
-                                                  __order_preserving_cast<__is_asc>(
+                                                  oneapi::dpl::__internal::__order_preserving_cast<__is_asc>(
                                                       std::invoke(__proj, __values.__v[__i])),
                                                   __begin_bit)
                                             : __bin_count - 1 /*default bin for out of range elements (when idx >= n)*/;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -22,7 +22,8 @@
 #include <new>
 #include <tuple>
 #include <utility>
-#include <climits>
+#include <limits>
+#include <climits> // for CHAR_BIT
 #include <iterator>
 #include <functional>
 #include <type_traits>
@@ -666,6 +667,97 @@ __dpl_signbit(const _T& __x)
     static_assert(std::is_signed_v<_T>, "Only signed types have a signbit.");
     constexpr __unsigned_type __mask = (__unsigned_type{1} << (sizeof(_T) * 8 - 1));
     return (__x & __mask) != 0;
+}
+
+//-----------------------------------------------------------------------
+// Order-preserving bitwise casts to unsigned integrals, used by radix sort
+//-----------------------------------------------------------------------
+
+template <std::size_t __size>
+struct __uint_for_size;
+template <>
+struct __uint_for_size<2>
+{
+    using type = std::uint16_t;
+};
+template <>
+struct __uint_for_size<4>
+{
+    using type = std::uint32_t;
+};
+template <>
+struct __uint_for_size<8>
+{
+    using type = std::uint64_t;
+};
+template <std::size_t __size>
+using __uint_for_size_t = typename __uint_for_size<__size>::type;
+
+// The floating-point types __order_preserving_cast is defined for: the ones with an unsigned integer of the same
+// size to map onto. A wider type, e.g. a 128-bit long double, is not supported.
+template <typename _T>
+inline constexpr bool __is_radix_sort_float_v =
+#if _ONEDPL_BACKEND_SYCL
+    std::is_same_v<_T, sycl::half> ||
+#    if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+    std::is_same_v<_T, sycl::ext::oneapi::bfloat16> ||
+#    endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
+#endif     // _ONEDPL_BACKEND_SYCL
+    (std::is_floating_point_v<_T> && (sizeof(_T) == sizeof(std::uint32_t) || sizeof(_T) == sizeof(std::uint64_t)));
+
+// Do not use bool directly - other unsupported types may be implicitly converted to bool
+template <bool __is_ascending, typename _BoolT, std::enable_if_t<std::is_same_v<_BoolT, bool>, int> = 0>
+bool
+__order_preserving_cast(_BoolT __val)
+{
+    if constexpr (__is_ascending)
+        return __val;
+    else
+        return !__val;
+}
+
+template <bool __is_ascending, typename _UInt,
+          std::enable_if_t<std::is_unsigned_v<_UInt> && !std::is_same_v<_UInt, bool>, int> = 0>
+_UInt
+__order_preserving_cast(_UInt __val)
+{
+    if constexpr (__is_ascending)
+        return __val;
+    else
+        return ~__val; //bitwise inversion
+}
+
+template <bool __is_ascending, typename _Int,
+          std::enable_if_t<std::is_integral_v<_Int> && std::is_signed_v<_Int>, int> = 0>
+std::make_unsigned_t<_Int>
+__order_preserving_cast(_Int __val)
+{
+    using _UInt = std::make_unsigned_t<_Int>;
+    // mask: 100..0 for ascending, 011..1 for descending
+    constexpr _UInt __mask =
+        (__is_ascending) ? _UInt(1) << std::numeric_limits<_Int>::digits : std::numeric_limits<_UInt>::max() >> 1;
+    return __val ^ __mask;
+}
+
+template <bool __is_ascending, typename _Float, std::enable_if_t<__is_radix_sort_float_v<_Float>, int> = 0>
+__uint_for_size_t<sizeof(_Float)>
+__order_preserving_cast(_Float __val)
+{
+    using _UInt = __uint_for_size_t<sizeof(_Float)>;
+    constexpr int __bits = std::numeric_limits<_UInt>::digits;
+    constexpr _UInt __sign_mask = _UInt(1) << (__bits - 1);
+    constexpr _UInt __magnitude_mask = _UInt(__sign_mask - 1);
+
+    _UInt __uint_val = __dpl_bit_cast<_UInt>(__val);
+    // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
+    if ((__uint_val & __magnitude_mask) == 0)
+        return __sign_mask;
+    _UInt __mask;
+    if constexpr (__is_ascending)
+        __mask = ((__uint_val & __sign_mask) == 0) ? __sign_mask : std::numeric_limits<_UInt>::max();
+    else
+        __mask = ((__uint_val & __sign_mask) == 0) ? __magnitude_mask : _UInt(0);
+    return __uint_val ^ __mask;
 }
 
 template <typename _Size, typename _Comparator>

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -748,10 +748,11 @@ __order_preserving_cast(_Float __val)
     constexpr _UInt __sign_mask = _UInt(1) << (__bits - 1);
     constexpr _UInt __magnitude_mask = _UInt(__sign_mask - 1);
 
-    _UInt __uint_val = __dpl_bit_cast<_UInt>(__val);
     // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
     if (__val == _Float{0})
         return __sign_mask;
+
+    _UInt __uint_val = __dpl_bit_cast<_UInt>(__val);
     _UInt __mask;
     if constexpr (__is_ascending)
         __mask = ((__uint_val & __sign_mask) == 0) ? __sign_mask : std::numeric_limits<_UInt>::max();

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -750,7 +750,7 @@ __order_preserving_cast(_Float __val)
 
     _UInt __uint_val = __dpl_bit_cast<_UInt>(__val);
     // Map +0/-0 to the uppermost bit to place zero at the negative/positive boundary in its unsigned representation.
-    if ((__uint_val & __magnitude_mask) == 0)
+    if (__val == _Float{0})
         return __sign_mask;
     _UInt __mask;
     if constexpr (__is_ascending)

--- a/test/kt/CMakeLists.txt
+++ b/test/kt/CMakeLists.txt
@@ -15,6 +15,13 @@
 option(ONEDPL_TEST_ENABLE_KT_ESIMD "Enable ESIMD-based kernel template tests")
 option(ONEDPL_TEST_ENABLE_KT_SYCL "Enable SYCL-based kernel template tests")
 
+# SYCL_EXT_ONEAPI_BFLOAT16 feature test macro was added only in 2026.0
+if (NOT INTEL_LLVM_COMPILER OR NOT INTEL_LLVM_COMPILER_VERSION VERSION_LESS 2026.0)
+    set(_bfloat16_key_type_supported TRUE)
+else()
+    set(_bfloat16_key_type_supported FALSE) # Skip silently in order not to spam the output
+endif()
+
 function(_generate_test _target_name _test_path)
     add_executable(${_target_name} EXCLUDE_FROM_ALL ${_test_path})
 
@@ -110,7 +117,10 @@ function(_generate_sort_tests _variant _key_value_pairs)
     if ("${_variant}" STREQUAL "kt_sycl")
         set(_data_per_work_item_all "1" "2" "3" "4" "5" "6" "7" "8" "9" "10" "11" "12" "13" "14" "15" "16")
         set(_work_group_size_all "1024" "512")
-        set(_type_all "char" "uint16_t" "int" "uint64_t" "float" "double" "sycl::half" "sycl::ext::oneapi::bfloat16")
+        set(_type_all "char" "uint16_t" "int" "uint64_t" "float" "double" "sycl::half")
+        if (_bfloat16_key_type_supported)
+            list(APPEND _type_all "sycl::ext::oneapi::bfloat16")
+        endif()
     else() # kt_esimd
         set(_data_per_work_item_all "32" "64" "96" "128" "160" "192" "224" "256" "288" "320" "352" "384" "416" "448" "480" "512")
         set(_work_group_size_all "64")
@@ -156,7 +166,9 @@ if (ONEDPL_TEST_ENABLE_KT_SYCL)
     _generate_sort_test("kt_sycl" "radix_sort_by_key_out_of_place" "3" "1024" "uint32_t" "uint32_t" 1000)
     _generate_sort_test("kt_sycl" "radix_sort_by_key" "5" "512" "float" "uint32_t" 1000)
     _generate_sort_test("kt_sycl" "radix_sort" "12" "1024" "int32_t" "" 1000)
-    _generate_sort_test("kt_sycl" "radix_sort_by_key" "7" "512" "sycl::ext::oneapi::bfloat16" "uint32_t" 1000)
+    if (_bfloat16_key_type_supported)
+        _generate_sort_test("kt_sycl" "radix_sort_by_key" "7" "512" "sycl::ext::oneapi::bfloat16" "uint32_t" 1000)
+    endif()
 endif()
 
 function (_generate_gpu_scan_test _data_per_work_item _work_group_size _type _probability_permille)

--- a/test/kt/CMakeLists.txt
+++ b/test/kt/CMakeLists.txt
@@ -110,12 +110,12 @@ function(_generate_sort_tests _variant _key_value_pairs)
     if ("${_variant}" STREQUAL "kt_sycl")
         set(_data_per_work_item_all "1" "2" "3" "4" "5" "6" "7" "8" "9" "10" "11" "12" "13" "14" "15" "16")
         set(_work_group_size_all "1024" "512")
+        set(_type_all "char" "uint16_t" "int" "uint64_t" "float" "double" "sycl::half" "sycl::ext::oneapi::bfloat16")
     else() # kt_esimd
         set(_data_per_work_item_all "32" "64" "96" "128" "160" "192" "224" "256" "288" "320" "352" "384" "416" "448" "480" "512")
         set(_work_group_size_all "64")
+        set(_type_all "char" "uint16_t" "int" "uint64_t" "float" "double" "sycl::half")
     endif()
-
-    set(_type_all "char" "uint16_t" "int" "uint64_t" "float" "double" "sycl::half")
 
     foreach (_data_per_work_item ${_data_per_work_item_all})
         foreach (_work_group_size ${_work_group_size_all})
@@ -156,6 +156,7 @@ if (ONEDPL_TEST_ENABLE_KT_SYCL)
     _generate_sort_test("kt_sycl" "radix_sort_by_key_out_of_place" "3" "1024" "uint32_t" "uint32_t" 1000)
     _generate_sort_test("kt_sycl" "radix_sort_by_key" "5" "512" "float" "uint32_t" 1000)
     _generate_sort_test("kt_sycl" "radix_sort" "12" "1024" "int32_t" "" 1000)
+    _generate_sort_test("kt_sycl" "radix_sort_by_key" "7" "512" "sycl::ext::oneapi::bfloat16" "uint32_t" 1000)
 endif()
 
 function (_generate_gpu_scan_test _data_per_work_item _work_group_size _type _probability_permille)

--- a/test/kt/CMakeLists.txt
+++ b/test/kt/CMakeLists.txt
@@ -16,7 +16,7 @@ option(ONEDPL_TEST_ENABLE_KT_ESIMD "Enable ESIMD-based kernel template tests")
 option(ONEDPL_TEST_ENABLE_KT_SYCL "Enable SYCL-based kernel template tests")
 
 # SYCL_EXT_ONEAPI_BFLOAT16 feature test macro was added only in 2026.0
-if (NOT INTEL_LLVM_COMPILER OR NOT INTEL_LLVM_COMPILER_VERSION VERSION_LESS 2026.0)
+if (INTEL_LLVM_COMPILER AND NOT INTEL_LLVM_COMPILER_VERSION VERSION_LESS 2026.0)
     set(_bfloat16_key_type_supported TRUE)
 else()
     set(_bfloat16_key_type_supported FALSE) # Skip silently in order not to spam the output

--- a/test/kt/radix_sort_by_key.cpp
+++ b/test/kt/radix_sort_by_key.cpp
@@ -144,7 +144,11 @@ int main()
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
                     q, size, TestUtils::create_new_kernel_param_idx<3>(params));
             }
-            if constexpr (std::is_floating_point_v<TEST_KEY_TYPE> || std::is_same_v<TEST_KEY_TYPE, sycl::half>)
+            if constexpr (std::is_floating_point_v<TEST_KEY_TYPE> || std::is_same_v<TEST_KEY_TYPE, sycl::half>
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+                          || std::is_same_v<TEST_KEY_TYPE, sycl::ext::oneapi::bfloat16>
+#endif
+            )
             {
                 test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
                     q, 64, TestUtils::create_new_kernel_param_idx<4>(params));

--- a/test/kt/radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/radix_sort_by_key_out_of_place.cpp
@@ -189,7 +189,11 @@ main()
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
                     q, size, TestUtils::create_new_kernel_param_idx<3>(params));
             }
-            if constexpr (std::is_floating_point_v<TEST_KEY_TYPE> || std::is_same_v<TEST_KEY_TYPE, sycl::half>)
+            if constexpr (std::is_floating_point_v<TEST_KEY_TYPE> || std::is_same_v<TEST_KEY_TYPE, sycl::half>
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+                          || std::is_same_v<TEST_KEY_TYPE, sycl::ext::oneapi::bfloat16>
+#endif
+            )
             {
                 test_negative_zero_stability<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
                     q, 64, TestUtils::create_new_kernel_param_idx<4>(params));

--- a/test/parallel_api/algorithm/alg.sorting/alg.sort/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.sort/sort.pass.cpp
@@ -50,6 +50,15 @@ int main()
     test_sort<TestUtils::float64_t>(SortTestConfig{cfg, "float64_t, device"}, small_sizes, Device<5>{},
                                     Converter<TestUtils::float64_t>{});
     test_sort<sycl::half>(SortTestConfig{cfg, "sycl::half, device"}, small_sizes, Device<6>{}, half_converter);
+
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+    auto bfloat16_converter = [](size_t /*index*/, size_t val) {
+        return TestUtils::sycl_bfloat16_convert(std::uint16_t(val & 0xFFFFu));
+    };
+    test_sort<sycl::ext::oneapi::bfloat16>(SortTestConfig{cfg, "sycl::ext::oneapi::bfloat16, device"}, small_sizes,
+                                           Device<7>{}, bfloat16_converter);
+#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
+
     // TODO: add a test for a MoveConstructible only type
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
@@ -299,7 +299,7 @@ test_device_policy(Policy&& exec, StabilityTag stability_tag)
                                                                                             large_size, stability_tag);
     test_with_buffers<sycl::ext::oneapi::bfloat16, sycl::ext::oneapi::bfloat16, 11>(CLONE_TEST_POLICY(exec),
                                                                                     small_size, stability_tag,
-                                                                                    custom_greater);
+                                                                                    std::greater{});
 #endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
 
     if constexpr (std::is_same_v<StabilityTag, StableSortTag>)

--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key_common.h
@@ -294,6 +294,14 @@ test_device_policy(Policy&& exec, StabilityTag stability_tag)
     test_with_buffers<Particle::energy_type, Particle, 4>(CLONE_TEST_POLICY(exec), large_size, stability_tag, custom_greater);
     test_with_buffers<Particle::energy_type, Particle, 5>(CLONE_TEST_POLICY(exec), small_size, stability_tag);
 
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+    test_with_usm<sycl::ext::oneapi::bfloat16, std::uint32_t, sycl::usm::alloc::shared, 10>(CLONE_TEST_POLICY(exec),
+                                                                                            large_size, stability_tag);
+    test_with_buffers<sycl::ext::oneapi::bfloat16, sycl::ext::oneapi::bfloat16, 11>(CLONE_TEST_POLICY(exec),
+                                                                                    small_size, stability_tag,
+                                                                                    custom_greater);
+#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
+
     if constexpr (std::is_same_v<StabilityTag, StableSortTag>)
     {
         test_negative_zero_stability<float, std::uint32_t, sycl::usm::alloc::shared, 6>(CLONE_TEST_POLICY(exec),
@@ -309,6 +317,10 @@ test_device_policy(Policy&& exec, StabilityTag stability_tag)
             test_negative_zero_stability<sycl::half, std::uint32_t, sycl::usm::alloc::shared, 8>(
                 CLONE_TEST_POLICY(exec), small_size);
         }
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+        test_negative_zero_stability<sycl::ext::oneapi::bfloat16, std::uint32_t, sycl::usm::alloc::shared, 9>(
+            CLONE_TEST_POLICY(exec), small_size);
+#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
     }
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1090,9 +1090,11 @@ generate_arithmetic_data(sycl::half* input, std::size_t size, std::uint32_t seed
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16)
 // Convert raw uint16 bits to a valid sycl::ext::oneapi::bfloat16, avoiding NaN values which
 // need a custom comparator due to: (x < NaN = false) and (NaN < x = false).
-// Also avoids denormals: bfloat16 shares float's 8-bit exponent, so a denormal bfloat16 widens to a genuine
-// float32 subnormal, which some compilers/devices flush to zero, making distinct keys compare as equal
-// under a floating-point reference comparator even though the library sorts them correctly by their bits.
+// Also avoids denormals: this compiler's bfloat16::operator< converts both operands to float
+// by reinterpreting the raw bits as float32 (bfloat16 is defined as float32's top 16 bits), so
+// a denormal bfloat16 becomes a denormal float32 during every comparison. Some compilers/devices
+// flush float32 denormals to zero, making distinct keys compare as equal even though
+// oneDPL sorts them correctly by their bits.
 inline sycl::ext::oneapi::bfloat16
 sycl_bfloat16_convert(std::uint16_t raw)
 {

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1090,11 +1090,6 @@ generate_arithmetic_data(sycl::half* input, std::size_t size, std::uint32_t seed
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16)
 // Convert raw uint16 bits to a valid sycl::ext::oneapi::bfloat16, avoiding NaN values which
 // need a custom comparator due to: (x < NaN = false) and (NaN < x = false).
-// Also avoids denormals: this compiler's bfloat16::operator< converts both operands to float
-// by reinterpreting the raw bits as float32 (bfloat16 is defined as float32's top 16 bits), so
-// a denormal bfloat16 becomes a denormal float32 during every comparison. Some compilers/devices
-// flush float32 denormals to zero, making distinct keys compare as equal even though
-// oneDPL sorts them correctly by their bits.
 inline sycl::ext::oneapi::bfloat16
 sycl_bfloat16_convert(std::uint16_t raw)
 {
@@ -1105,12 +1100,6 @@ sycl_bfloat16_convert(std::uint16_t raw)
     {
         constexpr std::uint16_t smallest_exp_bit = 0x0080u;
         raw = raw & (~smallest_exp_bit);
-    }
-    bool is_denormal = ((raw & exp_mask) == 0) && ((raw & frac_mask) != 0);
-    if (is_denormal)
-    {
-        constexpr std::uint16_t smallest_normal_exp_bit = 0x0080u;
-        raw = raw | smallest_normal_exp_bit;
     }
     return sycl::bit_cast<sycl::ext::oneapi::bfloat16>(raw);
 }

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -1086,6 +1086,46 @@ generate_arithmetic_data(sycl::half* input, std::size_t size, std::uint32_t seed
     for (std::uint32_t i = 0, j = unique_threshold; j < size; ++i, ++j)
         input[j] = input[i];
 }
+
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+// Convert raw uint16 bits to a valid sycl::ext::oneapi::bfloat16, avoiding NaN values which
+// need a custom comparator due to: (x < NaN = false) and (NaN < x = false).
+// Also avoids denormals: bfloat16 shares float's 8-bit exponent, so a denormal bfloat16 widens to a genuine
+// float32 subnormal, which some compilers/devices flush to zero, making distinct keys compare as equal
+// under a floating-point reference comparator even though the library sorts them correctly by their bits.
+inline sycl::ext::oneapi::bfloat16
+sycl_bfloat16_convert(std::uint16_t raw)
+{
+    constexpr std::uint16_t exp_mask = 0x7F80u;
+    constexpr std::uint16_t frac_mask = 0x007Fu;
+    bool is_nan = ((raw & exp_mask) == exp_mask) && ((raw & frac_mask) > 0);
+    if (is_nan)
+    {
+        constexpr std::uint16_t smallest_exp_bit = 0x0080u;
+        raw = raw & (~smallest_exp_bit);
+    }
+    bool is_denormal = ((raw & exp_mask) == 0) && ((raw & frac_mask) != 0);
+    if (is_denormal)
+    {
+        constexpr std::uint16_t smallest_normal_exp_bit = 0x0080u;
+        raw = raw | smallest_normal_exp_bit;
+    }
+    return sycl::bit_cast<sycl::ext::oneapi::bfloat16>(raw);
+}
+
+inline void
+generate_arithmetic_data(sycl::ext::oneapi::bfloat16* input, std::size_t size, std::uint32_t seed)
+{
+    std::default_random_engine gen{seed};
+    std::size_t unique_threshold = 75 * size / 100;
+    std::uniform_int_distribution<std::uint16_t> dist(0, 0xFFFFu);
+
+    assert(unique_threshold >= size / 2 && unique_threshold < size);
+    std::generate(input, input + unique_threshold, [&]() { return sycl_bfloat16_convert(dist(gen)); });
+    for (std::uint32_t i = 0, j = unique_threshold; j < size; ++i, ++j)
+        input[j] = input[i];
+}
+#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 // Utility that models __estimate_best_start_size in the SYCL backend parallel_for to ensure large enough inputs are

--- a/test/support/utils_sort.h
+++ b/test/support/utils_sort.h
@@ -244,6 +244,14 @@ Equal(const sycl::half& x, const sycl::half& y, bool /*is_stable*/)
 {
     return x == y;
 }
+
+#if defined(SYCL_EXT_ONEAPI_BFLOAT16)
+inline bool
+Equal(const sycl::ext::oneapi::bfloat16& x, const sycl::ext::oneapi::bfloat16& y, bool /*is_stable*/)
+{
+    return x == y;
+}
+#endif // defined(SYCL_EXT_ONEAPI_BFLOAT16)
 #endif
 
 template <typename T, typename Compare>


### PR DESCRIPTION
bfloat16_t description: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_bfloat16.asciidoc

Refactoring changes:

1. Unified floating point __order_preserving_cast functions.
2. Unified __order_preserving_cast implementations for core sort functions and KT SYCL radix sort. They were actually the same. I just moved them into the common utility header, which was already used by both implementations.