### PR TITLE
Increase the library version number.

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -37,7 +37,7 @@ copyright = 'Intel Corporation'
 author = 'Intel'
 
 # The full version, including alpha/beta/rc tags
-release = '2022.13.0'
+release = '2022.14.0'
 
 rst_epilog = """
 .. include:: /_auxiliary/variables.txt

--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -12,7 +12,7 @@
 
 // The library version
 #define ONEDPL_VERSION_MAJOR 2022
-#define ONEDPL_VERSION_MINOR 13
+#define ONEDPL_VERSION_MINOR 14
 #define ONEDPL_VERSION_PATCH 0
 
 // The oneAPI Specification version this implementation is compliant with

--- a/test/general/version.pass.cpp
+++ b/test/general/version.pass.cpp
@@ -25,7 +25,7 @@ static_assert(_PSTL_VERSION_PATCH == 0);
 #endif
 
 static_assert(ONEDPL_VERSION_MAJOR == 2022);
-static_assert(ONEDPL_VERSION_MINOR == 13);
+static_assert(ONEDPL_VERSION_MINOR == 14);
 static_assert(ONEDPL_VERSION_PATCH == 0);
 
 #include "support/utils.h"


### PR DESCRIPTION
#2776 will update the parallel range APIs feature test macro so I think this is all that is needed to complete version update work for the upcoming release.