### PR TITLE
Bugfix for adapters which may omit writes

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -517,7 +517,7 @@ struct __get_sycl_range
         assert(__first < __last);
 
         // no_init is dropped for the base sequence because all elements may not be written to for transform iterator.
-        // The unary functor many not expose the underlying references for writing for instance.
+        // The unary functor may not expose the underlying references for writing for instance.
         auto res = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(), __last.base());
         auto rng = oneapi::dpl::__ranges::transform_view_simple<decltype(res.all_view()), decltype(__first.functor())>{
             res.all_view(), __first.functor()};

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -516,7 +516,9 @@ struct __get_sycl_range
     {
         assert(__first < __last);
 
-        auto res = __process_input_iter<_LocalAccMode, _LocalNoInit>(__first.base(), __last.base());
+        // no_init is dropped for the base sequence because all elements may not be written to for transform iterator.
+        // The unary functor many not expose the underlying references for writing for instance.
+        auto res = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(), __last.base());
         auto rng = oneapi::dpl::__ranges::transform_view_simple<decltype(res.all_view()), decltype(__first.functor())>{
             res.all_view(), __first.functor()};
 
@@ -574,7 +576,8 @@ struct __get_sycl_range
         //   offset, and use that to recurse as a sycl_iterator over the __base_buffer.
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
-        auto res_src = __process_input_iter<_LocalAccMode, _LocalNoInit>(
+        // no_init is dropped for the base sequence because all elements may not be written to for permutation iterator
+        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(
             oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(), oneapi::dpl::end(__base_buffer));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
@@ -619,7 +622,10 @@ struct __get_sycl_range
         //      of a combination of fancy_iterators, sycl_iterators, and passed_directly types.
         //      Currently this relies on UB because the size of the accessor when handling sycl_iterators
         //      in recursion below this level is incorrect.
-        auto res_src = this->operator()(__first.base(), __first.base() + 1 /*source size*/);
+        
+        // no_init is dropped for the base sequence because all elements may not be written to
+        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(),
+                                                                                   __first.base() + 1 /*source size*/);
 
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -622,7 +622,7 @@ struct __get_sycl_range
         //      of a combination of fancy_iterators, sycl_iterators, and passed_directly types.
         //      Currently this relies on UB because the size of the accessor when handling sycl_iterators
         //      in recursion below this level is incorrect.
-        
+
         // no_init is dropped for the base sequence because all elements may not be written to
         auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(),
                                                                                    __first.base() + 1 /*source size*/);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -678,11 +678,12 @@ struct __get_sycl_range
     template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint = _DeferToUserHint,
               typename _Iter>
     auto
-    __process_input_iter(_Iter __first, _Iter __last) -> std::enable_if_t<
-        oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter>,
-        __range_holder<oneapi::dpl::__ranges::all_view<
-            val_t<_Iter>, __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>::__value,
-            __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>::__no_init>>>
+    __process_input_iter(_Iter __first, _Iter __last)
+        -> std::enable_if_t<
+            oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter>,
+            __range_holder<oneapi::dpl::__ranges::all_view<
+                val_t<_Iter>, __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>::__value,
+                __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>::__no_init>>>
     {
         using __resolver = __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>;
         constexpr sycl::access::mode __resolved_mode = __resolver::__value;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -450,19 +450,20 @@ struct __get_sycl_range
         _LocalAccMode == sycl::access::mode::read_write || _LocalAccMode == sycl::access::mode::write;
 
   private:
-    // Pass through the provided {mode, no_init}. When _DeferToUserHint is true and _Iter is a sycl_iterator,
+    // Pass through the provided {mode, no_init}. When _LocalDeferToUserHint is true and _Iter is a sycl_iterator,
     // the specialization below instead resolves them from the iterator's embedded user hint (the inverse of
     // __access_mode_resolver).
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename /*_Iter*/, typename = void>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint, typename /*_Iter*/,
+              typename = void>
     struct __resolve_access_mode
     {
         static constexpr sycl::access::mode __value = _LocalAccMode;
         static constexpr bool __no_init = _LocalNoInit;
     };
 
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
-    struct __resolve_access_mode<_LocalAccMode, _LocalNoInit, _Iter,
-                                 std::enable_if_t<_DeferToUserHint && is_sycl_iterator<_Iter>::value>>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint, typename _Iter>
+    struct __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter,
+                                 std::enable_if_t<_LocalDeferToUserHint && is_sycl_iterator<_Iter>::value>>
         : oneapi::dpl::__internal::__extracted_access_mode<_Iter::mode>
     {
     };
@@ -480,36 +481,36 @@ struct __get_sycl_range
     template <typename It>
     static constexpr bool __is_addressable_v = decltype(__is_addressable<It>(0))::value;
 
-    template <typename _F, typename _It, typename _DiffType>
-    static auto
-    __gen_view(_F& __f, _It __it, _DiffType __n) -> decltype(__f(__it, __it + __n))
-    {
-        return __f(__it, __it + __n);
-    }
-
-    template <typename _TupleType, typename _DiffType, ::std::size_t... _Ip>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint, typename _TupleType,
+              typename _DiffType, std::size_t... _Ip>
     auto
     gen_zip_view(_TupleType __t, _DiffType __n, ::std::index_sequence<_Ip...>)
     {
-        // Send each zipped iterator to `gen_view` which recursively calls __get_sycl_range() to process them.
-        auto tmp = oneapi::dpl::__internal::make_tuple(__gen_view(*this, ::std::get<_Ip>(__t), __n)...);
+        // Each zipped iterator is processed recursively, propagating the {access mode, no_init, user hint deference}
+        // of the zip_iterator itself to each of its constituent iterators.
+        auto tmp = oneapi::dpl::__internal::make_tuple(
+            __process_input_iter<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint>(std::get<_Ip>(__t),
+                                                                                     std::get<_Ip>(__t) + __n)...);
         return oneapi::dpl::__ranges::make_zip_view(::std::get<_Ip>(tmp).all_view()...);
     }
 
     //zip iterators
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename... Iters>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint = _DeferToUserHint,
+              typename... Iters>
     auto
     __process_input_iter(oneapi::dpl::zip_iterator<Iters...> __first, oneapi::dpl::zip_iterator<Iters...> __last)
     {
         assert(__first < __last);
 
         const ::std::size_t __num_it = sizeof...(Iters);
-        auto rng = gen_zip_view(__first.base(), __last - __first, ::std::make_index_sequence<__num_it>());
+        auto rng = gen_zip_view<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint>(
+            __first.base(), __last - __first, std::make_index_sequence<__num_it>());
         return __range_holder<decltype(rng)>{rng};
     }
 
     //specialization for transform_iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter, typename _UnaryFunction>
+    template <sycl::access::mode _LocalAccMode, bool /*_LocalNoInit*/,
+              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Iter, typename _UnaryFunction>
     auto
     __process_input_iter(oneapi::dpl::transform_iterator<_Iter, _UnaryFunction> __first,
                          oneapi::dpl::transform_iterator<_Iter, _UnaryFunction> __last)
@@ -518,7 +519,10 @@ struct __get_sycl_range
 
         // no_init is dropped for the base sequence because all elements may not be written to for transform iterator.
         // The unary functor may not expose the underlying references for writing for instance.
-        auto res = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(), __last.base());
+        // For the same reason, any access mode hint the user embedded into the base iterator is overridden, the
+        // adapter, not the user, dictates how the base sequence is accessed.
+        auto res = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false, /*_LocalDeferToUserHint=*/false>(
+            __first.base(), __last.base());
         auto rng = oneapi::dpl::__ranges::transform_view_simple<decltype(res.all_view()), decltype(__first.functor())>{
             res.all_view(), __first.functor()};
 
@@ -526,13 +530,15 @@ struct __get_sycl_range
     }
 
     //specialization for std::reverse_iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint = _DeferToUserHint,
+              typename _Iter>
     auto
-    __process_input_iter(::std::reverse_iterator<_Iter> __first, ::std::reverse_iterator<_Iter> __last)
+    __process_input_iter(std::reverse_iterator<_Iter> __first, std::reverse_iterator<_Iter> __last)
     {
         assert(__first < __last);
 
-        auto __res = __process_input_iter<_LocalAccMode, _LocalNoInit>(__last.base(), __first.base());
+        auto __res =
+            __process_input_iter<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint>(__last.base(), __first.base());
         auto __rng = oneapi::dpl::__ranges::reverse_view_simple<decltype(__res.all_view())>{__res.all_view()};
 
         return __range_holder<decltype(__rng)>{__rng};
@@ -551,14 +557,17 @@ struct __get_sycl_range
     auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {
-        //For permutation iterator, the Map iterator is always read (only) without no_init
-        auto view_map =
-            __process_input_iter<sycl::access_mode::read, /*_LocalNoInit=*/false>(__m, __m + __s).all_view();
+        //For permutation iterator, the Map iterator is always read (only) without no_init, regardless of any access
+        // mode hint the user may have embedded into it
+        auto view_map = __process_input_iter<sycl::access_mode::read, /*_LocalNoInit=*/false,
+                                             /*_LocalDeferToUserHint=*/false>(__m, __m + __s)
+                            .all_view();
         return oneapi::dpl::__ranges::permutation_view_simple<_R, decltype(view_map)>{__r, view_map};
     }
 
     //specialization for permutation_iterator using sycl_iterator as source
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _It, typename _Map,
+    template <sycl::access::mode _LocalAccMode, bool /*_LocalNoInit*/,
+              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _It, typename _Map,
               std::enable_if_t<oneapi::dpl::__ranges::is_hetero_iterator_v<_It>, int> = 0>
     auto
     __process_input_iter(oneapi::dpl::permutation_iterator<_It, _Map> __first,
@@ -576,8 +585,10 @@ struct __get_sycl_range
         //   offset, and use that to recurse as a sycl_iterator over the __base_buffer.
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
-        // no_init is dropped for the base sequence because all elements may not be written to for permutation iterator
-        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(
+        // no_init is dropped for the base sequence because all elements may not be written to for permutation iterator.
+        // For the same reason, any access mode hint the user embedded into the base iterator is overridden, the
+        // adapter, not the user, dictates how the base sequence is accessed.
+        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false, /*_LocalDeferToUserHint=*/false>(
             oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(), oneapi::dpl::end(__base_buffer));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
@@ -587,7 +598,8 @@ struct __get_sycl_range
     }
 
     //specialization for permutation_iterator using USM pointer or direct pass object as source
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter, typename _Map,
+    template <sycl::access::mode /*_LocalAccMode*/, bool /*_LocalNoInit*/,
+              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Iter, typename _Map,
               std::enable_if_t<!oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter> &&
                                    oneapi::dpl::__ranges::__is_passed_directly_device_ready_v<_Iter>,
                                int> = 0>
@@ -607,7 +619,8 @@ struct __get_sycl_range
 
     // specialization for general case, permutation_iterator with base iterator that is not sycl_iterator or
     // device accessible content iterators.
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter, typename _Map,
+    template <sycl::access::mode _LocalAccMode, bool /*_LocalNoInit*/,
+              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Iter, typename _Map,
               std::enable_if_t<!oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter> &&
                                    !oneapi::dpl::__ranges::__is_passed_directly_device_ready_v<_Iter>,
                                int> = 0>
@@ -623,9 +636,10 @@ struct __get_sycl_range
         //      Currently this relies on UB because the size of the accessor when handling sycl_iterators
         //      in recursion below this level is incorrect.
 
-        // no_init is dropped for the base sequence because all elements may not be written to
-        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(),
-                                                                                   __first.base() + 1 /*source size*/);
+        // no_init is dropped for the base sequence because all elements may not be written to. For the same reason, any
+        // access mode hint the user embedded into the base iterator is overridden.
+        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false, /*_LocalDeferToUserHint=*/false>(
+            __first.base(), __first.base() + 1 /*source size*/);
 
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);
 
@@ -633,7 +647,8 @@ struct __get_sycl_range
     }
 
     //specialization for permutation discard iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Map>
+    template <sycl::access::mode /*_LocalAccMode*/, bool /*_LocalNoInit*/,
+              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Map>
     auto
     __process_input_iter(oneapi::dpl::permutation_iterator<oneapi::dpl::discard_iterator, _Map> __first,
                          oneapi::dpl::permutation_iterator<oneapi::dpl::discard_iterator, _Map> __last)
@@ -647,7 +662,8 @@ struct __get_sycl_range
     }
 
     // for raw pointers and direct pass objects (for example, counting_iterator, iterator of USM-containers)
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
+    template <sycl::access::mode /*_LocalAccMode*/, bool /*_LocalNoInit*/,
+              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Iter>
     std::enable_if_t<!oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter> &&
                          oneapi::dpl::__ranges::__is_passed_directly_device_ready_v<_Iter>,
                      __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>>
@@ -659,17 +675,18 @@ struct __get_sycl_range
     }
 
     //specialization for hetero iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint = _DeferToUserHint,
+              typename _Iter>
     auto
-    __process_input_iter(_Iter __first, _Iter __last)
-        -> std::enable_if_t<oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter>,
-                            __range_holder<oneapi::dpl::__ranges::all_view<
-                                val_t<_Iter>, __resolve_access_mode<_LocalAccMode, _LocalNoInit, _Iter>::__value,
-                                __resolve_access_mode<_LocalAccMode, _LocalNoInit, _Iter>::__no_init>>>
+    __process_input_iter(_Iter __first, _Iter __last) -> std::enable_if_t<
+        oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter>,
+        __range_holder<oneapi::dpl::__ranges::all_view<
+            val_t<_Iter>, __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>::__value,
+            __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>::__no_init>>>
     {
-        constexpr sycl::access::mode __resolved_mode =
-            __resolve_access_mode<_LocalAccMode, _LocalNoInit, _Iter>::__value;
-        constexpr bool __resolved_no_init = __resolve_access_mode<_LocalAccMode, _LocalNoInit, _Iter>::__no_init;
+        using __resolver = __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>;
+        constexpr sycl::access::mode __resolved_mode = __resolver::__value;
+        constexpr bool __resolved_no_init = __resolver::__no_init;
 
         static_assert(!(__resolved_mode == sycl::access::mode::read && __resolved_no_init),
                       "Read mode cannot be used with no_init property.");
@@ -694,7 +711,8 @@ struct __get_sycl_range
     }
 
     //SFINAE-overload for a contiguous host iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool /*_LocalDeferToUserHint*/ = _DeferToUserHint,
+              typename _Iter>
     auto
     __process_input_iter(_Iter __first, _Iter __last)
         -> std::enable_if_t<is_temp_buff<_Iter>::value && __is_addressable_v<_Iter> && !is_zip<_Iter>::value &&
@@ -725,7 +743,8 @@ struct __get_sycl_range
     }
 
     //SFINAE-overload for non-contiguous host iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool /*_LocalDeferToUserHint*/ = _DeferToUserHint,
+              typename _Iter>
     auto
     __process_input_iter(_Iter __first, _Iter __last)
         -> std::enable_if_t<is_temp_buff<_Iter>::value && !__is_addressable_v<_Iter> && !is_zip<_Iter>::value &&
@@ -783,8 +802,9 @@ struct __get_sycl_range
     auto
     operator()(_ArgTypes... __args)
     {
-        //when called using operator(), use access mode and no_init flag provided by the struct template parameters
-        return __process_input_iter<AccMode, _IsNoInitRequested>(std::forward<_ArgTypes>(__args)...);
+        //when called using operator(), use access mode, no_init flag and user hint deference provided by the struct
+        // template parameters
+        return __process_input_iter<AccMode, _IsNoInitRequested, _DeferToUserHint>(std::forward<_ArgTypes>(__args)...);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -513,8 +513,10 @@ struct __get_sycl_range
     {
         assert(__first < __last);
 
-        // no_init is dropped for the base sequence because all elements may not be written to for transform iterator.
+        // no_init property coming from algorithmic "knowledge", (example: copy() should write all elements of output)
+        // is dropped for the base sequence because all elements may not be written to for transform iterator.
         // The unary functor may not expose the underlying references for writing for instance.
+        // note: User hints of no_init for sycl_iterators are still respected
         auto res = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(), __last.base());
         auto rng = oneapi::dpl::__ranges::transform_view_simple<decltype(res.all_view()), decltype(__first.functor())>{
             res.all_view(), __first.functor()};
@@ -574,6 +576,7 @@ struct __get_sycl_range
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
         // no_init is dropped for the base sequence because all elements may not be written to for permutation iterator
+        // note: this only applies to algorithmic "knowledge" no_init, user no_init hints are still respected
         auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(
             oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(), oneapi::dpl::end(__base_buffer));
 
@@ -621,6 +624,7 @@ struct __get_sycl_range
         //      in recursion below this level is incorrect.
 
         // no_init is dropped for the base sequence because all elements may not be written to
+        // note: this only applies to algorithmic "knowledge" no_init, user no_init hints are still respected
         auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(),
                                                                                    __first.base() + 1 /*source size*/);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -473,7 +473,7 @@ struct __get_sycl_range
     //SFINAE iterator type checks
     template <typename It>
     static constexpr auto
-    __is_addressable(int) -> decltype(std::addressof(*::std::declval<It&>()), std::true_type{});
+    __is_addressable(int) -> decltype(std::addressof(*std::declval<It&>()), std::true_type{});
     template <typename It>
     static constexpr std::false_type
     __is_addressable(...);
@@ -483,13 +483,13 @@ struct __get_sycl_range
     template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _TupleType, typename _DiffType,
               std::size_t... _Ip>
     auto
-    gen_zip_view(_TupleType __t, _DiffType __n, ::std::index_sequence<_Ip...>)
+    gen_zip_view(_TupleType __t, _DiffType __n, std::index_sequence<_Ip...>)
     {
         // Each zipped iterator is processed recursively, propagating the {access mode, no_init} of the zip_iterator
         // itself to each of its constituent iterators.
         auto tmp = oneapi::dpl::__internal::make_tuple(
             __process_input_iter<_LocalAccMode, _LocalNoInit>(std::get<_Ip>(__t), std::get<_Ip>(__t) + __n)...);
-        return oneapi::dpl::__ranges::make_zip_view(::std::get<_Ip>(tmp).all_view()...);
+        return oneapi::dpl::__ranges::make_zip_view(std::get<_Ip>(tmp).all_view()...);
     }
 
     //zip iterators
@@ -499,7 +499,7 @@ struct __get_sycl_range
     {
         assert(__first < __last);
 
-        const ::std::size_t __num_it = sizeof...(Iters);
+        const std::size_t __num_it = sizeof...(Iters);
         auto rng = gen_zip_view<_LocalAccMode, _LocalNoInit>(__first.base(), __last - __first,
                                                              std::make_index_sequence<__num_it>());
         return __range_holder<decltype(rng)>{rng};
@@ -536,7 +536,7 @@ struct __get_sycl_range
     }
 
     template <typename _R, typename _Map, typename _Size,
-              ::std::enable_if_t<oneapi::dpl::__internal::__is_functor<_Map>, int> = 0>
+              std::enable_if_t<oneapi::dpl::__internal::__is_functor<_Map>, int> = 0>
     static auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {
@@ -544,7 +544,7 @@ struct __get_sycl_range
     }
 
     template <typename _R, typename _Map, typename _Size,
-              ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator_v<_Map>, int> = 0>
+              std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator_v<_Map>, int> = 0>
     auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {
@@ -706,7 +706,7 @@ struct __get_sycl_range
             if constexpr (__is_copy_direct_v<_LocalAccMode, _LocalNoInit>)
             {
                 //wait and copy on a buffer destructor; an exclusive access buffer, good performance
-                return sycl::buffer<_T, 1>{::std::addressof(*__first), __last - __first};
+                return sycl::buffer<_T, 1>{std::addressof(*__first), __last - __first};
 
                 //No call to sycl::buffer::set_final_data() is required here because this sycl::buffer ctor
                 // guarantees by specification that data will be written back to this host data pointer upon destruction
@@ -715,7 +715,7 @@ struct __get_sycl_range
             else
             {
                 sycl::buffer<_T, 1> __buf(__last - __first);
-                __buf.set_final_data(::std::addressof(*__first)); //wait and fast copy on a buffer destructor
+                __buf.set_final_data(std::addressof(*__first)); //wait and fast copy on a buffer destructor
                 return __buf;
             }
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -450,20 +450,19 @@ struct __get_sycl_range
         _LocalAccMode == sycl::access::mode::read_write || _LocalAccMode == sycl::access::mode::write;
 
   private:
-    // Pass through the provided {mode, no_init}. When _LocalDeferToUserHint is true and _Iter is a sycl_iterator,
+    // Pass through the provided {mode, no_init}. When _DeferToUserHint is true and _Iter is a sycl_iterator,
     // the specialization below instead resolves them from the iterator's embedded user hint (the inverse of
     // __access_mode_resolver).
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint, typename /*_Iter*/,
-              typename = void>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename /*_Iter*/, typename = void>
     struct __resolve_access_mode
     {
         static constexpr sycl::access::mode __value = _LocalAccMode;
         static constexpr bool __no_init = _LocalNoInit;
     };
 
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint, typename _Iter>
-    struct __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter,
-                                 std::enable_if_t<_LocalDeferToUserHint && is_sycl_iterator<_Iter>::value>>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
+    struct __resolve_access_mode<_LocalAccMode, _LocalNoInit, _Iter,
+                                 std::enable_if_t<_DeferToUserHint && is_sycl_iterator<_Iter>::value>>
         : oneapi::dpl::__internal::__extracted_access_mode<_Iter::mode>
     {
     };
@@ -481,36 +480,33 @@ struct __get_sycl_range
     template <typename It>
     static constexpr bool __is_addressable_v = decltype(__is_addressable<It>(0))::value;
 
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint, typename _TupleType,
-              typename _DiffType, std::size_t... _Ip>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _TupleType, typename _DiffType,
+              std::size_t... _Ip>
     auto
     gen_zip_view(_TupleType __t, _DiffType __n, ::std::index_sequence<_Ip...>)
     {
-        // Each zipped iterator is processed recursively, propagating the {access mode, no_init, user hint deference}
-        // of the zip_iterator itself to each of its constituent iterators.
+        // Each zipped iterator is processed recursively, propagating the {access mode, no_init} of the zip_iterator
+        // itself to each of its constituent iterators.
         auto tmp = oneapi::dpl::__internal::make_tuple(
-            __process_input_iter<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint>(std::get<_Ip>(__t),
-                                                                                     std::get<_Ip>(__t) + __n)...);
+            __process_input_iter<_LocalAccMode, _LocalNoInit>(std::get<_Ip>(__t), std::get<_Ip>(__t) + __n)...);
         return oneapi::dpl::__ranges::make_zip_view(::std::get<_Ip>(tmp).all_view()...);
     }
 
     //zip iterators
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint = _DeferToUserHint,
-              typename... Iters>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename... Iters>
     auto
     __process_input_iter(oneapi::dpl::zip_iterator<Iters...> __first, oneapi::dpl::zip_iterator<Iters...> __last)
     {
         assert(__first < __last);
 
         const ::std::size_t __num_it = sizeof...(Iters);
-        auto rng = gen_zip_view<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint>(
-            __first.base(), __last - __first, std::make_index_sequence<__num_it>());
+        auto rng = gen_zip_view<_LocalAccMode, _LocalNoInit>(__first.base(), __last - __first,
+                                                             std::make_index_sequence<__num_it>());
         return __range_holder<decltype(rng)>{rng};
     }
 
     //specialization for transform_iterator
-    template <sycl::access::mode _LocalAccMode, bool /*_LocalNoInit*/,
-              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Iter, typename _UnaryFunction>
+    template <sycl::access::mode _LocalAccMode, bool /*_LocalNoInit*/, typename _Iter, typename _UnaryFunction>
     auto
     __process_input_iter(oneapi::dpl::transform_iterator<_Iter, _UnaryFunction> __first,
                          oneapi::dpl::transform_iterator<_Iter, _UnaryFunction> __last)
@@ -519,10 +515,7 @@ struct __get_sycl_range
 
         // no_init is dropped for the base sequence because all elements may not be written to for transform iterator.
         // The unary functor may not expose the underlying references for writing for instance.
-        // For the same reason, any access mode hint the user embedded into the base iterator is overridden, the
-        // adapter, not the user, dictates how the base sequence is accessed.
-        auto res = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false, /*_LocalDeferToUserHint=*/false>(
-            __first.base(), __last.base());
+        auto res = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(), __last.base());
         auto rng = oneapi::dpl::__ranges::transform_view_simple<decltype(res.all_view()), decltype(__first.functor())>{
             res.all_view(), __first.functor()};
 
@@ -530,15 +523,13 @@ struct __get_sycl_range
     }
 
     //specialization for std::reverse_iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint = _DeferToUserHint,
-              typename _Iter>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
     auto
     __process_input_iter(std::reverse_iterator<_Iter> __first, std::reverse_iterator<_Iter> __last)
     {
         assert(__first < __last);
 
-        auto __res =
-            __process_input_iter<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint>(__last.base(), __first.base());
+        auto __res = __process_input_iter<_LocalAccMode, _LocalNoInit>(__last.base(), __first.base());
         auto __rng = oneapi::dpl::__ranges::reverse_view_simple<decltype(__res.all_view())>{__res.all_view()};
 
         return __range_holder<decltype(__rng)>{__rng};
@@ -557,17 +548,14 @@ struct __get_sycl_range
     auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {
-        //For permutation iterator, the Map iterator is always read (only) without no_init, regardless of any access
-        // mode hint the user may have embedded into it
-        auto view_map = __process_input_iter<sycl::access_mode::read, /*_LocalNoInit=*/false,
-                                             /*_LocalDeferToUserHint=*/false>(__m, __m + __s)
-                            .all_view();
+        //For permutation iterator, the Map iterator is always read (only) without no_init
+        auto view_map =
+            __process_input_iter<sycl::access_mode::read, /*_LocalNoInit=*/false>(__m, __m + __s).all_view();
         return oneapi::dpl::__ranges::permutation_view_simple<_R, decltype(view_map)>{__r, view_map};
     }
 
     //specialization for permutation_iterator using sycl_iterator as source
-    template <sycl::access::mode _LocalAccMode, bool /*_LocalNoInit*/,
-              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _It, typename _Map,
+    template <sycl::access::mode _LocalAccMode, bool /*_LocalNoInit*/, typename _It, typename _Map,
               std::enable_if_t<oneapi::dpl::__ranges::is_hetero_iterator_v<_It>, int> = 0>
     auto
     __process_input_iter(oneapi::dpl::permutation_iterator<_It, _Map> __first,
@@ -585,10 +573,8 @@ struct __get_sycl_range
         //   offset, and use that to recurse as a sycl_iterator over the __base_buffer.
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
-        // no_init is dropped for the base sequence because all elements may not be written to for permutation iterator.
-        // For the same reason, any access mode hint the user embedded into the base iterator is overridden, the
-        // adapter, not the user, dictates how the base sequence is accessed.
-        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false, /*_LocalDeferToUserHint=*/false>(
+        // no_init is dropped for the base sequence because all elements may not be written to for permutation iterator
+        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(
             oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(), oneapi::dpl::end(__base_buffer));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
@@ -598,8 +584,7 @@ struct __get_sycl_range
     }
 
     //specialization for permutation_iterator using USM pointer or direct pass object as source
-    template <sycl::access::mode /*_LocalAccMode*/, bool /*_LocalNoInit*/,
-              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Iter, typename _Map,
+    template <sycl::access::mode /*_LocalAccMode*/, bool /*_LocalNoInit*/, typename _Iter, typename _Map,
               std::enable_if_t<!oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter> &&
                                    oneapi::dpl::__ranges::__is_passed_directly_device_ready_v<_Iter>,
                                int> = 0>
@@ -619,8 +604,7 @@ struct __get_sycl_range
 
     // specialization for general case, permutation_iterator with base iterator that is not sycl_iterator or
     // device accessible content iterators.
-    template <sycl::access::mode _LocalAccMode, bool /*_LocalNoInit*/,
-              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Iter, typename _Map,
+    template <sycl::access::mode _LocalAccMode, bool /*_LocalNoInit*/, typename _Iter, typename _Map,
               std::enable_if_t<!oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter> &&
                                    !oneapi::dpl::__ranges::__is_passed_directly_device_ready_v<_Iter>,
                                int> = 0>
@@ -636,10 +620,9 @@ struct __get_sycl_range
         //      Currently this relies on UB because the size of the accessor when handling sycl_iterators
         //      in recursion below this level is incorrect.
 
-        // no_init is dropped for the base sequence because all elements may not be written to. For the same reason, any
-        // access mode hint the user embedded into the base iterator is overridden.
-        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false, /*_LocalDeferToUserHint=*/false>(
-            __first.base(), __first.base() + 1 /*source size*/);
+        // no_init is dropped for the base sequence because all elements may not be written to
+        auto res_src = __process_input_iter<_LocalAccMode, /*_LocalNoInit=*/false>(__first.base(),
+                                                                                   __first.base() + 1 /*source size*/);
 
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);
 
@@ -647,8 +630,7 @@ struct __get_sycl_range
     }
 
     //specialization for permutation discard iterator
-    template <sycl::access::mode /*_LocalAccMode*/, bool /*_LocalNoInit*/,
-              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Map>
+    template <sycl::access::mode /*_LocalAccMode*/, bool /*_LocalNoInit*/, typename _Map>
     auto
     __process_input_iter(oneapi::dpl::permutation_iterator<oneapi::dpl::discard_iterator, _Map> __first,
                          oneapi::dpl::permutation_iterator<oneapi::dpl::discard_iterator, _Map> __last)
@@ -662,8 +644,7 @@ struct __get_sycl_range
     }
 
     // for raw pointers and direct pass objects (for example, counting_iterator, iterator of USM-containers)
-    template <sycl::access::mode /*_LocalAccMode*/, bool /*_LocalNoInit*/,
-              bool /*_LocalDeferToUserHint*/ = _DeferToUserHint, typename _Iter>
+    template <sycl::access::mode /*_LocalAccMode*/, bool /*_LocalNoInit*/, typename _Iter>
     std::enable_if_t<!oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter> &&
                          oneapi::dpl::__ranges::__is_passed_directly_device_ready_v<_Iter>,
                      __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>>
@@ -675,17 +656,15 @@ struct __get_sycl_range
     }
 
     //specialization for hetero iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool _LocalDeferToUserHint = _DeferToUserHint,
-              typename _Iter>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
     auto
     __process_input_iter(_Iter __first, _Iter __last)
-        -> std::enable_if_t<
-            oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter>,
-            __range_holder<oneapi::dpl::__ranges::all_view<
-                val_t<_Iter>, __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>::__value,
-                __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>::__no_init>>>
+        -> std::enable_if_t<oneapi::dpl::__ranges::is_hetero_iterator_v<_Iter>,
+                            __range_holder<oneapi::dpl::__ranges::all_view<
+                                val_t<_Iter>, __resolve_access_mode<_LocalAccMode, _LocalNoInit, _Iter>::__value,
+                                __resolve_access_mode<_LocalAccMode, _LocalNoInit, _Iter>::__no_init>>>
     {
-        using __resolver = __resolve_access_mode<_LocalAccMode, _LocalNoInit, _LocalDeferToUserHint, _Iter>;
+        using __resolver = __resolve_access_mode<_LocalAccMode, _LocalNoInit, _Iter>;
         constexpr sycl::access::mode __resolved_mode = __resolver::__value;
         constexpr bool __resolved_no_init = __resolver::__no_init;
 
@@ -712,8 +691,7 @@ struct __get_sycl_range
     }
 
     //SFINAE-overload for a contiguous host iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool /*_LocalDeferToUserHint*/ = _DeferToUserHint,
-              typename _Iter>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
     auto
     __process_input_iter(_Iter __first, _Iter __last)
         -> std::enable_if_t<is_temp_buff<_Iter>::value && __is_addressable_v<_Iter> && !is_zip<_Iter>::value &&
@@ -744,8 +722,7 @@ struct __get_sycl_range
     }
 
     //SFINAE-overload for non-contiguous host iterator
-    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, bool /*_LocalDeferToUserHint*/ = _DeferToUserHint,
-              typename _Iter>
+    template <sycl::access::mode _LocalAccMode, bool _LocalNoInit, typename _Iter>
     auto
     __process_input_iter(_Iter __first, _Iter __last)
         -> std::enable_if_t<is_temp_buff<_Iter>::value && !__is_addressable_v<_Iter> && !is_zip<_Iter>::value &&
@@ -803,9 +780,8 @@ struct __get_sycl_range
     auto
     operator()(_ArgTypes... __args)
     {
-        //when called using operator(), use access mode, no_init flag and user hint deference provided by the struct
-        // template parameters
-        return __process_input_iter<AccMode, _IsNoInitRequested, _DeferToUserHint>(std::forward<_ArgTypes>(__args)...);
+        //when called using operator(), use access mode and no_init flag provided by the struct template parameters
+        return __process_input_iter<AccMode, _IsNoInitRequested>(std::forward<_ArgTypes>(__args)...);
     }
 };
 

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -127,7 +127,7 @@ call_check_unwritten_elements_preserved(Policy&& exec, std::size_t n, const std:
         TestUtils::unsupported_types_notifier(exec.queue().get_device());
         return;
     }
-    #    if _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN
+#    if _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN
     // A guard region past the end would make the accessor cover only a sub-range of the buffer, and no_init is then
     // dropped anyway by the workaround for the broken ranged accessor no_init, leaving nothing for these checks to
     // observe. Cover the whole buffer instead, so that no_init is genuinely requested and the drop performed for the

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -127,7 +127,15 @@ call_check_unwritten_elements_preserved(Policy&& exec, std::size_t n, const std:
         TestUtils::unsupported_types_notifier(exec.queue().get_device());
         return;
     }
+    #    if _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN
+    // A guard region past the end would make the accessor cover only a sub-range of the buffer, and no_init is then
+    // dropped anyway by the workaround for the broken ranged accessor no_init, leaving nothing for these checks to
+    // observe. Cover the whole buffer instead, so that no_init is genuinely requested and the drop performed for the
+    // adapters below is what preserves the unwritten elements.
+    constexpr std::size_t guard_size = 0;
+#    else
     constexpr std::size_t guard_size = 5;
+#    endif
     const T sentinel = static_cast<T>(-999);
     const std::string base_descr = std::string("(sycl_iterator<") + type_text + std::string(">)");
     oneapi::dpl::discard_iterator discard{};

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -27,224 +27,6 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT
 
-// The value written into the visited elements by the checks below.
-template <typename T>
-inline constexpr T new_value = static_cast<T>(-333);
-
-// Functor for oneapi::dpl::for_each which assigns a constant to every element it visits.
-template <typename T>
-struct assign_constant
-{
-    T __value;
-    template <typename _Ref>
-    void
-    operator()(_Ref&& __ref) const
-    {
-        std::forward<_Ref>(__ref) = __value;
-    }
-};
-
-// Same, for a sequence of tuples: only the first element of the tuple is assigned, so that the other zipped sequences
-// are left alone.
-template <typename T>
-struct assign_constant_to_first
-{
-    T __value;
-    template <typename _Ref>
-    void
-    operator()(_Ref&& __ref) const
-    {
-        std::get<0>(std::forward<_Ref>(__ref)) = __value;
-    }
-};
-
-// A transform_iterator built with this functor swallows any write made through it, its base sequence is never written.
-inline constexpr auto drop_write = [](auto&&) { return std::ignore; };
-
-// A permutation_iterator built with this map functor sends every access to the 0th element of its base sequence,
-// leaving every other element of it unwritten.
-inline constexpr auto map_to_zero = [](auto) { return 0; };
-
-// Source sequence of the copy below: new_value<T> repeated, so that the elements which are written end up holding the
-// same value as with for_each, no matter which source element a write comes from.
-template <typename T>
-auto
-make_constant_source()
-{
-    return oneapi::dpl::make_transform_iterator(oneapi::dpl::counting_iterator<int>(0),
-                                                [](auto) { return new_value<T>; });
-}
-
-// Walks the wrapped sequence with oneapi::dpl::for_each, writing a constant into every element it visits. for_each is
-// one of the patterns which defers to the access mode hint a user may have embedded into a sycl_iterator, so it is run
-// on a sequence which carries a discarding one.
-template <typename T, bool __zipped>
-struct run_hinted_for_each
-{
-    static constexpr bool __hinted_base = true;
-    static constexpr const char* __descr = "for_each over ";
-
-    template <typename Policy, typename Iterator>
-    void
-    operator()(Policy&& exec, Iterator __first, Iterator __last) const
-    {
-        if constexpr (__zipped)
-            oneapi::dpl::for_each(std::forward<Policy>(exec), __first, __last,
-                                  assign_constant_to_first<T>{new_value<T>});
-        else
-            oneapi::dpl::for_each(std::forward<Policy>(exec), __first, __last, assign_constant<T>{new_value<T>});
-    }
-};
-
-// Copies a constant sequence into the wrapped sequence. copy requests no_init for its output internally, without any
-// hint from the user, so it is run on a plain sycl_iterator.
-template <typename T, bool __zipped>
-struct run_copy
-{
-    static constexpr bool __hinted_base = false;
-    static constexpr const char* __descr = "copy into ";
-
-    template <typename Policy, typename Iterator>
-    void
-    operator()(Policy&& exec, Iterator __first, Iterator __last) const
-    {
-        auto __src = make_constant_source<T>();
-        if constexpr (__zipped)
-        {
-            // The zipped sequence holds a discard_iterator besides the sequence under test, so the source is zipped
-            // with an arbitrary sequence to match its value type.
-            auto __zip_src = oneapi::dpl::make_zip_iterator(__src, oneapi::dpl::counting_iterator<int>(0));
-            oneapi::dpl::copy(std::forward<Policy>(exec), __zip_src, __zip_src + (__last - __first), __first);
-        }
-        else
-        {
-            oneapi::dpl::copy(std::forward<Policy>(exec), __src, __src + (__last - __first), __first);
-        }
-    }
-};
-
-// transform_iterator and permutation_iterator may leave elements of their base sequence unwritten, as the two wrappers
-// above do. They therefore never request no_init for that base sequence, and override any access mode hint the user
-// embedded into it: discarding its content would destroy the elements which are not written.
-//
-// The sequence under test is a sycl::buffer constructed over host memory, and its content is only ever written from the
-// host. That is what makes a discarding access mode observable: it elides the copy of the host data to the device, so
-// the elements which the kernel does not write come back as garbage rather than as the values written on the host.
-//
-// __num_written is the number of leading elements the wrapped sequence is expected to write through to the base.
-template <typename T, std::size_t __num_written, typename Policy, typename WrapIterator, typename RunPattern>
-void
-check_unwritten_elements_preserved(Policy&& exec, std::size_t n, std::size_t guard_size, T sentinel, WrapIterator wrap,
-                                   RunPattern run, const std::string& descr)
-{
-    const std::size_t total_size = n + guard_size;
-
-    std::vector<T> host_data(total_size, sentinel);
-    for (std::size_t i = 0; i != n; ++i)
-        host_data[i] = static_cast<T>(i);
-
-    std::vector<T> expected(host_data);
-    for (std::size_t i = 0; i != __num_written; ++i)
-        expected[i] = new_value<T>;
-
-    {
-        sycl::buffer<T> buf(host_data.data(), total_size);
-        if constexpr (RunPattern::__hinted_base)
-        {
-            // The user asks for the content of the sequence to be discarded. Any wrapper which may skip writes to it
-            // must ignore that request.
-            auto __base = oneapi::dpl::begin(buf, sycl::write_only, sycl::no_init);
-            auto __first = wrap(__base);
-            run(std::forward<Policy>(exec), __first, __first + n);
-        }
-        else
-        {
-            auto __base = oneapi::dpl::begin(buf);
-            auto __first = wrap(__base);
-            run(std::forward<Policy>(exec), __first, __first + n);
-        }
-    }
-    // The buffer is destroyed, so its content has been written back into host_data.
-
-    std::string msg = std::string("data destroyed by ") + RunPattern::__descr + descr;
-    EXPECT_EQ_N(expected.begin(), host_data.begin(), total_size, msg.c_str());
-}
-
-// Runs both patterns over a single wrapper stack.
-template <typename T, std::size_t __num_written, bool __zipped, typename Policy, typename WrapIterator>
-void
-check_stack(Policy&& exec, std::size_t n, std::size_t guard_size, T sentinel, WrapIterator wrap,
-            const std::string& descr)
-{
-    check_unwritten_elements_preserved<T, __num_written>(CLONE_TEST_POLICY_IDX(exec, 0), n, guard_size, sentinel, wrap,
-                                                         run_hinted_for_each<T, __zipped>{}, descr);
-    check_unwritten_elements_preserved<T, __num_written>(CLONE_TEST_POLICY_IDX(exec, 1), n, guard_size, sentinel, wrap,
-                                                         run_copy<T, __zipped>{}, descr);
-}
-
-template <typename T, typename Policy>
-void
-call_check_unwritten_elements_preserved(Policy&& exec, std::size_t n, const std::string& type_text)
-{
-    if (!TestUtils::has_types_support<T>(exec.queue().get_device()))
-    {
-        TestUtils::unsupported_types_notifier(exec.queue().get_device());
-        return;
-    }
-    constexpr std::size_t guard_size = 5;
-    const T sentinel = static_cast<T>(-999);
-    const std::string base_descr = std::string("(sycl_iterator<") + type_text + std::string(">)");
-    oneapi::dpl::discard_iterator discard{};
-
-    // No element of the base sequence is written.
-    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
-        CLONE_TEST_POLICY_IDX(exec, 0), n, guard_size, sentinel,
-        [](auto __it) { return oneapi::dpl::make_transform_iterator(__it, drop_write); },
-        std::string("transform_iterator") + base_descr);
-
-    // Only the 0th element of the base sequence is written.
-    check_stack<T, /*__num_written=*/1, /*__zipped=*/false>(
-        CLONE_TEST_POLICY_IDX(exec, 1), n, guard_size, sentinel,
-        [](auto __it) { return oneapi::dpl::make_permutation_iterator(__it, map_to_zero); },
-        std::string("permutation_iterator") + base_descr);
-
-    // Wrapped a second time, to check that the override is not lost in the recursion.
-    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
-        CLONE_TEST_POLICY_IDX(exec, 2), n, guard_size, sentinel,
-        [](auto __it) {
-            return oneapi::dpl::make_transform_iterator(oneapi::dpl::make_permutation_iterator(__it, map_to_zero),
-                                                        drop_write);
-        },
-        std::string("transform_iterator(permutation_iterator") + base_descr + std::string(")"));
-
-    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
-        CLONE_TEST_POLICY_IDX(exec, 3), n, guard_size, sentinel,
-        [](auto __it) {
-            return oneapi::dpl::make_permutation_iterator(oneapi::dpl::make_transform_iterator(__it, drop_write),
-                                                          map_to_zero);
-        },
-        std::string("permutation_iterator(transform_iterator") + base_descr + std::string(")"));
-
-    // A zip_iterator neither requests no_init for the sequences it zips nor overrides a hint on them, it propagates
-    // whatever the wrapper above it dictates. With a transform_iterator or a permutation_iterator above it, the
-    // override must reach the zipped sycl_iterator through it.
-    // The outermost wrapper is the transform_iterator, so the visible element is not a tuple.
-    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
-        CLONE_TEST_POLICY_IDX(exec, 4), n, guard_size, sentinel,
-        [discard](auto __it) {
-            return oneapi::dpl::make_transform_iterator(oneapi::dpl::make_zip_iterator(__it, discard), drop_write);
-        },
-        std::string("transform_iterator(zip_iterator") + base_descr + std::string(")"));
-
-    // Only the 0th element of the zipped sequence, and so the 0th element of the base sequence, is written.
-    check_stack<T, /*__num_written=*/1, /*__zipped=*/true>(
-        CLONE_TEST_POLICY_IDX(exec, 5), n, guard_size, sentinel,
-        [discard](auto __it) {
-            return oneapi::dpl::make_permutation_iterator(oneapi::dpl::make_zip_iterator(__it, discard), map_to_zero);
-        },
-        std::string("permutation_iterator(zip_iterator") + base_descr + std::string(")"));
-}
-
 template <typename T, int __recurse, typename Policy>
 void
 call_wrap_recurse(Policy&& exec, T trash, size_t n, const std::string& type_text)
@@ -257,29 +39,15 @@ call_wrap_recurse(Policy&& exec, T trash, size_t n, const std::string& type_text
 
         TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec, total_size);
         oneapi::dpl::counting_iterator<int> counting(0);
-        // sycl iterator over a buffer whose memory is owned by the SYCL runtime
-        {
-            sycl::buffer<T> buf(total_size);
-            //test all modes / wrappers
-            wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
-                         /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
-                         /*__is_reversible=*/false>(
-                CLONE_TEST_POLICY_IDX(exec, 0), oneapi::dpl::begin(buf), oneapi::dpl::begin(buf) + n, counting,
-                copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(), counting, trash,
-                std::string("sycl_iterator<") + type_text + std::string(">"), guard_size, sentinel);
-        }
-        // sycl iterator over a buffer constructed from host memory. An access mode which discards the content of
-        // the buffer is observable here, because it elides the copy of the host data to the device.
-        {
-            std::vector<T> host_data(total_size);
-            sycl::buffer<T> buf(host_data.data(), total_size);
-            wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
-                         /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
-                         /*__is_reversible=*/false>(
-                CLONE_TEST_POLICY_IDX(exec, 1), oneapi::dpl::begin(buf), oneapi::dpl::begin(buf) + n, counting,
-                copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(), counting, trash,
-                std::string("sycl_iterator<") + type_text + std::string(">(host memory)"), guard_size, sentinel);
-        }
+        // sycl iterator
+        sycl::buffer<T> buf(total_size);
+        //test all modes / wrappers
+        wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
+                     /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
+                     /*__is_reversible=*/false>(
+            std::forward<Policy>(exec), oneapi::dpl::begin(buf), oneapi::dpl::begin(buf) + n, counting,
+            copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(), counting, trash,
+            std::string("sycl_iterator<") + type_text + std::string(">"), guard_size, sentinel);
     }
     else
     {
@@ -300,9 +68,6 @@ test_impl(Policy&& exec)
 
     // big recursion step: 1 and 2 layers of wrapping
     call_wrap_recurse<std::int32_t, 2>(CLONE_TEST_POLICY_IDX(exec, 3), -666, n, "int32_t");
-
-    // wrappers which may skip writes to their base sequence must not honor a discarding access mode hint on it
-    call_check_unwritten_elements_preserved<std::int32_t>(CLONE_TEST_POLICY_IDX(exec, 4), n, "int32_t");
 }
 
 #endif //TEST_DPCPP_BACKEND_PRESENT

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -228,7 +228,7 @@ void
 test_impl(Policy&& exec)
 {
     constexpr size_t n = 10;
-
+    
     // baseline with no wrapping
     call_wrap_recurse<float, 0>(CLONE_TEST_POLICY_IDX(exec, 0), -666.0f, n, "float");
     call_wrap_recurse<double, 0>(CLONE_TEST_POLICY_IDX(exec, 1), -666.0, n, "double");
@@ -251,9 +251,9 @@ main()
     auto policy = TestUtils::get_dpcpp_test_policy();
     test_impl(policy);
 
-#    if TEST_CHECK_COMPILATION_WITH_DIFF_POLICY_VAL_CATEGORY
+#if TEST_CHECK_COMPILATION_WITH_DIFF_POLICY_VAL_CATEGORY
     TestUtils::check_compilation(policy, [](auto&& policy) { test_impl(std::forward<decltype(policy)>(policy)); });
-#    endif
+#endif
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
     return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -27,6 +27,224 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT
 
+// The value written into the visited elements by the checks below.
+template <typename T>
+inline constexpr T new_value = static_cast<T>(-333);
+
+// Functor for oneapi::dpl::for_each which assigns a constant to every element it visits.
+template <typename T>
+struct assign_constant
+{
+    T __value;
+    template <typename _Ref>
+    void
+    operator()(_Ref&& __ref) const
+    {
+        std::forward<_Ref>(__ref) = __value;
+    }
+};
+
+// Same, for a sequence of tuples: only the first element of the tuple is assigned, so that the other zipped sequences
+// are left alone.
+template <typename T>
+struct assign_constant_to_first
+{
+    T __value;
+    template <typename _Ref>
+    void
+    operator()(_Ref&& __ref) const
+    {
+        std::get<0>(std::forward<_Ref>(__ref)) = __value;
+    }
+};
+
+// A transform_iterator built with this functor swallows any write made through it, its base sequence is never written.
+inline constexpr auto drop_write = [](auto&&) { return std::ignore; };
+
+// A permutation_iterator built with this map functor sends every access to the 0th element of its base sequence,
+// leaving every other element of it unwritten.
+inline constexpr auto map_to_zero = [](auto) { return 0; };
+
+// Source sequence of the copy below: new_value<T> repeated, so that the elements which are written end up holding the
+// same value as with for_each, no matter which source element a write comes from.
+template <typename T>
+auto
+make_constant_source()
+{
+    return oneapi::dpl::make_transform_iterator(oneapi::dpl::counting_iterator<int>(0),
+                                                [](auto) { return new_value<T>; });
+}
+
+// Walks the wrapped sequence with oneapi::dpl::for_each, writing a constant into every element it visits. for_each is
+// one of the patterns which defers to the access mode hint a user may have embedded into a sycl_iterator, so it is run
+// on a sequence which carries a discarding one.
+template <typename T, bool __zipped>
+struct run_hinted_for_each
+{
+    static constexpr bool __hinted_base = true;
+    static constexpr const char* __descr = "for_each over ";
+
+    template <typename Policy, typename Iterator>
+    void
+    operator()(Policy&& exec, Iterator __first, Iterator __last) const
+    {
+        if constexpr (__zipped)
+            oneapi::dpl::for_each(std::forward<Policy>(exec), __first, __last,
+                                  assign_constant_to_first<T>{new_value<T>});
+        else
+            oneapi::dpl::for_each(std::forward<Policy>(exec), __first, __last, assign_constant<T>{new_value<T>});
+    }
+};
+
+// Copies a constant sequence into the wrapped sequence. copy requests no_init for its output internally, without any
+// hint from the user, so it is run on a plain sycl_iterator.
+template <typename T, bool __zipped>
+struct run_copy
+{
+    static constexpr bool __hinted_base = false;
+    static constexpr const char* __descr = "copy into ";
+
+    template <typename Policy, typename Iterator>
+    void
+    operator()(Policy&& exec, Iterator __first, Iterator __last) const
+    {
+        auto __src = make_constant_source<T>();
+        if constexpr (__zipped)
+        {
+            // The zipped sequence holds a discard_iterator besides the sequence under test, so the source is zipped
+            // with an arbitrary sequence to match its value type.
+            auto __zip_src = oneapi::dpl::make_zip_iterator(__src, oneapi::dpl::counting_iterator<int>(0));
+            oneapi::dpl::copy(std::forward<Policy>(exec), __zip_src, __zip_src + (__last - __first), __first);
+        }
+        else
+        {
+            oneapi::dpl::copy(std::forward<Policy>(exec), __src, __src + (__last - __first), __first);
+        }
+    }
+};
+
+// transform_iterator and permutation_iterator may leave elements of their base sequence unwritten, as the two wrappers
+// above do. They therefore never request no_init for that base sequence, and override any access mode hint the user
+// embedded into it: discarding its content would destroy the elements which are not written.
+//
+// The sequence under test is a sycl::buffer constructed over host memory, and its content is only ever written from the
+// host. That is what makes a discarding access mode observable: it elides the copy of the host data to the device, so
+// the elements which the kernel does not write come back as garbage rather than as the values written on the host.
+//
+// __num_written is the number of leading elements the wrapped sequence is expected to write through to the base.
+template <typename T, std::size_t __num_written, typename Policy, typename WrapIterator, typename RunPattern>
+void
+check_unwritten_elements_preserved(Policy&& exec, std::size_t n, std::size_t guard_size, T sentinel, WrapIterator wrap,
+                                   RunPattern run, const std::string& descr)
+{
+    const std::size_t total_size = n + guard_size;
+
+    std::vector<T> host_data(total_size, sentinel);
+    for (std::size_t i = 0; i != n; ++i)
+        host_data[i] = static_cast<T>(i);
+
+    std::vector<T> expected(host_data);
+    for (std::size_t i = 0; i != __num_written; ++i)
+        expected[i] = new_value<T>;
+
+    {
+        sycl::buffer<T> buf(host_data.data(), total_size);
+        if constexpr (RunPattern::__hinted_base)
+        {
+            // The user asks for the content of the sequence to be discarded. Any wrapper which may skip writes to it
+            // must ignore that request.
+            auto __base = oneapi::dpl::begin(buf, sycl::write_only, sycl::no_init);
+            auto __first = wrap(__base);
+            run(std::forward<Policy>(exec), __first, __first + n);
+        }
+        else
+        {
+            auto __base = oneapi::dpl::begin(buf);
+            auto __first = wrap(__base);
+            run(std::forward<Policy>(exec), __first, __first + n);
+        }
+    }
+    // The buffer is destroyed, so its content has been written back into host_data.
+
+    std::string msg = std::string("data destroyed by ") + RunPattern::__descr + descr;
+    EXPECT_EQ_N(expected.begin(), host_data.begin(), total_size, msg.c_str());
+}
+
+// Runs both patterns over a single wrapper stack.
+template <typename T, std::size_t __num_written, bool __zipped, typename Policy, typename WrapIterator>
+void
+check_stack(Policy&& exec, std::size_t n, std::size_t guard_size, T sentinel, WrapIterator wrap,
+            const std::string& descr)
+{
+    check_unwritten_elements_preserved<T, __num_written>(CLONE_TEST_POLICY_IDX(exec, 0), n, guard_size, sentinel, wrap,
+                                                         run_hinted_for_each<T, __zipped>{}, descr);
+    check_unwritten_elements_preserved<T, __num_written>(CLONE_TEST_POLICY_IDX(exec, 1), n, guard_size, sentinel, wrap,
+                                                         run_copy<T, __zipped>{}, descr);
+}
+
+template <typename T, typename Policy>
+void
+call_check_unwritten_elements_preserved(Policy&& exec, std::size_t n, const std::string& type_text)
+{
+    if (!TestUtils::has_types_support<T>(exec.queue().get_device()))
+    {
+        TestUtils::unsupported_types_notifier(exec.queue().get_device());
+        return;
+    }
+    constexpr std::size_t guard_size = 5;
+    const T sentinel = static_cast<T>(-999);
+    const std::string base_descr = std::string("(sycl_iterator<") + type_text + std::string(">)");
+    oneapi::dpl::discard_iterator discard{};
+
+    // No element of the base sequence is written.
+    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 0), n, guard_size, sentinel,
+        [](auto __it) { return oneapi::dpl::make_transform_iterator(__it, drop_write); },
+        std::string("transform_iterator") + base_descr);
+
+    // Only the 0th element of the base sequence is written.
+    check_stack<T, /*__num_written=*/1, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 1), n, guard_size, sentinel,
+        [](auto __it) { return oneapi::dpl::make_permutation_iterator(__it, map_to_zero); },
+        std::string("permutation_iterator") + base_descr);
+
+    // Wrapped a second time, to check that the override is not lost in the recursion.
+    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 2), n, guard_size, sentinel,
+        [](auto __it) {
+            return oneapi::dpl::make_transform_iterator(oneapi::dpl::make_permutation_iterator(__it, map_to_zero),
+                                                        drop_write);
+        },
+        std::string("transform_iterator(permutation_iterator") + base_descr + std::string(")"));
+
+    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 3), n, guard_size, sentinel,
+        [](auto __it) {
+            return oneapi::dpl::make_permutation_iterator(oneapi::dpl::make_transform_iterator(__it, drop_write),
+                                                          map_to_zero);
+        },
+        std::string("permutation_iterator(transform_iterator") + base_descr + std::string(")"));
+
+    // A zip_iterator neither requests no_init for the sequences it zips nor overrides a hint on them, it propagates
+    // whatever the wrapper above it dictates. With a transform_iterator or a permutation_iterator above it, the
+    // override must reach the zipped sycl_iterator through it.
+    // The outermost wrapper is the transform_iterator, so the visible element is not a tuple.
+    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 4), n, guard_size, sentinel,
+        [discard](auto __it) {
+            return oneapi::dpl::make_transform_iterator(oneapi::dpl::make_zip_iterator(__it, discard), drop_write);
+        },
+        std::string("transform_iterator(zip_iterator") + base_descr + std::string(")"));
+
+    // Only the 0th element of the zipped sequence, and so the 0th element of the base sequence, is written.
+    check_stack<T, /*__num_written=*/1, /*__zipped=*/true>(
+        CLONE_TEST_POLICY_IDX(exec, 5), n, guard_size, sentinel,
+        [discard](auto __it) {
+            return oneapi::dpl::make_permutation_iterator(oneapi::dpl::make_zip_iterator(__it, discard), map_to_zero);
+        },
+        std::string("permutation_iterator(zip_iterator") + base_descr + std::string(")"));
+}
+
 template <typename T, int __recurse, typename Policy>
 void
 call_wrap_recurse(Policy&& exec, T trash, size_t n, const std::string& type_text)
@@ -39,15 +257,29 @@ call_wrap_recurse(Policy&& exec, T trash, size_t n, const std::string& type_text
 
         TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec, total_size);
         oneapi::dpl::counting_iterator<int> counting(0);
-        // sycl iterator
-        sycl::buffer<T> buf(total_size);
-        //test all modes / wrappers
-        wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
-                     /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
-                     /*__is_reversible=*/false>(
-            std::forward<Policy>(exec), oneapi::dpl::begin(buf), oneapi::dpl::begin(buf) + n, counting,
-            copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(), counting, trash,
-            std::string("sycl_iterator<") + type_text + std::string(">"), guard_size, sentinel);
+        // sycl iterator over a buffer whose memory is owned by the SYCL runtime
+        {
+            sycl::buffer<T> buf(total_size);
+            //test all modes / wrappers
+            wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
+                         /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
+                         /*__is_reversible=*/false>(
+                CLONE_TEST_POLICY_IDX(exec, 0), oneapi::dpl::begin(buf), oneapi::dpl::begin(buf) + n, counting,
+                copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(), counting, trash,
+                std::string("sycl_iterator<") + type_text + std::string(">"), guard_size, sentinel);
+        }
+        // sycl iterator over a buffer constructed from host memory. An access mode which discards the content of
+        // the buffer is observable here, because it elides the copy of the host data to the device.
+        {
+            std::vector<T> host_data(total_size);
+            sycl::buffer<T> buf(host_data.data(), total_size);
+            wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
+                         /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
+                         /*__is_reversible=*/false>(
+                CLONE_TEST_POLICY_IDX(exec, 1), oneapi::dpl::begin(buf), oneapi::dpl::begin(buf) + n, counting,
+                copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(), counting, trash,
+                std::string("sycl_iterator<") + type_text + std::string(">(host memory)"), guard_size, sentinel);
+        }
     }
     else
     {
@@ -68,6 +300,9 @@ test_impl(Policy&& exec)
 
     // big recursion step: 1 and 2 layers of wrapping
     call_wrap_recurse<std::int32_t, 2>(CLONE_TEST_POLICY_IDX(exec, 3), -666, n, "int32_t");
+
+    // wrappers which may skip writes to their base sequence must not honor a discarding access mode hint on it
+    call_check_unwritten_elements_preserved<std::int32_t>(CLONE_TEST_POLICY_IDX(exec, 4), n, "int32_t");
 }
 
 #endif //TEST_DPCPP_BACKEND_PRESENT

--- a/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_sycl_iter.pass.cpp
@@ -27,6 +27,160 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT
 
+// The value written into the visited elements by the checks below.
+template <typename T>
+inline constexpr T new_value = static_cast<T>(-333);
+
+// A transform_iterator built with this functor swallows any write made through it, its base sequence is never written.
+inline constexpr auto drop_write = [](auto&&) { return std::ignore; };
+
+// A permutation_iterator built with this map functor sends every access to the 0th element of its base sequence,
+// leaving every other element of it unwritten.
+inline constexpr auto map_to_zero = [](auto) { return 0; };
+
+// Source sequence of the copy below: new_value<T> repeated, so that the elements which are written end up holding the
+// same value no matter which source element a write comes from.
+template <typename T>
+auto
+make_constant_source()
+{
+    return oneapi::dpl::make_transform_iterator(oneapi::dpl::counting_iterator<int>(0),
+                                                [](auto) { return new_value<T>; });
+}
+
+// Copies a constant sequence into the wrapped sequence. copy requests no_init for its output internally.
+template <typename T, bool __zipped>
+struct run_copy
+{
+    static constexpr const char* __descr = "copy into ";
+
+    template <typename Policy, typename Iterator>
+    void
+    operator()(Policy&& exec, Iterator __first, Iterator __last) const
+    {
+        auto __src = make_constant_source<T>();
+        if constexpr (__zipped)
+        {
+            // The zipped sequence holds a discard_iterator besides the sequence under test, so the source is zipped
+            // with an arbitrary sequence to match its value type.
+            auto __zip_src = oneapi::dpl::make_zip_iterator(__src, oneapi::dpl::counting_iterator<int>(0));
+            oneapi::dpl::copy(std::forward<Policy>(exec), __zip_src, __zip_src + (__last - __first), __first);
+        }
+        else
+        {
+            oneapi::dpl::copy(std::forward<Policy>(exec), __src, __src + (__last - __first), __first);
+        }
+    }
+};
+
+// transform_iterator and permutation_iterator may leave elements of their base sequence unwritten, as the wrapper
+// above does. A pattern requesting no_init for such a wrapped output must therefore not have that no_init reach the
+// base sequence: discarding its content would destroy the elements which are not written.
+//
+// The sequence under test is a sycl::buffer constructed over host memory, and its content is only ever written from the
+// host. That is what makes a discarding access mode observable: it elides the copy of the host data to the device, so
+// the elements which the kernel does not write come back as garbage rather than as the values written on the host.
+//
+// __num_written is the number of leading elements the wrapped sequence is expected to write through to the base.
+template <typename T, std::size_t __num_written, typename Policy, typename WrapIterator, typename RunPattern>
+void
+check_unwritten_elements_preserved(Policy&& exec, std::size_t n, std::size_t guard_size, T sentinel, WrapIterator wrap,
+                                   RunPattern run, const std::string& descr)
+{
+    const std::size_t total_size = n + guard_size;
+
+    std::vector<T> host_data(total_size, sentinel);
+    for (std::size_t i = 0; i != n; ++i)
+        host_data[i] = static_cast<T>(i);
+
+    std::vector<T> expected(host_data);
+    for (std::size_t i = 0; i != __num_written; ++i)
+        expected[i] = new_value<T>;
+
+    {
+        sycl::buffer<T> buf(host_data.data(), total_size);
+        auto __first = wrap(oneapi::dpl::begin(buf));
+        run(std::forward<Policy>(exec), __first, __first + n);
+    }
+    // The buffer is destroyed, so its content has been written back into host_data.
+
+    std::string msg = std::string("data destroyed by ") + RunPattern::__descr + descr;
+    EXPECT_EQ_N(expected.begin(), host_data.begin(), total_size, msg.c_str());
+}
+
+// Runs the pattern over a single wrapper stack.
+template <typename T, std::size_t __num_written, bool __zipped, typename Policy, typename WrapIterator>
+void
+check_stack(Policy&& exec, std::size_t n, std::size_t guard_size, T sentinel, WrapIterator wrap,
+            const std::string& descr)
+{
+    check_unwritten_elements_preserved<T, __num_written>(std::forward<Policy>(exec), n, guard_size, sentinel, wrap,
+                                                         run_copy<T, __zipped>{}, descr);
+}
+
+template <typename T, typename Policy>
+void
+call_check_unwritten_elements_preserved(Policy&& exec, std::size_t n, const std::string& type_text)
+{
+    if (!TestUtils::has_types_support<T>(exec.queue().get_device()))
+    {
+        TestUtils::unsupported_types_notifier(exec.queue().get_device());
+        return;
+    }
+    constexpr std::size_t guard_size = 5;
+    const T sentinel = static_cast<T>(-999);
+    const std::string base_descr = std::string("(sycl_iterator<") + type_text + std::string(">)");
+    oneapi::dpl::discard_iterator discard{};
+
+    // No element of the base sequence is written.
+    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 0), n, guard_size, sentinel,
+        [](auto __it) { return oneapi::dpl::make_transform_iterator(__it, drop_write); },
+        std::string("transform_iterator") + base_descr);
+
+    // Only the 0th element of the base sequence is written.
+    check_stack<T, /*__num_written=*/1, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 1), n, guard_size, sentinel,
+        [](auto __it) { return oneapi::dpl::make_permutation_iterator(__it, map_to_zero); },
+        std::string("permutation_iterator") + base_descr);
+
+    // Wrapped a second time, to check that the no_init drop is not lost in the recursion.
+    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 2), n, guard_size, sentinel,
+        [](auto __it) {
+            return oneapi::dpl::make_transform_iterator(oneapi::dpl::make_permutation_iterator(__it, map_to_zero),
+                                                        drop_write);
+        },
+        std::string("transform_iterator(permutation_iterator") + base_descr + std::string(")"));
+
+    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 3), n, guard_size, sentinel,
+        [](auto __it) {
+            return oneapi::dpl::make_permutation_iterator(oneapi::dpl::make_transform_iterator(__it, drop_write),
+                                                          map_to_zero);
+        },
+        std::string("permutation_iterator(transform_iterator") + base_descr + std::string(")"));
+
+    // A zip_iterator does not itself drop no_init for the sequences it zips, it propagates whatever the wrapper above
+    // it dictates. With a transform_iterator or a permutation_iterator above it, the drop must reach the zipped
+    // sycl_iterator through it.
+    // The outermost wrapper is the transform_iterator, so the visible element is not a tuple.
+    check_stack<T, /*__num_written=*/0, /*__zipped=*/false>(
+        CLONE_TEST_POLICY_IDX(exec, 4), n, guard_size, sentinel,
+        [discard](auto __it) {
+            return oneapi::dpl::make_transform_iterator(oneapi::dpl::make_zip_iterator(__it, discard), drop_write);
+        },
+        std::string("transform_iterator(zip_iterator") + base_descr + std::string(")"));
+
+    // Only the 0th element of the zipped sequence, and so the 0th element of the base sequence, is written.
+    check_stack<T, /*__num_written=*/1, /*__zipped=*/true>(
+        CLONE_TEST_POLICY_IDX(exec, 5), n, guard_size, sentinel,
+        [discard](auto __it) {
+            return oneapi::dpl::make_permutation_iterator(oneapi::dpl::make_zip_iterator(__it, discard), map_to_zero);
+        },
+        std::string("permutation_iterator(zip_iterator") + base_descr + std::string(")"));
+}
+
 template <typename T, int __recurse, typename Policy>
 void
 call_wrap_recurse(Policy&& exec, T trash, size_t n, const std::string& type_text)
@@ -39,15 +193,29 @@ call_wrap_recurse(Policy&& exec, T trash, size_t n, const std::string& type_text
 
         TestUtils::usm_data_transfer<sycl::usm::alloc::shared, T> copy_out(exec, total_size);
         oneapi::dpl::counting_iterator<int> counting(0);
-        // sycl iterator
-        sycl::buffer<T> buf(total_size);
-        //test all modes / wrappers
-        wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
-                     /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
-                     /*__is_reversible=*/false>(
-            std::forward<Policy>(exec), oneapi::dpl::begin(buf), oneapi::dpl::begin(buf) + n, counting,
-            copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(), counting, trash,
-            std::string("sycl_iterator<") + type_text + std::string(">"), guard_size, sentinel);
+        // sycl iterator over a buffer whose memory is owned by the SYCL runtime
+        {
+            sycl::buffer<T> buf(total_size);
+            //test all modes / wrappers
+            wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
+                         /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
+                         /*__is_reversible=*/false>(
+                CLONE_TEST_POLICY_IDX(exec, 0), oneapi::dpl::begin(buf), oneapi::dpl::begin(buf) + n, counting,
+                copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(), counting, trash,
+                std::string("sycl_iterator<") + type_text + std::string(">"), guard_size, sentinel);
+        }
+        // sycl iterator over a buffer constructed from host memory. An access mode which discards the content of
+        // the buffer is observable here, because it elides the copy of the host data to the device.
+        {
+            std::vector<T> host_data(total_size);
+            sycl::buffer<T> buf(host_data.data(), total_size);
+            wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
+                         /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/true,
+                         /*__is_reversible=*/false>(
+                CLONE_TEST_POLICY_IDX(exec, 1), oneapi::dpl::begin(buf), oneapi::dpl::begin(buf) + n, counting,
+                copy_out.get_data(), oneapi::dpl::begin(buf), copy_out.get_data(), counting, trash,
+                std::string("sycl_iterator<") + type_text + std::string(">(host memory)"), guard_size, sentinel);
+        }
     }
     else
     {
@@ -60,7 +228,7 @@ void
 test_impl(Policy&& exec)
 {
     constexpr size_t n = 10;
-    
+
     // baseline with no wrapping
     call_wrap_recurse<float, 0>(CLONE_TEST_POLICY_IDX(exec, 0), -666.0f, n, "float");
     call_wrap_recurse<double, 0>(CLONE_TEST_POLICY_IDX(exec, 1), -666.0, n, "double");
@@ -68,6 +236,9 @@ test_impl(Policy&& exec)
 
     // big recursion step: 1 and 2 layers of wrapping
     call_wrap_recurse<std::int32_t, 2>(CLONE_TEST_POLICY_IDX(exec, 3), -666, n, "int32_t");
+
+    // no_init requested for an output which is wrapped by an adapter that may skip writes must not reach the base
+    call_check_unwritten_elements_preserved<std::int32_t>(CLONE_TEST_POLICY_IDX(exec, 4), n, "int32_t");
 }
 
 #endif //TEST_DPCPP_BACKEND_PRESENT
@@ -80,9 +251,9 @@ main()
     auto policy = TestUtils::get_dpcpp_test_policy();
     test_impl(policy);
 
-#if TEST_CHECK_COMPILATION_WITH_DIFF_POLICY_VAL_CATEGORY
+#    if TEST_CHECK_COMPILATION_WITH_DIFF_POLICY_VAL_CATEGORY
     TestUtils::check_compilation(policy, [](auto&& policy) { test_impl(std::forward<decltype(policy)>(policy)); });
-#endif
+#    endif
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
     return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);


### PR DESCRIPTION
#2617 connected no_init properties to sycl buffers (making them real), and exposing this bug.  

transform_iterator and permutation_iterator are iterator adapters which make it such that we cannot guarantee all elements in a result range will be written to in something like 
`copy(input_beg,input_end, output_beg);`
where `output_beg=transform_iterator(oneapi::dpl::begin(buffer), [](auto a){return std::ignore;}))`

The unary functor may prevent some or all writes to the base sequence.  Therefore, in this case we cannot guarantee all elements of the output will be overwritten.  It is a similar story for permutation_iterator where a map determines which elements will and wont be written.  

This PR fixes this by turning off the `no_init` property when recursing through transform_iterator and permutation_iterator data processing.  This only affects inputs which have a transform_iterator and/or permutation_iterator which wraps at some lower level a iterator-like buffer wrapper object created with `oneapi::dpl::begin/end` called on a `sycl::buffer` object.

This PR also fixes a subtle bug where permutation iterators where not passing forward local accessor mode with `__process_input_iter`, but rather using the exterior `operator()`, which reintroduces the original `AccMode`.