### PR TITLE
Workaround for ranged buffer with no_init

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -45,7 +45,7 @@ template <typename _AccessorType, typename _BufferType, typename _DiffType>
 static _AccessorType
 __create_accessor(_BufferType& __buf, _DiffType __offset, _DiffType __n, bool __no_init_requested = false)
 {
-    _DiffType __n_buf = __dpl_sycl::__get_buffer_size(__buf);
+    _DiffType __n_buf = static_cast<_DiffType>(__dpl_sycl::__get_buffer_size(__buf));
     _DiffType __n_acc = (__n > 0 ? __n : __n_buf);
 
     assert(__offset + __n_acc <= __n_buf &&

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -43,13 +43,24 @@ namespace __internal
 {
 template <typename _AccessorType, typename _BufferType, typename _DiffType>
 static _AccessorType
-__create_accessor(_BufferType& __buf, _DiffType __offset, _DiffType __n, const sycl::property_list& __properties = {})
+__create_accessor(_BufferType& __buf, _DiffType __offset, _DiffType __n, bool __no_init = false)
 {
     auto __n_buf = __dpl_sycl::__get_buffer_size(__buf);
     auto __n_acc = (__n > 0 ? __n : __n_buf);
 
     assert(__offset + __n_acc <= __n_buf &&
            "The sum of accessRange and accessOffset should not exceed the range of buffer");
+
+#if _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN
+    // Only request no_init when the accessor spans the entire buffer, where discarding the whole buffer is what
+    // was asked for anyway. Dropping the property is always functionally safe: it merely costs a copy-in which
+    // no_init would have permitted the runtime to skip it.
+    if (__offset != 0 || _DiffType(__n_acc) != _DiffType(__n_buf))
+        __no_init = false;
+#endif
+
+    const sycl::property_list __properties =
+        __no_init ? sycl::property_list{__dpl_sycl::__no_init{}} : sycl::property_list{};
 
     return {__buf, sycl::range<1>(__n_acc), __offset, __properties};
 }
@@ -69,8 +80,7 @@ class all_view
     using value_type = _T;
 
     all_view(sycl::buffer<_T, 1> __buf = sycl::buffer<_T, 1>(0), __diff_type __offset = 0, __diff_type __n = 0)
-        : __m_acc(__internal::__create_accessor<__accessor_t>(
-              __buf, __offset, __n, _NoInit ? sycl::property_list{__dpl_sycl::__no_init{}} : sycl::property_list{}))
+        : __m_acc(__internal::__create_accessor<__accessor_t>(__buf, __offset, __n, _NoInit))
     {
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -43,10 +43,10 @@ namespace __internal
 {
 template <typename _AccessorType, typename _BufferType, typename _DiffType>
 static _AccessorType
-__create_accessor(_BufferType& __buf, _DiffType __offset, _DiffType __n, bool __no_init = false)
+__create_accessor(_BufferType& __buf, _DiffType __offset, _DiffType __n, bool __no_init_requested = false)
 {
-    auto __n_buf = __dpl_sycl::__get_buffer_size(__buf);
-    auto __n_acc = (__n > 0 ? __n : __n_buf);
+    _DiffType __n_buf = __dpl_sycl::__get_buffer_size(__buf);
+    _DiffType __n_acc = (__n > 0 ? __n : __n_buf);
 
     assert(__offset + __n_acc <= __n_buf &&
            "The sum of accessRange and accessOffset should not exceed the range of buffer");
@@ -55,12 +55,12 @@ __create_accessor(_BufferType& __buf, _DiffType __offset, _DiffType __n, bool __
     // Only request no_init when the accessor spans the entire buffer, where discarding the whole buffer is what
     // was asked for anyway. Dropping the property is always functionally safe: it merely costs a copy-in which
     // no_init would have permitted the runtime to skip it.
-    if (__offset != 0 || _DiffType(__n_acc) != _DiffType(__n_buf))
-        __no_init = false;
+    if (__offset != 0 || __n_acc != __n_buf)
+        __no_init_requested = false;
 #endif
 
     const sycl::property_list __properties =
-        __no_init ? sycl::property_list{__dpl_sycl::__no_init{}} : sycl::property_list{};
+        __no_init_requested ? sycl::property_list{__dpl_sycl::__no_init{}} : sycl::property_list{};
 
     return {__buf, sycl::range<1>(__n_acc), __offset, __properties};
 }

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -362,7 +362,7 @@
 // of the whole buffer in the DPC++ runtime, rather than only the elements within the accessor's range as specified.
 // Known broken in all released icpx versions to date; bump the bound once a fixed version ships.
 // version ships.
-#if __INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER <= 20260100
+#if __INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER <= _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER
 #    define _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN 1
 #else
 #    define _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN 0

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -98,6 +98,18 @@
 #    define _ONEDPL_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
 #endif
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// *** When updating we must audit each usage to ensure that the issue still exists in the latest version ***
+//
+// This section contains macros representing the "Latest" version of compilers, STL implementations, etc. for use in
+// broken macros to represent the latest version of something which still has an ongoing issue. The intention is to
+// update this section regularly to reflect the latest version.
+//
+// When such an issue is fixed, we must replace the usage of these "Latest" macros with the appropriate version number
+// before updating to the newest version in this section.
+#define _ONEDPL_LATEST_INTEL_LLVM_COMPILER 20260200
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 // Enable SIMD for compilers that support OpenMP 4.0
 #if (_OPENMP >= 201307) || __INTEL_LLVM_COMPILER || (__INTEL_COMPILER >= 1600) ||                                      \
     (!defined(__INTEL_LLVM_COMPILER) && !defined(__INTEL_COMPILER) && _ONEDPL_GCC_VERSION >= 40900)
@@ -360,9 +372,8 @@
 
 // sycl::property::no_init on a ranged accessor (one covering only a sub-range of its buffer) discards the contents
 // of the whole buffer in the DPC++ runtime, rather than only the elements within the accessor's range as specified.
-// Known broken in all released icpx versions to date; bump the bound once a fixed version ships.
-// version ships.
-#if __INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER <= _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER
+// Known broken in all released icpx versions to date.
+#if __INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER <= _ONEDPL_LATEST_INTEL_LLVM_COMPILER
 #    define _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN 1
 #else
 #    define _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN 0

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -358,6 +358,16 @@
 #    define _ONEDPL_HIDDEN_FRIENDS_SIBLING_ACCESS_BROKEN 0
 #endif
 
+// sycl::property::no_init on a ranged accessor (one covering only a sub-range of its buffer) discards the contents
+// of the whole buffer in the DPC++ runtime, rather than only the elements within the accessor's range as specified.
+// Known broken in all released icpx versions to date; bump the bound once a fixed version ships.
+// version ships.
+#if __INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER <= 20260100
+#    define _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN 1
+#else
+#    define _ONEDPL_SYCL_RANGED_ACCESSOR_NO_INIT_BROKEN 0
+#endif
+
 // -- Configure heterogeneous backends --
 
 #if !defined(ONEDPL_ALLOW_DEFERRED_WAITING)

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -98,17 +98,9 @@
 #    define _ONEDPL_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
 #endif
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// *** When updating we must audit each usage to ensure that the issue still exists in the latest version ***
-//
-// This section contains macros representing the "Latest" version of compilers, STL implementations, etc. for use in
-// broken macros to represent the latest version of something which still has an ongoing issue. The intention is to
-// update this section regularly to reflect the latest version.
-//
-// When such an issue is fixed, we must replace the usage of these "Latest" macros with the appropriate version number
-// before updating to the newest version in this section.
+// This macro represents the "latest" version of the intel llvm compiler, and is used in workarounds gated to the compiler version.
+// We must update this with the compiler and re-evaluate if the workarounds are still necessary each time.
 #define _ONEDPL_LATEST_INTEL_LLVM_COMPILER 20260200
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Enable SIMD for compilers that support OpenMP 4.0
 #if (_OPENMP >= 201307) || __INTEL_LLVM_COMPILER || (__INTEL_COMPILER >= 1600) ||                                      \


### PR DESCRIPTION
#2617 uncovered an issue with the icpx sycl runtime where ranged accessors to buffers with no_init improperly discards data outside the accessor range, despite the specification's guarantees that this other data is preserved.  

This PR adds a workaround, gated by a broken macro to avoid passing no_init for ranged accessors which do not cover the entire buffer. 

I've added a intel llvm latest macro similar to the one we have in the tests.  The intention is to update this in the same way as the test version.  This one is just used to trigger workarounds rather than skipping broken tests.