### PR TITLE
Remove multiple condition checks in `__parallel_transform_scan_single_group` function

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -349,13 +349,12 @@ __parallel_transform_scan_single_group(sycl::queue& __q, _InRng&& __in_rng, _Out
                 __unary_op);
         };
 
-        static constexpr std::array<std::uint16_t, 10> __supported_sizes = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
+        static constexpr std::array<std::uint16_t, 11> __supported_sizes = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
         for (std::uint16_t __size : __supported_sizes)
         {
-            if (__n <= __size)
+            if (__n <= __size || __size == 16384)
                 return __single_group_scan_f(std::integral_constant<std::uint16_t, __size>{});
         }
-        return __single_group_scan_f(std::integral_constant<std::uint16_t, 16384>{});
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -329,14 +329,14 @@ __parallel_transform_scan_single_group(sycl::queue& __q, _InRng&& __in_rng, _Out
     std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__q);
 
     // Specialization for devices that have a max work-group size of 1024
-    constexpr ::std::uint16_t __targeted_wg_size = 1024;
+    constexpr std::uint16_t __targeted_wg_size = 1024;
 
     if (__max_wg_size >= __targeted_wg_size)
     {
         auto __single_group_scan_f = [&](auto __size_constant) {
-            constexpr ::std::uint16_t __size = decltype(__size_constant)::value;
-            constexpr ::std::uint16_t __wg_size = ::std::min(__size, __targeted_wg_size);
-            constexpr ::std::uint16_t __num_elems_per_item =
+            constexpr std::uint16_t __size = decltype(__size_constant)::value;
+            constexpr std::uint16_t __wg_size = std::min(__size, __targeted_wg_size);
+            constexpr std::uint16_t __num_elems_per_item =
                 oneapi::dpl::__internal::__dpl_ceiling_div(__size, __wg_size);
 
             return __parallel_transform_scan_static_single_group_submitter<
@@ -353,9 +353,9 @@ __parallel_transform_scan_single_group(sycl::queue& __q, _InRng&& __in_rng, _Out
         for (std::uint16_t __size : __supported_sizes)
         {
             if (__n <= __size)
-                return __single_group_scan_f(std::integral_constant<::std::uint16_t, __size>{});
+                return __single_group_scan_f(std::integral_constant<std::uint16_t, __size>{});
         }
-        return __single_group_scan_f(std::integral_constant<::std::uint16_t, 16384>{});
+        return __single_group_scan_f(std::integral_constant<std::uint16_t, 16384>{});
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -326,7 +326,7 @@ __parallel_transform_scan_single_group(sycl::queue& __q, _InRng&& __in_rng, _Out
                                        _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op,
                                        _Inclusive)
 {
-    std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__q);
+    const std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__q);
 
     // Specialization for devices that have a max work-group size of 1024
     constexpr std::uint16_t __targeted_wg_size = 1024;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -348,28 +348,14 @@ __parallel_transform_scan_single_group(sycl::queue& __q, _InRng&& __in_rng, _Out
                 __q, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, __init, __binary_op,
                 __unary_op);
         };
-        if (__n <= 16)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 16>{});
-        else if (__n <= 32)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 32>{});
-        else if (__n <= 64)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 64>{});
-        else if (__n <= 128)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 128>{});
-        else if (__n <= 256)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 256>{});
-        else if (__n <= 512)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 512>{});
-        else if (__n <= 1024)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 1024>{});
-        else if (__n <= 2048)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 2048>{});
-        else if (__n <= 4096)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 4096>{});
-        else if (__n <= 8192)
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 8192>{});
-        else
-            return __single_group_scan_f(std::integral_constant<::std::uint16_t, 16384>{});
+
+        static constexpr std::array<std::uint16_t, 10> __supported_sizes = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
+        for (std::uint16_t __size : __supported_sizes)
+        {
+            if (__n <= __size)
+                return __single_group_scan_f(std::integral_constant<::std::uint16_t, __size>{});
+        }
+        return __single_group_scan_f(std::integral_constant<::std::uint16_t, 16384>{});
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -349,7 +349,7 @@ __parallel_transform_scan_single_group(sycl::queue& __q, _InRng&& __in_rng, _Out
                 __unary_op);
         };
 
-        static constexpr std::array<std::uint16_t, 11> __supported_sizes = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
+        constexpr std::array<std::uint16_t, 11> __supported_sizes = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
         for (std::uint16_t __size : __supported_sizes)
         {
             if (__n <= __size || __size == 16384)


### PR DESCRIPTION
## Summary

Simplifies the dispatch logic in `__parallel_transform_scan_single_group()` (`include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h`).

The long `if (__n <= 16) ... else if (__n <= 32) ... else ...` chain, which selected the compile-time single-group scan size, is replaced by a loop over a `static constexpr std::array<std::uint16_t, 10>` of the supported sizes `{16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192}`, with `16384` kept as the fallback for larger `__n`.

## Changes

- Replace the chain of `__n <= ...` conditions with an iteration over `__supported_sizes`; the selected size is still passed as a compile-time `std::integral_constant<std::uint16_t, __size>` to `__single_group_scan_f`, so the same set of kernel instantiations is produced.
- Declare `__max_wg_size` as `const`.
- Drop the legacy `::std::` qualification in favor of `std::` and remove redundant semicolons in the touched code.

## Behavior

No functional change:
- the same size thresholds are used, in the same order;
- the same specializations (`__parallel_transform_scan_static_single_group_submitter` with the same `__wg_size` / `__num_elems_per_item`) are instantiated;
- the fallback path for devices with `__max_wg_size < __targeted_wg_size` is untouched.

This is a readability/maintainability cleanup: adding or removing a supported size now means editing a single array instead of the condition chain.

## Testing

Covered by the existing scan tests (`transform_scan`, `inclusive_scan`, `exclusive_scan`, and related single-group paths); no new tests are required since behavior is unchanged.