### PR TITLE
Align the order of constraints in `requires`-clauses of range-based algorithms with the `oneAPI` specification

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -268,8 +268,8 @@ struct __internal::__find_end_fn
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-        && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
         && std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2>
+        && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
 
     std::ranges::borrowed_subrange_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1261,7 +1261,7 @@ struct __internal::__rotate_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::permutable<std::ranges::iterator_t<_R>> && std::ranges::sized_range<_R>
+                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle) const

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -246,8 +246,8 @@ struct __internal::__find_first_of_fn
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
     requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-        && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
         && std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2>
+        && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
 
     std::ranges::borrowed_iterator_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1329,7 +1329,7 @@ struct __internal::__shift_left_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::permutable<std::ranges::iterator_t<_R>> && std::ranges::sized_range<_R>
+                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1566,7 +1566,7 @@ struct __internal::__unique_fn
               std::indirect_equivalence_relation<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp =
                   std::ranges::equal_to>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::permutable<std::ranges::iterator_t<_R>> && std::ranges::sized_range<_R>
+                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1205,7 +1205,7 @@ struct __internal::__reverse_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::permutable<std::ranges::iterator_t<_R>> && std::ranges::sized_range<_R>
+                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r) const

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1385,9 +1385,9 @@ struct __internal::__mismatch_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
-    requires std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
-        && oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
+    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
         && (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>)
+        && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
 
     std::ranges::mismatch_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1364,7 +1364,7 @@ struct __internal::__shift_right_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::permutable<std::ranges::iterator_t<_R>> && std::ranges::sized_range<_R>
+                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -178,9 +178,9 @@ namespace __internal
 struct __destroy_fn
 {
     template <typename _ExecutionPolicy, __nothrow_random_access_range _R>
-        requires std::destructible<std::ranges::range_value_t<_R>> &&
-                 oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::destructible<std::ranges::range_value_t<_R>>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r) const

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -105,10 +105,10 @@ struct __uninitialized_copy_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
               __nothrow_random_access_range _OutRange>
-        requires std::constructible_from<std::ranges::range_value_t<_OutRange>,
-                                         std::ranges::range_reference_t<_InRange>> &&
-                 oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange> &&
+                 std::constructible_from<std::ranges::range_value_t<_OutRange>,
+                                         std::ranges::range_reference_t<_InRange>>
 
     std::ranges::uninitialized_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
                                            std::ranges::borrowed_iterator_t<_OutRange>>

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -156,9 +156,9 @@ namespace __internal
 struct __uninitialized_fill_fn
 {
     template <typename _ExecutionPolicy, __nothrow_random_access_range _R, typename _T = std::ranges::range_value_t<_R>>
-        requires std::constructible_from<std::ranges::range_value_t<_R>, const _T&> &&
-                 oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::constructible_from<std::ranges::range_value_t<_R>, const _T&>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value) const

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -82,9 +82,9 @@ namespace __internal
 struct __uninitialized_value_construct_fn
 {
     template <typename _ExecutionPolicy, __nothrow_random_access_range _R>
-        requires std::default_initializable<std::ranges::range_value_t<_R>> &&
-                 oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::default_initializable<std::ranges::range_value_t<_R>>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r) const

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -131,10 +131,10 @@ struct __uninitialized_move_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
               __nothrow_random_access_range _OutRange>
-        requires std::constructible_from<std::ranges::range_value_t<_OutRange>,
-                                         std::ranges::range_rvalue_reference_t<_InRange>> &&
-                 oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange> &&
+                 std::constructible_from<std::ranges::range_value_t<_OutRange>,
+                                         std::ranges::range_rvalue_reference_t<_InRange>>
 
     std::ranges::uninitialized_move_result<std::ranges::borrowed_iterator_t<_InRange>,
                                            std::ranges::borrowed_iterator_t<_OutRange>>

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -60,9 +60,9 @@ namespace __internal
 struct __uninitialized_default_construct_fn
 {
     template <typename _ExecutionPolicy, __nothrow_random_access_range _R>
-        requires std::default_initializable<std::ranges::range_value_t<_R>> &&
-                 oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::default_initializable<std::ranges::range_value_t<_R>>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r) const


### PR DESCRIPTION
## Summary

This PR aligns the order of constraints in the `requires`-clauses of the range-based algorithm and uninitialized memory algorithm implementations with the order used in the [oneAPI Specification, Parallel Range API](https://github.com/uxlfoundation/oneAPI-spec/blob/main/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst).

In several places the constraints were listed in an arbitrary order, which made it hard to compare the implementation against the specification during review. The specification consistently uses the following order:

1. `oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>`
2. `std::ranges::sized_range<...>` constraints
3. the remaining semantic constraints (`std::permutable`, `std::indirectly_comparable`, `std::constructible_from`, `std::default_initializable`, `std::destructible`, ...)

## What has changed

Only the order of the conjuncts inside the `requires`-clauses. There are **some kind of functional changes**: the set of constraints is exactly the same, and `&&` in a `requires`-clause is a conjunction of atomic constraints, so the accepted set of template arguments is unchanged.

Each change is a separate commit. The commit message contains the file name and the algorithm name, followed by the corresponding declaration from the specification that defines the expected order.

### `include/oneapi/dpl/pstl/glue_memory_ranges_impl.h`

- `uninitialized_default_construct`
- `uninitialized_value_construct`
- `uninitialized_copy`
- `uninitialized_move`
- `uninitialized_fill`
- `destroy`

### `include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h`

- `find_first_of`
- `find_end`
- `reverse`
- `rotate`
- `shift_left`
- `shift_right`
- `mismatch`
- `unique`

## Notes

- `include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h` contains no `requires`-clauses and therefore is not affected.
- No public API behavior is changed, so no new tests are required. The existing `std_ranges_*` tests cover the affected algorithms.