### PR TITLE
Additional formatting in `requires`-clauses of range-based algorithms + renames of types and parameters

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -55,8 +55,8 @@ namespace ranges
 
 struct __internal::__for_each_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirectly_unary_invocable<std::projected<std::ranges::iterator_t<_R>, _Proj>>  _Fun>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirectly_unary_invocable<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Fun>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     std::ranges::borrowed_iterator_t<_R>
@@ -75,15 +75,16 @@ inline constexpr __internal::__for_each_fn for_each;
 
 struct __internal::__transform_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R,
-             std::ranges::random_access_range _OutRange, std::copy_constructible _F, typename _Proj = std::identity>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
+              std::ranges::random_access_range _OutRange, std::copy_constructible _F, typename _Proj = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::indirectly_writable<
                      std::ranges::iterator_t<_OutRange>,
                      std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
-    std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
+    std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<_R>,
+                                        std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutRange&& __out_r, _F __op, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
@@ -97,9 +98,9 @@ struct __internal::__transform_fn
         return {std::ranges::begin(__r) + __size, std::ranges::begin(__out_r) +  __size};
     }
 
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-             std::ranges::random_access_range _OutRange, std::copy_constructible _F, typename _Proj1 = std::identity,
-             typename _Proj2 = std::identity>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
+              std::ranges::random_access_range _OutRange, std::copy_constructible _F, typename _Proj1 = std::identity,
+              typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
                  std::ranges::sized_range<_OutRange> &&
@@ -108,7 +109,7 @@ struct __internal::__transform_fn
                      std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
                                             std::projected<std::ranges::iterator_t<_R2>, _Proj2>>>
     std::ranges::binary_transform_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
-        std::ranges::borrowed_iterator_t<_OutRange>>
+                                         std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _F __binary_op,
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
@@ -248,11 +249,10 @@ inline constexpr __internal::__find_last_fn find_last;
 
 struct __internal::__find_first_of_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-             typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
+              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> &&
-                 std::ranges::sized_range<_R2> &&
+                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
                  std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     std::ranges::borrowed_iterator_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
@@ -270,8 +270,8 @@ inline constexpr __internal::__find_first_of_fn find_first_of;
 
 struct __internal::__find_end_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-             typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
+              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
@@ -292,8 +292,8 @@ inline constexpr __internal::__find_end_fn find_end;
 
 struct __internal::__any_of_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     bool
@@ -310,8 +310,8 @@ inline constexpr __internal::__any_of_fn any_of;
 
 struct __internal::__all_of_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     bool
@@ -328,8 +328,8 @@ inline constexpr __internal::__all_of_fn all_of;
 
 struct __internal::__none_of_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     bool
@@ -445,8 +445,8 @@ inline constexpr __internal::__contains_subrange_fn contains_subrange;
 
 struct __internal::__count_if_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     std::ranges::range_difference_t<_R>
@@ -461,8 +461,8 @@ inline constexpr __internal::__count_if_fn count_if;
 
 struct __internal::__count_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             typename _T = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_R>, _Proj>>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              typename _T = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_R>, _Proj>>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirect_binary_predicate<std::ranges::equal_to,
@@ -481,8 +481,8 @@ inline constexpr __internal::__count_fn count;
 
 struct __internal::__equal_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-             typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
+              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
                  std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
@@ -531,9 +531,9 @@ inline constexpr __internal::__lex_compare_fn lexicographical_compare;
 
 struct __internal::__is_sorted_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
-             _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
+              _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     bool
@@ -548,9 +548,9 @@ inline constexpr __internal::__is_sorted_fn is_sorted;
 
 struct __internal::__is_sorted_until_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
-             _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
+              _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     std::ranges::borrowed_iterator_t<_R>
@@ -671,7 +671,7 @@ inline constexpr __internal::__partial_sort_copy_fn partial_sort_copy;
 struct __internal::__is_heap_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-        std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     bool
@@ -687,7 +687,7 @@ inline constexpr __internal::__is_heap_fn is_heap;
 struct __internal::__is_heap_until_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-        std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     std::ranges::borrowed_iterator_t<_R>
@@ -704,9 +704,8 @@ inline constexpr __internal::__is_heap_until_fn is_heap_until;
 
 struct __internal::__min_element_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
-             _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     std::ranges::borrowed_iterator_t<_R>
@@ -721,8 +720,8 @@ inline constexpr __internal::__min_element_fn min_element;
 
 struct __internal::__max_element_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     std::ranges::borrowed_iterator_t<_R>
@@ -736,8 +735,8 @@ inline constexpr __internal::__max_element_fn max_element;
 
 struct __internal::__minmax_element_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-         std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     std::ranges::minmax_element_result<std::ranges::borrowed_iterator_t<_R>>
@@ -755,8 +754,8 @@ inline constexpr __internal::__minmax_element_fn minmax_element;
 
 struct __internal::__min_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
@@ -774,8 +773,8 @@ inline constexpr __internal::__min_fn min;
 
 struct __internal::__max_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
@@ -792,8 +791,8 @@ inline constexpr __internal::__max_fn max;
 
 struct __internal::__minmax_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-             std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
+              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
@@ -815,8 +814,8 @@ inline constexpr __internal::__minmax_fn minmax;
 
 struct __internal::__copy_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
-             std::ranges::random_access_range _OutRange>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+              std::ranges::random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_InRange> &&
                  std::ranges::sized_range<_OutRange> &&
@@ -1043,7 +1042,8 @@ inline constexpr __internal::__set_symmetric_difference_fn set_symmetric_differe
 
 struct __internal::__fill_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _T = std::ranges::range_value_t<_R>>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
+              typename _T = std::ranges::range_value_t<_R>>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirectly_writable<std::ranges::iterator_t<_R>, const _T&>
@@ -1061,7 +1061,8 @@ inline constexpr __internal::__fill_fn fill;
 
 struct __internal::__move_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _InRange, std::ranges::random_access_range _OutRange>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+              std::ranges::random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_InRange> &&
                  std::ranges::sized_range<_OutRange> &&
@@ -1394,8 +1395,8 @@ inline constexpr __internal::__shift_right_fn shift_right;
 
 struct __internal::__mismatch_fn
 {
-    template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-             typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
+              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
                  std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1380,11 +1380,11 @@ struct __internal::__shift_right_fn
                  std::ranges::sized_range<_R> &&
                  std::permutable<std::ranges::iterator_t<_R>>
     std::ranges::borrowed_subrange_t<_R>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __n) const
     {
         std::ranges::reverse_view __reverse_r{__r};
 
-        auto __res = oneapi::dpl::ranges::shift_left(std::forward<_ExecutionPolicy>(__exec), __reverse_r, __shift);
+        auto __res = oneapi::dpl::ranges::shift_left(std::forward<_ExecutionPolicy>(__exec), __reverse_r, __n);
 
         auto __last = std::ranges::begin(__r) + std::ranges::size(__r);
         return {__res.end().base(), __last};

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -252,7 +252,8 @@ struct __internal::__find_first_of_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
               typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
                  std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     std::ranges::borrowed_iterator_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -76,20 +76,20 @@ inline constexpr __internal::__for_each_fn for_each;
 struct __internal::__transform_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange, std::copy_constructible _F, typename _Proj = std::identity>
+              std::ranges::random_access_range _OutR, std::copy_constructible _F, typename _Proj = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_OutR> &&
                  std::indirectly_writable<
-                     std::ranges::iterator_t<_OutRange>,
+                     std::ranges::iterator_t<_OutR>,
                      std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
     std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<_R>,
-                                        std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutRange&& __out_r, _F __op, _Proj __proj = {}) const
+                                        std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _F __op, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
-        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutRange>>;
+        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
         const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
 
         oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -99,24 +99,24 @@ struct __internal::__transform_fn
     }
 
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-              std::ranges::random_access_range _OutRange, std::copy_constructible _F, typename _Proj1 = std::identity,
+              std::ranges::random_access_range _OutR, std::copy_constructible _F, typename _Proj1 = std::identity,
               typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
-                 std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_OutR> &&
                  std::indirectly_writable<
-                     std::ranges::iterator_t<_OutRange>,
+                     std::ranges::iterator_t<_OutR>,
                      std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
                                             std::projected<std::ranges::iterator_t<_R2>, _Proj2>>>
     std::ranges::binary_transform_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
-                                         std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _F __binary_op,
+                                         std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _F __binary_op,
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<oneapi::dpl::__internal::__range_size_t<_R1>,
-            oneapi::dpl::__internal::__range_size_t<_R2>, std::ranges::range_size_t<_OutRange>>;
+            oneapi::dpl::__internal::__range_size_t<_R2>, std::ranges::range_size_t<_OutR>>;
         _Size __size = std::ranges::size(__out_r);
         if constexpr(std::ranges::sized_range<_R1>)
             __size = std::ranges::min(__size, (_Size)std::ranges::size(__r1));
@@ -816,17 +816,17 @@ inline constexpr __internal::__minmax_fn minmax;
 struct __internal::__copy_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange>
+              std::ranges::random_access_range _OutR>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
-    std::ranges::copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r) const
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
+    std::ranges::copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
-        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutRange>>;
+        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
         const _Size __size = std::ranges::min((_Size)std::ranges::size(__in_r), (_Size)std::ranges::size(__out_r));
 
         oneapi::dpl::__internal::__ranges::__pattern_copy(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -840,19 +840,19 @@ inline constexpr __internal::__copy_fn copy;
 struct __internal::__copy_if_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange, typename _Proj = std::identity,
+              std::ranges::random_access_range _OutR, typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
-    std::ranges::copy_if_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r, _Pred __pred, _Proj __proj = {}) const
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
+    std::ranges::copy_if_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r, _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         // No minimum common size is calculated here, because the size of the output range is unknown
         return oneapi::dpl::__internal::__ranges::__pattern_copy_if_ranges(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::forward<_R>(__in_r), std::forward<_OutRange>(__out_r), __pred, __proj);
+            std::forward<_R>(__in_r), std::forward<_OutR>(__out_r), __pred, __proj);
     }
 }; //__copy_if_fn
 inline constexpr __internal::__copy_if_fn copy_if;
@@ -862,24 +862,24 @@ inline constexpr __internal::__copy_if_fn copy_if;
 struct __internal::__merge_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-              std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
+              std::ranges::random_access_range _OutR, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_OutR> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
-                                std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
+                                std::ranges::iterator_t<_OutR>, _Comp, _Proj1, _Proj2>
     std::ranges::merge_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
-                              std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {},
+                              std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         // TODO: develop a strategy to get a common minimum size
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_merge_ranges(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
     }
 }; //__merge_fn
 inline constexpr __internal::__merge_fn merge;
@@ -931,23 +931,23 @@ inline constexpr __internal::__includes_fn includes;
 struct __internal::__set_union_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-              std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
+              std::ranges::random_access_range _OutR, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_OutR> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
-                                std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
+                                std::ranges::iterator_t<_OutR>, _Comp, _Proj1, _Proj2>
     std::ranges::set_union_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
-                                  std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {},
+                                  std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_set_union(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
     }
 }; //__set_union_fn
 inline constexpr __internal::__set_union_fn set_union;
@@ -957,17 +957,17 @@ inline constexpr __internal::__set_union_fn set_union;
 struct __internal::__set_intersection_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-              std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
+              std::ranges::random_access_range _OutR, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_OutR> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
-                                std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
+                                std::ranges::iterator_t<_OutR>, _Comp, _Proj1, _Proj2>
     std::ranges::set_intersection_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
-                                         std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {},
+                                         std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
@@ -975,12 +975,12 @@ struct __internal::__set_intersection_fn
 #    if ONEDPL_SET_RANGE_ALGS_CPP26_LIKE
         return oneapi::dpl::__internal::__ranges::__pattern_set_intersection(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
 #    else
         return {std::ranges::begin(__r1) + std::ranges::size(__r1), std::ranges::begin(__r2) + std::ranges::size(__r2),
                 oneapi::dpl::__internal::__ranges::__pattern_set_intersection(
                     __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __r1, __r2,
-                    std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2)
+                    std::forward<_OutR>(__out_r), __comp, __proj1, __proj2)
                     .out};
 #    endif
     }
@@ -992,22 +992,22 @@ inline constexpr __internal::__set_intersection_fn set_intersection;
 struct __internal::__set_difference_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-              std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
+              std::ranges::random_access_range _OutR, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_OutR> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
-                                std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
-    oneapi::dpl::__utils::__set_difference_return_t<_R1, _R2, _OutRange>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {},
+                                std::ranges::iterator_t<_OutR>, _Comp, _Proj1, _Proj2>
+    oneapi::dpl::__utils::__set_difference_return_t<_R1, _R2, _OutR>
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_set_difference(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
     }
 }; //__set_difference_fn
 inline constexpr __internal::__set_difference_fn set_difference;
@@ -1017,24 +1017,24 @@ inline constexpr __internal::__set_difference_fn set_difference;
 struct __internal::__set_symmetric_difference_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-              std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
+              std::ranges::random_access_range _OutR, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_OutR> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
-                                std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
+                                std::ranges::iterator_t<_OutR>, _Comp, _Proj1, _Proj2>
     std::ranges::set_symmetric_difference_result<std::ranges::borrowed_iterator_t<_R1>,
                                                  std::ranges::borrowed_iterator_t<_R2>,
-                                                 std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {},
+                                                 std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_set_symmetric_difference(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutRange>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
     }
 }; //__set_symmetric_difference_fn
 inline constexpr __internal::__set_symmetric_difference_fn set_symmetric_difference;
@@ -1063,17 +1063,17 @@ inline constexpr __internal::__fill_fn fill;
 struct __internal::__move_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange>
+              std::ranges::random_access_range _OutR>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_movable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
-    std::ranges::move_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutRange&& __out_r) const
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_movable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
+    std::ranges::move_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
-        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutRange>>;
+        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
         const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
 
         oneapi::dpl::__internal::__ranges::__pattern_move(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -1158,21 +1158,21 @@ inline constexpr __internal::__replace_fn replace;
 struct __internal::__replace_copy_if_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange, class _T = std::ranges::range_value_t<_OutRange>,
+              std::ranges::random_access_range _OutR, class _T = std::ranges::range_value_t<_OutR>,
               typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>> &&
-                 std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T&>
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>> &&
+                 std::indirectly_writable<std::ranges::iterator_t<_OutR>, const _T&>
     std::ranges::replace_copy_if_result<std::ranges::borrowed_iterator_t<_R>,
-                                        std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r, _Pred __pred, const _T& __new_value,
+                                        std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r, _Pred __pred, const _T& __new_value,
                _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        const oneapi::dpl::__ranges::__common_size_t<_R, _OutRange> __size =
+        const oneapi::dpl::__ranges::__common_size_t<_R, _OutR> __size =
             oneapi::dpl::__ranges::__min_size_calc{}(__in_r, __out_r);
 
         oneapi::dpl::__internal::__ranges::__pattern_replace_copy_if(
@@ -1188,23 +1188,23 @@ inline constexpr __internal::__replace_copy_if_fn replace_copy_if;
 struct __internal::__replace_copy_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange, typename _Proj = std::identity,
+              std::ranges::random_access_range _OutR, typename _Proj = std::identity,
               typename _T1 = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_R>, _Proj>,
-              typename _T2 = std::ranges::range_value_t<_OutRange>>
+              typename _T2 = std::ranges::range_value_t<_OutR>>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>> &&
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>> &&
                  std::indirect_binary_predicate<std::ranges::equal_to,
                                                 std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T1*> &&
-                 std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T2&>
+                 std::indirectly_writable<std::ranges::iterator_t<_OutR>, const _T2&>
     std::ranges::replace_copy_result<std::ranges::borrowed_iterator_t<_R>,
-                                     std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r, const _T1& __old_value,
+                                     std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r, const _T1& __old_value,
                const _T2& __new_value, _Proj __proj = {}) const
     {
         return oneapi::dpl::ranges::replace_copy_if(
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r), std::forward<_OutRange>(__out_r),
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r), std::forward<_OutR>(__out_r),
             oneapi::dpl::__internal::__ranges_equal_value<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>, std::identity>{__old_value},
             __new_value, __proj);
@@ -1235,19 +1235,19 @@ inline constexpr __internal::__reverse_fn reverse;
 struct __internal::__reverse_copy_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange>
+              std::ranges::random_access_range _OutR>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_R>,
-                                  std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r) const
+                                  std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
-        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutRange>>;
+        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
         const _Size __in_size = std::ranges::size(__in_r);
         const _Size __out_size = std::ranges::size(__out_r);
         const _Size __min_size = std::ranges::min(__in_size, __out_size);
@@ -1307,16 +1307,16 @@ inline constexpr __internal::__rotate_fn rotate;
 struct __internal::__rotate_copy_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange>
+              std::ranges::random_access_range _OutR>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_R>,
-                                  std::ranges::borrowed_iterator_t<_OutRange>>
+                                  std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __in_r, std::ranges::iterator_t<_R> __middle,
-               _OutRange&& __out_r) const
+               _OutR&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         auto [__first_in, __last_in, __in_size] = oneapi::dpl::__ranges::__bounds_and_size(__in_r);
@@ -1596,22 +1596,22 @@ inline constexpr __internal::__unique_fn unique;
 struct __internal::__unique_copy_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange, typename _Proj = std::identity,
+              std::ranges::random_access_range _OutR, typename _Proj = std::identity,
               std::indirect_equivalence_relation<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp =
                   std::ranges::equal_to>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::unique_copy_result<std::ranges::borrowed_iterator_t<_R>,
-                                    std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r, _Comp __comp = {},
+                                    std::ranges::borrowed_iterator_t<_OutR>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r, _Comp __comp = {},
                _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_unique_copy(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r),
-            std::forward<_OutRange>(__out_r), __comp, __proj);
+            std::forward<_OutR>(__out_r), __comp, __proj);
     }
 }; //__unique_copy_fn
 inline constexpr __internal::__unique_copy_fn unique_copy;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -85,7 +85,7 @@ struct __internal::__transform_fn
                      std::indirect_result_t<_Fn&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
     std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<_R>,
                                         std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, _Fn __op, _Proj __proj = {}) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, _Fn __unary_op, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
@@ -93,7 +93,7 @@ struct __internal::__transform_fn
         const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__result));
 
         oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::ranges::take_view(__r, __size), std::ranges::take_view(__result, __size), __op, __proj);
+            std::ranges::take_view(__r, __size), std::ranges::take_view(__result, __size), __unary_op, __proj);
 
         return {std::ranges::begin(__r) + __size, std::ranges::begin(__result) +  __size};
     }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -253,8 +253,7 @@ struct __internal::__find_first_of_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
-                                            _Proj2>
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     std::ranges::borrowed_iterator_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -276,8 +275,7 @@ struct __internal::__find_end_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
-                                            _Proj2>
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     std::ranges::borrowed_subrange_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -372,8 +370,7 @@ struct __internal::__search_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
-                                            _Proj2>
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     std::ranges::borrowed_subrange_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -432,8 +429,7 @@ struct __internal::__contains_subrange_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
-                                            _Proj2>
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -489,8 +485,7 @@ struct __internal::__equal_fn
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
-                                            _Proj2>
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -1403,8 +1398,7 @@ struct __internal::__mismatch_fn
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
-                                            _Proj2>
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     std::ranges::mismatch_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
@@ -1452,8 +1446,7 @@ struct __internal::__starts_with_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
-                                            _Proj2>
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -1474,8 +1467,7 @@ struct __internal::__ends_with_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
-                                            _Proj2>
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -85,17 +85,17 @@ struct __internal::__transform_fn
                      std::indirect_result_t<_Fn&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
     std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<_R>,
                                         std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Fn __op, _Proj __proj = {}) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, _Fn __op, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
-        const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
+        const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__result));
 
         oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::ranges::take_view(__r, __size), std::ranges::take_view(__out_r, __size), __op, __proj);
+            std::ranges::take_view(__r, __size), std::ranges::take_view(__result, __size), __op, __proj);
 
-        return {std::ranges::begin(__r) + __size, std::ranges::begin(__out_r) +  __size};
+        return {std::ranges::begin(__r) + __size, std::ranges::begin(__result) +  __size};
     }
 
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
@@ -110,14 +110,14 @@ struct __internal::__transform_fn
                                             std::projected<std::ranges::iterator_t<_R2>, _Proj2>>>
     std::ranges::binary_transform_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
                                          std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Fn __binary_op,
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __result, _Fn __binary_op,
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<oneapi::dpl::__internal::__range_size_t<_R1>,
             oneapi::dpl::__internal::__range_size_t<_R2>, std::ranges::range_size_t<_OutR>>;
-        _Size __size = std::ranges::size(__out_r);
+        _Size __size = std::ranges::size(__result);
         if constexpr(std::ranges::sized_range<_R1>)
             __size = std::ranges::min(__size, (_Size)std::ranges::size(__r1));
         if constexpr(std::ranges::sized_range<_R2>)
@@ -127,9 +127,9 @@ struct __internal::__transform_fn
         oneapi::dpl::__internal::__ranges::__pattern_transform(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
             std::ranges::subrange(std::ranges::begin(__r1), std::ranges::begin(__r1) + __size),
             std::ranges::subrange(std::ranges::begin(__r2), std::ranges::begin(__r2) + __size),
-            std::ranges::take_view(__out_r, __size), __binary_op, __proj1, __proj2);
+            std::ranges::take_view(__result, __size), __binary_op, __proj1, __proj2);
 
-        return {std::ranges::begin(__r1) + __size, std::ranges::begin(__r2) + __size, std::ranges::begin(__out_r) + __size};
+        return {std::ranges::begin(__r1) + __size, std::ranges::begin(__r2) + __size, std::ranges::begin(__result) + __size};
     }
 }; //__transform_fn
 inline constexpr __internal::__transform_fn transform;
@@ -822,17 +822,17 @@ struct __internal::__copy_fn
                  std::ranges::sized_range<_OutR> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
-        const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
+        const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__result));
 
         oneapi::dpl::__internal::__ranges::__pattern_copy(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::ranges::take_view(__r, __size), std::ranges::take_view(__out_r, __size));
+            std::ranges::take_view(__r, __size), std::ranges::take_view(__result, __size));
 
-        return {std::ranges::begin(__r) + __size, std::ranges::begin(__out_r) +  __size};
+        return {std::ranges::begin(__r) + __size, std::ranges::begin(__result) +  __size};
     }
 }; //__copy_fn
 inline constexpr __internal::__copy_fn copy;
@@ -847,12 +847,12 @@ struct __internal::__copy_if_fn
                  std::ranges::sized_range<_OutR> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::copy_if_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Pred __pred, _Proj __proj = {}) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         // No minimum common size is calculated here, because the size of the output range is unknown
         return oneapi::dpl::__internal::__ranges::__pattern_copy_if_ranges(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::forward<_R>(__r), std::forward<_OutR>(__out_r), __pred, __proj);
+            std::forward<_R>(__r), std::forward<_OutR>(__result), __pred, __proj);
     }
 }; //__copy_if_fn
 inline constexpr __internal::__copy_if_fn copy_if;
@@ -872,14 +872,14 @@ struct __internal::__merge_fn
                                 std::ranges::iterator_t<_OutR>, _Comp, _Proj1, _Proj2>
     std::ranges::merge_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
                               std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __result, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         // TODO: develop a strategy to get a common minimum size
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_merge_ranges(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__result), __comp, __proj1, __proj2);
     }
 }; //__merge_fn
 inline constexpr __internal::__merge_fn merge;
@@ -941,13 +941,13 @@ struct __internal::__set_union_fn
                                 std::ranges::iterator_t<_OutR>, _Comp, _Proj1, _Proj2>
     std::ranges::set_union_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
                                   std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __result, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_set_union(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__result), __comp, __proj1, __proj2);
     }
 }; //__set_union_fn
 inline constexpr __internal::__set_union_fn set_union;
@@ -967,7 +967,7 @@ struct __internal::__set_intersection_fn
                                 std::ranges::iterator_t<_OutR>, _Comp, _Proj1, _Proj2>
     std::ranges::set_intersection_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
                                          std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __result, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
@@ -975,12 +975,12 @@ struct __internal::__set_intersection_fn
 #    if ONEDPL_SET_RANGE_ALGS_CPP26_LIKE
         return oneapi::dpl::__internal::__ranges::__pattern_set_intersection(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__result), __comp, __proj1, __proj2);
 #    else
         return {std::ranges::begin(__r1) + std::ranges::size(__r1), std::ranges::begin(__r2) + std::ranges::size(__r2),
                 oneapi::dpl::__internal::__ranges::__pattern_set_intersection(
                     __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __r1, __r2,
-                    std::forward<_OutR>(__out_r), __comp, __proj1, __proj2)
+                    std::forward<_OutR>(__result), __comp, __proj1, __proj2)
                     .out};
 #    endif
     }
@@ -1001,13 +1001,13 @@ struct __internal::__set_difference_fn
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutR>, _Comp, _Proj1, _Proj2>
     oneapi::dpl::__utils::__set_difference_return_t<_R1, _R2, _OutR>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __result, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_set_difference(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__result), __comp, __proj1, __proj2);
     }
 }; //__set_difference_fn
 inline constexpr __internal::__set_difference_fn set_difference;
@@ -1028,13 +1028,13 @@ struct __internal::__set_symmetric_difference_fn
     std::ranges::set_symmetric_difference_result<std::ranges::borrowed_iterator_t<_R1>,
                                                  std::ranges::borrowed_iterator_t<_R2>,
                                                  std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Comp __comp = {},
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __result, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_set_symmetric_difference(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R1>(__r1), std::forward<_R2>(__r2),
-            std::forward<_OutR>(__out_r), __comp, __proj1, __proj2);
+            std::forward<_OutR>(__result), __comp, __proj1, __proj2);
     }
 }; //__set_symmetric_difference_fn
 inline constexpr __internal::__set_symmetric_difference_fn set_symmetric_difference;
@@ -1069,17 +1069,17 @@ struct __internal::__move_fn
                  std::ranges::sized_range<_OutR> &&
                  std::indirectly_movable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::move_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
-        const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
+        const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__result));
 
         oneapi::dpl::__internal::__ranges::__pattern_move(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::ranges::take_view(__r, __size), std::ranges::take_view(__out_r, __size));
+            std::ranges::take_view(__r, __size), std::ranges::take_view(__result, __size));
 
-        return {std::ranges::begin(__r) + __size, std::ranges::begin(__out_r) + __size};
+        return {std::ranges::begin(__r) + __size, std::ranges::begin(__result) + __size};
     }
 }; //__move_fn
 inline constexpr __internal::__move_fn move;
@@ -1168,19 +1168,19 @@ struct __internal::__replace_copy_if_fn
                  std::indirectly_writable<std::ranges::iterator_t<_OutR>, const _T&>
     std::ranges::replace_copy_if_result<std::ranges::borrowed_iterator_t<_R>,
                                         std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Pred __pred, const _T& __new_value,
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, _Pred __pred, const _T& __new_value,
                _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         const oneapi::dpl::__ranges::__common_size_t<_R, _OutR> __size =
-            oneapi::dpl::__ranges::__min_size_calc{}(__r, __out_r);
+            oneapi::dpl::__ranges::__min_size_calc{}(__r, __result);
 
         oneapi::dpl::__internal::__ranges::__pattern_replace_copy_if(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::take_view(__r, __size),
-            std::ranges::take_view(__out_r, __size), __pred,
+            std::ranges::take_view(__result, __size), __pred,
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>{__new_value}, __proj);
 
-        return {std::ranges::begin(__r) + __size, std::ranges::begin(__out_r) + __size};
+        return {std::ranges::begin(__r) + __size, std::ranges::begin(__result) + __size};
     }
 }; //__replace_copy_if_fn
 inline constexpr __internal::__replace_copy_if_fn replace_copy_if;
@@ -1200,11 +1200,11 @@ struct __internal::__replace_copy_fn
                  std::indirectly_writable<std::ranges::iterator_t<_OutR>, const _T2&>
     std::ranges::replace_copy_result<std::ranges::borrowed_iterator_t<_R>,
                                      std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, const _T1& __old_value,
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, const _T1& __old_value,
                const _T2& __new_value, _Proj __proj = {}) const
     {
         return oneapi::dpl::ranges::replace_copy_if(
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__out_r),
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__result),
             oneapi::dpl::__internal::__ranges_equal_value<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>, std::identity>{__old_value},
             __new_value, __proj);
@@ -1243,17 +1243,17 @@ struct __internal::__reverse_copy_fn
     std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
         const _Size __in_size = std::ranges::size(__r);
-        const _Size __out_size = std::ranges::size(__out_r);
+        const _Size __out_size = std::ranges::size(__result);
         const _Size __min_size = std::ranges::min(__in_size, __out_size);
 
         auto __first_in = std::ranges::begin(__r);
-        auto __first_out = std::ranges::begin(__out_r);
+        auto __first_out = std::ranges::begin(__result);
 
         auto __last_in = __first_in + __in_size;
         auto __stop_in = __first_in + (__in_size - __min_size);
@@ -1316,12 +1316,12 @@ struct __internal::__rotate_copy_fn
                                   std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle,
-               _OutR&& __out_r) const
+               _OutR&& __result) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         auto [__first_in, __last_in, __in_size] = oneapi::dpl::__ranges::__bounds_and_size(__r);
-        auto __first_out = std::ranges::begin(__out_r);
-        const std::size_t __min_size = std::min<std::size_t>(__in_size, std::ranges::size(__out_r));
+        auto __first_out = std::ranges::begin(__result);
+        const std::size_t __min_size = std::min<std::size_t>(__in_size, std::ranges::size(__result));
 
         auto __stop_out = oneapi::dpl::__internal::__pattern_rotate_copy(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first_in, __middle, __last_in, __first_out,
@@ -1539,10 +1539,10 @@ struct __internal::__remove_copy_if_fn
                  std::ranges::sized_range<_OutR> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::remove_copy_if_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Pred __pred, _Proj __proj = {}) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, _Pred __pred, _Proj __proj = {}) const
     {
         return oneapi::dpl::ranges::copy_if(
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__out_r),
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__result),
             oneapi::dpl::__internal::__not_pred<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _Pred>>(__pred), __proj);
     }
@@ -1561,13 +1561,13 @@ struct __internal::__remove_copy_fn
                  std::indirect_binary_predicate<std::ranges::equal_to,
                                                 std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T*>
     std::ranges::remove_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, const _T& __value, _Proj __proj = {}) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, const _T& __value, _Proj __proj = {}) const
     {
         using __equal_to_pred_t = oneapi::dpl::__internal::__ranges_equal_value<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>;
 
         return oneapi::dpl::ranges::copy_if(
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__out_r),
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__result),
             oneapi::dpl::__internal::__not_pred<__equal_to_pred_t>(__equal_to_pred_t{__value}), __proj);
     }
 }; //__remove_copy_fn
@@ -1605,13 +1605,13 @@ struct __internal::__unique_copy_fn
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::unique_copy_result<std::ranges::borrowed_iterator_t<_R>,
                                     std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Comp __comp = {},
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __result, _Comp __comp = {},
                _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_unique_copy(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            std::forward<_OutR>(__out_r), __comp, __proj);
+            std::forward<_OutR>(__result), __comp, __proj);
     }
 }; //__unique_copy_fn
 inline constexpr __internal::__unique_copy_fn unique_copy;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1158,7 +1158,7 @@ inline constexpr __internal::__replace_fn replace;
 struct __internal::__replace_copy_if_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutR, class _T = std::ranges::range_value_t<_OutR>,
+              std::ranges::random_access_range _OutR, typename _T = std::ranges::range_value_t<_OutR>,
               typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -815,18 +815,18 @@ inline constexpr __internal::__minmax_fn minmax;
 
 struct __internal::__copy_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
               std::ranges::random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-    std::ranges::copy_result<std::ranges::borrowed_iterator_t<_InRange>, std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
+    std::ranges::copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
-        using _Size = std::common_type_t<std::ranges::range_size_t<_InRange>, std::ranges::range_size_t<_OutRange>>;
+        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutRange>>;
         const _Size __size = std::ranges::min((_Size)std::ranges::size(__in_r), (_Size)std::ranges::size(__out_r));
 
         oneapi::dpl::__internal::__ranges::__pattern_copy(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -839,20 +839,20 @@ inline constexpr __internal::__copy_fn copy;
 
 struct __internal::__copy_if_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
               std::ranges::random_access_range _OutRange, typename _Proj = std::identity,
-              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_InRange>, _Proj>> _Pred>
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-    std::ranges::copy_if_result<std::ranges::borrowed_iterator_t<_InRange>, std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Pred __pred, _Proj __proj = {}) const
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
+    std::ranges::copy_if_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r, _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         // No minimum common size is calculated here, because the size of the output range is unknown
         return oneapi::dpl::__internal::__ranges::__pattern_copy_if_ranges(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::forward<_InRange>(__in_r), std::forward<_OutRange>(__out_r), __pred, __proj);
+            std::forward<_R>(__in_r), std::forward<_OutRange>(__out_r), __pred, __proj);
     }
 }; //__copy_if_fn
 inline constexpr __internal::__copy_if_fn copy_if;
@@ -1062,18 +1062,18 @@ inline constexpr __internal::__fill_fn fill;
 
 struct __internal::__move_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
               std::ranges::random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_movable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-    std::ranges::move_result<std::ranges::borrowed_iterator_t<_InRange>, std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __r, _OutRange&& __out_r) const
+                 std::indirectly_movable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
+    std::ranges::move_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutRange&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
-        using _Size = std::common_type_t<std::ranges::range_size_t<_InRange>, std::ranges::range_size_t<_OutRange>>;
+        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutRange>>;
         const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
 
         oneapi::dpl::__internal::__ranges::__pattern_move(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
@@ -1157,22 +1157,22 @@ inline constexpr __internal::__replace_fn replace;
 
 struct __internal::__replace_copy_if_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
               std::ranges::random_access_range _OutRange, class _T = std::ranges::range_value_t<_OutRange>,
               typename _Proj = std::identity,
-              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_InRange>, _Proj>> _Pred>
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>> &&
                  std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T&>
-    std::ranges::replace_copy_if_result<std::ranges::borrowed_iterator_t<_InRange>,
+    std::ranges::replace_copy_if_result<std::ranges::borrowed_iterator_t<_R>,
                                         std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Pred __pred, const _T& __new_value,
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r, _Pred __pred, const _T& __new_value,
                _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        const oneapi::dpl::__ranges::__common_size_t<_InRange, _OutRange> __size =
+        const oneapi::dpl::__ranges::__common_size_t<_R, _OutRange> __size =
             oneapi::dpl::__ranges::__min_size_calc{}(__in_r, __out_r);
 
         oneapi::dpl::__internal::__ranges::__pattern_replace_copy_if(
@@ -1187,24 +1187,24 @@ inline constexpr __internal::__replace_copy_if_fn replace_copy_if;
 
 struct __internal::__replace_copy_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
               std::ranges::random_access_range _OutRange, typename _Proj = std::identity,
-              typename _T1 = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_InRange>, _Proj>,
+              typename _T1 = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_R>, _Proj>,
               typename _T2 = std::ranges::range_value_t<_OutRange>>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>> &&
                  std::indirect_binary_predicate<std::ranges::equal_to,
-                                                std::projected<std::ranges::iterator_t<_InRange>, _Proj>, const _T1*> &&
+                                                std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T1*> &&
                  std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T2&>
-    std::ranges::replace_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
+    std::ranges::replace_copy_result<std::ranges::borrowed_iterator_t<_R>,
                                      std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, const _T1& __old_value,
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r, const _T1& __old_value,
                const _T2& __new_value, _Proj __proj = {}) const
     {
         return oneapi::dpl::ranges::replace_copy_if(
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r), std::forward<_OutRange>(__out_r),
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r), std::forward<_OutRange>(__out_r),
             oneapi::dpl::__internal::__ranges_equal_value<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>, std::identity>{__old_value},
             __new_value, __proj);
@@ -1234,20 +1234,20 @@ inline constexpr __internal::__reverse_fn reverse;
 
 struct __internal::__reverse_copy_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
               std::ranges::random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-    std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_InRange>,
-                                  std::ranges::borrowed_iterator_t<_InRange>,
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
+    std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_R>,
+                                  std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
-        using _Size = std::common_type_t<std::ranges::range_size_t<_InRange>, std::ranges::range_size_t<_OutRange>>;
+        using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutRange>>;
         const _Size __in_size = std::ranges::size(__in_r);
         const _Size __out_size = std::ranges::size(__out_r);
         const _Size __min_size = std::ranges::min(__in_size, __out_size);
@@ -1306,16 +1306,16 @@ inline constexpr __internal::__rotate_fn rotate;
 
 struct __internal::__rotate_copy_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
               std::ranges::random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-    std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_InRange>,
-                                  std::ranges::borrowed_iterator_t<_InRange>,
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
+    std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_R>,
+                                  std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, std::ranges::iterator_t<_InRange> __middle,
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, std::ranges::iterator_t<_R> __middle,
                _OutRange&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
@@ -1595,22 +1595,22 @@ inline constexpr __internal::__unique_fn unique;
 
 struct __internal::__unique_copy_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
               std::ranges::random_access_range _OutRange, typename _Proj = std::identity,
-              std::indirect_equivalence_relation<std::projected<std::ranges::iterator_t<_InRange>, _Proj>> _Comp =
+              std::indirect_equivalence_relation<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp =
                   std::ranges::equal_to>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-    std::ranges::unique_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange>>
+    std::ranges::unique_copy_result<std::ranges::borrowed_iterator_t<_R>,
                                     std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Comp __comp = {},
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange&& __out_r, _Comp __comp = {},
                _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_unique_copy(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r),
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r),
             std::forward<_OutRange>(__out_r), __comp, __proj);
     }
 }; //__unique_copy_fn
@@ -1654,25 +1654,25 @@ inline constexpr __internal::__stable_partition_fn stable_partition;
 
 struct __internal::__partition_copy_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
               std::ranges::random_access_range _OutRange1, std::ranges::random_access_range _OutRange2,
               typename _Proj = std::identity,
-              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_InRange>, _Proj>> _Pred>
+              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutRange1> &&
                  std::ranges::sized_range<_OutRange2> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange1>> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange2>>
-    std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange1>> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange2>>
+    std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_R>,
                                        std::ranges::borrowed_iterator_t<_OutRange1>,
                                        std::ranges::borrowed_iterator_t<_OutRange2>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange1&& __out_true_r, _OutRange2&& __out_false_r,
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange1&& __out_true_r, _OutRange2&& __out_false_r,
                _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_partition_copy_ranges(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r),
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r),
             std::forward<_OutRange1>(__out_true_r), std::forward<_OutRange2>(__out_false_r), __pred, __proj);
     }
 }; //__partition_copy_fn

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -57,7 +57,8 @@ struct __internal::__for_each_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirectly_unary_invocable<std::projected<std::ranges::iterator_t<_R>, _Proj>>  _Fun>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Fun __f, _Proj __proj = {}) const
@@ -77,9 +78,12 @@ struct __internal::__transform_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R,
              std::ranges::random_access_range _OutRange, std::copy_constructible _F, typename _Proj = std::identity>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
-        && std::ranges::sized_range<_OutRange> && std::indirectly_writable<std::ranges::iterator_t<_OutRange>,
-                 std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::ranges::sized_range<_OutRange> &&
+                 std::indirectly_writable<
+                     std::ranges::iterator_t<_OutRange>,
+                     std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
 
     std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutRange&& __out_r, _F __op, _Proj __proj = {}) const
@@ -98,11 +102,13 @@ struct __internal::__transform_fn
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
              std::ranges::random_access_range _OutRange, std::copy_constructible _F, typename _Proj1 = std::identity,
              typename _Proj2 = std::identity>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && (std::ranges::sized_range<_R1>
-        || std::ranges::sized_range<_R2>) && std::ranges::sized_range<_OutRange>
-        && std::indirectly_writable<std::ranges::iterator_t<_OutRange>,
-            std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
-            std::projected<std::ranges::iterator_t<_R2>, _Proj2>>>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
+                 std::ranges::sized_range<_OutRange> &&
+                 std::indirectly_writable<
+                     std::ranges::iterator_t<_OutRange>,
+                     std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
+                                            std::projected<std::ranges::iterator_t<_R2>, _Proj2>>>
 
     std::ranges::binary_transform_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
         std::ranges::borrowed_iterator_t<_OutRange>>
@@ -248,9 +254,11 @@ struct __internal::__find_first_of_fn
 
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-        && std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2>
-        && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
+                                            _Proj2>
 
     std::ranges::borrowed_iterator_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
@@ -270,9 +278,11 @@ struct __internal::__find_end_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-        && std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2>
-        && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
+                                            _Proj2>
 
     std::ranges::borrowed_subrange_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
@@ -292,7 +302,8 @@ struct __internal::__any_of_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
     bool
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
@@ -309,7 +320,8 @@ struct __internal::__all_of_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
     bool
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
@@ -326,7 +338,8 @@ struct __internal::__none_of_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
     bool
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
@@ -363,7 +376,8 @@ struct __internal::__search_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
               typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
                  std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
                                             _Proj2>
     std::ranges::borrowed_subrange_t<_R1>
@@ -422,9 +436,10 @@ struct __internal::__contains_subrange_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
               typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
-                                            _Pred, _Proj1, _Proj2>
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
+                                            _Proj2>
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -442,7 +457,8 @@ struct __internal::__count_if_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
 
     std::ranges::range_difference_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
@@ -458,9 +474,10 @@ struct __internal::__count_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              typename _T = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_R>, _Proj>>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
-        && std::indirect_binary_predicate<std::ranges::equal_to, std::projected<std::ranges::iterator_t<_R>, _Proj>,
-                                          const _T*>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::indirect_binary_predicate<std::ranges::equal_to,
+                                                std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T*>
     std::ranges::range_difference_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
@@ -477,10 +494,10 @@ struct __internal::__equal_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-           && (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>)
-           && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
-           _Proj2>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
+                                            _Proj2>
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -507,8 +524,9 @@ struct __internal::__lex_compare_fn
               std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
                                               std::projected<std::ranges::iterator_t<_R2>, _Proj2>>
                   _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2>
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Comp __comp = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -528,7 +546,8 @@ struct __internal::__is_sorted_fn
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
              _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
     bool
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -544,7 +563,8 @@ struct __internal::__is_sorted_until_fn
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
              _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
@@ -575,7 +595,8 @@ struct __internal::__stable_sort_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,
               typename _Proj = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
+                 std::ranges::sized_range<_R> &&
+                 std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -604,7 +625,8 @@ struct __internal::__sort_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,
               typename _Proj = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
+                 std::ranges::sized_range<_R> &&
+                 std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -621,7 +643,8 @@ struct __internal::__partial_sort_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,
               typename _Proj = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
+                 std::ranges::sized_range<_R> &&
+                 std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle, _Comp __comp = {},
                _Proj __proj = {}) const
@@ -638,7 +661,8 @@ struct __internal::__partial_sort_copy_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, std::ranges::random_access_range _OutR,
               typename _Comp = std::ranges::less, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::ranges::sized_range<_OutR> &&
+                 std::ranges::sized_range<_R> &&
+                 std::ranges::sized_range<_OutR> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>> &&
                  std::sortable<std::ranges::iterator_t<_OutR>, _Comp, _Proj2> &&
                  std::indirect_strict_weak_order<_Comp, std::projected<std::ranges::iterator_t<_R>, _Proj1>,
@@ -661,8 +685,8 @@ struct __internal::__is_heap_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
         std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
     bool
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -677,8 +701,8 @@ struct __internal::__is_heap_until_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
         std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -696,7 +720,8 @@ struct __internal::__min_element_fn
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>>
              _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
@@ -712,7 +737,8 @@ struct __internal::__max_element_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
@@ -727,7 +753,8 @@ struct __internal::__minmax_element_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
          std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R>
 
     std::ranges::minmax_element_result<std::ranges::borrowed_iterator_t<_R>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
@@ -746,8 +773,9 @@ struct __internal::__min_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
-             && std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
 
     std::ranges::range_value_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
@@ -766,8 +794,9 @@ struct __internal::__max_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
-             && std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
 
     std::ranges::range_value_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
@@ -785,8 +814,9 @@ struct __internal::__minmax_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> && std::ranges::sized_range<_R>
-             && std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
 
     std::ranges::minmax_result<std::ranges::range_value_t<_R>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
@@ -809,9 +839,10 @@ struct __internal::__copy_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
              std::ranges::random_access_range _OutRange>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-        && std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange>
-        && std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
 
     std::ranges::copy_result<std::ranges::borrowed_iterator_t<_InRange>, std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
@@ -835,7 +866,8 @@ struct __internal::__copy_if_fn
               std::ranges::random_access_range _OutRange, typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_InRange>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
     std::ranges::copy_if_result<std::ranges::borrowed_iterator_t<_InRange>, std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Pred __pred, _Proj __proj = {}) const
@@ -856,7 +888,8 @@ struct __internal::__merge_fn
               std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
@@ -879,7 +912,8 @@ struct __internal::__inplace_merge_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,
               typename _Proj = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
+                 std::ranges::sized_range<_R> &&
+                 std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle, _Comp __comp = {},
                _Proj __proj = {}) const
@@ -902,7 +936,8 @@ struct __internal::__includes_fn
                                               std::projected<std::ranges::iterator_t<_R2>, _Proj2>>
                   _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2>
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2>
 
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Comp __comp = {}, _Proj1 __proj1 = {},
@@ -924,7 +959,8 @@ struct __internal::__set_union_fn
               std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
@@ -950,7 +986,8 @@ struct __internal::__set_intersection_fn
               std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
@@ -985,7 +1022,8 @@ struct __internal::__set_difference_fn
               std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
@@ -1010,7 +1048,8 @@ struct __internal::__set_symmetric_difference_fn
               std::ranges::random_access_range _OutRange, typename _Comp = std::ranges::less,
               typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
@@ -1034,8 +1073,9 @@ inline constexpr __internal::__set_symmetric_difference_fn set_symmetric_differe
 struct __internal::__fill_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _T = std::ranges::range_value_t<_R>>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-             std::ranges::sized_range<_R> && std::indirectly_writable<std::ranges::iterator_t<_R>, const _T&>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::indirectly_writable<std::ranges::iterator_t<_R>, const _T&>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value) const
@@ -1052,9 +1092,10 @@ inline constexpr __internal::__fill_fn fill;
 struct __internal::__move_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _InRange, std::ranges::random_access_range _OutRange>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-        && std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange>
-        && std::indirectly_movable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
+                 std::indirectly_movable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
 
     std::ranges::move_result<std::ranges::borrowed_iterator_t<_InRange>, std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __r, _OutRange&& __out_r) const
@@ -1078,7 +1119,8 @@ struct __internal::__swap_ranges_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
                  std::indirectly_swappable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>>
 
     std::ranges::swap_ranges_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>>
@@ -1104,8 +1146,9 @@ struct __internal::__replace_if_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
               typename _T = std::ranges::range_value_t<_R>,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R> && std::indirectly_writable<std::ranges::iterator_t<_R>, const _T&>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::indirectly_writable<std::ranges::iterator_t<_R>, const _T&>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, const _T& __new_value, _Proj __proj = {}) const
@@ -1125,10 +1168,11 @@ struct __internal::__replace_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
               typename _T1 = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_R>, _Proj>,
               typename _T2 = std::ranges::range_value_t<_R>>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R> && std::indirectly_writable<std::ranges::iterator_t<_R>, const _T2&>
-             && std::indirect_binary_predicate<std::ranges::equal_to,
-                                               std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T1*>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::indirectly_writable<std::ranges::iterator_t<_R>, const _T2&> &&
+                 std::indirect_binary_predicate<std::ranges::equal_to,
+                                                std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T1*>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T1& __old_value, const _T2& __new_value,
@@ -1149,10 +1193,11 @@ struct __internal::__replace_copy_if_fn
               std::ranges::random_access_range _OutRange, class _T = std::ranges::range_value_t<_OutRange>,
               typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_InRange>, _Proj>> _Pred>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange>
-             && std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-             && std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T&>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>> &&
+                 std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T&>
 
     std::ranges::replace_copy_if_result<std::ranges::borrowed_iterator_t<_InRange>,
                                         std::ranges::borrowed_iterator_t<_OutRange>>
@@ -1179,12 +1224,13 @@ struct __internal::__replace_copy_fn
               std::ranges::random_access_range _OutRange, typename _Proj = std::identity,
               typename _T1 = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_InRange>, _Proj>,
               typename _T2 = std::ranges::range_value_t<_OutRange>>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange>
-             && std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-             && std::indirect_binary_predicate<std::ranges::equal_to,
-                                               std::projected<std::ranges::iterator_t<_InRange>, _Proj>, const _T1*>
-             && std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T2&>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>> &&
+                 std::indirect_binary_predicate<std::ranges::equal_to,
+                                                std::projected<std::ranges::iterator_t<_InRange>, _Proj>, const _T1*> &&
+                 std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T2&>
 
     std::ranges::replace_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
                                      std::ranges::borrowed_iterator_t<_OutRange>>
@@ -1206,7 +1252,8 @@ struct __internal::__reverse_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
+                 std::ranges::sized_range<_R> &&
+                 std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r) const
@@ -1225,7 +1272,8 @@ struct __internal::__reverse_copy_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
               std::ranges::random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
 
     std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_InRange>,
@@ -1262,7 +1310,8 @@ struct __internal::__rotate_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
+                 std::ranges::sized_range<_R> &&
+                 std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle) const
@@ -1297,7 +1346,8 @@ struct __internal::__rotate_copy_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
               std::ranges::random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
 
     std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_InRange>,
@@ -1330,7 +1380,8 @@ struct __internal::__shift_left_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
+                 std::ranges::sized_range<_R> &&
+                 std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
@@ -1365,7 +1416,8 @@ struct __internal::__shift_right_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
+                 std::ranges::sized_range<_R> &&
+                 std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
@@ -1386,9 +1438,10 @@ struct __internal::__mismatch_fn
 {
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-        && (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>)
-        && std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1, _Proj2>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
+                                            _Proj2>
 
     std::ranges::mismatch_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
@@ -1435,9 +1488,10 @@ struct __internal::__starts_with_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
               typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
-                                            _Pred, _Proj1, _Proj2>
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
+                                            _Proj2>
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -1456,9 +1510,10 @@ struct __internal::__ends_with_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
               typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R1> && std::ranges::sized_range<_R2> &&
-                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
-                                            _Pred, _Proj1, _Proj2>
+                 std::ranges::sized_range<_R1> &&
+                 std::ranges::sized_range<_R2> &&
+                 std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
+                                            _Proj2>
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -1484,8 +1539,9 @@ struct __internal::__remove_if_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
@@ -1501,10 +1557,11 @@ struct __internal::__remove_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
               typename _T = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_R>, _Proj>>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
-             && std::indirect_binary_predicate<std::ranges::equal_to,
-                                               std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T*>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::permutable<std::ranges::iterator_t<_R>> &&
+                 std::indirect_binary_predicate<std::ranges::equal_to,
+                                                std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T*>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
@@ -1523,9 +1580,10 @@ struct __internal::__remove_copy_if_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, std::ranges::random_access_range _OutR,
               typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R> && std::ranges::sized_range<_OutR>
-             && std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
 
     std::ranges::remove_copy_if_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Pred __pred, _Proj __proj = {}) const
@@ -1543,11 +1601,12 @@ struct __internal::__remove_copy_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, std::ranges::random_access_range _OutR,
               typename _Proj = std::identity,
               typename _T = oneapi::dpl::projected_value_t<std::ranges::iterator_t<_R>, _Proj>>
-    requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>>
-             && std::ranges::sized_range<_R> && std::ranges::sized_range<_OutR>
-             && std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
-             && std::indirect_binary_predicate<std::ranges::equal_to,
-                                               std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T*>
+        requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
+                 std::ranges::sized_range<_R> &&
+                 std::ranges::sized_range<_OutR> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>> &&
+                 std::indirect_binary_predicate<std::ranges::equal_to,
+                                                std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T*>
 
     std::ranges::remove_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, const _T& __value, _Proj __proj = {}) const
@@ -1570,7 +1629,8 @@ struct __internal::__unique_fn
               std::indirect_equivalence_relation<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp =
                   std::ranges::equal_to>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
+                 std::ranges::sized_range<_R> &&
+                 std::permutable<std::ranges::iterator_t<_R>>
 
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
@@ -1589,7 +1649,8 @@ struct __internal::__unique_copy_fn
               std::indirect_equivalence_relation<std::projected<std::ranges::iterator_t<_InRange>, _Proj>> _Comp =
                   std::ranges::equal_to>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
 
     std::ranges::unique_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
@@ -1612,7 +1673,8 @@ struct __internal::__partition_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
+                 std::ranges::sized_range<_R> &&
+                 std::permutable<std::ranges::iterator_t<_R>>
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
@@ -1628,7 +1690,8 @@ struct __internal::__stable_partition_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::permutable<std::ranges::iterator_t<_R>>
+                 std::ranges::sized_range<_R> &&
+                 std::permutable<std::ranges::iterator_t<_R>>
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
@@ -1646,7 +1709,8 @@ struct __internal::__partition_copy_fn
               typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_InRange>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange1> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange1> &&
                  std::ranges::sized_range<_OutRange2> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange1>> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange2>>
@@ -1672,7 +1736,8 @@ struct __internal::__nth_element_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Comp = std::ranges::less,
               typename _Proj = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_R> && std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
+                 std::ranges::sized_range<_R> &&
+                 std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
 
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __nth, _Comp __comp = {},

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1655,25 +1655,25 @@ inline constexpr __internal::__stable_partition_fn stable_partition;
 struct __internal::__partition_copy_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutRange1, std::ranges::random_access_range _OutRange2,
+              std::ranges::random_access_range _OutR1, std::ranges::random_access_range _OutR2,
               typename _Proj = std::identity,
               std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
-                 std::ranges::sized_range<_OutRange1> &&
-                 std::ranges::sized_range<_OutRange2> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange1>> &&
-                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutRange2>>
+                 std::ranges::sized_range<_OutR1> &&
+                 std::ranges::sized_range<_OutR2> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR1>> &&
+                 std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR2>>
     std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_R>,
-                                       std::ranges::borrowed_iterator_t<_OutRange1>,
-                                       std::ranges::borrowed_iterator_t<_OutRange2>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutRange1&& __out_true_r, _OutRange2&& __out_false_r,
+                                       std::ranges::borrowed_iterator_t<_OutR1>,
+                                       std::ranges::borrowed_iterator_t<_OutR2>>
+    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR1&& __out_true_r, _OutR2&& __out_false_r,
                _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_partition_copy_ranges(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r),
-            std::forward<_OutRange1>(__out_true_r), std::forward<_OutRange2>(__out_false_r), __pred, __proj);
+            std::forward<_OutR1>(__out_true_r), std::forward<_OutR2>(__out_false_r), __pred, __proj);
     }
 }; //__partition_copy_fn
 inline constexpr __internal::__partition_copy_fn partition_copy;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -129,7 +129,8 @@ struct __internal::__transform_fn
             std::ranges::subrange(std::ranges::begin(__r2), std::ranges::begin(__r2) + __size),
             std::ranges::take_view(__result, __size), __binary_op, __proj1, __proj2);
 
-        return {std::ranges::begin(__r1) + __size, std::ranges::begin(__r2) + __size, std::ranges::begin(__result) + __size};
+        return {std::ranges::begin(__r1) + __size, std::ranges::begin(__r2) + __size,
+                std::ranges::begin(__result) + __size};
     }
 }; //__transform_fn
 inline constexpr __internal::__transform_fn transform;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -59,7 +59,6 @@ struct __internal::__for_each_fn
              std::indirectly_unary_invocable<std::projected<std::ranges::iterator_t<_R>, _Proj>>  _Fun>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Fun __f, _Proj __proj = {}) const
     {
@@ -84,7 +83,6 @@ struct __internal::__transform_fn
                  std::indirectly_writable<
                      std::ranges::iterator_t<_OutRange>,
                      std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
-
     std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutRange&& __out_r, _F __op, _Proj __proj = {}) const
     {
@@ -109,7 +107,6 @@ struct __internal::__transform_fn
                      std::ranges::iterator_t<_OutRange>,
                      std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
                                             std::projected<std::ranges::iterator_t<_R2>, _Proj2>>>
-
     std::ranges::binary_transform_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
         std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _F __binary_op,
@@ -251,7 +248,6 @@ inline constexpr __internal::__find_last_fn find_last;
 
 struct __internal::__find_first_of_fn
 {
-
     template<typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
              typename _Pred = std::ranges::equal_to, typename _Proj1 = std::identity, typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
@@ -259,7 +255,6 @@ struct __internal::__find_first_of_fn
                  std::ranges::sized_range<_R2> &&
                  std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
                                             _Proj2>
-
     std::ranges::borrowed_iterator_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -283,7 +278,6 @@ struct __internal::__find_end_fn
                  std::ranges::sized_range<_R2> &&
                  std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
                                             _Proj2>
-
     std::ranges::borrowed_subrange_t<_R1>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -459,7 +453,6 @@ struct __internal::__count_if_fn
              std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Pred>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
-
     std::ranges::range_difference_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
@@ -565,7 +558,6 @@ struct __internal::__is_sorted_until_fn
              _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -722,7 +714,6 @@ struct __internal::__min_element_fn
              _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -739,7 +730,6 @@ struct __internal::__max_element_fn
              std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -755,7 +745,6 @@ struct __internal::__minmax_element_fn
          std::indirect_strict_weak_order<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Comp = std::ranges::less>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
-
     std::ranges::minmax_element_result<std::ranges::borrowed_iterator_t<_R>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -776,7 +765,6 @@ struct __internal::__min_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
-
     std::ranges::range_value_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -786,7 +774,6 @@ struct __internal::__min_fn
         return oneapi::dpl::__internal::__ranges::__pattern_min(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj);
     }
-
 }; //__min_fn
 inline constexpr __internal::__min_fn min;
 
@@ -797,7 +784,6 @@ struct __internal::__max_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
-
     std::ranges::range_value_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -806,7 +792,6 @@ struct __internal::__max_fn
         return oneapi::dpl::ranges::min(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
             oneapi::dpl::__internal::__reorder_pred(__comp), __proj);
     }
-
 }; //__max_fn
 inline constexpr __internal::__max_fn max;
 
@@ -817,7 +802,6 @@ struct __internal::__minmax_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirectly_copyable_storable<std::ranges::iterator_t<_R>, std::ranges::range_value_t<_R>*>
-
     std::ranges::minmax_result<std::ranges::range_value_t<_R>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -829,7 +813,6 @@ struct __internal::__minmax_fn
 
         return {__min, __max};
     }
-
 }; //__minmax_fn
 inline constexpr __internal::__minmax_fn minmax;
 
@@ -843,7 +826,6 @@ struct __internal::__copy_fn
                  std::ranges::sized_range<_InRange> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-
     std::ranges::copy_result<std::ranges::borrowed_iterator_t<_InRange>, std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
     {
@@ -922,7 +904,6 @@ struct __internal::__inplace_merge_fn
         return oneapi::dpl::__internal::__ranges::__pattern_inplace_merge_ranges(
             __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __middle, __comp, __proj);
     }
-
 }; //__inplace_merge_fn
 inline constexpr __internal::__inplace_merge_fn inplace_merge;
 
@@ -938,7 +919,6 @@ struct __internal::__includes_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2>
-
     bool
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Comp __comp = {}, _Proj1 __proj1 = {},
                _Proj2 __proj2 = {}) const
@@ -964,7 +944,6 @@ struct __internal::__set_union_fn
                  std::ranges::sized_range<_OutRange> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
-
     std::ranges::set_union_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
                                   std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {},
@@ -991,7 +970,6 @@ struct __internal::__set_intersection_fn
                  std::ranges::sized_range<_OutRange> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
-
     std::ranges::set_intersection_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
                                          std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {},
@@ -1027,7 +1005,6 @@ struct __internal::__set_difference_fn
                  std::ranges::sized_range<_OutRange> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
-
     oneapi::dpl::__utils::__set_difference_return_t<_R1, _R2, _OutRange>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutRange&& __out_r, _Comp __comp = {},
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
@@ -1053,7 +1030,6 @@ struct __internal::__set_symmetric_difference_fn
                  std::ranges::sized_range<_OutRange> &&
                  std::mergeable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>,
                                 std::ranges::iterator_t<_OutRange>, _Comp, _Proj1, _Proj2>
-
     std::ranges::set_symmetric_difference_result<std::ranges::borrowed_iterator_t<_R1>,
                                                  std::ranges::borrowed_iterator_t<_R2>,
                                                  std::ranges::borrowed_iterator_t<_OutRange>>
@@ -1076,7 +1052,6 @@ struct __internal::__fill_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirectly_writable<std::ranges::iterator_t<_R>, const _T&>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value) const
     {
@@ -1096,7 +1071,6 @@ struct __internal::__move_fn
                  std::ranges::sized_range<_InRange> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::indirectly_movable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-
     std::ranges::move_result<std::ranges::borrowed_iterator_t<_InRange>, std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __r, _OutRange&& __out_r) const
     {
@@ -1122,7 +1096,6 @@ struct __internal::__swap_ranges_fn
                  std::ranges::sized_range<_R1> &&
                  std::ranges::sized_range<_R2> &&
                  std::indirectly_swappable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>>
-
     std::ranges::swap_ranges_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2) const
     {
@@ -1149,7 +1122,6 @@ struct __internal::__replace_if_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::indirectly_writable<std::ranges::iterator_t<_R>, const _T&>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, const _T& __new_value, _Proj __proj = {}) const
     {
@@ -1173,7 +1145,6 @@ struct __internal::__replace_fn
                  std::indirectly_writable<std::ranges::iterator_t<_R>, const _T2&> &&
                  std::indirect_binary_predicate<std::ranges::equal_to,
                                                 std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T1*>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T1& __old_value, const _T2& __new_value,
                _Proj __proj = {}) const
@@ -1198,7 +1169,6 @@ struct __internal::__replace_copy_if_fn
                  std::ranges::sized_range<_OutRange> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>> &&
                  std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T&>
-
     std::ranges::replace_copy_if_result<std::ranges::borrowed_iterator_t<_InRange>,
                                         std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Pred __pred, const _T& __new_value,
@@ -1231,7 +1201,6 @@ struct __internal::__replace_copy_fn
                  std::indirect_binary_predicate<std::ranges::equal_to,
                                                 std::projected<std::ranges::iterator_t<_InRange>, _Proj>, const _T1*> &&
                  std::indirectly_writable<std::ranges::iterator_t<_OutRange>, const _T2&>
-
     std::ranges::replace_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
                                      std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, const _T1& __old_value,
@@ -1254,7 +1223,6 @@ struct __internal::__reverse_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::permutable<std::ranges::iterator_t<_R>>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r) const
     {
@@ -1275,7 +1243,6 @@ struct __internal::__reverse_copy_fn
                  std::ranges::sized_range<_InRange> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-
     std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_InRange>,
                                   std::ranges::borrowed_iterator_t<_InRange>,
                                   std::ranges::borrowed_iterator_t<_OutRange>>
@@ -1312,7 +1279,6 @@ struct __internal::__rotate_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::permutable<std::ranges::iterator_t<_R>>
-
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle) const
     {
@@ -1349,7 +1315,6 @@ struct __internal::__rotate_copy_fn
                  std::ranges::sized_range<_InRange> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-
     std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_InRange>,
                                   std::ranges::borrowed_iterator_t<_InRange>,
                                   std::ranges::borrowed_iterator_t<_OutRange>>
@@ -1382,7 +1347,6 @@ struct __internal::__shift_left_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::permutable<std::ranges::iterator_t<_R>>
-
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
     {
@@ -1418,7 +1382,6 @@ struct __internal::__shift_right_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::permutable<std::ranges::iterator_t<_R>>
-
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
     {
@@ -1442,7 +1405,6 @@ struct __internal::__mismatch_fn
                  (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
                  std::indirectly_comparable<std::ranges::iterator_t<_R1>, std::ranges::iterator_t<_R2>, _Pred, _Proj1,
                                             _Proj2>
-
     std::ranges::mismatch_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>>
     operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
@@ -1542,7 +1504,6 @@ struct __internal::__remove_if_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::permutable<std::ranges::iterator_t<_R>>
-
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Pred __pred, _Proj __proj = {}) const
     {
@@ -1562,7 +1523,6 @@ struct __internal::__remove_fn
                  std::permutable<std::ranges::iterator_t<_R>> &&
                  std::indirect_binary_predicate<std::ranges::equal_to,
                                                 std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T*>
-
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
@@ -1584,7 +1544,6 @@ struct __internal::__remove_copy_if_fn
                  std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutR> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
-
     std::ranges::remove_copy_if_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Pred __pred, _Proj __proj = {}) const
     {
@@ -1607,7 +1566,6 @@ struct __internal::__remove_copy_fn
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>> &&
                  std::indirect_binary_predicate<std::ranges::equal_to,
                                                 std::projected<std::ranges::iterator_t<_R>, _Proj>, const _T*>
-
     std::ranges::remove_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, const _T& __value, _Proj __proj = {}) const
     {
@@ -1631,7 +1589,6 @@ struct __internal::__unique_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::permutable<std::ranges::iterator_t<_R>>
-
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
@@ -1652,7 +1609,6 @@ struct __internal::__unique_copy_fn
                  std::ranges::sized_range<_InRange> &&
                  std::ranges::sized_range<_OutRange> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange>>
-
     std::ranges::unique_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
                                     std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r, _Comp __comp = {},
@@ -1714,7 +1670,6 @@ struct __internal::__partition_copy_fn
                  std::ranges::sized_range<_OutRange2> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange1>> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_InRange>, std::ranges::iterator_t<_OutRange2>>
-
     std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
                                        std::ranges::borrowed_iterator_t<_OutRange1>,
                                        std::ranges::borrowed_iterator_t<_OutRange2>>
@@ -1738,7 +1693,6 @@ struct __internal::__nth_element_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::sortable<std::ranges::iterator_t<_R>, _Comp, _Proj>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __nth, _Comp __comp = {},
                _Proj __proj = {}) const

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1345,14 +1345,14 @@ struct __internal::__shift_left_fn
                  std::ranges::sized_range<_R> &&
                  std::permutable<std::ranges::iterator_t<_R>>
     std::ranges::borrowed_subrange_t<_R>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __shift) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::range_difference_t<_R> __n) const
     {
         using __dispatch_tag_t = decltype(oneapi::dpl::__ranges::__select_backend(__exec));
         auto [__first, __last] = oneapi::dpl::__ranges::__bounds(__r);
         if constexpr (std::is_same_v<__dispatch_tag_t, oneapi::dpl::__internal::__serial_tag<std::false_type>>)
         {
             // std::ranges::shift_left is only available since C++23
-            return {__first, std::shift_left(__first, __last, __shift)};
+            return {__first, std::shift_left(__first, __last, __n)};
         }
         else
         {
@@ -1361,12 +1361,12 @@ struct __internal::__shift_left_fn
             {
                 std::ranges::range_difference_t<_R> __res = oneapi::dpl::__internal::__pattern_shift_left(
                     __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec),
-                    oneapi::dpl::__ranges::__get_subscription_view(std::forward<_R>(__r)), __shift);
+                    oneapi::dpl::__ranges::__get_subscription_view(std::forward<_R>(__r)), __n);
                 return {__first, __first + __res};
             }
 #endif
             auto __res = oneapi::dpl::__internal::__pattern_shift_left(
-                __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __last, __shift);
+                __dispatch_tag_t{}, std::forward<_ExecutionPolicy>(__exec), __first, __last, __n);
             return {__first, __res};
         }
     }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -56,11 +56,11 @@ namespace ranges
 struct __internal::__for_each_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R, typename _Proj = std::identity,
-              std::indirectly_unary_invocable<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Fun>
+              std::indirectly_unary_invocable<std::projected<std::ranges::iterator_t<_R>, _Proj>> _Fn>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R>
     std::ranges::borrowed_iterator_t<_R>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Fun __f, _Proj __proj = {}) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _Fn __f, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         oneapi::dpl::__internal::__ranges::__pattern_for_each(
@@ -76,16 +76,16 @@ inline constexpr __internal::__for_each_fn for_each;
 struct __internal::__transform_fn
 {
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R,
-              std::ranges::random_access_range _OutR, std::copy_constructible _F, typename _Proj = std::identity>
+              std::ranges::random_access_range _OutR, std::copy_constructible _Fn, typename _Proj = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::ranges::sized_range<_OutR> &&
                  std::indirectly_writable<
                      std::ranges::iterator_t<_OutR>,
-                     std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
+                     std::indirect_result_t<_Fn&, std::projected<std::ranges::iterator_t<_R>, _Proj>>>
     std::ranges::unary_transform_result<std::ranges::borrowed_iterator_t<_R>,
                                         std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _F __op, _Proj __proj = {}) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Fn __op, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
@@ -99,18 +99,18 @@ struct __internal::__transform_fn
     }
 
     template <typename _ExecutionPolicy, std::ranges::random_access_range _R1, std::ranges::random_access_range _R2,
-              std::ranges::random_access_range _OutR, std::copy_constructible _F, typename _Proj1 = std::identity,
+              std::ranges::random_access_range _OutR, std::copy_constructible _Fn, typename _Proj1 = std::identity,
               typename _Proj2 = std::identity>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  (std::ranges::sized_range<_R1> || std::ranges::sized_range<_R2>) &&
                  std::ranges::sized_range<_OutR> &&
                  std::indirectly_writable<
                      std::ranges::iterator_t<_OutR>,
-                     std::indirect_result_t<_F&, std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
+                     std::indirect_result_t<_Fn&, std::projected<std::ranges::iterator_t<_R1>, _Proj1>,
                                             std::projected<std::ranges::iterator_t<_R2>, _Proj2>>>
     std::ranges::binary_transform_result<std::ranges::borrowed_iterator_t<_R1>, std::ranges::borrowed_iterator_t<_R2>,
                                          std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _F __binary_op,
+    operator()(_ExecutionPolicy&& __exec, _R1&& __r1, _R2&& __r2, _OutR&& __out_r, _Fn __binary_op,
                _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -822,17 +822,17 @@ struct __internal::__copy_fn
                  std::ranges::sized_range<_OutR> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
-        const _Size __size = std::ranges::min((_Size)std::ranges::size(__in_r), (_Size)std::ranges::size(__out_r));
+        const _Size __size = std::ranges::min((_Size)std::ranges::size(__r), (_Size)std::ranges::size(__out_r));
 
         oneapi::dpl::__internal::__ranges::__pattern_copy(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::ranges::take_view(__in_r, __size), std::ranges::take_view(__out_r, __size));
+            std::ranges::take_view(__r, __size), std::ranges::take_view(__out_r, __size));
 
-        return {std::ranges::begin(__in_r) + __size, std::ranges::begin(__out_r) +  __size};
+        return {std::ranges::begin(__r) + __size, std::ranges::begin(__out_r) +  __size};
     }
 }; //__copy_fn
 inline constexpr __internal::__copy_fn copy;
@@ -847,12 +847,12 @@ struct __internal::__copy_if_fn
                  std::ranges::sized_range<_OutR> &&
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::copy_if_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r, _Pred __pred, _Proj __proj = {}) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         // No minimum common size is calculated here, because the size of the output range is unknown
         return oneapi::dpl::__internal::__ranges::__pattern_copy_if_ranges(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec),
-            std::forward<_R>(__in_r), std::forward<_OutR>(__out_r), __pred, __proj);
+            std::forward<_R>(__r), std::forward<_OutR>(__out_r), __pred, __proj);
     }
 }; //__copy_if_fn
 inline constexpr __internal::__copy_if_fn copy_if;
@@ -1168,19 +1168,19 @@ struct __internal::__replace_copy_if_fn
                  std::indirectly_writable<std::ranges::iterator_t<_OutR>, const _T&>
     std::ranges::replace_copy_if_result<std::ranges::borrowed_iterator_t<_R>,
                                         std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r, _Pred __pred, const _T& __new_value,
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Pred __pred, const _T& __new_value,
                _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         const oneapi::dpl::__ranges::__common_size_t<_R, _OutR> __size =
-            oneapi::dpl::__ranges::__min_size_calc{}(__in_r, __out_r);
+            oneapi::dpl::__ranges::__min_size_calc{}(__r, __out_r);
 
         oneapi::dpl::__internal::__ranges::__pattern_replace_copy_if(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::take_view(__in_r, __size),
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::take_view(__r, __size),
             std::ranges::take_view(__out_r, __size), __pred,
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>{__new_value}, __proj);
 
-        return {std::ranges::begin(__in_r) + __size, std::ranges::begin(__out_r) + __size};
+        return {std::ranges::begin(__r) + __size, std::ranges::begin(__out_r) + __size};
     }
 }; //__replace_copy_if_fn
 inline constexpr __internal::__replace_copy_if_fn replace_copy_if;
@@ -1200,11 +1200,11 @@ struct __internal::__replace_copy_fn
                  std::indirectly_writable<std::ranges::iterator_t<_OutR>, const _T2&>
     std::ranges::replace_copy_result<std::ranges::borrowed_iterator_t<_R>,
                                      std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r, const _T1& __old_value,
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, const _T1& __old_value,
                const _T2& __new_value, _Proj __proj = {}) const
     {
         return oneapi::dpl::ranges::replace_copy_if(
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r), std::forward<_OutR>(__out_r),
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__out_r),
             oneapi::dpl::__internal::__ranges_equal_value<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>, std::identity>{__old_value},
             __new_value, __proj);
@@ -1243,16 +1243,16 @@ struct __internal::__reverse_copy_fn
     std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r) const
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         using _Size = std::common_type_t<std::ranges::range_size_t<_R>, std::ranges::range_size_t<_OutR>>;
-        const _Size __in_size = std::ranges::size(__in_r);
+        const _Size __in_size = std::ranges::size(__r);
         const _Size __out_size = std::ranges::size(__out_r);
         const _Size __min_size = std::ranges::min(__in_size, __out_size);
 
-        auto __first_in = std::ranges::begin(__in_r);
+        auto __first_in = std::ranges::begin(__r);
         auto __first_out = std::ranges::begin(__out_r);
 
         auto __last_in = __first_in + __in_size;
@@ -1315,11 +1315,11 @@ struct __internal::__rotate_copy_fn
     std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_R>,
                                   std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, std::ranges::iterator_t<_R> __middle,
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, std::ranges::iterator_t<_R> __middle,
                _OutR&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        auto [__first_in, __last_in, __in_size] = oneapi::dpl::__ranges::__bounds_and_size(__in_r);
+        auto [__first_in, __last_in, __in_size] = oneapi::dpl::__ranges::__bounds_and_size(__r);
         auto __first_out = std::ranges::begin(__out_r);
         const std::size_t __min_size = std::min<std::size_t>(__in_size, std::ranges::size(__out_r));
 
@@ -1605,12 +1605,12 @@ struct __internal::__unique_copy_fn
                  std::indirectly_copyable<std::ranges::iterator_t<_R>, std::ranges::iterator_t<_OutR>>
     std::ranges::unique_copy_result<std::ranges::borrowed_iterator_t<_R>,
                                     std::ranges::borrowed_iterator_t<_OutR>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR&& __out_r, _Comp __comp = {},
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, _Comp __comp = {},
                _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_unique_copy(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r),
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
             std::forward<_OutR>(__out_r), __comp, __proj);
     }
 }; //__unique_copy_fn
@@ -1667,12 +1667,12 @@ struct __internal::__partition_copy_fn
     std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<_R>,
                                        std::ranges::borrowed_iterator_t<_OutR1>,
                                        std::ranges::borrowed_iterator_t<_OutR2>>
-    operator()(_ExecutionPolicy&& __exec, _R&& __in_r, _OutR1&& __out_true_r, _OutR2&& __out_false_r,
+    operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR1&& __out_true_r, _OutR2&& __out_false_r,
                _Pred __pred, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_partition_copy_ranges(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__in_r),
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
             std::forward<_OutR1>(__out_true_r), std::forward<_OutR2>(__out_false_r), __pred, __proj);
     }
 }; //__partition_copy_fn

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -106,7 +106,8 @@ struct __uninitialized_copy_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
               __nothrow_random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
                  std::constructible_from<std::ranges::range_value_t<_OutRange>,
                                          std::ranges::range_reference_t<_InRange>>
 
@@ -132,7 +133,8 @@ struct __uninitialized_move_fn
     template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
               __nothrow_random_access_range _OutRange>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> && std::ranges::sized_range<_OutRange> &&
+                 std::ranges::sized_range<_InRange> &&
+                 std::ranges::sized_range<_OutRange> &&
                  std::constructible_from<std::ranges::range_value_t<_OutRange>,
                                          std::ranges::range_rvalue_reference_t<_InRange>>
 

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -110,13 +110,13 @@ struct __uninitialized_copy_fn
                                          std::ranges::range_reference_t<_IR>>
     std::ranges::uninitialized_copy_result<std::ranges::borrowed_iterator_t<_IR>,
                                            std::ranges::borrowed_iterator_t<_OR>>
-    operator()(_ExecutionPolicy&& __exec, _IR&& __in_r, _OR&& __out_r) const
+    operator()(_ExecutionPolicy&& __exec, _IR&& __in_range, _OR&& __out_range) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         return oneapi::dpl::__internal::__ranges::__pattern_uninitialized_copy(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_IR>(__in_r),
-            std::forward<_OR>(__out_r));
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_IR>(__in_range),
+            std::forward<_OR>(__out_range));
     }
 }; //__uninitialized_copy_fn
 } // namespace __internal
@@ -136,13 +136,13 @@ struct __uninitialized_move_fn
                                          std::ranges::range_rvalue_reference_t<_IR>>
     std::ranges::uninitialized_move_result<std::ranges::borrowed_iterator_t<_IR>,
                                            std::ranges::borrowed_iterator_t<_OR>>
-    operator()(_ExecutionPolicy&& __exec, _IR&& __in_r, _OR&& __out_r) const
+    operator()(_ExecutionPolicy&& __exec, _IR&& __in_range, _OR&& __out_range) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         return oneapi::dpl::__internal::__ranges::__pattern_uninitialized_move(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_IR>(__in_r),
-            std::forward<_OR>(__out_r));
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_IR>(__in_range),
+            std::forward<_OR>(__out_range));
     }
 }; //__uninitialized_move_fn
 } // namespace __internal

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -101,22 +101,22 @@ namespace __internal
 {
 struct __uninitialized_copy_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
-              __nothrow_random_access_range _OutRange>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _IR,
+              __nothrow_random_access_range _OR>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::constructible_from<std::ranges::range_value_t<_OutRange>,
-                                         std::ranges::range_reference_t<_InRange>>
-    std::ranges::uninitialized_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
-                                           std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
+                 std::ranges::sized_range<_IR> &&
+                 std::ranges::sized_range<_OR> &&
+                 std::constructible_from<std::ranges::range_value_t<_OR>,
+                                         std::ranges::range_reference_t<_IR>>
+    std::ranges::uninitialized_copy_result<std::ranges::borrowed_iterator_t<_IR>,
+                                           std::ranges::borrowed_iterator_t<_OR>>
+    operator()(_ExecutionPolicy&& __exec, _IR&& __in_r, _OR&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         return oneapi::dpl::__internal::__ranges::__pattern_uninitialized_copy(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r),
-            std::forward<_OutRange>(__out_r));
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_IR>(__in_r),
+            std::forward<_OR>(__out_r));
     }
 }; //__uninitialized_copy_fn
 } // namespace __internal
@@ -127,22 +127,22 @@ namespace __internal
 {
 struct __uninitialized_move_fn
 {
-    template <typename _ExecutionPolicy, std::ranges::random_access_range _InRange,
-              __nothrow_random_access_range _OutRange>
+    template <typename _ExecutionPolicy, std::ranges::random_access_range _IR,
+              __nothrow_random_access_range _OR>
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
-                 std::ranges::sized_range<_InRange> &&
-                 std::ranges::sized_range<_OutRange> &&
-                 std::constructible_from<std::ranges::range_value_t<_OutRange>,
-                                         std::ranges::range_rvalue_reference_t<_InRange>>
-    std::ranges::uninitialized_move_result<std::ranges::borrowed_iterator_t<_InRange>,
-                                           std::ranges::borrowed_iterator_t<_OutRange>>
-    operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
+                 std::ranges::sized_range<_IR> &&
+                 std::ranges::sized_range<_OR> &&
+                 std::constructible_from<std::ranges::range_value_t<_OR>,
+                                         std::ranges::range_rvalue_reference_t<_IR>>
+    std::ranges::uninitialized_move_result<std::ranges::borrowed_iterator_t<_IR>,
+                                           std::ranges::borrowed_iterator_t<_OR>>
+    operator()(_ExecutionPolicy&& __exec, _IR&& __in_r, _OR&& __out_r) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
 
         return oneapi::dpl::__internal::__ranges::__pattern_uninitialized_move(
-            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r),
-            std::forward<_OutRange>(__out_r));
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_IR>(__in_r),
+            std::forward<_OR>(__out_r));
     }
 }; //__uninitialized_move_fn
 } // namespace __internal

--- a/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_ranges_impl.h
@@ -63,7 +63,6 @@ struct __uninitialized_default_construct_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::default_initializable<std::ranges::range_value_t<_R>>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r) const
     {
@@ -85,7 +84,6 @@ struct __uninitialized_value_construct_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::default_initializable<std::ranges::range_value_t<_R>>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r) const
     {
@@ -110,7 +108,6 @@ struct __uninitialized_copy_fn
                  std::ranges::sized_range<_OutRange> &&
                  std::constructible_from<std::ranges::range_value_t<_OutRange>,
                                          std::ranges::range_reference_t<_InRange>>
-
     std::ranges::uninitialized_copy_result<std::ranges::borrowed_iterator_t<_InRange>,
                                            std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
@@ -137,7 +134,6 @@ struct __uninitialized_move_fn
                  std::ranges::sized_range<_OutRange> &&
                  std::constructible_from<std::ranges::range_value_t<_OutRange>,
                                          std::ranges::range_rvalue_reference_t<_InRange>>
-
     std::ranges::uninitialized_move_result<std::ranges::borrowed_iterator_t<_InRange>,
                                            std::ranges::borrowed_iterator_t<_OutRange>>
     operator()(_ExecutionPolicy&& __exec, _InRange&& __in_r, _OutRange&& __out_r) const
@@ -161,7 +157,6 @@ struct __uninitialized_fill_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::constructible_from<std::ranges::range_value_t<_R>, const _T&>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value) const
     {
@@ -183,7 +178,6 @@ struct __destroy_fn
         requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<_ExecutionPolicy>> &&
                  std::ranges::sized_range<_R> &&
                  std::destructible<std::ranges::range_value_t<_R>>
-
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r) const
     {


### PR DESCRIPTION
In this PR I have prepared additional formatting and renames to apply after https://github.com/uxlfoundation/oneDPL/pull/2801 without any functional changes.

Our documentation: https://github.com/uxlfoundation/oneAPI-spec/blob/main/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst

## Renaming of template parameters and function parameters

Additionally, the names of template parameters and function parameters of the `oneapi::dpl::ranges` algorithms have been aligned with the specification. These are naming-only changes: no functional or API behavior changes.

### `include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h` (`namespace oneapi::dpl::ranges`)

| Kind | Old name | New name | Spec name | Where |
| --- | --- | --- | --- | --- |
| template parameter | `_InRange` | `_R` | `R` | input range parameter of the range algorithms |
| template parameter | `_OutRange` | `_OutR` | `OutR` | output range parameter of the range algorithms |
| template parameter | `_OutRange1` / `_OutRange2` | `_OutR1` / `_OutR2` | `OutR1` / `OutR2` | `partition_copy` |
| template parameter | `_Fun` / `_F` | `_Fn` | `Fn` | `for_each`, `transform` |
| template parameter | `class _T` | `typename _T` | `typename T` | `replace_copy_if` (keyword spelling only) |
| function parameter | `__in_r` | `__r` | `r` | input range argument of the range algorithms |
| function parameter | `__out_r` | `__result` | `result` | output range argument of the range algorithms |
| function parameter | `__op` | `__unary_op` | `unary_op` | unary `transform` |
| function parameter | `__shift` | `__n` | `n` | `shift_left`, `shift_right` |

### `include/oneapi/dpl/pstl/glue_memory_ranges_impl.h` (`namespace oneapi::dpl::ranges`)

| Kind | Old name | New name | Spec name | Where |
| --- | --- | --- | --- | --- |
| template parameter | `_InRange` | `_IR` | `IR` | `uninitialized_copy`, `uninitialized_move` |
| template parameter | `_OutRange` | `_OR` | `OR` | `uninitialized_copy`, `uninitialized_move` |
| function parameter | `__in_r` | `__in_range` | `in_range` | `uninitialized_copy`, `uninitialized_move` |
| function parameter | `__out_r` | `__out_range` | `out_range` | `uninitialized_copy`, `uninitialized_move` |

Notes:
- `namespace oneapi::dpl::experimental::ranges` is not affected: the specification above does not cover it.
- The execution policy parameter keeps the name `__exec` used consistently across all oneDPL algorithms, instead of `pol` used in the specification.
- Each rename is a separate commit; the commit message quotes the corresponding declaration from the specification.
