### PR TITLE
Fix documentation error(s) about `oneapi::dpl::ranges` algorithms

### DIFF
--- a/documentation/specification/parallel_api/parallel_range_api.rst
+++ b/documentation/specification/parallel_api/parallel_range_api.rst
@@ -544,7 +544,7 @@ Sequence Transformation
     // replace_copy
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               std::ranges::random_access_range OutR, typename Proj = std::identity,
-              typename T1 = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>>,
+              typename T1 = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>,
               typename T2 = std::ranges::range_value_t<OutR>>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&

--- a/documentation/specification/parallel_api/parallel_range_api.rst
+++ b/documentation/specification/parallel_api/parallel_range_api.rst
@@ -1028,7 +1028,7 @@ Uninitialized Memory Algorithms
         uninitialized_value_construct (ExecutionPolicy&& pol, R&& r);
 
     // uninitialized_copy
-    template <typename ExecutionPolicy, std::random_access_range IR,
+    template <typename ExecutionPolicy, std::ranges::random_access_range IR,
               /*nothrow-random-access-range*/ OR>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<IR> && std::ranges::sized_range<OR> &&

--- a/documentation/specification/parallel_api/parallel_range_api.rst
+++ b/documentation/specification/parallel_api/parallel_range_api.rst
@@ -660,7 +660,7 @@ Sequence Filtering
               typename Proj = std::identity,
               typename T = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
-               std::ranges::sized_range<R> && std::permutable<std::ranges::iterator_t<R> &&
+               std::ranges::sized_range<R> && std::permutable<std::ranges::iterator_t<R>> &&
                std::indirect_binary_predicate< std::ranges::equal_to,
                                                std::projected<std::ranges::iterator_t<R>, Proj>,
                                                const T* >

--- a/documentation/specification/parallel_api/parallel_range_api.rst
+++ b/documentation/specification/parallel_api/parallel_range_api.rst
@@ -562,7 +562,7 @@ Sequence Transformation
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               std::ranges::random_access_range OutR,
               class T = std::ranges::range_value_t<OutR>, typename Proj = std::identity,
-              std::indirect_unary_predicate< std::projected<std::ranges::iterator_t<R>, Proj> > Pred,
+              std::indirect_unary_predicate< std::projected<std::ranges::iterator_t<R>, Proj> > Pred>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
                std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>> &&


### PR DESCRIPTION
In this PR we fix https://github.com/uxlfoundation/oneAPI-spec/issues/680

Documentation-only change: fixes typos in the signatures published in
`documentation/specification/parallel_api/parallel_range_api.rst`.
No implementation, API or behavior changes.

### Fixed declarations

| Algorithm | Problem | Fix |
| --- | --- | --- |
| `oneapi::dpl::ranges::remove` | missing closing `>` in the constraint `std::permutable<std::ranges::iterator_t<R>` | `std::permutable<std::ranges::iterator_t<R>>` |
| `oneapi::dpl::ranges::replace_copy` | extra `>` in the default template argument `/*projected-value-type*/<std::ranges::iterator_t<R>, Proj>>` | `/*projected-value-type*/<std::ranges::iterator_t<R>, Proj>` |
| `oneapi::dpl::ranges::replace_copy_if` | the template parameter list was terminated with `,` instead of `>` after `Pred` | `... > Pred>` |
| `oneapi::dpl::ranges::uninitialized_copy` | `std::random_access_range IR` (wrong namespace) | `std::ranges::random_access_range IR` |
