### PR TITLE
Use `std::ranges::equal_to` and `__ref_or_copy` in `C++20` range based algorithm

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -347,7 +347,7 @@ __pattern_count(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, const _T& __val
     return oneapi::dpl::__internal::__pattern_count(
         __tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__r),
         std::ranges::begin(__r) + std::ranges::size(__r),
-        oneapi::dpl::__internal::__ranges_equal_value<_T, _Proj>{__value, __proj});
+        oneapi::dpl::__internal::__ranges_equal_value<const _T&, _Proj>{__value, __proj});
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _T, typename _Proj>

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -347,7 +347,7 @@ __pattern_count(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, const _T& __val
     return oneapi::dpl::__internal::__pattern_count(
         __tag, std::forward<_ExecutionPolicy>(__exec), std::ranges::begin(__r),
         std::ranges::begin(__r) + std::ranges::size(__r),
-        oneapi::dpl::__internal::__count_fn_pred<_T, _Proj>{__value, __proj});
+        oneapi::dpl::__internal::__ranges_equal_value<_T, _Proj>{__value, __proj});
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _T, typename _Proj>

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1508,8 +1508,11 @@ struct __internal::__remove_fn
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
-        return oneapi::dpl::ranges::remove_if(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-                                              oneapi::dpl::__internal::__ranges_equal_to_pred<_T>{__value}, __proj);
+        return oneapi::dpl::ranges::remove_if(
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
+            oneapi::dpl::__internal::__ranges_equal_to_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>{__value},
+            __proj);
     }
 }; //__remove_fn
 inline constexpr __internal::__remove_fn remove;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1553,11 +1553,13 @@ struct __internal::__remove_copy_fn
     std::ranges::remove_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, const _T& __value, _Proj __proj = {}) const
     {
-        // TODO: make sure std::ranges::equal_to is used for comparison
         return oneapi::dpl::ranges::copy_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__out_r),
-            oneapi::dpl::__internal::__not_equal_value<
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>(__value), __proj);
+            oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__ranges_equal_to_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>>(
+                oneapi::dpl::__internal::__ranges_equal_to_pred<
+                    oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>{__value}),
+            __proj);
     }
 }; //__remove_copy_fn
 inline constexpr __internal::__remove_copy_fn remove_copy;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -391,6 +391,9 @@ struct __internal::__search_n_fn
                _Pred __pred = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        // TODO: __pattern_search_n stores __value into a predicate by value, which requires the value type to be
+        // copy constructible even for the host policies. Pass oneapi::dpl::__internal::__ref_or_copy down to the
+        // pattern to keep a reference for the host policies and to make a copy for the device policies only.
         return oneapi::dpl::__internal::__ranges::__pattern_search_n(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __count, __value, __pred, __proj);
     }
@@ -465,6 +468,10 @@ struct __internal::__count_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
+        // TODO: __pattern_count builds oneapi::dpl::__internal::__count_fn_pred, which stores __value by value and
+        // so requires the value type to be copy constructible even for the host policies. Pass
+        // oneapi::dpl::__internal::__ref_or_copy down to the pattern to keep a reference for the host policies and
+        // to make a copy for the device policies only.
         return oneapi::dpl::__internal::__ranges::__pattern_count(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __value, __proj);
     }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -175,10 +175,11 @@ struct __internal::__find_fn
     std::ranges::borrowed_iterator_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
-        // TODO: make sure std::ranges::equal_to is used for comparison
-        return oneapi::dpl::ranges::find_if(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__equal_value<oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>
-                (__value), __proj);
+        return oneapi::dpl::ranges::find_if(
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
+            oneapi::dpl::__internal::__ranges_equal_to_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>{__value},
+            __proj);
     }
 }; //__find_fn
 inline constexpr __internal::__find_fn find;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -465,7 +465,6 @@ struct __internal::__count_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        // TODO: make sure std::ranges::equal_to is used for comparison
         return oneapi::dpl::__internal::__ranges::__pattern_count(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __value, __proj);
     }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1552,13 +1552,12 @@ struct __internal::__remove_copy_fn
     std::ranges::remove_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, const _T& __value, _Proj __proj = {}) const
     {
+        using __equal_to_pred_t = oneapi::dpl::__internal::__ranges_equal_to_pred<
+            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>;
+
         return oneapi::dpl::ranges::copy_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__out_r),
-            oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__ranges_equal_to_pred<
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>>(
-                oneapi::dpl::__internal::__ranges_equal_to_pred<
-                    oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>{__value}),
-            __proj);
+            oneapi::dpl::__internal::__not_pred<__equal_to_pred_t>(__equal_to_pred_t{__value}), __proj);
     }
 }; //__remove_copy_fn
 inline constexpr __internal::__remove_copy_fn remove_copy;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -177,7 +177,7 @@ struct __internal::__find_fn
     {
         return oneapi::dpl::ranges::find_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__count_fn_pred<
+            oneapi::dpl::__internal::__ranges_equal_value<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>{__value},
             __proj);
     }
@@ -234,7 +234,7 @@ struct __internal::__find_last_fn
     {
         return oneapi::dpl::ranges::find_last_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__count_fn_pred<
+            oneapi::dpl::__internal::__ranges_equal_value<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>{__value},
             __proj);
     }
@@ -468,7 +468,7 @@ struct __internal::__count_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        // TODO: __pattern_count builds oneapi::dpl::__internal::__count_fn_pred, which stores __value by value and
+        // TODO: __pattern_count builds oneapi::dpl::__internal::__ranges_equal_value, which stores __value by value and
         // so requires the value type to be copy constructible even for the host policies. Pass
         // oneapi::dpl::__internal::__ref_or_copy down to the pattern to keep a reference for the host policies and
         // to make a copy for the device policies only.
@@ -1143,7 +1143,7 @@ struct __internal::__replace_fn
     {
         return oneapi::dpl::ranges::replace_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__count_fn_pred<
+            oneapi::dpl::__internal::__ranges_equal_value<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>, std::identity>{__old_value},
             __new_value, __proj);
     }
@@ -1200,7 +1200,7 @@ struct __internal::__replace_copy_fn
     {
         return oneapi::dpl::ranges::replace_copy_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r), std::forward<_OutRange>(__out_r),
-            oneapi::dpl::__internal::__count_fn_pred<
+            oneapi::dpl::__internal::__ranges_equal_value<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>, std::identity>{__old_value},
             __new_value, __proj);
     }
@@ -1518,7 +1518,7 @@ struct __internal::__remove_fn
     {
         return oneapi::dpl::ranges::remove_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__count_fn_pred<
+            oneapi::dpl::__internal::__ranges_equal_value<
                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>{__value},
             __proj);
     }
@@ -1559,7 +1559,7 @@ struct __internal::__remove_copy_fn
     std::ranges::remove_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, const _T& __value, _Proj __proj = {}) const
     {
-        using __equal_to_pred_t = oneapi::dpl::__internal::__count_fn_pred<
+        using __equal_to_pred_t = oneapi::dpl::__internal::__ranges_equal_value<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>;
 
         return oneapi::dpl::ranges::copy_if(

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -177,8 +177,8 @@ struct __internal::__find_fn
     {
         return oneapi::dpl::ranges::find_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__ranges_equal_to_pred<
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>{__value},
+            oneapi::dpl::__internal::__count_fn_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>{__value},
             __proj);
     }
 }; //__find_fn
@@ -234,8 +234,8 @@ struct __internal::__find_last_fn
     {
         return oneapi::dpl::ranges::find_last_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__ranges_equal_to_pred<
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>{__value},
+            oneapi::dpl::__internal::__count_fn_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>{__value},
             __proj);
     }
 }; //__find_last_fn
@@ -1143,8 +1143,8 @@ struct __internal::__replace_fn
     {
         return oneapi::dpl::ranges::replace_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__ranges_equal_to_pred<
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>>{__old_value},
+            oneapi::dpl::__internal::__count_fn_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>, std::identity>{__old_value},
             __new_value, __proj);
     }
 }; //__replace_fn
@@ -1200,8 +1200,8 @@ struct __internal::__replace_copy_fn
     {
         return oneapi::dpl::ranges::replace_copy_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r), std::forward<_OutRange>(__out_r),
-            oneapi::dpl::__internal::__ranges_equal_to_pred<
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>>{__old_value},
+            oneapi::dpl::__internal::__count_fn_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>, std::identity>{__old_value},
             __new_value, __proj);
     }
 }; //__replace_copy_fn
@@ -1518,8 +1518,8 @@ struct __internal::__remove_fn
     {
         return oneapi::dpl::ranges::remove_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__ranges_equal_to_pred<
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>{__value},
+            oneapi::dpl::__internal::__count_fn_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>{__value},
             __proj);
     }
 }; //__remove_fn
@@ -1559,8 +1559,8 @@ struct __internal::__remove_copy_fn
     std::ranges::remove_copy_result<std::ranges::borrowed_iterator_t<_R>, std::ranges::borrowed_iterator_t<_OutR>>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _OutR&& __out_r, const _T& __value, _Proj __proj = {}) const
     {
-        using __equal_to_pred_t = oneapi::dpl::__internal::__ranges_equal_to_pred<
-            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>;
+        using __equal_to_pred_t = oneapi::dpl::__internal::__count_fn_pred<
+            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>;
 
         return oneapi::dpl::ranges::copy_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), std::forward<_OutR>(__out_r),

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -391,9 +391,6 @@ struct __internal::__search_n_fn
                _Pred __pred = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        // TODO: __pattern_search_n stores __value into a predicate by value, which requires the value type to be
-        // copy constructible even for the host policies. Pass oneapi::dpl::__internal::__ref_or_copy down to the
-        // pattern to keep a reference for the host policies and to make a copy for the device policies only.
         return oneapi::dpl::__internal::__ranges::__pattern_search_n(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __count, __value, __pred, __proj);
     }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1194,8 +1194,8 @@ struct __internal::__replace_copy_fn
     {
         return oneapi::dpl::ranges::replace_copy_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_InRange>(__in_r), std::forward<_OutRange>(__out_r),
-            oneapi::dpl::__internal::__equal_value<oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>>(
-                __old_value),
+            oneapi::dpl::__internal::__ranges_equal_to_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>>{__old_value},
             __new_value, __proj);
     }
 }; //__replace_copy_fn

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1508,9 +1508,8 @@ struct __internal::__remove_fn
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
-        // TODO: change lambda to a special functor
         return oneapi::dpl::ranges::remove_if(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            [__value](auto&& __a) { return std::ranges::equal_to{}(__a, __value);}, __proj);
+                                              oneapi::dpl::__internal::__ranges_equal_to_pred<_T>{__value}, __proj);
     }
 }; //__remove_fn
 inline constexpr __internal::__remove_fn remove;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -1135,11 +1135,10 @@ struct __internal::__replace_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T1& __old_value, const _T2& __new_value,
                _Proj __proj = {}) const
     {
-        // TODO: make sure std::ranges::equal_to is used for comparison
         return oneapi::dpl::ranges::replace_if(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__equal_value<oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>>(
-                __old_value),
+            oneapi::dpl::__internal::__ranges_equal_to_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T1>>{__old_value},
             __new_value, __proj);
     }
 }; //__replace_fn

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -232,9 +232,11 @@ struct __internal::__find_last_fn
     std::ranges::borrowed_subrange_t<_R>
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
-        return oneapi::dpl::ranges::find_last_if(std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
-            oneapi::dpl::__internal::__equal_value<oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>
-                (__value), __proj);
+        return oneapi::dpl::ranges::find_last_if(
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r),
+            oneapi::dpl::__internal::__ranges_equal_to_pred<
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _T>>{__value},
+            __proj);
     }
 }; //__find_last_fn
 inline constexpr __internal::__find_last_fn find_last;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -465,10 +465,6 @@ struct __internal::__count_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        // TODO: __pattern_count builds oneapi::dpl::__internal::__ranges_equal_value, which stores __value by value and
-        // so requires the value type to be copy constructible even for the host policies. Pass
-        // oneapi::dpl::__internal::__ref_or_copy down to the pattern to keep a reference for the host policies and
-        // to make a copy for the device policies only.
         return oneapi::dpl::__internal::__ranges::__pattern_count(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __value, __proj);
     }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -673,7 +673,7 @@ template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename
 std::ranges::range_difference_t<_R>
 __pattern_count(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, const _T& __value, _Proj __proj)
 {
-    oneapi::dpl::__internal::__count_fn_pred<_T, _Proj> __pred{__value, __proj};
+    oneapi::dpl::__internal::__ranges_equal_value<_T, _Proj> __pred{__value, __proj};
     return oneapi::dpl::__internal::__ranges::__pattern_count(
         __tag, std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__ranges::views::all_read(std::forward<_R>(__r)),
         __pred);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -129,6 +129,9 @@ struct __binary_search_impl_fn;
 #if _ONEDPL_CPP20_RANGES_PRESENT
 template <typename _T, typename _Proj>
 struct __count_fn_pred;
+
+template <typename _T>
+struct __ranges_equal_to_pred;
 #endif
 
 template <typename _ReduceValueType, typename _Compare>
@@ -312,6 +315,12 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 template <typename _T, typename _Proj>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__count_fn_pred, _T, _Proj)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_T, _Proj>
+{
+};
+
+template <typename _T>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__ranges_equal_to_pred, _T)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_T>
 {
 };
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -129,9 +129,6 @@ struct __binary_search_impl_fn;
 #if _ONEDPL_CPP20_RANGES_PRESENT
 template <typename _T, typename _Proj>
 struct __count_fn_pred;
-
-template <typename _T>
-struct __ranges_equal_to_pred;
 #endif
 
 template <typename _ReduceValueType, typename _Compare>
@@ -315,12 +312,6 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 template <typename _T, typename _Proj>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__count_fn_pred, _T, _Proj)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_T, _Proj>
-{
-};
-
-template <typename _T>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__ranges_equal_to_pred, _T)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<_T>
 {
 };
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -128,7 +128,7 @@ struct __binary_search_impl_fn;
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
 template <typename _T, typename _Proj>
-struct __count_fn_pred;
+struct __ranges_equal_value;
 #endif
 
 template <typename _ReduceValueType, typename _Compare>
@@ -310,7 +310,7 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
 template <typename _T, typename _Proj>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__count_fn_pred, _T, _Proj)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__ranges_equal_value, _T, _Proj)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_T, _Proj>
 {
 };

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -1274,7 +1274,7 @@ __get_last_arg(_T, _Rest... __args)
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
 template <typename _T, typename _Proj>
-struct __count_fn_pred
+struct __ranges_equal_value
 {
     _T __value;
     _Proj __proj;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -1286,6 +1286,19 @@ struct __count_fn_pred
         return std::ranges::equal_to{}(std::invoke(__proj, std::forward<_TValue>(__val)), __value);
     }
 };
+
+template <typename _T>
+struct __ranges_equal_to_pred
+{
+    _T __value;
+
+    template <typename _TValue>
+    bool
+    operator()(_TValue&& __val) const
+    {
+        return std::ranges::equal_to{}(std::forward<_TValue>(__val), __value);
+    }
+};
 #endif
 
 template <typename _ValueType, typename _FlagType, typename _BinaryOp>

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -1286,19 +1286,6 @@ struct __count_fn_pred
         return std::ranges::equal_to{}(std::invoke(__proj, std::forward<_TValue>(__val)), __value);
     }
 };
-
-template <typename _T>
-struct __ranges_equal_to_pred
-{
-    _T __value;
-
-    template <typename _TValue>
-    bool
-    operator()(_TValue&& __val) const
-    {
-        return std::ranges::equal_to{}(std::forward<_TValue>(__val), __value);
-    }
-};
 #endif
 
 template <typename _ValueType, typename _FlagType, typename _BinaryOp>

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -286,10 +286,10 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_equal_value<int_device_copyable>>,
                   "__not_equal_value is not device copyable with device copyable types");
 #if _ONEDPL_CPP20_RANGES_PRESENT
-    //__count_fn_pred
+    //__ranges_equal_value
     static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::__internal::__count_fn_pred<int_device_copyable, noop_device_copyable>>,
-                  "__count_fn_pred is not device copyable with device copyable types");
+                      oneapi::dpl::__internal::__ranges_equal_value<int_device_copyable, noop_device_copyable>>,
+                  "__ranges_equal_value is not device copyable with device copyable types");
 #endif
     //__transform_functor
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__transform_functor<noop_device_copyable>>,
@@ -598,13 +598,13 @@ test_non_device_copyable()
                   "__not_equal_value is device copyable with non device copyable types");
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
-    //__count_fn_pred
+    //__ranges_equal_value
     static_assert(!sycl::is_device_copyable_v<
-                      oneapi::dpl::__internal::__count_fn_pred<int_non_device_copyable, noop_device_copyable>>,
-                  "__count_fn_pred is device copyable with non device copyable types");
+                      oneapi::dpl::__internal::__ranges_equal_value<int_non_device_copyable, noop_device_copyable>>,
+                  "__ranges_equal_value is device copyable with non device copyable types");
     static_assert(!sycl::is_device_copyable_v<
-                      oneapi::dpl::__internal::__count_fn_pred<int_device_copyable, noop_non_device_copyable>>,
-                  "__count_fn_pred is device copyable with non device copyable types");
+                      oneapi::dpl::__internal::__ranges_equal_value<int_device_copyable, noop_non_device_copyable>>,
+                  "__ranges_equal_value is device copyable with non device copyable types");
 #endif
 
     //__transform_functor

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -286,9 +286,6 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_equal_value<int_device_copyable>>,
                   "__not_equal_value is not device copyable with device copyable types");
 #if _ONEDPL_CPP20_RANGES_PRESENT
-    //__ranges_equal_to_pred
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__ranges_equal_to_pred<int_device_copyable>>,
-                  "__ranges_equal_to_pred is not device copyable with device copyable types");
     //__count_fn_pred
     static_assert(sycl::is_device_copyable_v<
                       oneapi::dpl::__internal::__count_fn_pred<int_device_copyable, noop_device_copyable>>,
@@ -601,10 +598,6 @@ test_non_device_copyable()
                   "__not_equal_value is device copyable with non device copyable types");
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
-    //__ranges_equal_to_pred
-    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__ranges_equal_to_pred<int_non_device_copyable>>,
-                  "__ranges_equal_to_pred is device copyable with non device copyable types");
-
     //__count_fn_pred
     static_assert(!sycl::is_device_copyable_v<
                       oneapi::dpl::__internal::__count_fn_pred<int_non_device_copyable, noop_device_copyable>>,

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -285,6 +285,11 @@ test_device_copyable()
     //__not_equal_value
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_equal_value<int_device_copyable>>,
                   "__not_equal_value is not device copyable with device copyable types");
+#if _ONEDPL_CPP20_RANGES_PRESENT
+    //__ranges_equal_to_pred
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__ranges_equal_to_pred<int_device_copyable>>,
+                  "__ranges_equal_to_pred is not device copyable with device copyable types");
+#endif
     //__transform_functor
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__transform_functor<noop_device_copyable>>,
                   "__transform_functor is not device copyable with device copyable types");
@@ -590,6 +595,12 @@ test_non_device_copyable()
     //__not_equal_value
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__not_equal_value<int_non_device_copyable>>,
                   "__not_equal_value is device copyable with non device copyable types");
+
+#if _ONEDPL_CPP20_RANGES_PRESENT
+    //__ranges_equal_to_pred
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__ranges_equal_to_pred<int_non_device_copyable>>,
+                  "__ranges_equal_to_pred is device copyable with non device copyable types");
+#endif
 
     //__transform_functor
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__transform_functor<noop_non_device_copyable>>,

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -289,6 +289,10 @@ test_device_copyable()
     //__ranges_equal_to_pred
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__ranges_equal_to_pred<int_device_copyable>>,
                   "__ranges_equal_to_pred is not device copyable with device copyable types");
+    //__count_fn_pred
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__internal::__count_fn_pred<int_device_copyable, noop_device_copyable>>,
+                  "__count_fn_pred is not device copyable with device copyable types");
 #endif
     //__transform_functor
     static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::__transform_functor<noop_device_copyable>>,
@@ -600,6 +604,14 @@ test_non_device_copyable()
     //__ranges_equal_to_pred
     static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::__ranges_equal_to_pred<int_non_device_copyable>>,
                   "__ranges_equal_to_pred is device copyable with non device copyable types");
+
+    //__count_fn_pred
+    static_assert(!sycl::is_device_copyable_v<
+                      oneapi::dpl::__internal::__count_fn_pred<int_non_device_copyable, noop_device_copyable>>,
+                  "__count_fn_pred is device copyable with non device copyable types");
+    static_assert(!sycl::is_device_copyable_v<
+                      oneapi::dpl::__internal::__count_fn_pred<int_device_copyable, noop_non_device_copyable>>,
+                  "__count_fn_pred is device copyable with non device copyable types");
 #endif
 
     //__transform_functor


### PR DESCRIPTION
## Summary

Several C++20 range based algorithms in `glue_algorithm_ranges_impl.h` were constrained with `std::indirect_binary_predicate` in their `requires`-clauses, but internally compared elements with plain `operator==` / `operator!=` (via `__equal_value` / `__not_equal_value`) or with an inline lambda. This PR makes all of them compare through `std::ranges::equal_to`, as the constraints promise, and closes the corresponding `// TODO: make sure std::ranges::equal_to is used for comparison` notes.

Additionally, the value is now wrapped into `oneapi::dpl::__internal::__ref_or_copy`, which removes an unnecessary requirement on the value type for host policies (see below).

## Reused internal helper

No new predicate type is introduced. The already existing functor from [`utils.h`](include/oneapi/dpl/pstl/utils.h) is reused:

```cpp
template <typename _T, typename _Proj>
struct __ranges_equal_value
{
    _T __value;
    _Proj __proj;

    template <typename _TValue>
    bool
    operator()(_TValue&& __val) const
    {
        return std::ranges::equal_to{}(std::invoke(__proj, std::forward<_TValue>(__val)), __value);
    }
};
```

The functor was previously named `__count_fn_pred`, because it was only used by `ranges::count`. Since it now backs six more algorithms, it was renamed to `__ranges_equal_value` — a name that describes what it actually does (compares a projected value with the stored one by `std::ranges::equal_to`) and makes it a ranges counterpart of the existing `__equal_value`. This is a pure rename with no behavior change.

A named functor is required here instead of a lambda because a closure type cannot be specialized for `sycl::is_device_copyable`; it is usable in device code only when it happens to be trivially copyable. The specialization in [`sycl_traits.h`](include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h) is based on `__are_all_device_copyable<_T, _Proj>` and was already present.

## Fixed algorithms

| Algorithm | Was | Now |
| --- | --- | --- |
| `ranges::remove` | inline lambda calling `std::ranges::equal_to` | `__ranges_equal_value` |
| `ranges::find` | `__equal_value` (`operator==`) | `__ranges_equal_value` |
| `ranges::find_last` | `__equal_value` (`operator==`) | `__ranges_equal_value` |
| `ranges::replace` | `__equal_value` (`operator==`) | `__ranges_equal_value` |
| `ranges::replace_copy` | `__equal_value` (`operator==`) | `__ranges_equal_value` |
| `ranges::remove_copy` | `__not_equal_value` (`operator!=`) | `__not_pred<__ranges_equal_value<...>>` |
| `ranges::count` | already correct, stale TODO | TODO removed; value is now stored by reference in the host pattern |

In all six call sites the predicate is instantiated with `std::identity` as the projection, because the user provided projection is already passed separately to the underlying `*_if` algorithm.

For `remove_copy` the existing `__not_pred` is reused instead of adding a dedicated not-equal functor: both `__not_pred` and `__ranges_equal_value` already have `sycl::is_device_copyable` specializations, so no new trait is needed.

## Value category of the stored value

The predicates built in `glue_algorithm_ranges_impl.h` are now instantiated as `__ranges_equal_value<__ref_or_copy<_ExecutionPolicy, const _T>, std::identity>`, the same pattern that is already used for `__equal_value` and `__not_pred` elsewhere in this file.

`__ref_or_copy` resolves to:
- `const _T&` for host policies (`seq`, `unseq`, `par`, `par_unseq`);
- `const _T` for `device_policy` and `fpga_policy`, where the predicate has to be captured into the kernel.

This is a deliberate relaxation of the requirements on the value type. Previously the predicate always stored `_T` by value, so for host policies the user's type had to support operations that the algorithm does not actually need:
- a **copy constructor** (`_T(const _T&)`) to initialize the stored member;
- consequently, the type had to be **copy-constructible / destructible on every predicate copy**, since the predicate itself is passed by value down the call chain and copied again.

With `__ref_or_copy` the host path only binds a reference to the caller's `__value`, whose lifetime covers the whole algorithm call, so none of these operations is required anymore. Types that are expensive to copy, or copy-constructible only in a limited way, can now be used with host policies. For device policies the copy is still made, as it is unavoidable for kernel capture.

## `ranges::count`

`ranges::count` does not build the predicate in the glue layer: it forwards the value to `__pattern_count`, which constructs `__ranges_equal_value` internally. Because of that, wrapping the argument at the call site with `__ref_or_copy` does not help — the wrapper never reaches the place where the predicate is created.

Instead, the choice is made in the patterns themselves, which already know whether they run on the host or on the device:
- the parallel/vector host overload of `__pattern_count` in [`algorithm_ranges_impl.h`](include/oneapi/dpl/pstl/algorithm_ranges_impl.h) now builds `__ranges_equal_value<const _T&, _Proj>`, so no copy of the value is made and no copy constructor is required; the caller's `__value` outlives the synchronous pattern call;
- the `__hetero_tag` overload in [`algorithm_ranges_impl_hetero.h`](include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h) keeps storing `_T` by value, which is required for kernel capture and keeps the `sycl::is_device_copyable` specialization valid;
- the `__serial_tag` overload delegates to `std::ranges::count` and is unaffected.

The corresponding `TODO` in `__internal::__count_fn::operator()` is therefore removed.

## Removed inaccurate TODO for `ranges::search_n`

The `TODO` about `__ref_or_copy` in `__internal::__search_n_fn::operator()` was misleading and is removed: none of the `oneapi::dpl::ranges::search_n` code paths copies the value for host policies. The `__serial_tag` overload delegates to `std::ranges::search_n`; the parallel/vector overload forwards `const _T&` to the iterator based `__pattern_search_n`, which passes it further to `__brick_search_n` / `__find_subrange` by reference; the `__hetero_tag` overload also forwards `const _T&`, and the value is stored into `__pattern_search_n_fn` only for the device path, where a copy is needed for kernel capture anyway.

## Tests

[`test/general/implementation_details/device_copyable.pass.cpp`](test/general/implementation_details/device_copyable.pass.cpp) now covers the `sycl::is_device_copyable` specialization of `__ranges_equal_value`, which stores both the searched value and the projection:
- `test_device_copyable` checks that the functor is device copyable when both the value type and the projection are device copyable;
- `test_non_device_copyable` checks that it is not device copyable when either the value type or the projection is not.

The checks are guarded by `_ONEDPL_CPP20_RANGES_PRESENT`, since the functor is only defined under this macro.

## About old implementations of experimental range-based algorithms

These experimental implementations aren't touched in this PR. I believe they are out of scope for this PR.
So, for example, they continue the usage of `__not_equal_value`, whose implementation is based on an `==` call:
```cpp
//! Logical negation of ==value
template <typename _Tp>
class __not_equal_value
{
    const _Tp _M_value;

  public:
    explicit __not_equal_value(const _Tp& __value) : _M_value(__value) {}

    template <typename _Arg>
    bool
    operator()(_Arg&& __arg) const
    {
        return !(::std::forward<_Arg>(__arg) == _M_value);
    }
};
```