### PR TITLE
Correct docs for mismatched access mode

### DIFF
--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -102,7 +102,7 @@ must assign a proper value to every element before its further use; otherwise, t
   int main(){
     sycl::buffer<Point> pts{ sycl::range<1>(1000) };
 
-    // begin and end calls whose returns are used together must match hints, mismatches result in a compilation error
+    // Hints must match between a begin and end used together, otherwise compilation fails.
     auto out_write_no_init_beg = oneapi::dpl::begin(pts, sycl::write_only, sycl::no_init);
     auto out_write_no_init_end = oneapi::dpl::end(pts, sycl::write_only, sycl::no_init);
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -102,7 +102,7 @@ must assign a proper value to every element before its further use; otherwise, t
   int main(){
     sycl::buffer<Point> pts{ sycl::range<1>(1000) };
 
-    // begin and end calls whose returns are used together must match hints, mismatches result in undefined behavior
+    // begin and end calls whose returns are used together must match hints, mismatches result in a compilation error
     auto out_write_no_init_beg = oneapi::dpl::begin(pts, sycl::write_only, sycl::no_init);
     auto out_write_no_init_end = oneapi::dpl::end(pts, sycl::write_only, sycl::no_init);
 


### PR DESCRIPTION
Its not undefined behavior, but rather a compilation error as the access mode is encoded into the type itself, and begin / end types must match for external APIs