### PR TITLE
Add new known issue about `oneapi::dpl::ranges` algorithms

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -69,8 +69,9 @@ See oneDPL Guide for other `restrictions and known limitations`_.
       require a default-initializable value type and an addressable comparator; ``min_element``,
       ``max_element``, ``minmax_element`` also require a copyable value type, and ``minmax_element``
       also requires construction and assignment from iterator reference types.
-    - ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union`` require
-      an output value type constructible from input reference types and a non-proxy output iterator.
+    - ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union`` with both host
+      and device policies require an output value type constructible from input reference types and
+      a non-proxy output iterator.
  
 
 New in 2022.13.0

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -65,13 +65,13 @@ See oneDPL Guide for other `restrictions and known limitations`_.
   to the device compiler.
 - Some algorithms in ``oneapi::dpl::ranges`` require more than their ``requires`` clauses specify:
 
-    - ``min``, ``max``, ``minmax``, ``min_element``, ``max_element``, ``minmax_element`` with host policies
-      require a default-initializable value type and an addressable comparator; ``min_element``,
-      ``max_element``, ``minmax_element`` also require a copyable value type, and ``minmax_element``
-      also requires construction and assignment from iterator reference types.
-    - ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union`` with both host
-      and device policies require an output value type constructible from input reference types and
-      a non-proxy output iterator.
+  * ``min``, ``max``, ``minmax``, ``min_element``, ``max_element``, ``minmax_element`` with host policies
+    require a default-initializable value type and an addressable comparator; ``min_element``,
+    ``max_element``, ``minmax_element`` also require a copyable value type, and ``minmax_element``
+    also requires construction and assignment from iterator reference types.
+  * ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union`` with both host
+    and device policies require an output value type constructible from input reference types and
+    a non-proxy output iterator.
  
 
 New in 2022.13.0

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -65,14 +65,13 @@ See oneDPL Guide for other `restrictions and known limitations`_.
   to the device compiler.
 - Some algorithms in the ``oneapi::dpl::ranges`` family have known implementation issues where the implementation
   relies on operations that are not guaranteed to be supported by the types satisfying the requirements
-  specified in the ``requires`` clauses: ``max``, ``max_element``, ``min``, ``min_element``, ``minmax``,
-  ``minmax_element``, ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union``.
-  For host policies, ``min``, ``max``, and ``minmax`` additionally require a default-initializable value type and
-  an addressable comparator; ``min_element``, ``max_element``, and ``minmax_element`` additionally require a
-  default-initializable and copyable value type, while ``minmax_element`` also requires construction/assignment
-  from iterator reference types. For host and device policies, ``set_difference``, ``set_intersection``,
-  ``set_symmetric_difference``, and ``set_union`` additionally require an output value type constructible from
-  input reference types and a non-proxy output iterator.
+  specified in the ``requires`` clauses.
+  With host policies, ``min``, ``max``, and ``minmax`` require a default-initializable value type and an
+  addressable comparator, while ``min_element``, ``max_element``, and ``minmax_element`` also require a
+  copyable value type, and ``minmax_element`` requires construction/assignment from iterator reference types.
+  With host and device policies, ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, and
+  ``set_union`` require an output value type constructible from input reference types and a non-proxy output
+  iterator.
 
 
 New in 2022.13.0

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -63,16 +63,15 @@ See oneDPL Guide for other `restrictions and known limitations`_.
 - ``kt::gpu::radix_sort_by_key`` function may produce incorrect results on RHEL 10 or earlier when run on
   Intel® Data Center GPU Max Series with SYCL buffer passed as input data and no optimization flags passed 
   to the device compiler.
-- Some algorithms in the ``oneapi::dpl::ranges`` family have known implementation issues where the implementation
-  relies on operations that are not guaranteed to be supported by the types satisfying the requirements
-  specified in the ``requires`` clauses.
-  With host policies, ``min``, ``max``, and ``minmax`` require a default-initializable value type and an
-  addressable comparator, while ``min_element``, ``max_element``, and ``minmax_element`` also require a
-  copyable value type, and ``minmax_element`` requires construction/assignment from iterator reference types.
-  With host and device policies, ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, and
-  ``set_union`` require an output value type constructible from input reference types and a non-proxy output
-  iterator.
+- Some algorithms in ``oneapi::dpl::ranges`` require more than their ``requires`` clauses specify:
 
+    - ``min``, ``max``, ``minmax``, ``min_element``, ``max_element``, ``minmax_element`` with host policies
+      require a default-initializable value type and an addressable comparator; ``min_element``,
+      ``max_element``, ``minmax_element`` also require a copyable value type, and ``minmax_element``
+      also requires construction/assignment from iterator reference types.
+    - ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union`` require
+      an output value type constructible from input reference types and a non-proxy output iterator.
+ 
 
 New in 2022.13.0
 ================

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -67,8 +67,9 @@ See oneDPL Guide for other `restrictions and known limitations`_.
 
   * ``min``, ``max``, ``minmax``, ``min_element``, ``max_element``, ``minmax_element`` with host policies
     require a default-initializable value type and an addressable comparator; ``min_element``,
-    ``max_element``, ``minmax_element`` also require a copyable value type, and ``minmax_element``
-    also requires construction and assignment from iterator reference types.
+    ``max_element``, ``minmax_element`` also require a copyable value type, and
+    ``minmax_element`` also requires it to be constructible from and assignable from
+    the type obtained by dereferencing the range's iterator.
   * ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union`` with both host
     and device policies require an output value type constructible from input reference types and
     a non-proxy output iterator.

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -68,7 +68,7 @@ See oneDPL Guide for other `restrictions and known limitations`_.
     - ``min``, ``max``, ``minmax``, ``min_element``, ``max_element``, ``minmax_element`` with host policies
       require a default-initializable value type and an addressable comparator; ``min_element``,
       ``max_element``, ``minmax_element`` also require a copyable value type, and ``minmax_element``
-      also requires construction/assignment from iterator reference types.
+      also requires construction and assignment from iterator reference types.
     - ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union`` require
       an output value type constructible from input reference types and a non-proxy output iterator.
  

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -65,10 +65,14 @@ See oneDPL Guide for other `restrictions and known limitations`_.
   to the device compiler.
 - Some algorithms in the ``oneapi::dpl::ranges`` family have known implementation issues where the implementation
   relies on operations that are not guaranteed to be supported by the types satisfying the requirements
-  specified in the ``requires`` clauses: ``contains``, ``count``, ``fill``, ``find``, ``find_last``,
-  ``max``, ``max_element``, ``min``, ``min_element``, ``minmax``, ``minmax_element``, ``remove``,
-  ``remove_if``, ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union``,
-  ``sort``, ``stable_sort``, ``unique``.
+  specified in the ``requires`` clauses: ``max``, ``max_element``, ``min``, ``min_element``, ``minmax``,
+  ``minmax_element``, ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union``.
+  For host policies, ``min``, ``max``, and ``minmax`` additionally require a default-initializable value type and
+  an addressable comparator; ``min_element``, ``max_element``, and ``minmax_element`` additionally require a
+  default-initializable and copyable value type, while ``minmax_element`` also requires construction/assignment
+  from iterator reference types. For host and device policies, ``set_difference``, ``set_intersection``,
+  ``set_symmetric_difference``, and ``set_union`` additionally require an output value type constructible from
+  input reference types and a non-proxy output iterator.
 
 
 New in 2022.13.0

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -63,6 +63,13 @@ See oneDPL Guide for other `restrictions and known limitations`_.
 - ``kt::gpu::radix_sort_by_key`` function may produce incorrect results on RHEL 10 or earlier when run on
   Intel® Data Center GPU Max Series with SYCL buffer passed as input data and no optimization flags passed 
   to the device compiler.
+- Some algorithms in the ``oneapi::dpl::ranges`` family have known implementation issues where the implementation
+  relies on operations that are not guaranteed to be supported by the types satisfying the requirements
+  specified in the ``requires`` clauses: ``contains``, ``count``, ``fill``, ``find``, ``find_last``,
+  ``max``, ``max_element``, ``min``, ``min_element``, ``minmax``, ``minmax_element``, ``remove``,
+  ``remove_if``, ``set_difference``, ``set_intersection``, ``set_symmetric_difference``, ``set_union``,
+  ``sort``, ``stable_sort``, ``unique``.
+
 
 New in 2022.13.0
 ================


### PR DESCRIPTION
## Summary

Adds a known-issue entry to `documentation/release_notes.rst` stating that several `oneapi::dpl::ranges` algorithms rely on operations that are not guaranteed by the types satisfying their declared `requires` clauses.

This description documents the detailed analysis behind that entry: for each algorithm, which extra requirements the implementation imposes beyond the declared constraints, and where in the sources they originate.

## Detailed analysis

### `oneapi::dpl::ranges::min` / `oneapi::dpl::ranges::max`

*Affected implementations: host.*

Additional requirements imposed by the `__simd_min_element()` implementation. Both algorithms already declare `std::indirectly_copyable_storable<iterator_t<_R>, range_value_t<_R>*>` (`glue_algorithm_ranges_impl.h:750`), which covers copy construction and copy assignment; therefore only the following remain extra:

1. `std::ranges::range_value_t<_R>` must be default initializable — `unseq_backend_simd.h:635`
2. The comparator must be addressable — `unseq_backend_simd.h:655`

### `oneapi::dpl::ranges::min_element` / `oneapi::dpl::ranges::max_element`

*Affected implementations: host.*

Additional requirements imposed by the `__simd_min_element()` implementation, beyond the declared constraints (`random_access_range`, `sized_range`, `indirect_strict_weak_order`):

1. `std::ranges::range_value_t<_R>` must be default initializable — `_ComplexType::__min_val{}`, `unseq_backend_simd.h:635`
2. `std::ranges::range_value_t<_R>` must be copy constructible and copy assignable — `unseq_backend_simd.h:636-640,662-666`; note that these algorithms do not declare `std::indirectly_copyable_storable`, so this is genuinely extra
3. The comparator must be addressable, i.e. `operator&` must not be overloaded — `&__comp`, `unseq_backend_simd.h:655`

### `oneapi::dpl::ranges::minmax`

*Affected implementations: host.*

Additional requirements imposed by the `__simd_minmax_element()` implementation. `minmax` declares `std::indirectly_copyable_storable` (`glue_algorithm_ranges_impl.h:789`), so copy construction/assignment are already part of the contract:

1. `std::ranges::range_value_t<_R>` must be default initializable — `unseq_backend_simd.h:695`
2. `std::ranges::range_value_t<_R>` must be assignable from `std::iter_reference_t<std::ranges::iterator_t<_R>>` without an explicit conversion — `unseq_backend_simd.h:742`
3. The comparator must be addressable — `unseq_backend_simd.h:733`

### `oneapi::dpl::ranges::minmax_element`

*Affected implementations: host.*

Additional requirements imposed by the `__simd_minmax_element()` implementation:

1. `std::ranges::range_value_t<_R>` must be default initializable — `_ComplexType::__min_val{}, __max_val{}`, `unseq_backend_simd.h:695`
2. `std::ranges::range_value_t<_R>` must be copy constructible and copy assignable — `unseq_backend_simd.h:696-701,710-750`; `minmax_element` does not declare `std::indirectly_copyable_storable` either
3. `std::ranges::range_value_t<_R>` must be constructible and assignable from `std::iter_reference_t<std::ranges::iterator_t<_R>>` without an explicit conversion — `auto __current = __first[__i];`, `unseq_backend_simd.h:742`; unlike `__simd_min_element()` (line 663) the type is deduced from the reference type, which additionally breaks for proxy iterators
4. The comparator must be addressable — `&__comp`, `unseq_backend_simd.h:733`

### `oneapi::dpl::ranges::set_union` / `set_intersection` / `set_difference` / `set_symmetric_difference`

*Affected implementations: host + hetero.*

Additional requirements imposed by the implementation:

1. `std::ranges::range_value_t<_OutRange>` must be constructible from `iter_reference_t` of both input iterators — the implementation copy-constructs into raw buffer memory: `set_algorithms_utils.h:91`, `new (std::addressof(*__it_out)) _OutValueType(*__it_in);` — whereas `std::mergeable` only guarantees `*out = *in`.
2. `std::ranges::iterator_t<_OutRange>` must not be a proxy iterator: `std::addressof(*__it_out)` requires a real lvalue (`set_algorithms_utils.h:91`).

## Summary table

| Algorithm | Implementations | Extra requirements |
|---|---|---|
| `min`, `max` | host | default initializable value type; addressable comparator |
| `min_element`, `max_element` | host | default initializable; copy constructible + copy assignable; addressable comparator |
| `minmax` | host | default initializable; assignable from `iter_reference_t`; addressable comparator |
| `minmax_element` | host | default initializable; copy constructible + copy assignable; constructible/assignable from `iter_reference_t`; addressable comparator |
| `set_union`, `set_intersection`, `set_difference`, `set_symmetric_difference` | host + hetero | output value type constructible from `iter_reference_t`; non-proxy output iterator |
