### PR TITLE
Fix implementation of `all_view::begin()`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -18,6 +18,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include <memory> // for std::addressof
 
 #include "../../utils_ranges.h"
 #include "../../iterator_impl.h"
@@ -89,7 +90,7 @@ class all_view
     __return_t*
     begin() const
     {
-        return &__m_acc[0];
+        return std::addressof(__m_acc[0]);
     } //or “honest” iterator over an accessor and a sentinel
 
     __return_t*


### PR DESCRIPTION
## Summary

Replace `&__m_acc[0]` with `std::addressof(__m_acc[0])` in `oneapi::dpl::__ranges::all_view::begin()`.

## Why this change is needed

`all_view::begin()` is intended to return a pointer to the first element exposed by the SYCL accessor. Using the built-in address-of expression here is too strong a requirement: it assumes that taking the address with `operator&` is valid for the accessor reference type.

`std::addressof` is the standard way to obtain the actual object address without depending on user-defined or deleted `operator&`. This matches other places in oneDPL that already use `std::addressof` when raw addresses are required.

## When the old code does not work

The previous implementation

```cpp
return &__m_acc[0];
```

fails when `__m_acc[0]` yields an object type for which `operator&` is unavailable as a normal address-of operation, for example:

- `operator&` is explicitly deleted;
- `operator&` is overloaded and does not return the real object address;
- the reference/proxy type intentionally prevents direct address taking.

In such cases, `all_view::begin()` may fail to compile or may not produce the expected pointer semantics.

## Change

- [`include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h`](https://github.com/uxlfoundation/oneDPL/blob/410aaddac32649541dddbfd3a73bab160d4f5f6d/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h#L90-L93): use `std::addressof(__m_acc[0])` in `all_view::begin()`.

This keeps the implementation aligned with the intended requirement: obtaining the underlying address, not requiring a usable overloaded `operator&`.
