### PR TITLE
Adding Device Container Version Macro

### DIFF
--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -38,6 +38,15 @@ Use these macros to test presence of specific |onedpl_short| functionality.
 ================================== ===============================================
 Macro                              Macro values and the functionality
 ================================== ===============================================
+``ONEDPL_HAS_DEVICE_CONTAINERS``   Device containers and the allocator they use.
+
+                                   The macro is only defined when device execution policies are enabled,
+                                   see ``ONEDPL_USE_DPCPP_BACKEND``.
+
+                                   * ``202608L`` - added ``oneapi::dpl::experimental::device_array``
+                                     (requires ``std::span`` or ``sycl::span`` to be available)
+                                     and a baseline ``oneapi::dpl::experimental::device_allocator``.
+---------------------------------- -----------------------------------------------
 ``ONEDPL_HAS_RANDOM_NUMBERS``      Pseudo-random number generators and distributions.
 
                                    * ``202409L`` - added support of comparison and I/O stream operators and an experimental Philox engine.

--- a/include/oneapi/dpl/experimental/device_array
+++ b/include/oneapi/dpl/experimental/device_array
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //===----------------------------------------------------------------------===//
 //
-// Copyright (C) Intel Corporation
+// Copyright (C) UXL Foundation Contributors
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/include/oneapi/dpl/experimental/device_array
+++ b/include/oneapi/dpl/experimental/device_array
@@ -20,6 +20,7 @@
 // _ONEDPL_SPAN_PRESENT, which gates device_array: without a span there is no way to express its interface.
 #include "../pstl/hetero/dpcpp/span_impl.h"
 
+#include "device_allocator_impl.h"
 #if _ONEDPL_SPAN_PRESENT
 #include "../pstl/hetero/dpcpp/device_array_impl.h"
 namespace dpl = oneapi::dpl;

--- a/include/oneapi/dpl/experimental/device_array
+++ b/include/oneapi/dpl/experimental/device_array
@@ -20,7 +20,7 @@
 // _ONEDPL_SPAN_PRESENT, which gates device_array: without a span there is no way to express its interface.
 #include "../pstl/hetero/dpcpp/span_impl.h"
 
-#include "device_allocator_impl.h"
+#include "../pstl/hetero/dpcpp/device_allocator_impl.h"
 #if _ONEDPL_SPAN_PRESENT
 #include "../pstl/hetero/dpcpp/device_array_impl.h"
 namespace dpl = oneapi::dpl;

--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -71,8 +71,6 @@
 
 #if _ONEDPL_BACKEND_SYCL
 // Device containers will only be defined with the dpcpp backend.
-//
-// device_array requires the availability of std::span and / or sycl::span.
 #    define ONEDPL_HAS_DEVICE_CONTAINERS 202608L
 #endif
 

--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -50,4 +50,30 @@
 #    define ONEDPL_HAS_RANGE_ALGORITHMS   202608L
 #endif
 
+// -- Check availability of heterogeneous backends --
+
+// If DPCPP backend is explicitly requested, optimistically assume SYCL availability;
+// otherwise, make sure that it is definitely available additionally checking SYCL_LANGUAGE_VERSION
+#if __has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>)
+#    if SYCL_LANGUAGE_VERSION || CL_SYCL_LANGUAGE_VERSION || ONEDPL_USE_DPCPP_BACKEND
+#        define _ONEDPL_SYCL_AVAILABLE 1
+#    endif
+#else
+#    if ONEDPL_USE_DPCPP_BACKEND
+#        error "Device execution policies are requested, but SYCL* headers are not found"
+#    endif
+#endif
+
+// If DPCPP backend is not explicitly turned off and SYCL is available, enable it
+#if (ONEDPL_USE_DPCPP_BACKEND || !defined(ONEDPL_USE_DPCPP_BACKEND)) && _ONEDPL_SYCL_AVAILABLE
+#    define _ONEDPL_BACKEND_SYCL 1
+#endif
+
+#if _ONEDPL_BACKEND_SYCL
+// Device containers will only be defined with the dpcpp backend.
+//
+// device_array requires the availability of std::span and / or sycl::span.
+#    define ONEDPL_HAS_DEVICE_CONTAINERS 202608L
+#endif
+
 #endif // _ONEDPL_VERSION_IMPL_H

--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -18,6 +18,25 @@
 // The oneAPI Specification version this implementation is compliant with
 #define ONEDPL_SPEC_VERSION 105
 
+// -- Check availability of heterogeneous backends --
+
+// If DPCPP backend is explicitly requested, optimistically assume SYCL availability;
+// otherwise, make sure that it is definitely available additionally checking SYCL_LANGUAGE_VERSION
+#if __has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>)
+#    if SYCL_LANGUAGE_VERSION || CL_SYCL_LANGUAGE_VERSION || ONEDPL_USE_DPCPP_BACKEND
+#        define _ONEDPL_SYCL_AVAILABLE 1
+#    endif
+#else
+#    if ONEDPL_USE_DPCPP_BACKEND
+#        error "Device execution policies are requested, but SYCL* headers are not found"
+#    endif
+#endif
+
+// If DPCPP backend is not explicitly turned off and SYCL is available, enable it
+#if (ONEDPL_USE_DPCPP_BACKEND || !defined(ONEDPL_USE_DPCPP_BACKEND)) && _ONEDPL_SYCL_AVAILABLE
+#    define _ONEDPL_BACKEND_SYCL 1
+#endif
+
 // -- Check for C++ standard library feature macros --
 #if __has_include(<version>)
 #    include <version>
@@ -48,25 +67,6 @@
 #define ONEDPL_HAS_RANDOM_NUMBERS         202603L
 #if _ONEDPL_CPP20_RANGES_PRESENT
 #    define ONEDPL_HAS_RANGE_ALGORITHMS   202608L
-#endif
-
-// -- Check availability of heterogeneous backends --
-
-// If DPCPP backend is explicitly requested, optimistically assume SYCL availability;
-// otherwise, make sure that it is definitely available additionally checking SYCL_LANGUAGE_VERSION
-#if __has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>)
-#    if SYCL_LANGUAGE_VERSION || CL_SYCL_LANGUAGE_VERSION || ONEDPL_USE_DPCPP_BACKEND
-#        define _ONEDPL_SYCL_AVAILABLE 1
-#    endif
-#else
-#    if ONEDPL_USE_DPCPP_BACKEND
-#        error "Device execution policies are requested, but SYCL* headers are not found"
-#    endif
-#endif
-
-// If DPCPP backend is not explicitly turned off and SYCL is available, enable it
-#if (ONEDPL_USE_DPCPP_BACKEND || !defined(ONEDPL_USE_DPCPP_BACKEND)) && _ONEDPL_SYCL_AVAILABLE
-#    define _ONEDPL_BACKEND_SYCL 1
 #endif
 
 #if _ONEDPL_BACKEND_SYCL

--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -18,7 +18,7 @@
 // The oneAPI Specification version this implementation is compliant with
 #define ONEDPL_SPEC_VERSION 105
 
-// -- Check availability of heterogeneous backends --
+// -- Check if SYCL backend should be enabled --
 
 // If DPCPP backend is explicitly requested, optimistically assume SYCL availability;
 // otherwise, make sure that it is definitely available additionally checking SYCL_LANGUAGE_VERSION

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/device_allocator_impl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/device_allocator_impl.h
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //===----------------------------------------------------------------------===//
 //
-// Copyright (C) Intel Corporation
+// Copyright (C) UXL Foundation Contributors
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/device_array_impl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/device_array_impl.h
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //===----------------------------------------------------------------------===//
 //
-// Copyright (C) Intel Corporation
+// Copyright (C) UXL Foundation Contributors
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/device_storage_base_impl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/device_storage_base_impl.h
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //===----------------------------------------------------------------------===//
 //
-// Copyright (C) Intel Corporation
+// Copyright (C) UXL Foundation Contributors
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -38,26 +38,7 @@
         but OpenMP headers are not found or the compiler does not support OpenMP"
 #endif
 
-// -- Check availability of heterogeneous backends --
-
-// If DPCPP backend is explicitly requested, optimistically assume SYCL availability;
-// otherwise, make sure that it is definitely available additionally checking SYCL_LANGUAGE_VERSION
-#if __has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>)
-#    if SYCL_LANGUAGE_VERSION || CL_SYCL_LANGUAGE_VERSION || ONEDPL_USE_DPCPP_BACKEND
-#        define _ONEDPL_SYCL_AVAILABLE 1
-#    endif
-#else
-#    if ONEDPL_USE_DPCPP_BACKEND
-#        error "Device execution policies are requested, but SYCL* headers are not found"
-#    endif
-#endif
-
-// If DPCPP backend is not explicitly turned off and SYCL is available, enable it
-#if (ONEDPL_USE_DPCPP_BACKEND || !defined(ONEDPL_USE_DPCPP_BACKEND)) && _ONEDPL_SYCL_AVAILABLE
-#    define _ONEDPL_BACKEND_SYCL 1
-#endif
-
-// If at least one heterogeneous backend is available, enable them
+// If at least one heterogeneous backend is available, enable them (defined in version_impl.h)
 #if _ONEDPL_BACKEND_SYCL
 #    if _ONEDPL_HETERO_BACKEND
 #        undef _ONEDPL_HETERO_BACKEND

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -38,7 +38,10 @@
         but OpenMP headers are not found or the compiler does not support OpenMP"
 #endif
 
-// If at least one heterogeneous backend is available, enable them (defined in version_impl.h)
+// -- Check availability of heterogeneous backends --
+
+// Due to the use in feature test macros, _ONEDPL_BACKEND_SYCL is defined in version_impl.h
+// If at least one heterogeneous backend is available, enable them
 #if _ONEDPL_BACKEND_SYCL
 #    if _ONEDPL_HETERO_BACKEND
 #        undef _ONEDPL_HETERO_BACKEND

--- a/test/parallel_api/device_array/device_array.pass.cpp
+++ b/test/parallel_api/device_array/device_array.pass.cpp
@@ -18,16 +18,111 @@
 
 #include "support/utils.h"
 
-// device_array is only available where oneapi::dpl::span is, which under C++17 requires the SYCL
-// implementation to provide sycl::span.
-#if TEST_DPCPP_BACKEND_PRESENT && TEST_SPAN_PRESENT
+#if ONEDPL_HAS_DEVICE_CONTAINERS >= 202608L
+#    define TEST_DEVICE_CONTAINERS_PRESENT 1
+#else
+#    define TEST_DEVICE_CONTAINERS_PRESENT 0
+#endif
+
+// device_array, unlike device_allocator, is only available where oneapi::dpl::span is, which under
+// C++17 requires the SYCL implementation to provide sycl::span.
+#if TEST_DEVICE_CONTAINERS_PRESENT && TEST_SPAN_PRESENT
 #    define TEST_DEVICE_ARRAY_PRESENT 1
 #else
 #    define TEST_DEVICE_ARRAY_PRESENT 0
 #endif
 
+// -- device_allocator, which does not depend on device_array --
+
+#if TEST_DEVICE_CONTAINERS_PRESENT
+#    include "support/utils_sycl.h"
+
+#    include <cstddef>
+#    include <cstdint>
+#    include <type_traits>
+
+namespace
+{
+
+template <typename _Fp>
+bool
+throws_memory_allocation(_Fp __f)
+{
+    try
+    {
+        __f();
+    }
+    catch (const sycl::exception& __e)
+    {
+        return __e.code() == sycl::make_error_code(sycl::errc::memory_allocation);
+    }
+    return false;
+}
+
+void
+test_device_allocator(sycl::queue __q)
+{
+    using alloc_t = oneapi::dpl::experimental::device_allocator<int>;
+
+    static_assert(std::is_same_v<alloc_t::value_type, int>, "device_allocator::value_type");
+    static_assert(!std::is_default_constructible_v<alloc_t>, "device_allocator must not be default constructible");
+    static_assert(std::is_copy_constructible_v<alloc_t>, "device_allocator must be copy constructible");
+    static_assert(std::is_copy_assignable_v<alloc_t>, "device_allocator must be copy assignable");
+    static_assert(std::is_move_constructible_v<alloc_t>, "device_allocator must be move constructible");
+    static_assert(std::is_move_assignable_v<alloc_t>, "device_allocator must be move assignable");
+
+    // Both constructor forms, as on usm_allocator.
+    alloc_t __a(__q);
+    alloc_t __b(__q.get_context(), __q.get_device());
+
+    // The converting constructor carries the allocation target over.
+    oneapi::dpl::experimental::device_allocator<double> __converted(__a);
+
+    // Equality spans the value type and ignores the property list, but distinguishes the alignment, as
+    // SYCL 2020 section 4.8.3.1 requires of usm_allocator.
+    oneapi::dpl::experimental::device_allocator<int, 256> __aligned_a(__q);
+    oneapi::dpl::experimental::device_allocator<double, 256> __aligned_b(__q);
+    EXPECT_TRUE(__a == __b, "allocators on the same context and device must compare equal");
+    EXPECT_TRUE(!(__a != __b), "operator!= must be the negation of operator==");
+    EXPECT_TRUE(__a == __converted, "equality must span the value type");
+    EXPECT_TRUE(__a != __aligned_a, "allocators with different alignments must compare unequal");
+    EXPECT_TRUE(__aligned_a == __aligned_b, "equality must span the value type for a nonzero alignment");
+
+    // A distinct context over the same device makes the allocators non interchangeable.
+    sycl::context __other_ctx(__q.get_device());
+    alloc_t __other(__other_ctx, __q.get_device());
+    EXPECT_TRUE(__a != __other, "allocators on different contexts must compare unequal");
+    EXPECT_TRUE(!(__a == __other), "operator== must be the negation of operator!=");
+
+    // allocate/deallocate round trip, and the count == 0 short circuit.
+    int* __p = __a.allocate(128);
+    EXPECT_TRUE(__p != nullptr, "device_allocator::allocate returned null for a nonzero count");
+    __a.deallocate(__p, 128);
+    EXPECT_TRUE(__a.allocate(0) == nullptr, "device_allocator::allocate(0) must return nullptr");
+    __a.deallocate(nullptr, 0); // must be a no-op
+
+    // The aligned form dispatches to sycl::aligned_alloc_device.
+    oneapi::dpl::experimental::device_allocator<int, 256> __aligned(__q);
+    int* __ap = __aligned.allocate(64);
+    EXPECT_TRUE(__ap != nullptr, "the aligned device_allocator returned null");
+    EXPECT_TRUE(reinterpret_cast<std::uintptr_t>(__ap) % 256 == 0, "the aligned device_allocator ignored _Alignment");
+    __aligned.deallocate(__ap, 64);
+
+    EXPECT_TRUE(throws_memory_allocation([&] { __a.allocate(std::size_t(1) << 50); }),
+                "device_allocator::allocate must throw errc::memory_allocation when allocation fails");
+
+    // An unsupported (non power of two) alignment.
+    oneapi::dpl::experimental::device_allocator<int, 3> __bad_alignment(__q);
+    EXPECT_TRUE(throws_memory_allocation([&] { __bad_alignment.allocate(16); }),
+                "the aligned device_allocator must throw when _Alignment is unsupported");
+}
+
+} // namespace
+#endif // TEST_DEVICE_CONTAINERS_PRESENT
+
+// -- device_array --
+
 #if TEST_DEVICE_ARRAY_PRESENT
-#include "support/utils_sycl.h"
 #include "support/utils_device_copyable.h"
 
 #include <cstddef>
@@ -78,21 +173,6 @@ throws_out_of_range(_Fp __f)
     catch (const std::out_of_range&)
     {
         return true;
-    }
-    return false;
-}
-
-template <typename _Fp>
-bool
-throws_memory_allocation(_Fp __f)
-{
-    try
-    {
-        __f();
-    }
-    catch (const sycl::exception& __e)
-    {
-        return __e.code() == sycl::make_error_code(sycl::errc::memory_allocation);
     }
     return false;
 }
@@ -194,63 +274,10 @@ test_no_span_conversion()
                   "device_array must not implicitly convert to a span, not even for an element type from std");
 }
 
+// device_array construction propagates an allocation failure out of the allocator.
 void
-test_device_allocator(sycl::queue __q)
+test_allocation_failure(sycl::queue __q)
 {
-    using alloc_t = oneapi::dpl::experimental::device_allocator<int>;
-
-    static_assert(std::is_same_v<alloc_t::value_type, int>, "device_allocator::value_type");
-    static_assert(!std::is_default_constructible_v<alloc_t>, "device_allocator must not be default constructible");
-    static_assert(std::is_copy_constructible_v<alloc_t>, "device_allocator must be copy constructible");
-    static_assert(std::is_copy_assignable_v<alloc_t>, "device_allocator must be copy assignable");
-    static_assert(std::is_move_constructible_v<alloc_t>, "device_allocator must be move constructible");
-    static_assert(std::is_move_assignable_v<alloc_t>, "device_allocator must be move assignable");
-
-    // Both constructor forms, as on usm_allocator.
-    alloc_t __a(__q);
-    alloc_t __b(__q.get_context(), __q.get_device());
-
-    // The converting constructor carries the allocation target over.
-    oneapi::dpl::experimental::device_allocator<double> __converted(__a);
-
-    // Equality spans the value type and ignores the property list, but distinguishes the alignment, as
-    // SYCL 2020 section 4.8.3.1 requires of usm_allocator.
-    oneapi::dpl::experimental::device_allocator<int, 256> __aligned_a(__q);
-    oneapi::dpl::experimental::device_allocator<double, 256> __aligned_b(__q);
-    EXPECT_TRUE(__a == __b, "allocators on the same context and device must compare equal");
-    EXPECT_TRUE(!(__a != __b), "operator!= must be the negation of operator==");
-    EXPECT_TRUE(__a == __converted, "equality must span the value type");
-    EXPECT_TRUE(__a != __aligned_a, "allocators with different alignments must compare unequal");
-    EXPECT_TRUE(__aligned_a == __aligned_b, "equality must span the value type for a nonzero alignment");
-
-    // A distinct context over the same device makes the allocators non interchangeable.
-    sycl::context __other_ctx(__q.get_device());
-    alloc_t __other(__other_ctx, __q.get_device());
-    EXPECT_TRUE(__a != __other, "allocators on different contexts must compare unequal");
-    EXPECT_TRUE(!(__a == __other), "operator== must be the negation of operator!=");
-
-    // allocate/deallocate round trip, and the count == 0 short circuit.
-    int* __p = __a.allocate(128);
-    EXPECT_TRUE(__p != nullptr, "device_allocator::allocate returned null for a nonzero count");
-    __a.deallocate(__p, 128);
-    EXPECT_TRUE(__a.allocate(0) == nullptr, "device_allocator::allocate(0) must return nullptr");
-    __a.deallocate(nullptr, 0); // must be a no-op
-
-    // The aligned form dispatches to sycl::aligned_alloc_device.
-    oneapi::dpl::experimental::device_allocator<int, 256> __aligned(__q);
-    int* __ap = __aligned.allocate(64);
-    EXPECT_TRUE(__ap != nullptr, "the aligned device_allocator returned null");
-    EXPECT_TRUE(reinterpret_cast<std::uintptr_t>(__ap) % 256 == 0, "the aligned device_allocator ignored _Alignment");
-    __aligned.deallocate(__ap, 64);
-
-    EXPECT_TRUE(throws_memory_allocation([&] { __a.allocate(std::size_t(1) << 50); }),
-                "device_allocator::allocate must throw errc::memory_allocation when allocation fails");
-
-    // An unsupported (non power of two) alignment.
-    oneapi::dpl::experimental::device_allocator<int, 3> __bad_alignment(__q);
-    EXPECT_TRUE(throws_memory_allocation([&] { __bad_alignment.allocate(16); }),
-                "the aligned device_allocator must throw when _Alignment is unsupported");
-
     EXPECT_TRUE(throws_memory_allocation([&] { device_array<int> __d(std::size_t(1) << 50, __q); }),
                 "device_array construction must throw when its allocation fails");
 }
@@ -841,11 +868,15 @@ test_all_common(sycl::queue __q)
 int
 main()
 {
-#if TEST_DEVICE_ARRAY_PRESENT
+#if TEST_DEVICE_CONTAINERS_PRESENT
     sycl::queue q = TestUtils::get_test_queue();
 
-    test_no_span_conversion();
     test_device_allocator(q);
+#endif // TEST_DEVICE_CONTAINERS_PRESENT
+
+#if TEST_DEVICE_ARRAY_PRESENT
+    test_no_span_conversion();
+    test_allocation_failure(q);
 
     test_all_common<int>(q);
     test_all_common<float>(q);
@@ -858,5 +889,5 @@ main()
     test_depends_on(q);
 #endif // TEST_DEVICE_ARRAY_PRESENT
 
-    return TestUtils::done(TEST_DEVICE_ARRAY_PRESENT);
+    return TestUtils::done(TEST_DEVICE_CONTAINERS_PRESENT);
 }

--- a/test/parallel_api/device_array/device_array_algorithms.pass.cpp
+++ b/test/parallel_api/device_array/device_array_algorithms.pass.cpp
@@ -22,9 +22,7 @@
 
 #include "support/utils.h"
 
-// device_array is only available where oneapi::dpl::span is, which under C++17 requires the SYCL
-// implementation to provide sycl::span.
-#if TEST_DPCPP_BACKEND_PRESENT && TEST_SPAN_PRESENT
+#if ONEDPL_HAS_DEVICE_CONTAINERS >= 202608L && TEST_SPAN_PRESENT
 #    define TEST_DEVICE_ARRAY_PRESENT 1
 #else
 #    define TEST_DEVICE_ARRAY_PRESENT 0


### PR DESCRIPTION
Added version macro: `ONEDPL_HAS_DEVICE_CONTAINERS`
Currently defined to `202608L`, but only when device policies are enabled.

`device_array` also requires an available implementation of either `std::span` or `sycl::span`.  This should be available for any sycl 2020 compliant implementation.  

Added to the docs, and guarding the tests.