### PR TITLE
Replace `__semiregular_v` with the exact requirements of the SIMD `min` / `max` / `minmax` path

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -4876,7 +4876,7 @@ __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last,
                     /* __is_vector = */ ::std::true_type) noexcept
 {
 #if _ONEDPL_UDR_PRESENT // _PSTL_UDR_PRESENT
-    if constexpr (__is_value_storable_and_comparable_v<_RandomAccessIterator, _Compare>)
+    if constexpr (__unseq_backend::__is_value_storable_and_comparable_v<_RandomAccessIterator, _Compare>)
         return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
 #endif
 
@@ -4944,7 +4944,7 @@ __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __la
                        /* __is_vector = */ ::std::true_type) noexcept
 {
 #if _ONEDPL_UDR_PRESENT // _PSTL_UDR_PRESENT
-    if constexpr (__is_value_storable_and_comparable_v<_RandomAccessIterator, _Compare>)
+    if constexpr (__unseq_backend::__is_value_storable_and_comparable_v<_RandomAccessIterator, _Compare>)
         return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
 #endif
 

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -628,21 +628,20 @@ inline constexpr bool __is_brace_constructible_v<_Tp, decltype(void(_Tp{}))> = t
 // An output iterator reports void as its value type: such a value cannot be stored, and forming const _ValueType&
 // for it would be ill-formed rather than merely unsatisfied, so void is rejected up front.
 template <typename _Iterator, typename _Compare,
-          typename _ReferenceType = typename std::iterator_traits<_Iterator>::reference,
           typename _ValueType = typename std::iterator_traits<_Iterator>::value_type, typename = void>
 inline constexpr bool __is_value_storable_and_comparable_v = false;
 
-// Every requirement below is the expression the implementation uses rather than the concept it resembles:
-// std::semiregular would also require moving, an assignment returning _ValueType& and a non-throwing destructor,
-// std::convertible_to would also require static_cast<_ValueType>(_ReferenceType), and std::predicate would also require
-// the comparison result to support operator!. The implementation does negate it, but an object whose comparison result
-// cannot be negated does not meet the Compare requirements of these algorithms anyway, so it fails to compile in C++17
-// and C++20 instead of being rejected here.
-template <typename _Iterator, typename _Compare, typename _ReferenceType, typename _ValueType>
-inline constexpr bool __is_value_storable_and_comparable_v<_Iterator, _Compare, _ReferenceType, _ValueType,
+// The requirement covers only what the vectorized bricks add on top of the input the algorithms already require: the
+// value type has to be storable in the reduction object and the comparator has to be applicable to the stored copies.
+// What the algorithms require themselves is not re-checked here and fails to compile if it is not met: that *__first is
+// convertible to the value type, and that the result of the comparison can be negated.
+// Every requirement is the expression the implementation uses rather than the concept it resembles: std::semiregular
+// would also require moving, an assignment returning _ValueType& and a non-throwing destructor.
+template <typename _Iterator, typename _Compare, typename _ValueType>
+inline constexpr bool __is_value_storable_and_comparable_v<_Iterator, _Compare, _ValueType,
                                                            std::enable_if_t<!std::is_void_v<_ValueType>>> =
     __is_brace_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&
-    std::is_copy_assignable_v<_ValueType> && std::is_convertible_v<_ReferenceType, _ValueType> &&
+    std::is_copy_assignable_v<_ValueType> &&
     std::is_invocable_r_v<bool, _Compare&, const _ValueType&, const _ValueType&>;
 
 // The implementation keeps copies of the values in the reduction object and compares those copies, so the value

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -632,16 +632,12 @@ template <typename _Iterator, typename _Compare,
           typename _ValueType = typename std::iterator_traits<_Iterator>::value_type, typename = void>
 inline constexpr bool __is_value_storable_and_comparable_v = false;
 
-// The value is stored in a brace-initialized object and updated there by assignment, so the requirements are brace
-// initialization, copy construction and copy assignment. std::semiregular would be a natural name for them, but it is
-// stricter: it also requires move construction, move assignment, an assignment returning _ValueType& and a
-// non-throwing destructor, none of which is used here. The element is only copy-initialized into a _ValueType, so an
-// implicit conversion is all that is required of the reference type: std::convertible_to would be stricter again, since
-// it also requires static_cast<_ValueType>(_ReferenceType) to be well-formed. The comparison is required to be callable
-// on const lvalues and to return something convertible to bool; std::predicate would be stricter, since it also requires
-// the result to support operator!, which the implementation does apply to it. A comparison object whose result cannot be
-// negated does not meet the Compare requirements the standard states for these algorithms in the first place, so it is
-// not detected here: it is left to fail to compile, the same way in C++17 and in C++20.
+// Every requirement below is the expression the implementation uses rather than the concept it resembles:
+// std::semiregular would also require moving, an assignment returning _ValueType& and a non-throwing destructor,
+// std::convertible_to would also require static_cast<_ValueType>(_ReferenceType), and std::predicate would also require
+// the comparison result to support operator!. The implementation does negate it, but an object whose comparison result
+// cannot be negated does not meet the Compare requirements of these algorithms anyway, so it fails to compile in C++17
+// and C++20 instead of being rejected here.
 template <typename _Iterator, typename _Compare, typename _ReferenceType, typename _ValueType>
 inline constexpr bool __is_value_storable_and_comparable_v<_Iterator, _Compare, _ReferenceType, _ValueType,
                                                            std::enable_if_t<!std::is_void_v<_ValueType>>> =

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -635,12 +635,14 @@ inline constexpr bool __is_value_storable_and_comparable_v = false;
 // The value is stored in a brace-initialized object and updated there by assignment, so the requirements are brace
 // initialization, copy construction and copy assignment. std::semiregular would be a natural name for them, but it is
 // stricter: it also requires move construction, move assignment, an assignment returning _ValueType& and a
-// non-throwing destructor, none of which is used here.
+// non-throwing destructor, none of which is used here. The element is only copy-initialized into a _ValueType, so an
+// implicit conversion is all that is required of the reference type: std::convertible_to would be stricter again, since
+// it also requires static_cast<_ValueType>(_ReferenceType) to be well-formed.
 template <typename _Iterator, typename _Compare, typename _ReferenceType, typename _ValueType>
 inline constexpr bool __is_value_storable_and_comparable_v<_Iterator, _Compare, _ReferenceType, _ValueType,
                                                            std::enable_if_t<!std::is_void_v<_ValueType>>> =
     __is_brace_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&
-    std::is_copy_assignable_v<_ValueType> && __internal::__convertible_to_v<_ReferenceType, _ValueType> &&
+    std::is_copy_assignable_v<_ValueType> && std::is_convertible_v<_ReferenceType, _ValueType> &&
     __internal::__predicate_v<_Compare&, const _ValueType&, const _ValueType&>;
 
 // The implementation keeps copies of the values in the reduction object and compares those copies, so the value

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -19,6 +19,7 @@
 #include <type_traits>
 #include <memory>   // for std::addressof
 #include <iterator> // for std::iterator_traits
+#include <utility>  // for std::as_const
 
 #include "utils.h"
 
@@ -695,7 +696,9 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
     _ONEDPL_PRAGMA_SIMD_REDUCTION(__min_func : __init)
     for (_Size __i = 1; __i < __n; ++__i)
     {
-        const _ValueType __min_val = __init.__min_val;
+        // The candidate is read through a const reference, so that copying it requires nothing but copy construction
+        // from const _ValueType&.
+        const _ValueType __min_val = std::as_const(__init).__min_val;
         const _ValueType __current = __first[__i];
         if (std::invoke(__comp, __current, __min_val))
         {
@@ -779,9 +782,11 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
     _ONEDPL_PRAGMA_SIMD_REDUCTION(__min_func : __init)
     for (_Size __i = 1; __i < __n; ++__i)
     {
-        auto __min_val = __init.__min_val;
-        auto __max_val = __init.__max_val;
-        auto __current = __first[__i];
+        // The candidates are read through a const reference and the element is materialized as a _ValueType, so that
+        // copying and storing them requires nothing but copy construction and copy assignment from const _ValueType&.
+        const _ValueType __min_val = std::as_const(__init).__min_val;
+        const _ValueType __max_val = std::as_const(__init).__max_val;
+        const _ValueType __current = __first[__i];
         if (std::invoke(__comp, __current, __min_val))
         {
             __init.__min_val = __current;

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -696,9 +696,9 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
     _ONEDPL_PRAGMA_SIMD_REDUCTION(__min_func : __init)
     for (_Size __i = 1; __i < __n; ++__i)
     {
-        // The candidate is read through a const reference, so that copying it requires nothing but copy construction
-        // from const _ValueType&.
-        const _ValueType __min_val = std::as_const(__init).__min_val;
+        // The candidate is read through a const reference and copied by direct initialization, so that copying it
+        // requires nothing but std::is_copy_constructible_v, which is stated in terms of direct initialization too.
+        const _ValueType __min_val(std::as_const(__init).__min_val);
         const _ValueType __current = __first[__i];
         if (std::invoke(__comp, __current, __min_val))
         {
@@ -782,10 +782,11 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
     _ONEDPL_PRAGMA_SIMD_REDUCTION(__min_func : __init)
     for (_Size __i = 1; __i < __n; ++__i)
     {
-        // The candidates are read through a const reference and the element is materialized as a _ValueType, so that
-        // copying and storing them requires nothing but copy construction and copy assignment from const _ValueType&.
-        const _ValueType __min_val = std::as_const(__init).__min_val;
-        const _ValueType __max_val = std::as_const(__init).__max_val;
+        // The candidates are read through a const reference and copied by direct initialization, and the element is
+        // materialized as a _ValueType, so that copying and storing them requires nothing but
+        // std::is_copy_constructible_v and std::is_copy_assignable_v.
+        const _ValueType __min_val(std::as_const(__init).__min_val);
+        const _ValueType __max_val(std::as_const(__init).__max_val);
         const _ValueType __current = __first[__i];
         if (std::invoke(__comp, __current, __min_val))
         {

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -637,13 +637,17 @@ inline constexpr bool __is_value_storable_and_comparable_v = false;
 // stricter: it also requires move construction, move assignment, an assignment returning _ValueType& and a
 // non-throwing destructor, none of which is used here. The element is only copy-initialized into a _ValueType, so an
 // implicit conversion is all that is required of the reference type: std::convertible_to would be stricter again, since
-// it also requires static_cast<_ValueType>(_ReferenceType) to be well-formed.
+// it also requires static_cast<_ValueType>(_ReferenceType) to be well-formed. The comparison is required to be callable
+// on const lvalues and to return something convertible to bool; std::predicate would be stricter, since it also requires
+// the result to support operator!, which the implementation does apply to it. A comparison object whose result cannot be
+// negated does not meet the Compare requirements the standard states for these algorithms in the first place, so it is
+// not detected here: it is left to fail to compile, the same way in C++17 and in C++20.
 template <typename _Iterator, typename _Compare, typename _ReferenceType, typename _ValueType>
 inline constexpr bool __is_value_storable_and_comparable_v<_Iterator, _Compare, _ReferenceType, _ValueType,
                                                            std::enable_if_t<!std::is_void_v<_ValueType>>> =
     __is_brace_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&
     std::is_copy_assignable_v<_ValueType> && std::is_convertible_v<_ReferenceType, _ValueType> &&
-    __internal::__predicate_v<_Compare&, const _ValueType&, const _ValueType&>;
+    std::is_invocable_r_v<bool, _Compare&, const _ValueType&, const _ValueType&>;
 
 // The implementation keeps copies of the values in the reduction object and compares those copies, so the value
 // type has to be usable in a user-defined reduction and the comparator has to be applicable to the copies:

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -17,7 +17,8 @@
 #define _ONEDPL_UNSEQ_BACKEND_SIMD_H
 
 #include <type_traits>
-#include <memory> // for std::addressof
+#include <memory>   // for std::addressof
+#include <iterator> // for std::iterator_traits
 
 #include "utils.h"
 
@@ -613,15 +614,33 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
     return ::std::make_pair(__result + __n, __init_.__value);
 }
 
+// An output iterator reports void as its value type: such a value cannot be stored, and forming const _ValueType&
+// for it would be ill-formed rather than merely unsatisfied, so void is rejected up front.
+template <typename _Iterator, typename _Compare,
+          typename _ReferenceType = typename std::iterator_traits<_Iterator>::reference,
+          typename _ValueType = typename std::iterator_traits<_Iterator>::value_type, typename = void>
+inline constexpr bool __is_value_storable_and_comparable_v = false;
+
+// The value is stored in a default-constructed object and updated there by assignment, so the requirements are default
+// construction, copy construction and copy assignment. std::semiregular would be a natural name for them, but it is
+// stricter: it also requires move construction, move assignment, an assignment returning _ValueType& and a
+// non-throwing destructor, none of which is used here.
+template <typename _Iterator, typename _Compare, typename _ReferenceType, typename _ValueType>
+inline constexpr bool __is_value_storable_and_comparable_v<_Iterator, _Compare, _ReferenceType, _ValueType,
+                                                           std::enable_if_t<!std::is_void_v<_ValueType>>> =
+    std::is_default_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&
+    std::is_copy_assignable_v<_ValueType> && __internal::__convertible_to_v<_ReferenceType, _ValueType> &&
+    __internal::__predicate_v<_Compare&, const _ValueType&, const _ValueType&>;
+
 // The implementation keeps copies of the values in the reduction object and compares those copies, so the value
 // type has to be usable in a user-defined reduction and the comparator has to be applicable to the copies:
-// __internal::__is_value_storable_and_comparable_v is the requirement checked by the callers.
+// __is_value_storable_and_comparable_v is the requirement checked by the callers.
 // complexity [violation] - We will have at most (__n-1 + number_of_lanes) comparisons instead of at most __n-1.
 template <typename _ForwardIterator, typename _Size, typename _Compare>
 _ForwardIterator
 __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
 {
-    static_assert(__internal::__is_value_storable_and_comparable_v<_ForwardIterator, _Compare>,
+    static_assert(__is_value_storable_and_comparable_v<_ForwardIterator, _Compare>,
                   "The value type of the iterator must be storable in the reduction object and __comp must be "
                   "a predicate over objects of that type");
 
@@ -679,13 +698,13 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
 
 // The implementation keeps copies of the values in the reduction object and compares those copies, so the value
 // type has to be usable in a user-defined reduction and the comparator has to be applicable to the copies:
-// __internal::__is_value_storable_and_comparable_v is the requirement checked by the callers.
+// __is_value_storable_and_comparable_v is the requirement checked by the callers.
 // complexity [violation] - We will have at most (2*(__n-1) + 4*number_of_lanes) comparisons instead of at most [1.5*(__n-1)].
 template <typename _ForwardIterator, typename _Size, typename _Compare>
 std::pair<_ForwardIterator, _ForwardIterator>
 __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
 {
-    static_assert(__internal::__is_value_storable_and_comparable_v<_ForwardIterator, _Compare>,
+    static_assert(__is_value_storable_and_comparable_v<_ForwardIterator, _Compare>,
                   "The value type of the iterator must be storable in the reduction object and __comp must be "
                   "a predicate over objects of that type");
 

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -614,6 +614,16 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
     return ::std::make_pair(__result + __n, __init_.__value);
 }
 
+// The reduction object initializes its value members with _ValueType{}, which is not what
+// std::is_default_constructible_v checks: that trait stands for _ValueType v;, and the two differ both ways. An
+// aggregate whose member has an explicit default constructor is default-constructible but not brace-initializable,
+// while an aggregate with a const member without a default member initializer is the other way round.
+template <typename _Tp, typename = void>
+inline constexpr bool __is_brace_constructible_v = false;
+
+template <typename _Tp>
+inline constexpr bool __is_brace_constructible_v<_Tp, decltype(void(_Tp{}))> = true;
+
 // An output iterator reports void as its value type: such a value cannot be stored, and forming const _ValueType&
 // for it would be ill-formed rather than merely unsatisfied, so void is rejected up front.
 template <typename _Iterator, typename _Compare,
@@ -621,14 +631,14 @@ template <typename _Iterator, typename _Compare,
           typename _ValueType = typename std::iterator_traits<_Iterator>::value_type, typename = void>
 inline constexpr bool __is_value_storable_and_comparable_v = false;
 
-// The value is stored in a default-constructed object and updated there by assignment, so the requirements are default
-// construction, copy construction and copy assignment. std::semiregular would be a natural name for them, but it is
+// The value is stored in a brace-initialized object and updated there by assignment, so the requirements are brace
+// initialization, copy construction and copy assignment. std::semiregular would be a natural name for them, but it is
 // stricter: it also requires move construction, move assignment, an assignment returning _ValueType& and a
 // non-throwing destructor, none of which is used here.
 template <typename _Iterator, typename _Compare, typename _ReferenceType, typename _ValueType>
 inline constexpr bool __is_value_storable_and_comparable_v<_Iterator, _Compare, _ReferenceType, _ValueType,
                                                            std::enable_if_t<!std::is_void_v<_ValueType>>> =
-    std::is_default_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&
+    __is_brace_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&
     std::is_copy_assignable_v<_ValueType> && __internal::__convertible_to_v<_ReferenceType, _ValueType> &&
     __internal::__predicate_v<_Compare&, const _ValueType&, const _ValueType&>;
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -1104,25 +1104,14 @@ struct __is_type_with_iterator_traits<
 template <typename _T>
 static constexpr bool __is_type_with_iterator_traits_v = __is_type_with_iterator_traits<_T>::value;
 
-// The requirements below are named after the concepts they stand for: C++20 uses those concepts directly, while
-// C++17 gets an approximation of each of them.
+// The requirement below is named after the concept it stands for: C++20 uses that concept directly, while C++17 gets
+// an approximation of it.
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
-
-template <typename _From, typename _To>
-inline constexpr bool __convertible_to_v = std::convertible_to<_From, _To>;
 
 template <typename _Fp, typename... _Args>
 inline constexpr bool __predicate_v = std::predicate<_Fp, _Args...>;
 
 #else
-
-// std::convertible_to also requires an explicit conversion, which std::is_convertible_v does not check.
-template <typename _From, typename _To, typename = void>
-inline constexpr bool __convertible_to_v = false;
-
-template <typename _From, typename _To>
-inline constexpr bool __convertible_to_v<_From, _To, std::void_t<decltype(static_cast<_To>(std::declval<_From>()))>> =
-    std::is_convertible_v<_From, _To>;
 
 // std::predicate requires the result to be boolean-testable, which is stronger than being convertible to bool, but
 // the difference only shows for types with an unusable operator!.

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -49,7 +49,7 @@
 #endif
 
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
-#    include <concepts> // for std::equality_comparable_with, std::predicate
+#    include <concepts> // for std::equality_comparable_with
 #endif
 
 #include "functional_impl.h"
@@ -1103,22 +1103,6 @@ struct __is_type_with_iterator_traits<
 
 template <typename _T>
 static constexpr bool __is_type_with_iterator_traits_v = __is_type_with_iterator_traits<_T>::value;
-
-// The requirement below is named after the concept it stands for: C++20 uses that concept directly, while C++17 gets
-// an approximation of it.
-#if _ONEDPL_CPP20_CONCEPTS_PRESENT
-
-template <typename _Fp, typename... _Args>
-inline constexpr bool __predicate_v = std::predicate<_Fp, _Args...>;
-
-#else
-
-// std::predicate requires the result to be boolean-testable, which is stronger than being convertible to bool, but
-// the difference only shows for types with an unusable operator!.
-template <typename _Fp, typename... _Args>
-inline constexpr bool __predicate_v = std::is_invocable_r_v<bool, _Fp, _Args...>;
-
-#endif // _ONEDPL_CPP20_CONCEPTS_PRESENT
 
 // Storage helper since _Tp may not have a default constructor.
 template <typename _Tp>

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -49,7 +49,7 @@
 #endif
 
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
-#    include <concepts> // for std::equality_comparable_with, std::semiregular, std::convertible_to, std::predicate
+#    include <concepts> // for std::equality_comparable_with, std::convertible_to, std::predicate
 #endif
 
 #include "functional_impl.h"
@@ -1111,9 +1111,6 @@ static constexpr bool __is_type_with_iterator_traits_v = __is_type_with_iterator
 template <typename _From, typename _To>
 inline constexpr bool __convertible_to_v = std::convertible_to<_From, _To>;
 
-template <typename _Tp>
-inline constexpr bool __semiregular_v = std::semiregular<_Tp>;
-
 template <typename _Fp, typename... _Args>
 inline constexpr bool __predicate_v = std::predicate<_Fp, _Args...>;
 
@@ -1127,73 +1124,12 @@ template <typename _From, typename _To>
 inline constexpr bool __convertible_to_v<_From, _To, std::void_t<decltype(static_cast<_To>(std::declval<_From>()))>> =
     std::is_convertible_v<_From, _To>;
 
-// std::assignable_from also requires the assignment to return _Tp&, which std::is_assignable_v does not check.
-template <typename _Tp, typename _Up, typename = void>
-inline constexpr bool __assignable_from_v = false;
-
-template <typename _Tp, typename _Up>
-inline constexpr bool __assignable_from_v<_Tp, _Up, std::void_t<decltype(std::declval<_Tp&>() = std::declval<_Up>())>> =
-    std::is_same_v<decltype(std::declval<_Tp&>() = std::declval<_Up>()), _Tp&>;
-
-// std::constructible_from, which includes std::destructible
-template <typename _Tp, typename... _Args>
-inline constexpr bool __constructible_from_v =
-    std::is_nothrow_destructible_v<_Tp> && std::is_constructible_v<_Tp, _Args...>;
-
-// std::move_constructible
-template <typename _Tp>
-inline constexpr bool __move_constructible_v = __constructible_from_v<_Tp, _Tp> && __convertible_to_v<_Tp, _Tp>;
-
-// std::copy_constructible. Void is rejected up front because the requirement below forms _Tp&, which would be
-// ill-formed rather than merely unsatisfied, and std::copy_constructible is not satisfied for void anyway.
-template <typename _Tp, typename = void>
-inline constexpr bool __copy_constructible_v = false;
-
-template <typename _Tp>
-inline constexpr bool __copy_constructible_v<_Tp, std::enable_if_t<!std::is_void_v<_Tp>>> =
-    __move_constructible_v<_Tp> && __constructible_from_v<_Tp, _Tp&> && __convertible_to_v<_Tp&, _Tp> &&
-    __constructible_from_v<_Tp, const _Tp&> && __convertible_to_v<const _Tp&, _Tp> &&
-    __constructible_from_v<_Tp, const _Tp> && __convertible_to_v<const _Tp, _Tp>;
-
-// std::movable, less std::swappable: the latter is implied by move construction and move assignment, since
-// std::swappable falls back to a move-based implementation, while std::is_swappable_v would additionally reject a
-// type with a deleted ADL swap.
-template <typename _Tp>
-inline constexpr bool __movable_v = std::is_object_v<_Tp> && __move_constructible_v<_Tp> && __assignable_from_v<_Tp, _Tp>;
-
-// std::copyable. Void is rejected up front for the same reason as in __copy_constructible_v above.
-template <typename _Tp, typename = void>
-inline constexpr bool __copyable_v = false;
-
-template <typename _Tp>
-inline constexpr bool __copyable_v<_Tp, std::enable_if_t<!std::is_void_v<_Tp>>> =
-    __copy_constructible_v<_Tp> && __movable_v<_Tp> && __assignable_from_v<_Tp, _Tp&> &&
-    __assignable_from_v<_Tp, const _Tp&> && __assignable_from_v<_Tp, const _Tp>;
-
-// std::semiregular. std::default_initializable also requires _Tp{} and ::new _Tp to be valid, which
-// std::is_default_constructible_v does not check.
-template <typename _Tp>
-inline constexpr bool __semiregular_v = __copyable_v<_Tp> && std::is_default_constructible_v<_Tp>;
-
 // std::predicate requires the result to be boolean-testable, which is stronger than being convertible to bool, but
 // the difference only shows for types with an unusable operator!.
 template <typename _Fp, typename... _Args>
 inline constexpr bool __predicate_v = std::is_invocable_r_v<bool, _Fp, _Args...>;
 
 #endif // _ONEDPL_CPP20_CONCEPTS_PRESENT
-
-// An output iterator reports void as its value type: such a value cannot be stored, and forming const _ValueType&
-// for it would be ill-formed rather than merely unsatisfied, so void is rejected up front.
-template <typename _Iterator, typename _Compare,
-          typename _ReferenceType = typename std::iterator_traits<_Iterator>::reference,
-          typename _ValueType = typename std::iterator_traits<_Iterator>::value_type, typename = void>
-inline constexpr bool __is_value_storable_and_comparable_v = false;
-
-template <typename _Iterator, typename _Compare, typename _ReferenceType, typename _ValueType>
-inline constexpr bool __is_value_storable_and_comparable_v<_Iterator, _Compare, _ReferenceType, _ValueType,
-                                                           std::enable_if_t<!std::is_void_v<_ValueType>>> =
-    __semiregular_v<_ValueType> && __convertible_to_v<_ReferenceType, _ValueType> &&
-    __predicate_v<_Compare&, const _ValueType&, const _ValueType&>;
 
 // Storage helper since _Tp may not have a default constructor.
 template <typename _Tp>

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -49,7 +49,7 @@
 #endif
 
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
-#    include <concepts> // for std::equality_comparable_with, std::convertible_to, std::predicate
+#    include <concepts> // for std::equality_comparable_with, std::predicate
 #endif
 
 #include "functional_impl.h"

--- a/test/general/implementation_details/value_storable_and_comparable.pass.cpp
+++ b/test/general/implementation_details/value_storable_and_comparable.pass.cpp
@@ -8,8 +8,10 @@
 //===------------------------------------------------------===//
 
 // Compile-time checks for oneapi::dpl::__unseq_backend::__is_value_storable_and_comparable_v and for the requirements
-// it is built from: oneapi::dpl::__unseq_backend::__is_brace_constructible_v and oneapi::dpl::__internal::__predicate_v.
-// Every requirement is checked both ways: a type that satisfies it and a type that does not.
+// it is built from.
+// The two of them that are not standard type traits, oneapi::dpl::__unseq_backend::__is_brace_constructible_v
+// and oneapi::dpl::__internal::__predicate_v, are checked on their own as well. Every requirement is checked both ways:
+// a type that satisfies it and a type that does not.
 
 #include "support/test_config.h"
 
@@ -161,6 +163,25 @@ struct CopyOnlyNoMove
     }
 };
 
+// Copyable and assignable from a const lvalue only, which is enough here, because the candidates are read through
+// std::as_const and the element is materialized as a const _ValueType.
+struct ConstCopyOnly
+{
+    int val = 0;
+    ConstCopyOnly() = default;
+    ConstCopyOnly(const ConstCopyOnly&) = default;
+    ConstCopyOnly&
+    operator=(const ConstCopyOnly&) = default;
+    ConstCopyOnly(ConstCopyOnly&) = delete;
+    ConstCopyOnly&
+    operator=(ConstCopyOnly&) = delete;
+    bool
+    operator<(const ConstCopyOnly& other) const
+    {
+        return val < other.val;
+    }
+};
+
 //----------------------------------------------------------------------------//
 // __is_brace_constructible_v
 //----------------------------------------------------------------------------//
@@ -262,7 +283,7 @@ static_assert(!dpl_internal::__predicate_v<std::less<int>&, const Regular&, cons
 // __is_value_storable_and_comparable_v
 //----------------------------------------------------------------------------//
 
-// An iterator whose reference type is not convertible to its value type.
+// A reference type that does not convert to the value type.
 struct OpaqueRef
 {
 };
@@ -288,6 +309,27 @@ struct ExplicitlyNotConvertible
     }
 };
 
+// A value type whose copy constructor is explicit, which is enough here, because the candidates are copied by direct
+// initialization, and so is std::is_copy_constructible_v defined.
+struct ExplicitCopyCtor
+{
+    int val = 0;
+    ExplicitCopyCtor() = default;
+    explicit ExplicitCopyCtor(const ExplicitCopyCtor& other) : val(other.val) {}
+    ExplicitCopyCtor&
+    operator=(const ExplicitCopyCtor&) = default;
+    bool
+    operator<(const ExplicitCopyCtor&) const
+    {
+        return false;
+    }
+};
+
+struct ExplicitCopyCtorSource
+{
+    operator ExplicitCopyCtor() const;
+};
+
 template <typename _ValueType, typename _ReferenceType>
 struct FakeIterator
 {
@@ -308,10 +350,12 @@ static_assert(dpl_unseq::__is_value_storable_and_comparable_v<std::vector<int>::
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<std::vector<int>::const_iterator, std::less<>>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<Regular*, std::less<Regular>>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<ExplicitDefaultCtor*, std::less<ExplicitDefaultCtor>>);
-// Accepted: the requirements are default construction, copy construction and copy assignment, and nothing else.
+// Accepted: the requirements are brace initialization, copy construction and copy assignment, and nothing else.
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<CopyOnlyNoMove*, std::less<CopyOnlyNoMove>>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<VoidAssign*, std::less<VoidAssign>>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<ThrowingDtor*, std::less<ThrowingDtor>>);
+// Accepted: copying and storing a value only ever reads it through a const reference.
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<const ConstCopyOnly*, std::less<ConstCopyOnly>>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, MoveOnlyLess>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, IntResultLess>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, bool (*)(const int&, const int&)>);
@@ -326,8 +370,14 @@ static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<std::
 static_assert(std::is_convertible_v<ImplicitSource, ExplicitlyNotConvertible>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<ExplicitlyNotConvertible, ImplicitSource>,
                                                              std::less<ExplicitlyNotConvertible>>);
+// An explicit copy constructor is enough for copying a candidate, as long as the reference type converts to the value
+// type without it.
+static_assert(std::is_copy_constructible_v<ExplicitCopyCtor>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<ExplicitCopyCtor, ExplicitCopyCtorSource>,
+                                                             std::less<ExplicitCopyCtor>>);
 
-// Rejected because of the value type: brace initialization, copy assignment and copy construction respectively.
+// Rejected because of the value type: the first two fail brace initialization, then copy assignment and copy
+// construction.
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<NoDefaultCtor*, std::less<NoDefaultCtor>>);
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<AggregateOfExplicitDefaultCtor*,
                                                               std::less<AggregateOfExplicitDefaultCtor>>);
@@ -336,6 +386,10 @@ static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<MoveOnly*, std::l
 
 // Rejected because the reference type does not convert to the value type.
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<int, OpaqueRef>, std::less<int>>);
+// The same for a non-const reference to a value type that is only copyable from a const lvalue, and for a value type
+// that is only copyable by direct initialization.
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<ConstCopyOnly*, std::less<ConstCopyOnly>>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<ExplicitCopyCtor*, std::less<ExplicitCopyCtor>>);
 
 // Rejected because an output iterator reports void as its value type.
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<std::back_insert_iterator<std::vector<int>>,

--- a/test/general/implementation_details/value_storable_and_comparable.pass.cpp
+++ b/test/general/implementation_details/value_storable_and_comparable.pass.cpp
@@ -181,6 +181,23 @@ struct ConstCopyOnly
     }
 };
 
+// A value type whose copy constructor is explicit, which is enough for copying the candidates, because they are copied
+// by direct initialization, and so is std::is_copy_constructible_v defined. Copy-initializing an element of such a type
+// is ill-formed, so an iterator over it does not meet the requirements of a forward iterator.
+struct ExplicitCopyCtor
+{
+    int val = 0;
+    ExplicitCopyCtor() = default;
+    explicit ExplicitCopyCtor(const ExplicitCopyCtor& other) : val(other.val) {}
+    ExplicitCopyCtor&
+    operator=(const ExplicitCopyCtor&) = default;
+    bool
+    operator<(const ExplicitCopyCtor&) const
+    {
+        return false;
+    }
+};
+
 //----------------------------------------------------------------------------//
 // __is_brace_constructible_v
 //----------------------------------------------------------------------------//
@@ -283,54 +300,14 @@ struct NotNegatableResultLess
 };
 
 //----------------------------------------------------------------------------//
-// __is_value_storable_and_comparable_v
+// Reference types
 //----------------------------------------------------------------------------//
 
-// A reference type that does not convert to the value type.
+// A reference type that does not convert to the value type: an iterator reporting it does not meet the requirements of
+// a forward iterator, which state that *__first is convertible to the value type, so the requirement does not look at
+// the reference type at all.
 struct OpaqueRef
 {
-};
-
-// A value type whose only constructor taking ImplicitSource is deleted and explicit: copy-initialization ignores it and
-// picks the conversion operator, while static_cast selects the deleted constructor. The implementation only
-// copy-initializes the value, so such a reference type is enough for it, unlike for std::convertible_to.
-struct ExplicitlyNotConvertible;
-
-struct ImplicitSource
-{
-    operator ExplicitlyNotConvertible() const;
-};
-
-struct ExplicitlyNotConvertible
-{
-    ExplicitlyNotConvertible() = default;
-    explicit ExplicitlyNotConvertible(ImplicitSource) = delete;
-    bool
-    operator<(const ExplicitlyNotConvertible&) const
-    {
-        return false;
-    }
-};
-
-// A value type whose copy constructor is explicit, which is enough here, because the candidates are copied by direct
-// initialization, and so is std::is_copy_constructible_v defined.
-struct ExplicitCopyCtor
-{
-    int val = 0;
-    ExplicitCopyCtor() = default;
-    explicit ExplicitCopyCtor(const ExplicitCopyCtor& other) : val(other.val) {}
-    ExplicitCopyCtor&
-    operator=(const ExplicitCopyCtor&) = default;
-    bool
-    operator<(const ExplicitCopyCtor&) const
-    {
-        return false;
-    }
-};
-
-struct ExplicitCopyCtorSource
-{
-    operator ExplicitCopyCtor() const;
 };
 
 template <typename _ValueType, typename _ReferenceType>
@@ -345,6 +322,10 @@ struct FakeIterator
     reference
     operator*() const;
 };
+
+//----------------------------------------------------------------------------//
+// __is_value_storable_and_comparable_v
+//----------------------------------------------------------------------------//
 
 // Accepted: the value type is storable and the comparator is callable on const values.
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, std::less<int>>);
@@ -367,20 +348,21 @@ static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, bool (*)(con
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, NotNegatableResultLess>);
 // The comparator max_element passes down to the min_element brick.
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, dpl_internal::__reorder_pred<std::less<int>>>);
-// A proxy reference is fine as long as it converts to the value type.
+// The reference type is not part of the requirement, so a proxy reference and an iterator returning the value type by
+// value are accepted like any other.
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<std::vector<bool>::iterator, std::less<bool>>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<int, int>, std::less<int>>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<std::pair<int, int>, std::pair<int&, int&>>,
                                                              std::less<std::pair<int, int>>>);
-// An implicit conversion is enough, even when the explicit one is ill-formed.
-static_assert(std::is_convertible_v<ImplicitSource, ExplicitlyNotConvertible>);
-static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<ExplicitlyNotConvertible, ImplicitSource>,
-                                                             std::less<ExplicitlyNotConvertible>>);
-// An explicit copy constructor is enough for copying a candidate, as long as the reference type converts to the value
-// type without it.
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<CopyOnlyNoMove, CopyOnlyNoMove>,
+                                                             std::less<CopyOnlyNoMove>>);
+// Accepted although the bricks do not compile for them: an element of these iterators cannot be copy-initialized into
+// the value type, so they do not meet the requirements of a forward iterator, which is not detected here either. The
+// value types themselves are copy-constructible, which is stated in terms of direct initialization.
 static_assert(std::is_copy_constructible_v<ExplicitCopyCtor>);
-static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<ExplicitCopyCtor, ExplicitCopyCtorSource>,
-                                                             std::less<ExplicitCopyCtor>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<ExplicitCopyCtor*, std::less<ExplicitCopyCtor>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<ConstCopyOnly*, std::less<ConstCopyOnly>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<int, OpaqueRef>, std::less<int>>);
 
 // Rejected because of the value type: the first two fail brace initialization, the third copy assignment, and the
 // move-only one copy construction, and with it every other requirement that copies a value.
@@ -389,13 +371,6 @@ static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<AggregateOfExplic
                                                               std::less<AggregateOfExplicitDefaultCtor>>);
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<NoCopyAssign*, std::less<NoCopyAssign>>);
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<MoveOnly*, std::less<MoveOnly>>);
-
-// Rejected because the reference type does not convert to the value type.
-static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<int, OpaqueRef>, std::less<int>>);
-// The same for a non-const reference to a value type that is only copyable from a const lvalue, and for a value type
-// that is only copyable by direct initialization.
-static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<ConstCopyOnly*, std::less<ConstCopyOnly>>);
-static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<ExplicitCopyCtor*, std::less<ExplicitCopyCtor>>);
 
 // Rejected because an output iterator reports void as its value type.
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<std::back_insert_iterator<std::vector<int>>,

--- a/test/general/implementation_details/value_storable_and_comparable.pass.cpp
+++ b/test/general/implementation_details/value_storable_and_comparable.pass.cpp
@@ -376,8 +376,8 @@ static_assert(std::is_copy_constructible_v<ExplicitCopyCtor>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<ExplicitCopyCtor, ExplicitCopyCtorSource>,
                                                              std::less<ExplicitCopyCtor>>);
 
-// Rejected because of the value type: the first two fail brace initialization, then copy assignment and copy
-// construction.
+// Rejected because of the value type: the first two fail brace initialization, the third copy assignment, and the
+// move-only one copy construction, and with it every other requirement that copies a value.
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<NoDefaultCtor*, std::less<NoDefaultCtor>>);
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<AggregateOfExplicitDefaultCtor*,
                                                               std::less<AggregateOfExplicitDefaultCtor>>);

--- a/test/general/implementation_details/value_storable_and_comparable.pass.cpp
+++ b/test/general/implementation_details/value_storable_and_comparable.pass.cpp
@@ -7,13 +7,13 @@
 //
 //===------------------------------------------------------===//
 
-// Compile-time checks for oneapi::dpl::__internal::__is_value_storable_and_comparable_v and for each of the
-// requirements it is built from: __convertible_to_v, __semiregular_v and __predicate_v, plus the C++17 building blocks
-// of __semiregular_v (__constructible_from_v, __move_constructible_v, __copy_constructible_v, __assignable_from_v, __movable_v,
-// __copyable_v). Every requirement is checked both ways: a type that satisfies it and a type that does not.
+// Compile-time checks for oneapi::dpl::__unseq_backend::__is_value_storable_and_comparable_v and for the requirements
+// it is built from: oneapi::dpl::__internal::__convertible_to_v and __predicate_v. Every requirement is checked both ways:
+// a type that satisfies it and a type that does not.
 
 #include "support/test_config.h"
 
+#include <oneapi/dpl/pstl/unseq_backend_simd.h>
 #include <oneapi/dpl/pstl/utils.h>
 
 #include <cstddef>
@@ -26,12 +26,13 @@
 #include "support/utils.h"
 
 namespace dpl_internal = oneapi::dpl::__internal;
+namespace dpl_unseq = oneapi::dpl::__unseq_backend;
 
 //----------------------------------------------------------------------------//
 // Value types
 //----------------------------------------------------------------------------//
 
-// Satisfies every requirement: default-constructible, copyable, less-than comparable.
+// Satisfies every requirement: default-constructible, copy-constructible, copy-assignable, less-than comparable.
 struct Regular
 {
     int val = 0;
@@ -42,7 +43,7 @@ struct Regular
     }
 };
 
-// std::default_initializable accepts an explicit default constructor, since T{} stays valid.
+// An explicit default constructor is enough, since the value is stored in a default-constructed object.
 struct ExplicitDefaultCtor
 {
     int val;
@@ -79,7 +80,7 @@ struct NoCopyAssign
     }
 };
 
-// std::is_assignable_v is satisfied, but the assignment does not return VoidAssign&.
+// The assignment does not return VoidAssign&, which is enough here because the result is never used.
 struct VoidAssign
 {
     int val = 0;
@@ -95,7 +96,7 @@ struct VoidAssign
     }
 };
 
-// std::destructible, and hence __constructible_from_v, requires the destructor to be noexcept.
+// The destructor is not noexcept, which is enough here because storing a value never has to be non-throwing.
 struct ThrowingDtor
 {
     int val = 0;
@@ -119,6 +120,24 @@ struct MoveOnly
     operator=(const MoveOnly&) = delete;
     bool
     operator<(const MoveOnly& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// Deleting the move operations while keeping the copy ones is enough here, because the value is never moved.
+struct CopyOnlyNoMove
+{
+    int val = 0;
+    CopyOnlyNoMove() = default;
+    CopyOnlyNoMove(const CopyOnlyNoMove&) = default;
+    CopyOnlyNoMove&
+    operator=(const CopyOnlyNoMove&) = default;
+    CopyOnlyNoMove(CopyOnlyNoMove&&) = delete;
+    CopyOnlyNoMove&
+    operator=(CopyOnlyNoMove&&) = delete;
+    bool
+    operator<(const CopyOnlyNoMove& other) const
     {
         return val < other.val;
     }
@@ -161,26 +180,6 @@ static_assert(!dpl_internal::__convertible_to_v<int, ExplicitFromInt>);
 static_assert(!dpl_internal::__convertible_to_v<const MoveOnly&, MoveOnly>);
 static_assert(std::is_convertible_v<ImplicitSource, ExplicitlyNotConvertible>);
 static_assert(!dpl_internal::__convertible_to_v<ImplicitSource, ExplicitlyNotConvertible>);
-
-//----------------------------------------------------------------------------//
-// __semiregular_v
-//----------------------------------------------------------------------------//
-
-static_assert(dpl_internal::__semiregular_v<int>);
-static_assert(dpl_internal::__semiregular_v<int*>);
-static_assert(dpl_internal::__semiregular_v<Regular>);
-static_assert(dpl_internal::__semiregular_v<ExplicitDefaultCtor>);
-static_assert(dpl_internal::__semiregular_v<std::pair<int, int>>);
-
-static_assert(!dpl_internal::__semiregular_v<NoDefaultCtor>);
-static_assert(!dpl_internal::__semiregular_v<NoCopyAssign>);
-static_assert(!dpl_internal::__semiregular_v<VoidAssign>);
-static_assert(!dpl_internal::__semiregular_v<ThrowingDtor>);
-static_assert(!dpl_internal::__semiregular_v<MoveOnly>);
-static_assert(!dpl_internal::__semiregular_v<int&>);
-// Output iterators report void as their value type, so void must be rejected rather than rejecting the program.
-static_assert(!dpl_internal::__semiregular_v<void>);
-static_assert(!dpl_internal::__semiregular_v<const void>);
 
 //----------------------------------------------------------------------------//
 // __predicate_v
@@ -264,62 +263,6 @@ static_assert(!dpl_internal::__predicate_v<int&, const int&, const int&>);
 static_assert(!dpl_internal::__predicate_v<std::less<int>&, const Regular&, const Regular&>);
 
 //----------------------------------------------------------------------------//
-// C++17 building blocks of __semiregular_v. In C++20 the standard concepts are used directly, so these helpers only
-// exist in the C++17 branch.
-//----------------------------------------------------------------------------//
-
-#if !_ONEDPL_CPP20_CONCEPTS_PRESENT
-
-static_assert(dpl_internal::__constructible_from_v<int, int>);
-static_assert(dpl_internal::__constructible_from_v<Regular>);
-static_assert(dpl_internal::__constructible_from_v<NoDefaultCtor, int>);
-static_assert(!dpl_internal::__constructible_from_v<NoDefaultCtor>);
-static_assert(!dpl_internal::__constructible_from_v<ThrowingDtor>);
-static_assert(!dpl_internal::__constructible_from_v<Regular, int>);
-
-static_assert(dpl_internal::__assignable_from_v<int, int>);
-static_assert(dpl_internal::__assignable_from_v<Regular, const Regular&>);
-static_assert(dpl_internal::__assignable_from_v<MoveOnly, MoveOnly>);
-static_assert(!dpl_internal::__assignable_from_v<VoidAssign, const VoidAssign&>);
-static_assert(std::is_assignable_v<VoidAssign&, const VoidAssign&>);
-static_assert(!dpl_internal::__assignable_from_v<NoCopyAssign, const NoCopyAssign&>);
-static_assert(!dpl_internal::__assignable_from_v<MoveOnly, const MoveOnly&>);
-
-static_assert(dpl_internal::__move_constructible_v<Regular>);
-static_assert(dpl_internal::__move_constructible_v<MoveOnly>);
-static_assert(!dpl_internal::__move_constructible_v<ThrowingDtor>);
-static_assert(!dpl_internal::__move_constructible_v<NoDefaultCtor[2]>);
-
-static_assert(dpl_internal::__copy_constructible_v<Regular>);
-static_assert(dpl_internal::__copy_constructible_v<NoCopyAssign>);
-static_assert(!dpl_internal::__copy_constructible_v<MoveOnly>);
-static_assert(!dpl_internal::__copy_constructible_v<ThrowingDtor>);
-
-static_assert(dpl_internal::__movable_v<Regular>);
-static_assert(dpl_internal::__movable_v<MoveOnly>);
-static_assert(!dpl_internal::__movable_v<VoidAssign>);
-static_assert(!dpl_internal::__movable_v<int&>);
-
-static_assert(dpl_internal::__copyable_v<Regular>);
-static_assert(dpl_internal::__copyable_v<NoDefaultCtor>);
-static_assert(!dpl_internal::__copyable_v<MoveOnly>);
-static_assert(!dpl_internal::__copyable_v<NoCopyAssign>);
-static_assert(!dpl_internal::__copyable_v<VoidAssign>);
-
-// Each building block has to yield false for void instead of failing to compile, since forming void& is ill-formed
-// rather than merely unsatisfied.
-static_assert(!dpl_internal::__constructible_from_v<void>);
-static_assert(!dpl_internal::__assignable_from_v<void, void>);
-static_assert(!dpl_internal::__move_constructible_v<void>);
-static_assert(!dpl_internal::__copy_constructible_v<void>);
-static_assert(!dpl_internal::__movable_v<void>);
-static_assert(!dpl_internal::__copyable_v<void>);
-static_assert(!dpl_internal::__copy_constructible_v<const void>);
-static_assert(!dpl_internal::__copyable_v<const void>);
-
-#endif // !_ONEDPL_CPP20_CONCEPTS_PRESENT
-
-//----------------------------------------------------------------------------//
 // __is_value_storable_and_comparable_v
 //----------------------------------------------------------------------------//
 
@@ -342,45 +285,45 @@ struct FakeIterator
 };
 
 // Accepted: the value type is storable and the comparator is callable on const values.
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<int*, std::less<int>>);
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<const int*, std::less<int>>);
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<std::vector<int>::iterator, std::less<int>>);
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<std::vector<int>::const_iterator, std::less<>>);
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<Regular*, std::less<Regular>>);
-static_assert(
-    dpl_internal::__is_value_storable_and_comparable_v<ExplicitDefaultCtor*, std::less<ExplicitDefaultCtor>>);
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<int*, MoveOnlyLess>);
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<int*, IntResultLess>);
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<int*, bool (*)(const int&, const int&)>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, std::less<int>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<const int*, std::less<int>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<std::vector<int>::iterator, std::less<int>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<std::vector<int>::const_iterator, std::less<>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<Regular*, std::less<Regular>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<ExplicitDefaultCtor*, std::less<ExplicitDefaultCtor>>);
+// Accepted: the requirements are default construction, copy construction and copy assignment, and nothing else.
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<CopyOnlyNoMove*, std::less<CopyOnlyNoMove>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<VoidAssign*, std::less<VoidAssign>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<ThrowingDtor*, std::less<ThrowingDtor>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, MoveOnlyLess>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, IntResultLess>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, bool (*)(const int&, const int&)>);
 // The comparator max_element passes down to the min_element brick.
-static_assert(
-    dpl_internal::__is_value_storable_and_comparable_v<int*, dpl_internal::__reorder_pred<std::less<int>>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, dpl_internal::__reorder_pred<std::less<int>>>);
 // A proxy reference is fine as long as it converts to the value type.
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<std::vector<bool>::iterator, std::less<bool>>);
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<FakeIterator<int, int>, std::less<int>>);
-static_assert(dpl_internal::__is_value_storable_and_comparable_v<FakeIterator<std::pair<int, int>, std::pair<int&, int&>>,
-                                                                std::less<std::pair<int, int>>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<std::vector<bool>::iterator, std::less<bool>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<int, int>, std::less<int>>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<std::pair<int, int>, std::pair<int&, int&>>,
+                                                             std::less<std::pair<int, int>>>);
 
-// Rejected because of the value type.
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<NoDefaultCtor*, std::less<NoDefaultCtor>>);
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<NoCopyAssign*, std::less<NoCopyAssign>>);
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<VoidAssign*, std::less<VoidAssign>>);
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<ThrowingDtor*, std::less<ThrowingDtor>>);
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<MoveOnly*, std::less<MoveOnly>>);
+// Rejected because of the value type: default construction, copy assignment and copy construction respectively.
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<NoDefaultCtor*, std::less<NoDefaultCtor>>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<NoCopyAssign*, std::less<NoCopyAssign>>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<MoveOnly*, std::less<MoveOnly>>);
 
 // Rejected because the reference type does not convert to the value type.
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<FakeIterator<int, OpaqueRef>, std::less<int>>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<int, OpaqueRef>, std::less<int>>);
 
 // Rejected because an output iterator reports void as its value type.
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<std::back_insert_iterator<std::vector<int>>,
-                                                                 std::less<int>>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<std::back_insert_iterator<std::vector<int>>,
+                                                              std::less<int>>);
 
 // Rejected because of the comparator.
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<int*, NotBoolResultLess>);
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<int*, MutableRefLess>);
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<int*, RvalueOnlyLess>);
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<int*, UnaryLess>);
-static_assert(!dpl_internal::__is_value_storable_and_comparable_v<int*, std::less<Regular>>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, NotBoolResultLess>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, MutableRefLess>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, RvalueOnlyLess>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, UnaryLess>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, std::less<Regular>>);
 
 int
 main()

--- a/test/general/implementation_details/value_storable_and_comparable.pass.cpp
+++ b/test/general/implementation_details/value_storable_and_comparable.pass.cpp
@@ -8,8 +8,9 @@
 //===------------------------------------------------------===//
 
 // Compile-time checks for oneapi::dpl::__unseq_backend::__is_value_storable_and_comparable_v and for the requirements
-// it is built from: oneapi::dpl::__internal::__convertible_to_v and __predicate_v. Every requirement is checked both ways:
-// a type that satisfies it and a type that does not.
+// it is built from: oneapi::dpl::__unseq_backend::__is_brace_constructible_v and oneapi::dpl::__internal::
+// __convertible_to_v and __predicate_v. Every requirement is checked both ways: a type that satisfies it and a type that
+// does not.
 
 #include "support/test_config.h"
 
@@ -43,7 +44,7 @@ struct Regular
     }
 };
 
-// An explicit default constructor is enough, since the value is stored in a default-constructed object.
+// An explicit default constructor is enough, since _ValueType{} is a direct initialization, which may use it.
 struct ExplicitDefaultCtor
 {
     int val;
@@ -52,6 +53,24 @@ struct ExplicitDefaultCtor
     operator<(const ExplicitDefaultCtor& other) const
     {
         return val < other.val;
+    }
+};
+
+struct ExplicitDefaultCtorMember
+{
+    int val;
+    explicit ExplicitDefaultCtorMember() : val(0) {}
+};
+
+// Default-constructible, but not brace-initializable: an aggregate is initialized member by member, and the member is
+// copy-initialized from an empty list, which may not use its explicit default constructor.
+struct AggregateOfExplicitDefaultCtor
+{
+    ExplicitDefaultCtorMember member;
+    bool
+    operator<(const AggregateOfExplicitDefaultCtor& other) const
+    {
+        return member.val < other.member.val;
     }
 };
 
@@ -142,6 +161,22 @@ struct CopyOnlyNoMove
         return val < other.val;
     }
 };
+
+//----------------------------------------------------------------------------//
+// __is_brace_constructible_v
+//----------------------------------------------------------------------------//
+
+static_assert(dpl_unseq::__is_brace_constructible_v<int>);
+static_assert(dpl_unseq::__is_brace_constructible_v<int*>);
+static_assert(dpl_unseq::__is_brace_constructible_v<Regular>);
+static_assert(dpl_unseq::__is_brace_constructible_v<ExplicitDefaultCtor>);
+static_assert(dpl_unseq::__is_brace_constructible_v<MoveOnly>);
+
+static_assert(std::is_default_constructible_v<AggregateOfExplicitDefaultCtor>);
+static_assert(!dpl_unseq::__is_brace_constructible_v<AggregateOfExplicitDefaultCtor>);
+static_assert(!dpl_unseq::__is_brace_constructible_v<NoDefaultCtor>);
+// void{} is a valid expression, so this requirement does not reject void: that is done separately.
+static_assert(dpl_unseq::__is_brace_constructible_v<void>);
 
 //----------------------------------------------------------------------------//
 // __convertible_to_v
@@ -306,8 +341,10 @@ static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<int, 
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<std::pair<int, int>, std::pair<int&, int&>>,
                                                              std::less<std::pair<int, int>>>);
 
-// Rejected because of the value type: default construction, copy assignment and copy construction respectively.
+// Rejected because of the value type: brace initialization, copy assignment and copy construction respectively.
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<NoDefaultCtor*, std::less<NoDefaultCtor>>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<AggregateOfExplicitDefaultCtor*,
+                                                              std::less<AggregateOfExplicitDefaultCtor>>);
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<NoCopyAssign*, std::less<NoCopyAssign>>);
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<MoveOnly*, std::less<MoveOnly>>);
 

--- a/test/general/implementation_details/value_storable_and_comparable.pass.cpp
+++ b/test/general/implementation_details/value_storable_and_comparable.pass.cpp
@@ -9,9 +9,8 @@
 
 // Compile-time checks for oneapi::dpl::__unseq_backend::__is_value_storable_and_comparable_v and for the requirements
 // it is built from.
-// The two of them that are not standard type traits, oneapi::dpl::__unseq_backend::__is_brace_constructible_v
-// and oneapi::dpl::__internal::__predicate_v, are checked on their own as well. Every requirement is checked both ways:
-// a type that satisfies it and a type that does not.
+// The only one of them that is not a standard type trait, oneapi::dpl::__unseq_backend::__is_brace_constructible_v, is
+// checked on its own as well. Every requirement is checked both ways: a type that satisfies it and a type that does not.
 
 #include "support/test_config.h"
 
@@ -199,7 +198,7 @@ static_assert(!dpl_unseq::__is_brace_constructible_v<NoDefaultCtor>);
 static_assert(dpl_unseq::__is_brace_constructible_v<void>);
 
 //----------------------------------------------------------------------------//
-// __predicate_v
+// Comparison objects
 //----------------------------------------------------------------------------//
 
 struct NotBool
@@ -266,18 +265,22 @@ struct MoveOnlyLess
     }
 };
 
-static_assert(dpl_internal::__predicate_v<std::less<int>&, const int&, const int&>);
-static_assert(dpl_internal::__predicate_v<std::less<>&, const int&, const int&>);
-static_assert(dpl_internal::__predicate_v<IntResultLess&, const int&, const int&>);
-static_assert(dpl_internal::__predicate_v<MoveOnlyLess&, const int&, const int&>);
-static_assert(dpl_internal::__predicate_v<std::less<Regular>&, const Regular&, const Regular&>);
+struct NotNegatableResult
+{
+    operator bool() const;
+    bool
+    operator!() const = delete;
+};
 
-static_assert(!dpl_internal::__predicate_v<NotBoolResultLess&, const int&, const int&>);
-static_assert(!dpl_internal::__predicate_v<MutableRefLess&, const int&, const int&>);
-static_assert(!dpl_internal::__predicate_v<RvalueOnlyLess&, const int&, const int&>);
-static_assert(!dpl_internal::__predicate_v<UnaryLess&, const int&, const int&>);
-static_assert(!dpl_internal::__predicate_v<int&, const int&, const int&>);
-static_assert(!dpl_internal::__predicate_v<std::less<int>&, const Regular&, const Regular&>);
+// The result of the comparison is convertible to bool, but cannot be negated, while the vectorized bricks do negate it.
+// Such a comparison object does not meet the Compare requirements the standard states for the algorithms, so it is not
+// rejected here: the requirement accepts it in both C++17 and C++20, and instantiating the brick for it is a compile
+// error rather than a fallback to the serial implementation.
+struct NotNegatableResultLess
+{
+    NotNegatableResult
+    operator()(const int& lhs, const int& rhs) const;
+};
 
 //----------------------------------------------------------------------------//
 // __is_value_storable_and_comparable_v
@@ -359,6 +362,9 @@ static_assert(dpl_unseq::__is_value_storable_and_comparable_v<const ConstCopyOnl
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, MoveOnlyLess>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, IntResultLess>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, bool (*)(const int&, const int&)>);
+// Accepted although the bricks do not compile for it: a comparison object that does not meet the Compare requirements
+// of the algorithms is not detected here, see NotNegatableResultLess above.
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, NotNegatableResultLess>);
 // The comparator max_element passes down to the min_element brick.
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<int*, dpl_internal::__reorder_pred<std::less<int>>>);
 // A proxy reference is fine as long as it converts to the value type.
@@ -401,6 +407,7 @@ static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, MutableRefL
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, RvalueOnlyLess>);
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, UnaryLess>);
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, std::less<Regular>>);
+static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<int*, int>);
 
 int
 main()

--- a/test/general/implementation_details/value_storable_and_comparable.pass.cpp
+++ b/test/general/implementation_details/value_storable_and_comparable.pass.cpp
@@ -8,9 +8,8 @@
 //===------------------------------------------------------===//
 
 // Compile-time checks for oneapi::dpl::__unseq_backend::__is_value_storable_and_comparable_v and for the requirements
-// it is built from: oneapi::dpl::__unseq_backend::__is_brace_constructible_v and oneapi::dpl::__internal::
-// __convertible_to_v and __predicate_v. Every requirement is checked both ways: a type that satisfies it and a type that
-// does not.
+// it is built from: oneapi::dpl::__unseq_backend::__is_brace_constructible_v and oneapi::dpl::__internal::__predicate_v.
+// Every requirement is checked both ways: a type that satisfies it and a type that does not.
 
 #include "support/test_config.h"
 
@@ -179,44 +178,6 @@ static_assert(!dpl_unseq::__is_brace_constructible_v<NoDefaultCtor>);
 static_assert(dpl_unseq::__is_brace_constructible_v<void>);
 
 //----------------------------------------------------------------------------//
-// __convertible_to_v
-//----------------------------------------------------------------------------//
-
-struct ExplicitFromInt
-{
-    explicit ExplicitFromInt(int) {}
-};
-
-// A destination whose only constructor taking ImplicitSource is deleted and explicit: copy-initialization ignores it
-// and picks the conversion operator, so std::is_convertible_v is satisfied, while static_cast selects the deleted
-// constructor. This is the difference std::convertible_to catches and std::is_convertible_v does not.
-struct ExplicitlyNotConvertible;
-
-struct ImplicitSource
-{
-    operator ExplicitlyNotConvertible() const;
-};
-
-struct ExplicitlyNotConvertible
-{
-    ExplicitlyNotConvertible() = default;
-    explicit ExplicitlyNotConvertible(ImplicitSource) = delete;
-};
-
-static_assert(dpl_internal::__convertible_to_v<int, int>);
-static_assert(dpl_internal::__convertible_to_v<const int&, int>);
-static_assert(dpl_internal::__convertible_to_v<int&, long>);
-static_assert(dpl_internal::__convertible_to_v<const Regular&, Regular>);
-static_assert(dpl_internal::__convertible_to_v<std::pair<int&, int&>, std::pair<int, int>>);
-
-static_assert(!dpl_internal::__convertible_to_v<int*, int>);
-static_assert(!dpl_internal::__convertible_to_v<Regular, int>);
-static_assert(!dpl_internal::__convertible_to_v<int, ExplicitFromInt>);
-static_assert(!dpl_internal::__convertible_to_v<const MoveOnly&, MoveOnly>);
-static_assert(std::is_convertible_v<ImplicitSource, ExplicitlyNotConvertible>);
-static_assert(!dpl_internal::__convertible_to_v<ImplicitSource, ExplicitlyNotConvertible>);
-
-//----------------------------------------------------------------------------//
 // __predicate_v
 //----------------------------------------------------------------------------//
 
@@ -306,6 +267,27 @@ struct OpaqueRef
 {
 };
 
+// A value type whose only constructor taking ImplicitSource is deleted and explicit: copy-initialization ignores it and
+// picks the conversion operator, while static_cast selects the deleted constructor. The implementation only
+// copy-initializes the value, so such a reference type is enough for it, unlike for std::convertible_to.
+struct ExplicitlyNotConvertible;
+
+struct ImplicitSource
+{
+    operator ExplicitlyNotConvertible() const;
+};
+
+struct ExplicitlyNotConvertible
+{
+    ExplicitlyNotConvertible() = default;
+    explicit ExplicitlyNotConvertible(ImplicitSource) = delete;
+    bool
+    operator<(const ExplicitlyNotConvertible&) const
+    {
+        return false;
+    }
+};
+
 template <typename _ValueType, typename _ReferenceType>
 struct FakeIterator
 {
@@ -340,6 +322,10 @@ static_assert(dpl_unseq::__is_value_storable_and_comparable_v<std::vector<bool>:
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<int, int>, std::less<int>>);
 static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<std::pair<int, int>, std::pair<int&, int&>>,
                                                              std::less<std::pair<int, int>>>);
+// An implicit conversion is enough, even when the explicit one is ill-formed.
+static_assert(std::is_convertible_v<ImplicitSource, ExplicitlyNotConvertible>);
+static_assert(dpl_unseq::__is_value_storable_and_comparable_v<FakeIterator<ExplicitlyNotConvertible, ImplicitSource>,
+                                                             std::less<ExplicitlyNotConvertible>>);
 
 // Rejected because of the value type: brace initialization, copy assignment and copy construction respectively.
 static_assert(!dpl_unseq::__is_value_storable_and_comparable_v<NoDefaultCtor*, std::less<NoDefaultCtor>>);

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -375,6 +375,24 @@ struct MoveOnlyCompare
     }
 };
 
+template <typename T, typename Iterator>
+static void
+check_by_type_host_policies(Iterator first, Iterator last)
+{
+#ifdef _PSTL_TEST_MIN_ELEMENT
+    invoke_on_all_host_policies()(check_minelement<T>(), first, last);
+    invoke_on_all_host_policies()(check_minelement_predicate<T>(), first, last);
+#endif
+#ifdef _PSTL_TEST_MAX_ELEMENT
+    invoke_on_all_host_policies()(check_maxelement<T>(), first, last);
+    invoke_on_all_host_policies()(check_maxelement_predicate<T>(), first, last);
+#endif
+#ifdef _PSTL_TEST_MINMAX_ELEMENT
+    invoke_on_all_host_policies()(check_minmaxelement<T>(), first, last);
+    invoke_on_all_host_policies()(check_minmaxelement_predicate<T>(), first, last);
+#endif
+}
+
 // The sequence is built in place because the value types checked here either do not satisfy the requirements of
 // TestUtils::Sequence (which default-constructs and assigns its elements) or are not trivially copyable, and thus
 // cannot be checked with device policies.
@@ -389,21 +407,23 @@ test_by_type_host_policies(::std::size_t n)
 
     using Iterator = ::std::conditional_t<UseConstIterators, typename ::std::vector<T>::const_iterator,
                                           typename ::std::vector<T>::iterator>;
-    const Iterator first = data.begin();
-    const Iterator last = data.end();
+    check_by_type_host_policies<T>(Iterator(data.begin()), Iterator(data.end()));
+}
 
-#ifdef _PSTL_TEST_MIN_ELEMENT
-    invoke_on_all_host_policies()(check_minelement<T>(), first, last);
-    invoke_on_all_host_policies()(check_minelement_predicate<T>(), first, last);
-#endif
-#ifdef _PSTL_TEST_MAX_ELEMENT
-    invoke_on_all_host_policies()(check_maxelement<T>(), first, last);
-    invoke_on_all_host_policies()(check_maxelement_predicate<T>(), first, last);
-#endif
-#ifdef _PSTL_TEST_MINMAX_ELEMENT
-    invoke_on_all_host_policies()(check_minmaxelement<T>(), first, last);
-    invoke_on_all_host_policies()(check_minmaxelement_predicate<T>(), first, last);
-#endif
+// A value type with deleted move operations cannot be stored in a std::vector, because the growth path of the container
+// moves its elements, so the sequence is a plain array here and its elements are assigned from const lvalues.
+template <typename T, ::std::size_t N>
+static void
+test_by_type_host_policies_array()
+{
+    T data[N];
+    for (::std::size_t i = 0; i < N; ++i)
+    {
+        const T value(std::int32_t(TestUtils::HashBits(i, 30)));
+        data[i] = value;
+    }
+
+    check_by_type_host_policies<T>(data, data + N);
 }
 
 template <typename T>
@@ -462,7 +482,7 @@ main()
     // These value types are accepted by the vector code path as well, and the point of checking them is that the vector
     // code is instantiated for them: each of them violates one of the requirements of std::semiregular that the vector
     // code does not have. That does not depend on the sequence size either.
-    test_by_type_host_policies<CopyOnlyNoMoveCompare>(NSmall);
+    test_by_type_host_policies_array<CopyOnlyNoMoveCompare, NSmall>();
     test_by_type_host_policies<VoidAssignCompare>(NSmall);
     test_by_type_host_policies<ThrowingDtorCompare>(NSmall);
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <cmath>
 #include <set>
+#include <type_traits>
 #include <vector>
 
 #if  !defined(_PSTL_TEST_MIN_ELEMENT) && !defined(_PSTL_TEST_MAX_ELEMENT) &&\
@@ -247,6 +248,27 @@ struct ExplicitDefaultCtorCompare
     }
 };
 
+// The value type can be copied and assigned from a const lvalue only. The vector code path is still applicable for it,
+// because the vector code reads both the elements and the stored candidates through const references, but it requires
+// const iterators here: the reference type of a non-const iterator does not convert to such a value type.
+struct ConstCopyOnlyCompare
+{
+    std::int32_t val;
+    ConstCopyOnlyCompare() : val(0) {}
+    ConstCopyOnlyCompare(std::int32_t val_) : val(val_) {}
+    ConstCopyOnlyCompare(const ConstCopyOnlyCompare&) = default;
+    ConstCopyOnlyCompare(ConstCopyOnlyCompare&) = delete;
+    ConstCopyOnlyCompare&
+    operator=(const ConstCopyOnlyCompare&) = default;
+    ConstCopyOnlyCompare&
+    operator=(ConstCopyOnlyCompare&) = delete;
+    bool
+    operator<(const ConstCopyOnlyCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
 // The value type is not default-constructible, so it cannot be used in a user-defined reduction
 // and the vector code path must not be selected for it. The same holds for NoCopyAssignCompare and
 // MoveOnlyCompare below: each of them violates one of the requirements the vector code path puts on the
@@ -302,7 +324,7 @@ struct MoveOnlyCompare
 // The sequence is built in place because the value types checked here either do not satisfy the requirements of
 // TestUtils::Sequence (which default-constructs and assigns its elements) or are not trivially copyable, and thus
 // cannot be checked with device policies.
-template <typename T>
+template <typename T, bool UseConstIterators = false>
 static void
 test_by_type_host_policies(::std::size_t n)
 {
@@ -311,17 +333,22 @@ test_by_type_host_policies(::std::size_t n)
     for (::std::size_t i = 0; i < n; ++i)
         data.emplace_back(std::int32_t(TestUtils::HashBits(i, 30)));
 
+    using Iterator = ::std::conditional_t<UseConstIterators, typename ::std::vector<T>::const_iterator,
+                                          typename ::std::vector<T>::iterator>;
+    const Iterator first = data.begin();
+    const Iterator last = data.end();
+
 #ifdef _PSTL_TEST_MIN_ELEMENT
-    invoke_on_all_host_policies()(check_minelement<T>(), data.begin(), data.end());
-    invoke_on_all_host_policies()(check_minelement_predicate<T>(), data.begin(), data.end());
+    invoke_on_all_host_policies()(check_minelement<T>(), first, last);
+    invoke_on_all_host_policies()(check_minelement_predicate<T>(), first, last);
 #endif
 #ifdef _PSTL_TEST_MAX_ELEMENT
-    invoke_on_all_host_policies()(check_maxelement<T>(), data.begin(), data.end());
-    invoke_on_all_host_policies()(check_maxelement_predicate<T>(), data.begin(), data.end());
+    invoke_on_all_host_policies()(check_maxelement<T>(), first, last);
+    invoke_on_all_host_policies()(check_maxelement_predicate<T>(), first, last);
 #endif
 #ifdef _PSTL_TEST_MINMAX_ELEMENT
-    invoke_on_all_host_policies()(check_minmaxelement<T>(), data.begin(), data.end());
-    invoke_on_all_host_policies()(check_minmaxelement_predicate<T>(), data.begin(), data.end());
+    invoke_on_all_host_policies()(check_minmaxelement<T>(), first, last);
+    invoke_on_all_host_policies()(check_minmaxelement_predicate<T>(), first, last);
 #endif
 }
 
@@ -377,6 +404,11 @@ main()
     // This value type is accepted by the vector code path, exactly like OnlyLessCompare above: it differs from it only
     // by an explicit default constructor, which the path has to accept at compile time, so one size is enough.
     test_by_type<ExplicitDefaultCtorCompare>(NSmall);
+
+    // This value type is accepted by the vector code path through const iterators, so the point of checking it is that
+    // the vector code copies the elements and the stored candidates from const lvalues only. That does not depend on
+    // the sequence size either.
+    test_by_type_host_policies<ConstCopyOnlyCompare, /*UseConstIterators*/ true>(NSmall);
 
     // These value types are rejected by the vector code path, so the point of checking them is that the call compiles
     // and falls back to the serial implementation. That does not depend on the sequence size, so one size is enough.

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -248,6 +248,60 @@ struct ExplicitDefaultCtorCompare
     }
 };
 
+// The move operations of the value type are deleted: the vector code path is still applicable for it, because the
+// vector code never moves a value.
+struct CopyOnlyNoMoveCompare
+{
+    std::int32_t val;
+    CopyOnlyNoMoveCompare() : val(0) {}
+    CopyOnlyNoMoveCompare(std::int32_t val_) : val(val_) {}
+    CopyOnlyNoMoveCompare(const CopyOnlyNoMoveCompare&) = default;
+    CopyOnlyNoMoveCompare&
+    operator=(const CopyOnlyNoMoveCompare&) = default;
+    CopyOnlyNoMoveCompare(CopyOnlyNoMoveCompare&&) = delete;
+    CopyOnlyNoMoveCompare&
+    operator=(CopyOnlyNoMoveCompare&&) = delete;
+    bool
+    operator<(const CopyOnlyNoMoveCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// The assignment of the value type does not return VoidAssignCompare&: the vector code path is still applicable for it,
+// because the vector code never uses the result of an assignment.
+struct VoidAssignCompare
+{
+    std::int32_t val;
+    VoidAssignCompare() : val(0) {}
+    VoidAssignCompare(std::int32_t val_) : val(val_) {}
+    void
+    operator=(const VoidAssignCompare& other)
+    {
+        val = other.val;
+    }
+    bool
+    operator<(const VoidAssignCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// The destructor of the value type is not noexcept: the vector code path is still applicable for it, because storing
+// a value never has to be non-throwing.
+struct ThrowingDtorCompare
+{
+    std::int32_t val;
+    ThrowingDtorCompare() : val(0) {}
+    ThrowingDtorCompare(std::int32_t val_) : val(val_) {}
+    ~ThrowingDtorCompare() noexcept(false) {}
+    bool
+    operator<(const ThrowingDtorCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
 // The value type can be copied and assigned from a const lvalue only. The vector code path is still applicable for it,
 // because the vector code reads both the elements and the stored candidates through const references, but it requires
 // const iterators here: the reference type of a non-const iterator does not convert to such a value type.
@@ -404,6 +458,13 @@ main()
     // This value type is accepted by the vector code path, exactly like OnlyLessCompare above: it differs from it only
     // by an explicit default constructor, which the path has to accept at compile time, so one size is enough.
     test_by_type<ExplicitDefaultCtorCompare>(NSmall);
+
+    // These value types are accepted by the vector code path as well, and the point of checking them is that the vector
+    // code is instantiated for them: each of them violates one of the requirements of std::semiregular that the vector
+    // code does not have. That does not depend on the sequence size either.
+    test_by_type_host_policies<CopyOnlyNoMoveCompare>(NSmall);
+    test_by_type_host_policies<VoidAssignCompare>(NSmall);
+    test_by_type_host_policies<ThrowingDtorCompare>(NSmall);
 
     // This value type is accepted by the vector code path through const iterators, so the point of checking it is that
     // the vector code copies the elements and the stored candidates from const lvalues only. That does not depend on


### PR DESCRIPTION
Fixes https://github.com/uxlfoundation/oneDPL/pull/2816#discussion_r3948487738 and the follow-up
https://github.com/uxlfoundation/oneDPL/pull/2821#discussion_r3948753861.

## What changed

`__internal::__is_value_storable_and_comparable_v` (`__semiregular_v` + `__convertible_to_v` + `__predicate_v`) is
replaced by `__unseq_backend::__is_value_storable_and_comparable_v`, which sits next to the bricks it guards and is
literally the same in C++17 and C++20 (`V` is `std::iterator_traits<_Iterator>::value_type`):

```
+-- __is_brace_constructible_v<V>                               V{} in the reduction object
+-- std::is_copy_constructible_v<V>                             V(const V&) for the candidates
+-- std::is_copy_assignable_v<V>                                the candidates, and omp_priv = omp_orig
+-- std::is_invocable_r_v<bool, _Compare&, const V&, const V&>  the comparison, on const lvalues
```

It checks only the **additional** constraints the SIMD implementation imposes on top of what the algorithms require of
their input: the value type has to be storable in the reduction object and the comparator has to be applicable to the
stored copies. What the algorithms require themselves is not re-checked and fails to compile instead of falling back to
the serial implementation, exactly as it does in `main`, which has no gate at all: that `*__first` is convertible to `V`
([input.iterators]) and that the result of the comparison can be negated ([algorithms.requirements]).

`void`, which an output iterator reports as its value type, is rejected in a separate step, because forming `const V&`
for it would be ill-formed rather than merely unsatisfied.

Nothing the gate is built from approximates a concept any more, so `utils.h` loses `__semiregular_v`, `__copyable_v`,
`__movable_v`, `__copy_constructible_v`, `__move_constructible_v`, `__constructible_from_v`, `__assignable_from_v`,
`__convertible_to_v` and `__predicate_v`.

## Why every requirement is now the exact expression the implementation uses

| requirement | spelling before | why it did not fit |
|---|---|---|
| `__is_brace_constructible_v<V>` | `std::is_default_constructible_v<V>` / `std::default_initializable` | it stands for `V v;`, while the reduction object writes `V{}`. For an aggregate whose member has an `explicit` default constructor the trait is satisfied and `V{}` is ill-formed, so the gate accepted a type the brick does not compile for |
| `std::is_copy_constructible_v<V>`, `std::is_copy_assignable_v<V>` | `std::semiregular<V>` | the concept also requires move construction, move assignment, an assignment expression of type `V&` and a non-throwing destructor, none of which the bodies use |
| `std::is_invocable_r_v<bool, _Compare&, const V&, const V&>` | `std::predicate` in C++20, `std::is_invocable_r_v` in C++17 | `std::predicate` also requires the result to support `operator!`, so a comparison object whose result cannot be negated was rejected in C++20 and a compile error in C++17. Such an object does not meet `Compare`, so both modes now let it fail to compile |
| dropped | `std::convertible_to<reference, V>` | it restated "`*a` is convertible to `T`", so it held for every conforming iterator and could only reject non-conforming input, which `main` does not serve either; on top of that `std::convertible_to` required `static_cast<V>(reference)`, which the body never does |

Two bodies were changed so that the copies match the requirements: the candidates are read through `std::as_const` and
`minmax_element` materializes the element as `const _ValueType` like `min_element` already did (this also stops
`minmax_element` from passing a proxy reference to the comparator), and the candidates are copied by direct
initialization, `_ValueType v(source);`, which is what `std::is_copy_constructible_v` stands for.

The alternative suggested in the review, `_ValueType()` in the reduction object, closes the same gap; it was not taken
because it changes the algorithm to fit its requirement check, and leaving the members out of the member initializer
list makes MSVC report C26495 six times in this header.

## Effect, measured with icpx 2026.1 in C++17 and C++20

Now vectorized instead of falling back to the serial implementation, some of them thanks to the body changes above:
move operations explicitly deleted, assignment operator returning `void`, destructor `noexcept(false)`, copyable and
assignable from a const lvalue only, and an `explicit` copy constructor reached through a proxy reference. An aggregate
for which `V{}` is ill-formed used to be accepted and a hard compile error; it falls back now. Still rejected, and
correctly: not default-constructible, copy assignment deleted, move-only.

This was not C++17-specific: `std::semiregular` rejected the same types in C++20, which is why the concept is dropped
from both language modes.

## Tests

`test/general/implementation_details/value_storable_and_comparable.pass.cpp` checks every requirement both ways at
compile time, and pins down what the gate accepts on purpose although the bricks do not compile for it: a comparison
result that cannot be negated, and an element that cannot be copy-initialized into `V`.

`test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp` runs the vector code path for
`ExplicitDefaultCtorCompare`, `CopyOnlyNoMoveCompare`, `VoidAssignCompare`, `ThrowingDtorCompare` and
`ConstCopyOnlyCompare` (through const iterators), and checks that `NoDefaultCtorCompare`, `NoCopyAssignCompare` and
`MoveOnlyCompare` compile through the serial fallback.
