### PR TITLE
Fix `SIMD` `min_element` / `minmax_element` for value types unusable in a user-defined reduction - simplifications

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -4875,10 +4875,10 @@ _RandomAccessIterator
 __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                     /* __is_vector = */ ::std::true_type) noexcept
 {
-#if _ONEDPL_UDR_PRESENT // _PSTL_UDR_PRESENT
+#if _ONEDPL_UDR_PRESENT
     if constexpr (__unseq_backend::__is_value_storable_v<_RandomAccessIterator>)
         return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
-#endif
+#endif // _ONEDPL_UDR_PRESENT
 
     return std::min_element(__first, __last, __comp);
 }
@@ -4943,10 +4943,10 @@ template <typename _RandomAccessIterator, typename _Compare>
 __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                        /* __is_vector = */ ::std::true_type) noexcept
 {
-#if _ONEDPL_UDR_PRESENT // _PSTL_UDR_PRESENT
+#if _ONEDPL_UDR_PRESENT
     if constexpr (__unseq_backend::__is_value_storable_v<_RandomAccessIterator>)
         return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
-#endif
+#endif // _ONEDPL_UDR_PRESENT
 
     return std::minmax_element(__first, __last, __comp);
 }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -4877,10 +4877,14 @@ __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last,
 {
 #if _ONEDPL_UDR_PRESENT
     if constexpr (__unseq_backend::__is_value_storable_v<_RandomAccessIterator>)
+    {
         return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
+    }
+    else
 #endif // _ONEDPL_UDR_PRESENT
-
-    return std::min_element(__first, __last, __comp);
+    {
+        return std::min_element(__first, __last, __comp);
+    }
 }
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>
@@ -4945,10 +4949,14 @@ __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __la
 {
 #if _ONEDPL_UDR_PRESENT
     if constexpr (__unseq_backend::__is_value_storable_v<_RandomAccessIterator>)
+    {
         return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
+    }
+    else
 #endif // _ONEDPL_UDR_PRESENT
-
-    return std::minmax_element(__first, __last, __comp);
+    {
+        return std::minmax_element(__first, __last, __comp);
+    }
 }
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -625,12 +625,9 @@ inline constexpr bool __is_value_storable_v =
 
 // complexity [violation] - We will have at most (__n-1 + number_of_lanes) comparisons instead of at most __n-1.
 template <typename _ForwardIterator, typename _Size, typename _Compare>
-_ForwardIterator
+std::enable_if_t<__is_value_storable_v<_ForwardIterator>, _ForwardIterator>
 __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
 {
-    static_assert(__is_value_storable_v<_ForwardIterator>,
-                  "The value type of the iterator must be storable in the reduction object");
-
     if (__n == 0)
     {
         return __first;
@@ -684,12 +681,9 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
 
 // complexity [violation] - We will have at most (2*(__n-1) + 4*number_of_lanes) comparisons instead of at most [1.5*(__n-1)].
 template <typename _ForwardIterator, typename _Size, typename _Compare>
-std::pair<_ForwardIterator, _ForwardIterator>
+std::enable_if_t<__is_value_storable_v<_ForwardIterator>, std::pair<_ForwardIterator, _ForwardIterator>>
 __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
 {
-    static_assert(__is_value_storable_v<_ForwardIterator>,
-                  "The value type of the iterator must be storable in the reduction object");
-
     if (__n == 0)
     {
         return ::std::make_pair(__first, __first);

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -17,8 +17,10 @@
 #define _ONEDPL_UNSEQ_BACKEND_SIMD_H
 
 #include <type_traits>
-#include <memory>   // for std::addressof
-#include <iterator> // for std::iterator_traits
+#include <memory>     // for std::addressof
+#include <iterator>   // for std::iterator_traits
+#include <functional> // for std::invoke
+#include <utility>    // for std::pair, std::make_pair
 
 #include "utils.h"
 
@@ -625,9 +627,13 @@ inline constexpr bool __is_value_storable_v =
 
 // complexity [violation] - We will have at most (__n-1 + number_of_lanes) comparisons instead of at most __n-1.
 template <typename _ForwardIterator, typename _Size, typename _Compare>
-std::enable_if_t<__is_value_storable_v<_ForwardIterator>, _ForwardIterator>
+_ForwardIterator
 __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
 {
+    static_assert(__is_value_storable_v<_ForwardIterator>,
+                  "The value type of the iterator must be default-constructible, copy-constructible and "
+                  "copy-assignable");
+
     if (__n == 0)
     {
         return __first;
@@ -643,10 +649,7 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
         // However, some compilers may require it.
 
         _ComplexType() : __min_val(), __min_ind(0), __min_comp(nullptr) {}
-        _ComplexType(const _ValueType& val, const _Compare* comp)
-            : __min_val(val), __min_ind(0), __min_comp(const_cast<_Compare*>(comp))
-        {
-        }
+        _ComplexType(const _ValueType& val, _Compare* comp) : __min_val(val), __min_ind(0), __min_comp(comp) {}
         _ComplexType(const _ComplexType& __obj) = default;
 
         _ONEDPL_PRAGMA_DECLARE_SIMD
@@ -662,7 +665,8 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
         }
     };
 
-    _ComplexType __init{*__first, std::addressof(__comp)};
+    // Parentheses, not braces: list-initialization would reject a narrowing conversion from the reference type.
+    _ComplexType __init(*__first, std::addressof(__comp));
 
     _ONEDPL_PRAGMA_DECLARE_REDUCTION(__min_func, _ComplexType)
 
@@ -681,9 +685,13 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
 
 // complexity [violation] - We will have at most (2*(__n-1) + 4*number_of_lanes) comparisons instead of at most [1.5*(__n-1)].
 template <typename _ForwardIterator, typename _Size, typename _Compare>
-std::enable_if_t<__is_value_storable_v<_ForwardIterator>, std::pair<_ForwardIterator, _ForwardIterator>>
+std::pair<_ForwardIterator, _ForwardIterator>
 __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
 {
+    static_assert(__is_value_storable_v<_ForwardIterator>,
+                  "The value type of the iterator must be default-constructible, copy-constructible and "
+                  "copy-assignable");
+
     if (__n == 0)
     {
         return ::std::make_pair(__first, __first);
@@ -701,9 +709,8 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
         // However, some compilers may require it.
 
         _ComplexType() : __min_val(), __max_val(), __min_ind(0), __max_ind(0), __minmax_comp(nullptr) {}
-        _ComplexType(const _ValueType& min_val, const _ValueType& max_val, const _Compare* comp)
-            : __min_val(min_val), __max_val(max_val), __min_ind(0), __max_ind(0),
-              __minmax_comp(const_cast<_Compare*>(comp))
+        _ComplexType(const _ValueType& min_val, const _ValueType& max_val, _Compare* comp)
+            : __min_val(min_val), __max_val(max_val), __min_ind(0), __max_ind(0), __minmax_comp(comp)
         {
         }
         _ComplexType(const _ComplexType& __obj) = default;
@@ -738,7 +745,8 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
         }
     };
 
-    _ComplexType __init{*__first, *__first, std::addressof(__comp)};
+    // Parentheses, not braces: list-initialization would reject a narrowing conversion from the reference type.
+    _ComplexType __init(*__first, *__first, std::addressof(__comp));
 
     _ONEDPL_PRAGMA_DECLARE_REDUCTION(__min_func, _ComplexType);
 

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -646,14 +646,14 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
     struct _ComplexType
     {
         _ValueType __min_val;
-        _Size __min_ind;
-        _Compare* __min_comp;
+        _Size __min_ind = 0;
+        _Compare* __min_comp = nullptr;
         // The default constructor is not used during the algorithm, so it is not required for it.
         // However, some compilers may require it.
 
-        _ComplexType() : __min_val{}, __min_ind{}, __min_comp(nullptr) {}
+        _ComplexType() : __min_val{} {}
         _ComplexType(const _ValueType& val, const _Compare* comp)
-            : __min_val(val), __min_ind(0), __min_comp(const_cast<_Compare*>(comp))
+            : __min_val(val), __min_comp(const_cast<_Compare*>(comp))
         {
         }
         _ComplexType(const _ComplexType& __obj) = default;
@@ -706,16 +706,15 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
     {
         _ValueType __min_val;
         _ValueType __max_val;
-        _Size __min_ind;
-        _Size __max_ind;
-        _Compare* __minmax_comp;
+        _Size __min_ind = 0;
+        _Size __max_ind = 0;
+        _Compare* __minmax_comp = nullptr;
         // The default constructor is not used during the algorithm, so it is not required for it.
         // However, some compilers may require it.
 
-        _ComplexType() : __min_val{}, __max_val{}, __min_ind{}, __max_ind{}, __minmax_comp(nullptr) {}
+        _ComplexType() : __min_val{}, __max_val{} {}
         _ComplexType(const _ValueType& min_val, const _ValueType& max_val, const _Compare* comp)
-            : __min_val(min_val), __max_val(max_val), __min_ind(0), __max_ind(0),
-              __minmax_comp(const_cast<_Compare*>(comp))
+            : __min_val(min_val), __max_val(max_val), __minmax_comp(const_cast<_Compare*>(comp))
         {
         }
         _ComplexType(const _ComplexType& __obj) = default;

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -658,7 +658,7 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
         operator()(const _ComplexType& __obj)
         {
             if (!std::invoke(*__min_comp, __min_val, __obj.__min_val) &&
-                (std::invoke(*__min_comp, __obj.__min_val, __min_val) || __obj.__min_ind < __min_ind))
+                (std::invoke(*__min_comp, __obj.__min_val, __min_val) || __obj.__min_ind - __min_ind < 0))
             {
                 __min_val = __obj.__min_val;
                 __min_ind = __obj.__min_ind;
@@ -728,7 +728,7 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
             else if (!std::invoke(*__minmax_comp, __min_val, __obj.__min_val))
             {
                 __min_val = __obj.__min_val;
-                __min_ind = (__min_ind < __obj.__min_ind) ? __min_ind : __obj.__min_ind;
+                __min_ind = (__min_ind - __obj.__min_ind < 0) ? __min_ind : __obj.__min_ind;
             }
 
             // max
@@ -740,7 +740,7 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
             else if (!std::invoke(*__minmax_comp, __obj.__max_val, __max_val))
             {
                 __max_val = __obj.__max_val;
-                __max_ind = (__max_ind < __obj.__max_ind) ? __obj.__max_ind : __max_ind;
+                __max_ind = (__max_ind - __obj.__max_ind < 0) ? __obj.__max_ind : __max_ind;
             }
         }
     };

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -673,7 +673,6 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
         }
     };
 
-    // Parentheses, not braces: list-initialization would reject a narrowing conversion from the reference type.
     _ComplexType __init(*__first, std::addressof(__comp));
 
     _ONEDPL_PRAGMA_DECLARE_REDUCTION(__min_func, _ComplexType)
@@ -752,7 +751,6 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
         }
     };
 
-    // Parentheses, not braces: list-initialization would reject a narrowing conversion from the reference type.
     _ComplexType __init(*__first, *__first, std::addressof(__comp));
 
     _ONEDPL_PRAGMA_DECLARE_REDUCTION(__min_func, _ComplexType);

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -19,7 +19,6 @@
 #include <type_traits>
 #include <memory>   // for std::addressof
 #include <iterator> // for std::iterator_traits
-#include <utility>  // for std::as_const
 
 #include "utils.h"
 
@@ -679,9 +678,8 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
     _ONEDPL_PRAGMA_SIMD_REDUCTION(__min_func : __init)
     for (_Size __i = 1; __i < __n; ++__i)
     {
-        const _ValueType __min_val(std::as_const(__init).__min_val);
         const _ValueType __current = __first[__i];
-        if (std::invoke(__comp, __current, __min_val))
+        if (std::invoke(__comp, __current, __init.__min_val))
         {
             __init.__min_val = __current;
             __init.__min_ind = __i;
@@ -759,15 +757,13 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
     _ONEDPL_PRAGMA_SIMD_REDUCTION(__min_func : __init)
     for (_Size __i = 1; __i < __n; ++__i)
     {
-        const _ValueType __min_val(std::as_const(__init).__min_val);
-        const _ValueType __max_val(std::as_const(__init).__max_val);
         const _ValueType __current = __first[__i];
-        if (std::invoke(__comp, __current, __min_val))
+        if (std::invoke(__comp, __current, __init.__min_val))
         {
             __init.__min_val = __current;
             __init.__min_ind = __i;
         }
-        else if (!std::invoke(__comp, __current, __max_val))
+        else if (!std::invoke(__comp, __current, __init.__max_val))
         {
             __init.__max_val = __current;
             __init.__max_ind = __i;

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -646,9 +646,9 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
         // The default constructor is not used during the algorithm, so it is not required for it.
         // However, some compilers may require it.
 
-        _ComplexType() : __min_val(), __min_ind(), __min_comp(nullptr) {}
+        _ComplexType() : __min_val(), __min_ind(0), __min_comp(nullptr) {}
         _ComplexType(const _ValueType& val, const _Compare* comp)
-            : __min_val(val), __min_ind(), __min_comp(const_cast<_Compare*>(comp))
+            : __min_val(val), __min_ind(0), __min_comp(const_cast<_Compare*>(comp))
         {
         }
         _ComplexType(const _ComplexType& __obj) = default;
@@ -707,9 +707,9 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
         // The default constructor is not used during the algorithm, so it is not required for it.
         // However, some compilers may require it.
 
-        _ComplexType() : __min_val(), __max_val(), __min_ind(), __max_ind(), __minmax_comp(nullptr) {}
+        _ComplexType() : __min_val(), __max_val(), __min_ind(0), __max_ind(0), __minmax_comp(nullptr) {}
         _ComplexType(const _ValueType& min_val, const _ValueType& max_val, const _Compare* comp)
-            : __min_val(min_val), __max_val(max_val), __min_ind(), __max_ind(),
+            : __min_val(min_val), __max_val(max_val), __min_ind(0), __max_ind(0),
               __minmax_comp(const_cast<_Compare*>(comp))
         {
         }

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -641,14 +641,14 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
     struct _ComplexType
     {
         _ValueType __min_val;
-        _Size __min_ind = 0;
-        _Compare* __min_comp = nullptr;
+        _Size __min_ind;
+        _Compare* __min_comp;
         // The default constructor is not used during the algorithm, so it is not required for it.
         // However, some compilers may require it.
 
-        _ComplexType() : __min_val() {}
+        _ComplexType() : __min_val(), __min_ind(), __min_comp(nullptr) {}
         _ComplexType(const _ValueType& val, const _Compare* comp)
-            : __min_val(val), __min_comp(const_cast<_Compare*>(comp))
+            : __min_val(val), __min_ind(), __min_comp(const_cast<_Compare*>(comp))
         {
         }
         _ComplexType(const _ComplexType& __obj) = default;
@@ -701,15 +701,16 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
     {
         _ValueType __min_val;
         _ValueType __max_val;
-        _Size __min_ind = 0;
-        _Size __max_ind = 0;
-        _Compare* __minmax_comp = nullptr;
+        _Size __min_ind;
+        _Size __max_ind;
+        _Compare* __minmax_comp;
         // The default constructor is not used during the algorithm, so it is not required for it.
         // However, some compilers may require it.
 
-        _ComplexType() : __min_val(), __max_val() {}
+        _ComplexType() : __min_val(), __max_val(), __min_ind(), __max_ind(), __minmax_comp(nullptr) {}
         _ComplexType(const _ValueType& min_val, const _ValueType& max_val, const _Compare* comp)
-            : __min_val(min_val), __max_val(max_val), __minmax_comp(const_cast<_Compare*>(comp))
+            : __min_val(min_val), __max_val(max_val), __min_ind(), __max_ind(),
+              __minmax_comp(const_cast<_Compare*>(comp))
         {
         }
         _ComplexType(const _ComplexType& __obj) = default;

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -614,19 +614,14 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
     return ::std::make_pair(__result + __n, __init_.__value);
 }
 
-template <typename _Tp, typename = void>
-inline constexpr bool __is_brace_constructible_v = false;
-
-template <typename _Tp>
-inline constexpr bool __is_brace_constructible_v<_Tp, decltype(void(_Tp{}))> = true;
-
 // Requirements needed by __simd_min_element and __simd_minmax_element implementations:
-// - __is_brace_constructible_v: the _ComplexType default constructor needs _ValueType{} to be well-formed.
-// - std::is_copy_constructible_v: _ComplexType copy constructor is deleted if _ValueType is not copy constructible.
+// - std::is_default_constructible_v: the _ComplexType default constructor value-initializes its _ValueType members.
+// - std::is_copy_constructible_v: _ComplexType copy-constructs its _ValueType members from a const _ValueType&, and its
+//   copy constructor is deleted if _ValueType is not copy constructible.
 // - std::is_copy_assignable_v: the _ONEDPL_PRAGMA_SIMD_REDUCTION loop assigns _ValueType.
 template <typename _Iterator, typename _ValueType = typename std::iterator_traits<_Iterator>::value_type>
 inline constexpr bool __is_value_storable_v =
-    __is_brace_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&
+    std::is_default_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&
     std::is_copy_assignable_v<_ValueType>;
 
 // complexity [violation] - We will have at most (__n-1 + number_of_lanes) comparisons instead of at most __n-1.
@@ -651,7 +646,7 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
         // The default constructor is not used during the algorithm, so it is not required for it.
         // However, some compilers may require it.
 
-        _ComplexType() : __min_val{} {}
+        _ComplexType() : __min_val() {}
         _ComplexType(const _ValueType& val, const _Compare* comp)
             : __min_val(val), __min_comp(const_cast<_Compare*>(comp))
         {
@@ -712,7 +707,7 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
         // The default constructor is not used during the algorithm, so it is not required for it.
         // However, some compilers may require it.
 
-        _ComplexType() : __min_val{}, __max_val{} {}
+        _ComplexType() : __min_val(), __max_val() {}
         _ComplexType(const _ValueType& min_val, const _ValueType& max_val, const _Compare* comp)
             : __min_val(min_val), __max_val(max_val), __minmax_comp(const_cast<_Compare*>(comp))
         {

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -614,11 +614,10 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
     return ::std::make_pair(__result + __n, __init_.__value);
 }
 
-// Requirements needed by __simd_min_element and __simd_minmax_element implementations:
-// - std::is_default_constructible_v: the _ComplexType default constructor value-initializes its _ValueType members.
-// - std::is_copy_constructible_v: _ComplexType copy-constructs its _ValueType members from a const _ValueType&, and its
-//   copy constructor is deleted if _ValueType is not copy constructible.
-// - std::is_copy_assignable_v: the _ONEDPL_PRAGMA_SIMD_REDUCTION loop assigns _ValueType.
+// The _ValueType operations __simd_min_element / __simd_minmax_element perform through _ComplexType, and nothing else:
+// - default construction: its default constructor value-initializes the value members.
+// - copy construction: its value-taking constructor and its defaulted copy constructor.
+// - copy assignment: the _ONEDPL_PRAGMA_SIMD_REDUCTION loop and the combiner.
 template <typename _Iterator, typename _ValueType = typename std::iterator_traits<_Iterator>::value_type>
 inline constexpr bool __is_value_storable_v =
     std::is_default_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -658,7 +658,7 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
         operator()(const _ComplexType& __obj)
         {
             if (!std::invoke(*__min_comp, __min_val, __obj.__min_val) &&
-                (std::invoke(*__min_comp, __obj.__min_val, __min_val) || __obj.__min_ind - __min_ind < 0))
+                (std::invoke(*__min_comp, __obj.__min_val, __min_val) || __obj.__min_ind < __min_ind))
             {
                 __min_val = __obj.__min_val;
                 __min_ind = __obj.__min_ind;
@@ -727,7 +727,7 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
             else if (!std::invoke(*__minmax_comp, __min_val, __obj.__min_val))
             {
                 __min_val = __obj.__min_val;
-                __min_ind = (__min_ind - __obj.__min_ind < 0) ? __min_ind : __obj.__min_ind;
+                __min_ind = (__min_ind < __obj.__min_ind) ? __min_ind : __obj.__min_ind;
             }
 
             // max
@@ -739,7 +739,7 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
             else if (!std::invoke(*__minmax_comp, __obj.__max_val, __max_val))
             {
                 __max_val = __obj.__max_val;
-                __max_ind = (__max_ind - __obj.__max_ind < 0) ? __obj.__max_ind : __max_ind;
+                __max_ind = (__max_ind < __obj.__max_ind) ? __obj.__max_ind : __max_ind;
             }
         }
     };

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -650,9 +650,7 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
         _ValueType __min_val;
         _Size __min_ind;
         _Compare* __min_comp;
-        // No default constructor: the reduction object is always built from a value, and requiring one of _ValueType
-        // would exclude value types that work perfectly well here. Verified with gcc 16.1, clang 23.1 and icpx 2026.1;
-        // MSVC never gets here, as it reports _OPENMP=200203 even with /openmp:llvm, so _ONEDPL_UDR_PRESENT is 0.
+
         _ComplexType(const _ValueType& val, _Compare* comp) : __min_val(val), __min_ind(0), __min_comp(comp) {}
         _ComplexType(const _ComplexType& __obj) = default;
 
@@ -708,9 +706,7 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
         _Size __min_ind;
         _Size __max_ind;
         _Compare* __minmax_comp;
-        // No default constructor: the reduction object is always built from a value, and requiring one of _ValueType
-        // would exclude value types that work perfectly well here. Verified with gcc 16.1, clang 23.1 and icpx 2026.1;
-        // MSVC never gets here, as it reports _OPENMP=200203 even with /openmp:llvm, so _ONEDPL_UDR_PRESENT is 0.
+
         _ComplexType(const _ValueType& min_val, const _ValueType& max_val, _Compare* comp)
             : __min_val(min_val), __max_val(max_val), __min_ind(0), __max_ind(0), __minmax_comp(comp)
         {

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -616,14 +616,23 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
     return ::std::make_pair(__result + __n, __init_.__value);
 }
 
-// The _ValueType operations __simd_min_element / __simd_minmax_element perform through _ComplexType, and nothing else:
-// - default construction: its default constructor value-initializes the value members.
-// - copy construction: its value-taking constructor and its defaulted copy constructor.
-// - copy assignment: the _ONEDPL_PRAGMA_SIMD_REDUCTION loop and the combiner.
-template <typename _Iterator, typename _ValueType = typename std::iterator_traits<_Iterator>::value_type>
+// Implementation detail of __simd_min_element / __simd_minmax_element, not a contract of the algorithms: it states
+// exactly what those two do with an element, and nothing more. Each requirement has one reason to be here:
+// - copy construction: the _ComplexType reduction object below is built from a value, and the OpenMP clause
+//   initializer(omp_priv = omp_orig) copy-initializes the whole reduction object, hence its members.
+// - copy assignment: the reduction combiner and the loop body overwrite the current best value.
+// - convertibility of the reference type: the value is copy-initialized from what the iterator dereferences to, both
+//   to build the initial reduction object and to read every element. Copy-constructibility does not imply this - it
+//   also holds for an explicit copy constructor and for one deleted for non-const lvalues.
+template <typename _ValueType, typename _ReferenceType>
+inline constexpr bool __is_value_storable_from_v =
+    std::is_copy_constructible_v<_ValueType> && std::is_copy_assignable_v<_ValueType> &&
+    std::is_convertible_v<_ReferenceType, _ValueType>;
+
+template <typename _Iterator>
 inline constexpr bool __is_value_storable_v =
-    std::is_default_constructible_v<_ValueType> && std::is_copy_constructible_v<_ValueType> &&
-    std::is_copy_assignable_v<_ValueType>;
+    __is_value_storable_from_v<typename std::iterator_traits<_Iterator>::value_type,
+                               typename std::iterator_traits<_Iterator>::reference>;
 
 // complexity [violation] - We will have at most (__n-1 + number_of_lanes) comparisons instead of at most __n-1.
 template <typename _ForwardIterator, typename _Size, typename _Compare>
@@ -631,8 +640,8 @@ _ForwardIterator
 __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
 {
     static_assert(__is_value_storable_v<_ForwardIterator>,
-                  "The value type of the iterator must be default-constructible, copy-constructible and "
-                  "copy-assignable");
+                  "The value type of the iterator must be copy-constructible, copy-assignable and copy-initializable "
+                  "from the iterator's reference type");
 
     if (__n == 0)
     {
@@ -645,10 +654,9 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
         _ValueType __min_val;
         _Size __min_ind;
         _Compare* __min_comp;
-        // The default constructor is not used during the algorithm, so it is not required for it.
-        // However, some compilers may require it.
-
-        _ComplexType() : __min_val(), __min_ind(0), __min_comp(nullptr) {}
+        // No default constructor: the reduction object is always built from a value, and requiring one of _ValueType
+        // would exclude value types that work perfectly well here. Verified with gcc 16.1, clang 23.1 and icpx 2026.1;
+        // MSVC never gets here, as it reports _OPENMP=200203 even with /openmp:llvm, so _ONEDPL_UDR_PRESENT is 0.
         _ComplexType(const _ValueType& val, _Compare* comp) : __min_val(val), __min_ind(0), __min_comp(comp) {}
         _ComplexType(const _ComplexType& __obj) = default;
 
@@ -689,8 +697,8 @@ std::pair<_ForwardIterator, _ForwardIterator>
 __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
 {
     static_assert(__is_value_storable_v<_ForwardIterator>,
-                  "The value type of the iterator must be default-constructible, copy-constructible and "
-                  "copy-assignable");
+                  "The value type of the iterator must be copy-constructible, copy-assignable and copy-initializable "
+                  "from the iterator's reference type");
 
     if (__n == 0)
     {
@@ -705,10 +713,9 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
         _Size __min_ind;
         _Size __max_ind;
         _Compare* __minmax_comp;
-        // The default constructor is not used during the algorithm, so it is not required for it.
-        // However, some compilers may require it.
-
-        _ComplexType() : __min_val(), __max_val(), __min_ind(0), __max_ind(0), __minmax_comp(nullptr) {}
+        // No default constructor: the reduction object is always built from a value, and requiring one of _ValueType
+        // would exclude value types that work perfectly well here. Verified with gcc 16.1, clang 23.1 and icpx 2026.1;
+        // MSVC never gets here, as it reports _OPENMP=200203 even with /openmp:llvm, so _ONEDPL_UDR_PRESENT is 0.
         _ComplexType(const _ValueType& min_val, const _ValueType& max_val, _Compare* comp)
             : __min_val(min_val), __max_val(max_val), __min_ind(0), __max_ind(0), __minmax_comp(comp)
         {

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -624,15 +624,11 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
 // - convertibility of the reference type: the value is copy-initialized from what the iterator dereferences to, both
 //   to build the initial reduction object and to read every element. Copy-constructibility does not imply this - it
 //   also holds for an explicit copy constructor and for one deleted for non-const lvalues.
-template <typename _ValueType, typename _ReferenceType>
-inline constexpr bool __is_value_storable_from_v =
+template <typename _Iterator, typename _ValueType = typename std::iterator_traits<_Iterator>::value_type,
+          typename _ReferenceType = typename std::iterator_traits<_Iterator>::reference>
+inline constexpr bool __is_value_storable_v =
     std::is_copy_constructible_v<_ValueType> && std::is_copy_assignable_v<_ValueType> &&
     std::is_convertible_v<_ReferenceType, _ValueType>;
-
-template <typename _Iterator>
-inline constexpr bool __is_value_storable_v =
-    __is_value_storable_from_v<typename std::iterator_traits<_Iterator>::value_type,
-                               typename std::iterator_traits<_Iterator>::reference>;
 
 // complexity [violation] - We will have at most (__n-1 + number_of_lanes) comparisons instead of at most __n-1.
 template <typename _ForwardIterator, typename _Size, typename _Compare>

--- a/test/general/implementation_details/value_storable.pass.cpp
+++ b/test/general/implementation_details/value_storable.pass.cpp
@@ -63,28 +63,39 @@ static_assert(dpl_unseq::__is_value_storable_v<std::vector<int>::const_iterator>
 static_assert(dpl_unseq::__is_value_storable_v<TestUtils::OnlyLessCompare*>);
 static_assert(dpl_unseq::__is_value_storable_v<TestUtils::ExplicitDefaultCtorCompare*>);
 static_assert(dpl_unseq::__is_value_storable_v<TestUtils::AggregateOfExplicitDefaultCtorCompare*>);
-// The requirements are default construction, copy construction and copy assignment, and nothing else.
+// Default construction is not required: the reduction object is always built from a value.
+static_assert(!std::is_default_constructible_v<TestUtils::NoDefaultCtorWrapper<int>>);
+static_assert(dpl_unseq::__is_value_storable_v<TestUtils::NoDefaultCtorWrapper<int>*>);
+static_assert(!std::is_default_constructible_v<TestUtils::BraceInitOnlyCompare>);
+static_assert(dpl_unseq::__is_value_storable_v<TestUtils::BraceInitOnlyCompare*>);
+// The requirements are copy construction, copy assignment and copy-initialization from the reference type, and nothing
+// else - in particular the move operations are not required.
 static_assert(dpl_unseq::__is_value_storable_v<TestUtils::CopyOnlyNoMoveCompare*>);
 static_assert(dpl_unseq::__is_value_storable_v<TestUtils::VoidAssignCompare*>);
 static_assert(dpl_unseq::__is_value_storable_v<const TestUtils::ConstCopyOnlyCompare*>);
-// The reference type is not part of the requirement.
+// A proxy reference is accepted as long as the value type can be copy-initialized from it.
 static_assert(dpl_unseq::__is_value_storable_v<std::vector<bool>::iterator>);
 static_assert(dpl_unseq::__is_value_storable_v<FakeIterator<int, int>>);
 static_assert(dpl_unseq::__is_value_storable_v<FakeIterator<std::pair<int, int>, std::pair<int&, int&>>>);
-static_assert(
-    dpl_unseq::__is_value_storable_v<FakeIterator<TestUtils::CopyOnlyNoMoveCompare, TestUtils::CopyOnlyNoMoveCompare>>);
-// Accepted although the bricks do not compile for them: these iterators do not meet the requirements of a forward
-// iterator, which is not detected here.
-static_assert(std::is_copy_constructible_v<TestUtils::ExplicitCopyCtorCompare>);
-static_assert(dpl_unseq::__is_value_storable_v<TestUtils::ExplicitCopyCtorCompare*>);
-static_assert(dpl_unseq::__is_value_storable_v<TestUtils::ConstCopyOnlyCompare*>);
-static_assert(dpl_unseq::__is_value_storable_v<FakeIterator<int, OpaqueRef>>);
 
-// Rejected because of the value type: default construction (the first two), copy assignment, copy construction.
-static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::NoDefaultCtorWrapper<int>*>);
-static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::BraceInitOnlyCompare*>);
+// Rejected because of the value type: copy assignment, copy construction.
 static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::NoCopyAssignCompare*>);
 static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::MoveOnlyCompare*>);
+
+// Rejected because the value cannot be copy-initialized from what the iterator dereferences to, which is how the
+// bricks read an element. Copy-constructibility of the value type alone does not imply that: it also holds for an
+// explicit copy constructor and for a type whose copy constructor is deleted for a non-const lvalue.
+static_assert(std::is_copy_constructible_v<TestUtils::ExplicitCopyCtorCompare>);
+static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::ExplicitCopyCtorCompare*>);
+static_assert(std::is_copy_constructible_v<TestUtils::ConstCopyOnlyCompare>);
+static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::ConstCopyOnlyCompare*>);
+static_assert(!dpl_unseq::__is_value_storable_v<FakeIterator<int, OpaqueRef>>);
+
+// Rejected conservatively: the conversion is checked from an rvalue of the reference type, while the bricks initialize
+// from *__first, which is a prvalue here and needs no move constructor. Such an iterator stays correct through the
+// serial fallback, it only misses vectorization.
+static_assert(!dpl_unseq::__is_value_storable_v<
+              FakeIterator<TestUtils::CopyOnlyNoMoveCompare, TestUtils::CopyOnlyNoMoveCompare>>);
 
 // Rejected because an output iterator reports void as its value type.
 static_assert(!dpl_unseq::__is_value_storable_v<std::back_insert_iterator<std::vector<int>>>);

--- a/test/general/implementation_details/value_storable.pass.cpp
+++ b/test/general/implementation_details/value_storable.pass.cpp
@@ -7,14 +7,14 @@
 //
 //===------------------------------------------------------===//
 
-// Compile-time checks for oneapi::dpl::__unseq_backend::__is_value_storable_v.
+// Compile-time checks for oneapi::dpl::__unseq_backend::__is_value_storable_v, the condition that selects the vector
+// code path of min_element and minmax_element.
 
 #include "support/test_config.h"
 
 #include <oneapi/dpl/pstl/unseq_backend_simd.h>
 
 #include <cstddef>
-#include <initializer_list>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -24,104 +24,10 @@
 
 namespace dpl_unseq = oneapi::dpl::__unseq_backend;
 
-//----------------------------------------------------------------------------//
-// Value types
-//----------------------------------------------------------------------------//
-
-// Satisfies every requirement: default-constructible, copy-constructible, copy-assignable.
-struct Regular
-{
-    int val = 0;
-};
-
-struct ExplicitDefaultCtor
-{
-    int val;
-    explicit ExplicitDefaultCtor() : val(0) {}
-};
-
-// Default-constructible: the aggregate default-initializes its member through its explicit default constructor.
-struct AggregateOfExplicitDefaultCtor
-{
-    ExplicitDefaultCtor member;
-};
-
-// Not default-constructible: its only constructor takes an initializer list.
-struct BraceInitOnly
-{
-    int val;
-    BraceInitOnly(std::initializer_list<int> init) : val(init.size() == 0 ? 0 : *init.begin()) {}
-};
-
-// A type that is not default-constructible is taken from the test utilities: TestUtils::NoDefaultCtorWrapper<int>.
-
-struct NoCopyAssign
-{
-    int val = 0;
-    NoCopyAssign() = default;
-    NoCopyAssign(const NoCopyAssign&) = default;
-    NoCopyAssign&
-    operator=(const NoCopyAssign&) = delete;
-};
-
-// The copy assignment returns void instead of VoidAssign&.
-struct VoidAssign
-{
-    int val = 0;
-    void
-    operator=(const VoidAssign& other)
-    {
-        val = other.val;
-    }
-};
-
-struct MoveOnly
-{
-    int val = 0;
-    MoveOnly() = default;
-    MoveOnly(MoveOnly&&) = default;
-    MoveOnly&
-    operator=(MoveOnly&&) = default;
-    MoveOnly(const MoveOnly&) = delete;
-    MoveOnly&
-    operator=(const MoveOnly&) = delete;
-};
-
-// Copyable, but with deleted move operations.
-struct CopyOnlyNoMove
-{
-    int val = 0;
-    CopyOnlyNoMove() = default;
-    CopyOnlyNoMove(const CopyOnlyNoMove&) = default;
-    CopyOnlyNoMove&
-    operator=(const CopyOnlyNoMove&) = default;
-    CopyOnlyNoMove(CopyOnlyNoMove&&) = delete;
-    CopyOnlyNoMove&
-    operator=(CopyOnlyNoMove&&) = delete;
-};
-
-// Copyable and assignable from a const lvalue only.
-struct ConstCopyOnly
-{
-    int val = 0;
-    ConstCopyOnly() = default;
-    ConstCopyOnly(const ConstCopyOnly&) = default;
-    ConstCopyOnly&
-    operator=(const ConstCopyOnly&) = default;
-    ConstCopyOnly(ConstCopyOnly&) = delete;
-    ConstCopyOnly&
-    operator=(ConstCopyOnly&) = delete;
-};
-
-// The copy constructor is explicit, so the type is copy-constructible, but its elements cannot be copy-initialized.
-struct ExplicitCopyCtor
-{
-    int val = 0;
-    ExplicitCopyCtor() = default;
-    explicit ExplicitCopyCtor(const ExplicitCopyCtor& other) : val(other.val) {}
-    ExplicitCopyCtor&
-    operator=(const ExplicitCopyCtor&) = default;
-};
+// The value types with restricted operations are defined in test/support/utils.h, so that
+// test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp runs the algorithms on the very same set
+// that is checked against the trait here. TestUtils::NoDefaultCtorWrapper<int> is the type that is not
+// default-constructible.
 
 //----------------------------------------------------------------------------//
 // Reference types
@@ -154,30 +60,31 @@ static_assert(dpl_unseq::__is_value_storable_v<int*>);
 static_assert(dpl_unseq::__is_value_storable_v<const int*>);
 static_assert(dpl_unseq::__is_value_storable_v<std::vector<int>::iterator>);
 static_assert(dpl_unseq::__is_value_storable_v<std::vector<int>::const_iterator>);
-static_assert(dpl_unseq::__is_value_storable_v<Regular*>);
-static_assert(dpl_unseq::__is_value_storable_v<ExplicitDefaultCtor*>);
-static_assert(dpl_unseq::__is_value_storable_v<AggregateOfExplicitDefaultCtor*>);
+static_assert(dpl_unseq::__is_value_storable_v<TestUtils::OnlyLessCompare*>);
+static_assert(dpl_unseq::__is_value_storable_v<TestUtils::ExplicitDefaultCtorCompare*>);
+static_assert(dpl_unseq::__is_value_storable_v<TestUtils::AggregateOfExplicitDefaultCtorCompare*>);
 // The requirements are default construction, copy construction and copy assignment, and nothing else.
-static_assert(dpl_unseq::__is_value_storable_v<CopyOnlyNoMove*>);
-static_assert(dpl_unseq::__is_value_storable_v<VoidAssign*>);
-static_assert(dpl_unseq::__is_value_storable_v<const ConstCopyOnly*>);
+static_assert(dpl_unseq::__is_value_storable_v<TestUtils::CopyOnlyNoMoveCompare*>);
+static_assert(dpl_unseq::__is_value_storable_v<TestUtils::VoidAssignCompare*>);
+static_assert(dpl_unseq::__is_value_storable_v<const TestUtils::ConstCopyOnlyCompare*>);
 // The reference type is not part of the requirement.
 static_assert(dpl_unseq::__is_value_storable_v<std::vector<bool>::iterator>);
 static_assert(dpl_unseq::__is_value_storable_v<FakeIterator<int, int>>);
 static_assert(dpl_unseq::__is_value_storable_v<FakeIterator<std::pair<int, int>, std::pair<int&, int&>>>);
-static_assert(dpl_unseq::__is_value_storable_v<FakeIterator<CopyOnlyNoMove, CopyOnlyNoMove>>);
+static_assert(
+    dpl_unseq::__is_value_storable_v<FakeIterator<TestUtils::CopyOnlyNoMoveCompare, TestUtils::CopyOnlyNoMoveCompare>>);
 // Accepted although the bricks do not compile for them: these iterators do not meet the requirements of a forward
 // iterator, which is not detected here.
-static_assert(std::is_copy_constructible_v<ExplicitCopyCtor>);
-static_assert(dpl_unseq::__is_value_storable_v<ExplicitCopyCtor*>);
-static_assert(dpl_unseq::__is_value_storable_v<ConstCopyOnly*>);
+static_assert(std::is_copy_constructible_v<TestUtils::ExplicitCopyCtorCompare>);
+static_assert(dpl_unseq::__is_value_storable_v<TestUtils::ExplicitCopyCtorCompare*>);
+static_assert(dpl_unseq::__is_value_storable_v<TestUtils::ConstCopyOnlyCompare*>);
 static_assert(dpl_unseq::__is_value_storable_v<FakeIterator<int, OpaqueRef>>);
 
 // Rejected because of the value type: default construction (the first two), copy assignment, copy construction.
 static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::NoDefaultCtorWrapper<int>*>);
-static_assert(!dpl_unseq::__is_value_storable_v<BraceInitOnly*>);
-static_assert(!dpl_unseq::__is_value_storable_v<NoCopyAssign*>);
-static_assert(!dpl_unseq::__is_value_storable_v<MoveOnly*>);
+static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::BraceInitOnlyCompare*>);
+static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::NoCopyAssignCompare*>);
+static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::MoveOnlyCompare*>);
 
 // Rejected because an output iterator reports void as its value type.
 static_assert(!dpl_unseq::__is_value_storable_v<std::back_insert_iterator<std::vector<int>>>);

--- a/test/general/implementation_details/value_storable.pass.cpp
+++ b/test/general/implementation_details/value_storable.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===------------------------------------------------------===//
 
-// Compile-time checks for oneapi::dpl::__unseq_backend::__is_value_storable_v and __is_brace_constructible_v.
+// Compile-time checks for oneapi::dpl::__unseq_backend::__is_value_storable_v.
 
 #include "support/test_config.h"
 
@@ -40,14 +40,14 @@ struct ExplicitDefaultCtor
     explicit ExplicitDefaultCtor() : val(0) {}
 };
 
-// Default-constructible, but not brace-initializable: the member is copy-initialized from an empty list, which may not
-// use its explicit default constructor.
+// Default-constructible: default-initializing the aggregate default-initializes the member through its explicit default
+// constructor.
 struct AggregateOfExplicitDefaultCtor
 {
     ExplicitDefaultCtor member;
 };
 
-// Brace-initializable, but not default-constructible: empty braces select the initializer-list constructor.
+// Not default-constructible: the only constructor takes an initializer list, so `BraceInitOnly obj;` is ill-formed.
 struct BraceInitOnly
 {
     int val;
@@ -125,24 +125,6 @@ struct ExplicitCopyCtor
 };
 
 //----------------------------------------------------------------------------//
-// __is_brace_constructible_v
-//----------------------------------------------------------------------------//
-
-static_assert(dpl_unseq::__is_brace_constructible_v<int>);
-static_assert(dpl_unseq::__is_brace_constructible_v<int*>);
-static_assert(dpl_unseq::__is_brace_constructible_v<Regular>);
-static_assert(dpl_unseq::__is_brace_constructible_v<ExplicitDefaultCtor>);
-static_assert(dpl_unseq::__is_brace_constructible_v<MoveOnly>);
-
-// Brace initialization differs from default construction in both directions.
-static_assert(std::is_default_constructible_v<AggregateOfExplicitDefaultCtor>);
-static_assert(!dpl_unseq::__is_brace_constructible_v<AggregateOfExplicitDefaultCtor>);
-static_assert(!std::is_default_constructible_v<BraceInitOnly>);
-static_assert(dpl_unseq::__is_brace_constructible_v<BraceInitOnly>);
-
-static_assert(!dpl_unseq::__is_brace_constructible_v<TestUtils::NoDefaultCtorWrapper<int>>);
-
-//----------------------------------------------------------------------------//
 // Reference types
 //----------------------------------------------------------------------------//
 
@@ -175,8 +157,8 @@ static_assert(dpl_unseq::__is_value_storable_v<std::vector<int>::iterator>);
 static_assert(dpl_unseq::__is_value_storable_v<std::vector<int>::const_iterator>);
 static_assert(dpl_unseq::__is_value_storable_v<Regular*>);
 static_assert(dpl_unseq::__is_value_storable_v<ExplicitDefaultCtor*>);
-static_assert(dpl_unseq::__is_value_storable_v<BraceInitOnly*>);
-// The requirements are brace initialization, copy construction and copy assignment, and nothing else.
+static_assert(dpl_unseq::__is_value_storable_v<AggregateOfExplicitDefaultCtor*>);
+// The requirements are default construction, copy construction and copy assignment, and nothing else.
 static_assert(dpl_unseq::__is_value_storable_v<CopyOnlyNoMove*>);
 static_assert(dpl_unseq::__is_value_storable_v<VoidAssign*>);
 static_assert(dpl_unseq::__is_value_storable_v<const ConstCopyOnly*>);
@@ -192,10 +174,10 @@ static_assert(dpl_unseq::__is_value_storable_v<ExplicitCopyCtor*>);
 static_assert(dpl_unseq::__is_value_storable_v<ConstCopyOnly*>);
 static_assert(dpl_unseq::__is_value_storable_v<FakeIterator<int, OpaqueRef>>);
 
-// Rejected because of the value type: the first two fail brace initialization, the third copy assignment, and the last
+// Rejected because of the value type: the first two fail default construction, the third copy assignment, and the last
 // one copy construction.
 static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::NoDefaultCtorWrapper<int>*>);
-static_assert(!dpl_unseq::__is_value_storable_v<AggregateOfExplicitDefaultCtor*>);
+static_assert(!dpl_unseq::__is_value_storable_v<BraceInitOnly*>);
 static_assert(!dpl_unseq::__is_value_storable_v<NoCopyAssign*>);
 static_assert(!dpl_unseq::__is_value_storable_v<MoveOnly*>);
 

--- a/test/general/implementation_details/value_storable.pass.cpp
+++ b/test/general/implementation_details/value_storable.pass.cpp
@@ -40,14 +40,13 @@ struct ExplicitDefaultCtor
     explicit ExplicitDefaultCtor() : val(0) {}
 };
 
-// Default-constructible: default-initializing the aggregate default-initializes the member through its explicit default
-// constructor.
+// Default-constructible: the aggregate default-initializes its member through its explicit default constructor.
 struct AggregateOfExplicitDefaultCtor
 {
     ExplicitDefaultCtor member;
 };
 
-// Not default-constructible: the only constructor takes an initializer list, so `BraceInitOnly obj;` is ill-formed.
+// Not default-constructible: its only constructor takes an initializer list.
 struct BraceInitOnly
 {
     int val;
@@ -174,8 +173,7 @@ static_assert(dpl_unseq::__is_value_storable_v<ExplicitCopyCtor*>);
 static_assert(dpl_unseq::__is_value_storable_v<ConstCopyOnly*>);
 static_assert(dpl_unseq::__is_value_storable_v<FakeIterator<int, OpaqueRef>>);
 
-// Rejected because of the value type: the first two fail default construction, the third copy assignment, and the last
-// one copy construction.
+// Rejected because of the value type: default construction (the first two), copy assignment, copy construction.
 static_assert(!dpl_unseq::__is_value_storable_v<TestUtils::NoDefaultCtorWrapper<int>*>);
 static_assert(!dpl_unseq::__is_value_storable_v<BraceInitOnly*>);
 static_assert(!dpl_unseq::__is_value_storable_v<NoCopyAssign*>);

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -302,6 +302,19 @@ struct ExplicitDefaultCtorCompare
     }
 };
 
+// Default-constructible, but not brace-initializable: default-initializing the aggregate default-initializes the member
+// through its explicit default constructor, while empty braces would copy-list-initialize it, which the explicit
+// constructor rejects.
+struct AggregateOfExplicitDefaultCtorCompare
+{
+    ExplicitDefaultCtorCompare member;
+    bool
+    operator<(const AggregateOfExplicitDefaultCtorCompare& other) const
+    {
+        return member < other.member;
+    }
+};
+
 // Not default-constructible: neither constructor can be called without arguments, so `BraceInitOnlyCompare obj;` is
 // ill-formed. Empty braces, in contrast, select the initializer-list constructor.
 struct BraceInitOnlyCompare
@@ -443,6 +456,20 @@ test_by_type_host_policies(std::size_t n)
     check_by_type_host_policies<T>(Iterator(data.begin()), Iterator(data.end()));
 }
 
+// An aggregate cannot be constructed with parentheses before C++20, so the elements are brace-initialized instead of
+// being emplaced.
+template <typename T>
+static void
+test_by_type_host_policies_brace_init(std::size_t n)
+{
+    std::vector<T> data;
+    data.reserve(n);
+    for (std::size_t i = 0; i < n; ++i)
+        data.push_back(T{std::int32_t(TestUtils::HashBits(i, 30))});
+
+    check_by_type_host_policies<T>(data.begin(), data.end());
+}
+
 // A type with deleted move operations cannot be pushed into a std::vector, so the vector is sized up front and its
 // elements are assigned. A plain array is not used on purpose: with the bounds known at compile time, GCC reports a
 // false out-of-bounds subscript in the parallel reduction.
@@ -528,6 +555,7 @@ main()
     // These value types are accepted by the vector code path: it must be instantiated for them. Whether it compiles
     // does not depend on the sequence size, so a single small size is enough for all the checks below.
     test_by_type<ExplicitDefaultCtorCompare>(NSmall);
+    test_by_type_host_policies_brace_init<AggregateOfExplicitDefaultCtorCompare>(NSmall);
     test_by_type_host_policies_no_move<CopyOnlyNoMoveCompare>(NSmall);
     test_by_type_host_policies<VoidAssignCompare>(NSmall);
     test_by_type_host_policies<ConstCopyOnlyCompare, /*UseConstIterators*/ true>(NSmall);

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -396,6 +396,9 @@ main()
     using TestUtils::float64_t;
     const std::size_t N = 100000;
     const std::size_t NSmall = 10;
+    // Large enough for the parallel backend to split the sequence into several chunks and to combine their results, and
+    // for the vector loop to reduce over several lanes rather than to fall entirely into its remainder.
+    const std::size_t NMultiChunk = 1000;
 
     for (std::size_t n = 0; n < N; n = n < 16 ? n + 1 : size_t(3.14159 * n))
     {
@@ -421,8 +424,9 @@ main()
     test_by_type_host_policies<NoCopyAssignCompare>(NSmall);
     test_by_type_host_policies<MoveOnlyCompare>(NSmall);
 
-    // The sequence is long enough for the vector code to process several blocks and to combine their results.
-    test_comparator_with_overloaded_address_of(1000);
+    // The comparator has to work both inside the vector loop and in the combining of its results, so the sequence is
+    // not a small one here.
+    test_comparator_with_overloaded_address_of(NMultiChunk);
 
 #ifdef _PSTL_TEST_MIN_ELEMENT
     test_algo_basic_single<std::int32_t>(run_for_rnd_fw<test_non_const_min_element<std::int32_t>>());

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -302,7 +302,8 @@ struct ExplicitDefaultCtorCompare
     }
 };
 
-// Not default-constructible, but brace-initializable: empty braces select the initializer-list constructor.
+// Not default-constructible: neither constructor can be called without arguments, so `BraceInitOnlyCompare obj;` is
+// ill-formed. Empty braces, in contrast, select the initializer-list constructor.
 struct BraceInitOnlyCompare
 {
     std::int32_t val;
@@ -527,13 +528,13 @@ main()
     // These value types are accepted by the vector code path: it must be instantiated for them. Whether it compiles
     // does not depend on the sequence size, so a single small size is enough for all the checks below.
     test_by_type<ExplicitDefaultCtorCompare>(NSmall);
-    test_by_type_host_policies<BraceInitOnlyCompare>(NSmall);
     test_by_type_host_policies_no_move<CopyOnlyNoMoveCompare>(NSmall);
     test_by_type_host_policies<VoidAssignCompare>(NSmall);
     test_by_type_host_policies<ConstCopyOnlyCompare, /*UseConstIterators*/ true>(NSmall);
 
     // These value types are rejected by the vector code path: the call must compile and fall back to the serial one.
     test_by_type_host_policies<TestUtils::NoDefaultCtorWrapper<std::int32_t>>(NSmall);
+    test_by_type_host_policies<BraceInitOnlyCompare>(NSmall);
     test_by_type_host_policies<NoCopyAssignCompare>(NSmall);
     test_by_type_host_policies<MoveOnlyCompare>(NSmall);
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -20,12 +20,9 @@
 
 #include "support/utils.h"
 
+#include <set>
 #include <cassert>
 #include <cmath>
-#include <initializer_list>
-#include <set>
-#include <type_traits>
-#include <vector>
 
 #if  !defined(_PSTL_TEST_MIN_ELEMENT) && !defined(_PSTL_TEST_MAX_ELEMENT) &&\
      !defined(_PSTL_TEST_MINMAX_ELEMENT) && !_PSTL_ICPX_TEST_MINMAX_ELEMENT_PASS_BROKEN

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -302,9 +302,8 @@ struct ExplicitDefaultCtorCompare
     }
 };
 
-// Default-constructible, but not brace-initializable: default-initializing the aggregate default-initializes the member
-// through its explicit default constructor, while empty braces would copy-list-initialize it, which the explicit
-// constructor rejects.
+// Default-constructible, but not brace-initializable: empty braces copy-list-initialize the member, which its explicit
+// default constructor rejects.
 struct AggregateOfExplicitDefaultCtorCompare
 {
     ExplicitDefaultCtorCompare member;
@@ -315,8 +314,7 @@ struct AggregateOfExplicitDefaultCtorCompare
     }
 };
 
-// Not default-constructible: neither constructor can be called without arguments, so `BraceInitOnlyCompare obj;` is
-// ill-formed. Empty braces, in contrast, select the initializer-list constructor.
+// Not default-constructible: neither constructor takes zero arguments. Empty braces select the initializer-list one.
 struct BraceInitOnlyCompare
 {
     std::int32_t val;
@@ -456,8 +454,7 @@ test_by_type_host_policies(std::size_t n)
     check_by_type_host_policies<T>(Iterator(data.begin()), Iterator(data.end()));
 }
 
-// An aggregate cannot be constructed with parentheses before C++20, so the elements are brace-initialized instead of
-// being emplaced.
+// An aggregate cannot be constructed with parentheses before C++20, so elements are brace-initialized, not emplaced.
 template <typename T>
 static void
 test_by_type_host_policies_brace_init(std::size_t n)

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -416,10 +416,11 @@ main()
     test_by_type_host_policies_no_move<CopyOnlyNoMoveCompare>(NSmall);
     test_by_type_host_policies<VoidAssignCompare>(NSmall);
     test_by_type_host_policies<ConstCopyOnlyCompare, /*UseConstIterators*/ true>(NSmall);
-
-    // These value types are rejected by the vector code path: the call must compile and fall back to the serial one.
+    // Default construction is not required, so these two are accepted as well.
     test_by_type_host_policies<TestUtils::NoDefaultCtorWrapper<std::int32_t>>(NSmall);
     test_by_type_host_policies<BraceInitOnlyCompare>(NSmall);
+
+    // These value types are rejected by the vector code path: the call must compile and fall back to the serial one.
     test_by_type_host_policies<NoCopyAssignCompare>(NSmall);
     test_by_type_host_policies<MoveOnlyCompare>(NSmall);
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -276,150 +276,10 @@ test_by_type(std::size_t n)
     }
 }
 
-// should provide minimal requirements only
-struct OnlyLessCompare
-{
-    std::int32_t val;
-    OnlyLessCompare() : val(0) {}
-    OnlyLessCompare(std::int32_t val_) : val(val_) {}
-    bool
-    operator<(const OnlyLessCompare& other) const
-    {
-        return val < other.val;
-    }
-};
-
-// Default-constructible through an explicit default constructor only.
-struct ExplicitDefaultCtorCompare
-{
-    std::int32_t val;
-    explicit ExplicitDefaultCtorCompare() : val(0) {}
-    ExplicitDefaultCtorCompare(std::int32_t val_) : val(val_) {}
-    bool
-    operator<(const ExplicitDefaultCtorCompare& other) const
-    {
-        return val < other.val;
-    }
-};
-
-// Default-constructible, but not brace-initializable: empty braces copy-list-initialize the member, which its explicit
-// default constructor rejects.
-struct AggregateOfExplicitDefaultCtorCompare
-{
-    ExplicitDefaultCtorCompare member;
-    bool
-    operator<(const AggregateOfExplicitDefaultCtorCompare& other) const
-    {
-        return member < other.member;
-    }
-};
-
-// Not default-constructible: neither constructor takes zero arguments. Empty braces select the initializer-list one.
-struct BraceInitOnlyCompare
-{
-    std::int32_t val;
-    BraceInitOnlyCompare(std::initializer_list<std::int32_t> init) : val(init.size() == 0 ? 0 : *init.begin()) {}
-    BraceInitOnlyCompare(std::int32_t val_) : val(val_) {}
-    bool
-    operator<(const BraceInitOnlyCompare& other) const
-    {
-        return val < other.val;
-    }
-};
-
-// Copyable, but with deleted move operations.
-struct CopyOnlyNoMoveCompare
-{
-    std::int32_t val;
-    CopyOnlyNoMoveCompare() : val(0) {}
-    CopyOnlyNoMoveCompare(std::int32_t val_) : val(val_) {}
-    CopyOnlyNoMoveCompare(const CopyOnlyNoMoveCompare&) = default;
-    CopyOnlyNoMoveCompare&
-    operator=(const CopyOnlyNoMoveCompare&) = default;
-    CopyOnlyNoMoveCompare(CopyOnlyNoMoveCompare&&) = delete;
-    CopyOnlyNoMoveCompare&
-    operator=(CopyOnlyNoMoveCompare&&) = delete;
-    bool
-    operator<(const CopyOnlyNoMoveCompare& other) const
-    {
-        return val < other.val;
-    }
-};
-
-// The copy assignment returns void instead of VoidAssignCompare&.
-struct VoidAssignCompare
-{
-    std::int32_t val;
-    VoidAssignCompare() : val(0) {}
-    VoidAssignCompare(std::int32_t val_) : val(val_) {}
-    void
-    operator=(const VoidAssignCompare& other)
-    {
-        val = other.val;
-    }
-    bool
-    operator<(const VoidAssignCompare& other) const
-    {
-        return val < other.val;
-    }
-};
-
-// Copyable and assignable from a const lvalue only, so it requires const iterators.
-struct ConstCopyOnlyCompare
-{
-    std::int32_t val;
-    ConstCopyOnlyCompare() : val(0) {}
-    ConstCopyOnlyCompare(std::int32_t val_) : val(val_) {}
-    ConstCopyOnlyCompare(const ConstCopyOnlyCompare&) = default;
-    ConstCopyOnlyCompare(ConstCopyOnlyCompare&) = delete;
-    ConstCopyOnlyCompare&
-    operator=(const ConstCopyOnlyCompare&) = default;
-    ConstCopyOnlyCompare&
-    operator=(ConstCopyOnlyCompare&) = delete;
-    bool
-    operator<(const ConstCopyOnlyCompare& other) const
-    {
-        return val < other.val;
-    }
-};
-
-// A type that is not default-constructible is taken from the test utilities:
-// TestUtils::NoDefaultCtorWrapper<std::int32_t>. It compares through its conversion to the underlying type.
-
-// Not copy-assignable.
-struct NoCopyAssignCompare
-{
-    std::int32_t val;
-    NoCopyAssignCompare() : val(0) {}
-    NoCopyAssignCompare(std::int32_t val_) : val(val_) {}
-    NoCopyAssignCompare(const NoCopyAssignCompare&) = default;
-    NoCopyAssignCompare&
-    operator=(const NoCopyAssignCompare&) = delete;
-    bool
-    operator<(const NoCopyAssignCompare& other) const
-    {
-        return val < other.val;
-    }
-};
-
-// Not copy-constructible.
-struct MoveOnlyCompare
-{
-    std::int32_t val;
-    MoveOnlyCompare() : val(0) {}
-    MoveOnlyCompare(std::int32_t val_) : val(val_) {}
-    MoveOnlyCompare(MoveOnlyCompare&&) = default;
-    MoveOnlyCompare&
-    operator=(MoveOnlyCompare&&) = default;
-    MoveOnlyCompare(const MoveOnlyCompare&) = delete;
-    MoveOnlyCompare&
-    operator=(const MoveOnlyCompare&) = delete;
-    bool
-    operator<(const MoveOnlyCompare& other) const
-    {
-        return val < other.val;
-    }
-};
+// The value types with restricted operations that the test runs the algorithms on - OnlyLessCompare and the rest, plus
+// TestUtils::NoDefaultCtorWrapper<std::int32_t>, which is not default-constructible - are defined in
+// test/support/utils.h, because test/general/implementation_details/value_storable.pass.cpp checks the very same set
+// against the trait that selects the vector code path.
 
 template <typename T, typename Iterator>
 static void
@@ -450,7 +310,7 @@ test_by_type_host_policies(std::size_t n)
         data.emplace_back(std::int32_t(TestUtils::HashBits(i, 30)));
 
     using Iterator = std::conditional_t<UseConstIterators, typename std::vector<T>::const_iterator,
-                                          typename std::vector<T>::iterator>;
+                                        typename std::vector<T>::iterator>;
     check_by_type_host_policies<T>(Iterator(data.begin()), Iterator(data.end()));
 }
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <cstdint>
 #include <cstdlib>
+#include <initializer_list>
 #include <cstring>
 #include <iostream>
 #include <iterator>
@@ -1402,6 +1403,179 @@ struct NoDefaultCtorWrapper {
     ~NoDefaultCtorWrapper()
     {
         value.~_T();
+    }
+};
+
+//----------------------------------------------------------------------------//
+// Value types with restricted operations
+//----------------------------------------------------------------------------//
+//
+// Each of these types provides the minimal interface of an algorithm's element - default construction, construction
+// from std::int32_t and operator< - with exactly one further operation restricted, so that a test can tell which
+// operations an implementation really requires of its value type. The name says what the restriction is.
+//
+// They are shared by test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp, which runs the
+// algorithms on them, and test/general/implementation_details/value_storable.pass.cpp, which checks the trait that
+// selects the vector code path for them. Keep them in lock-step: a type accepted by the trait has to be one the
+// algorithms actually compile for.
+
+// Nothing is restricted: this is the baseline the others are compared against.
+struct OnlyLessCompare
+{
+    std::int32_t val;
+    OnlyLessCompare() : val(0) {}
+    OnlyLessCompare(std::int32_t val_) : val(val_) {}
+    bool
+    operator<(const OnlyLessCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// Default-constructible through an explicit default constructor only.
+struct ExplicitDefaultCtorCompare
+{
+    std::int32_t val;
+    explicit ExplicitDefaultCtorCompare() : val(0) {}
+    ExplicitDefaultCtorCompare(std::int32_t val_) : val(val_) {}
+    bool
+    operator<(const ExplicitDefaultCtorCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// Default-constructible, but not brace-initializable: empty braces copy-list-initialize the member, which its explicit
+// default constructor rejects. It is an aggregate, so it takes no std::int32_t constructor.
+struct AggregateOfExplicitDefaultCtorCompare
+{
+    ExplicitDefaultCtorCompare member;
+    bool
+    operator<(const AggregateOfExplicitDefaultCtorCompare& other) const
+    {
+        return member < other.member;
+    }
+};
+
+// Not default-constructible: neither constructor takes zero arguments. Empty braces select the initializer-list one.
+struct BraceInitOnlyCompare
+{
+    std::int32_t val;
+    BraceInitOnlyCompare(std::initializer_list<std::int32_t> init) : val(init.size() == 0 ? 0 : *init.begin()) {}
+    BraceInitOnlyCompare(std::int32_t val_) : val(val_) {}
+    bool
+    operator<(const BraceInitOnlyCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// Copyable, but with deleted move operations.
+struct CopyOnlyNoMoveCompare
+{
+    std::int32_t val;
+    CopyOnlyNoMoveCompare() : val(0) {}
+    CopyOnlyNoMoveCompare(std::int32_t val_) : val(val_) {}
+    CopyOnlyNoMoveCompare(const CopyOnlyNoMoveCompare&) = default;
+    CopyOnlyNoMoveCompare&
+    operator=(const CopyOnlyNoMoveCompare&) = default;
+    CopyOnlyNoMoveCompare(CopyOnlyNoMoveCompare&&) = delete;
+    CopyOnlyNoMoveCompare&
+    operator=(CopyOnlyNoMoveCompare&&) = delete;
+    bool
+    operator<(const CopyOnlyNoMoveCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// The copy assignment returns void instead of VoidAssignCompare&. The copy constructor has to be declared explicitly:
+// a user-declared copy assignment operator only deprecates the implicit one, which -Wdeprecated-copy reports.
+struct VoidAssignCompare
+{
+    std::int32_t val;
+    VoidAssignCompare() : val(0) {}
+    VoidAssignCompare(std::int32_t val_) : val(val_) {}
+    VoidAssignCompare(const VoidAssignCompare&) = default;
+    void
+    operator=(const VoidAssignCompare& other)
+    {
+        val = other.val;
+    }
+    bool
+    operator<(const VoidAssignCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// Copyable and assignable from a const lvalue only, so it requires const iterators.
+struct ConstCopyOnlyCompare
+{
+    std::int32_t val;
+    ConstCopyOnlyCompare() : val(0) {}
+    ConstCopyOnlyCompare(std::int32_t val_) : val(val_) {}
+    ConstCopyOnlyCompare(const ConstCopyOnlyCompare&) = default;
+    ConstCopyOnlyCompare(ConstCopyOnlyCompare&) = delete;
+    ConstCopyOnlyCompare&
+    operator=(const ConstCopyOnlyCompare&) = default;
+    ConstCopyOnlyCompare&
+    operator=(ConstCopyOnlyCompare&) = delete;
+    bool
+    operator<(const ConstCopyOnlyCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// Copy-constructible, but its elements cannot be copy-initialized, because the copy constructor is explicit.
+struct ExplicitCopyCtorCompare
+{
+    std::int32_t val;
+    ExplicitCopyCtorCompare() : val(0) {}
+    ExplicitCopyCtorCompare(std::int32_t val_) : val(val_) {}
+    explicit ExplicitCopyCtorCompare(const ExplicitCopyCtorCompare& other) : val(other.val) {}
+    ExplicitCopyCtorCompare&
+    operator=(const ExplicitCopyCtorCompare&) = default;
+    bool
+    operator<(const ExplicitCopyCtorCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// Not copy-assignable.
+struct NoCopyAssignCompare
+{
+    std::int32_t val;
+    NoCopyAssignCompare() : val(0) {}
+    NoCopyAssignCompare(std::int32_t val_) : val(val_) {}
+    NoCopyAssignCompare(const NoCopyAssignCompare&) = default;
+    NoCopyAssignCompare&
+    operator=(const NoCopyAssignCompare&) = delete;
+    bool
+    operator<(const NoCopyAssignCompare& other) const
+    {
+        return val < other.val;
+    }
+};
+
+// Not copy-constructible.
+struct MoveOnlyCompare
+{
+    std::int32_t val;
+    MoveOnlyCompare() : val(0) {}
+    MoveOnlyCompare(std::int32_t val_) : val(val_) {}
+    MoveOnlyCompare(MoveOnlyCompare&&) = default;
+    MoveOnlyCompare&
+    operator=(MoveOnlyCompare&&) = default;
+    MoveOnlyCompare(const MoveOnlyCompare&) = delete;
+    MoveOnlyCompare&
+    operator=(const MoveOnlyCompare&) = delete;
+    bool
+    operator<(const MoveOnlyCompare& other) const
+    {
+        return val < other.val;
     }
 };
 


### PR DESCRIPTION
Follow-up to #2816, on top of its branch; this describes #2816 + this PR relative to `main`.

The main goals of this propose:
- avoid `__is_brace_constructible_v` and rewrite all checks for `__simd_min_element()` and `__simd_minmax_element()` by
```cpp
template <typename _Iterator, typename _ValueType = typename std::iterator_traits<_Iterator>::value_type,
          typename _ReferenceType = typename std::iterator_traits<_Iterator>::reference>
inline constexpr bool __is_value_storable_v =
    std::is_copy_constructible_v<_ValueType> && std::is_copy_assignable_v<_ValueType> &&
    std::is_convertible_v<_ReferenceType, _ValueType>;
```
- some changes in`__simd_min_element` and in `__simd_minmax_element` to assign values inside by more universal way;
- some additional test cases and moving test type into `utils.h`

Also we rewrite the compile-time dispatcher between our own `simd`-implementation and implementations from standard library:
```cpp
#if _ONEDPL_UDR_PRESENT
    if constexpr (__unseq_backend::__is_value_storable_v<_RandomAccessIterator>)
    {
        return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
    }
    else
#endif // _ONEDPL_UDR_PRESENT
    {
        return std::min_element(__first, __last, __comp);
    }
```
The goal of this change:
1) to avoid warnings about unreachable code in the case when `_ONEDPL_UDR_PRESENT == 1` and `__unseq_backend::__is_value_storable_v<_RandomAccessIterator>` is `true`;
2) to avoid extra instantiations of `std::min_element(__first, __last, __comp);`.